### PR TITLE
Remove containerBuilder global variable

### DIFF
--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -1352,6 +1352,10 @@ return [
                 '$transformations' => '@transformations',
                 '$relation' => '@relation',
                 '$dbi' => '@dbi',
+                '$sqlController' => '@' . Sql\SqlController::class,
+                '$databaseSqlController' => '@' . Database\SqlController::class,
+                '$changeController' => '@' . Table\ChangeController::class,
+                '$tableSqlController' => '@' . Table\SqlController::class,
             ],
         ],
         Table\SearchController::class => [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8326,11 +8326,6 @@ parameters:
 			path: src/Core.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method Symfony\\\\Component\\\\DependencyInjection\\\\Container\\:\\:setParameter\\(\\) expects string, \\(int\\|string\\) given\\.$#"
-			count: 1
-			path: src/Core.php
-
-		-
 			message: "#^Parameter \\#1 \\$pattern of function preg_match expects string, mixed given\\.$#"
 			count: 1
 			path: src/Core.php
@@ -8352,11 +8347,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, \\(int\\|string\\) given\\.$#"
-			count: 1
-			path: src/Core.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method Symfony\\\\Component\\\\DependencyInjection\\\\Container\\:\\:setParameter\\(\\) expects array\\|bool\\|float\\|int\\|string\\|UnitEnum\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Core.php
 
@@ -11261,17 +11251,7 @@ parameters:
 			path: src/Http/Middleware/CurrentServerGlobalSetting.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of method Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\:\\:setParameter\\(\\) expects array\\|bool\\|float\\|int\\|string\\|UnitEnum\\|null, mixed given\\.$#"
-			count: 1
-			path: src/Http/Middleware/CurrentServerGlobalSetting.php
-
-		-
 			message: "#^Cannot access offset 'table' on mixed\\.$#"
-			count: 1
-			path: src/Http/Middleware/DatabaseAndTableSetting.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\:\\:setParameter\\(\\) expects array\\|bool\\|float\\|int\\|string\\|UnitEnum\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Http/Middleware/DatabaseAndTableSetting.php
 
@@ -11303,11 +11283,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$page of static method PhpMyAdmin\\\\Core\\:\\:checkPageValidity\\(\\) expects string, mixed given\\.$#"
 			count: 2
-			path: src/Http/Middleware/UrlParamsSetting.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\:\\:setParameter\\(\\) expects array\\|bool\\|float\\|int\\|string\\|UnitEnum\\|null, mixed given\\.$#"
-			count: 3
 			path: src/Http/Middleware/UrlParamsSetting.php
 
 		-
@@ -19841,11 +19816,6 @@ parameters:
 			path: test/classes/Controllers/Database/StructureControllerTest.php
 
 		-
-			message: "#^Cannot call method setParameter\\(\\) on mixed\\.$#"
-			count: 2
-			path: test/classes/Controllers/Database/StructureControllerTest.php
-
-		-
 			message: "#^Cannot use array destructuring on mixed\\.$#"
 			count: 8
 			path: test/classes/Controllers/Database/StructureControllerTest.php
@@ -19951,28 +19921,13 @@ parameters:
 			path: test/classes/Controllers/Sql/EnumValuesControllerTest.php
 
 		-
-			message: "#^Cannot call method setParameter\\(\\) on mixed\\.$#"
-			count: 4
-			path: test/classes/Controllers/Sql/EnumValuesControllerTest.php
-
-		-
 			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
 			count: 2
-			path: test/classes/Controllers/Sql/SetValuesControllerTest.php
-
-		-
-			message: "#^Cannot call method setParameter\\(\\) on mixed\\.$#"
-			count: 4
 			path: test/classes/Controllers/Sql/SetValuesControllerTest.php
 
 		-
 			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
 			count: 1
-			path: test/classes/Controllers/Table/OperationsControllerTest.php
-
-		-
-			message: "#^Cannot call method setParameter\\(\\) on mixed\\.$#"
-			count: 2
 			path: test/classes/Controllers/Table/OperationsControllerTest.php
 
 		-
@@ -20018,11 +19973,6 @@ parameters:
 		-
 			message: "#^Cannot call method method\\(\\) on mixed\\.$#"
 			count: 1
-			path: test/classes/Controllers/Table/SearchControllerTest.php
-
-		-
-			message: "#^Cannot call method setParameter\\(\\) on mixed\\.$#"
-			count: 2
 			path: test/classes/Controllers/Table/SearchControllerTest.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19416,21 +19416,6 @@ parameters:
 			path: test/classes/AbstractTestCase.php
 
 		-
-			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
-			count: 4
-			path: test/classes/AbstractTestCase.php
-
-		-
-			message: "#^Cannot call method set\\(\\) on mixed\\.$#"
-			count: 2
-			path: test/classes/AbstractTestCase.php
-
-		-
-			message: "#^Cannot call method setAlias\\(\\) on mixed\\.$#"
-			count: 2
-			path: test/classes/AbstractTestCase.php
-
-		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) with 'formula' and array\\{id\\: non\\-empty\\-string, name\\: string, precondition\\?\\: non\\-empty\\-string, formula\\: non\\-empty\\-string, test\\: non\\-empty\\-string, issue\\: string, recommendation\\: string, justification\\: string, \\.\\.\\.\\} will always evaluate to true\\.$#"
 			count: 1
 			path: test/classes/Advisory/RulesTest.php
@@ -19761,11 +19746,6 @@ parameters:
 			path: test/classes/ConfigTest.php
 
 		-
-			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
-			count: 1
-			path: test/classes/Controllers/Database/MultiTableQuery/TablesControllerTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$needle of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: test/classes/Controllers/Database/PrivilegesControllerTest.php
@@ -19811,11 +19791,6 @@ parameters:
 			path: test/classes/Controllers/Database/StructureControllerTest.php
 
 		-
-			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
-			count: 1
-			path: test/classes/Controllers/Database/StructureControllerTest.php
-
-		-
 			message: "#^Cannot use array destructuring on mixed\\.$#"
 			count: 8
 			path: test/classes/Controllers/Database/StructureControllerTest.php
@@ -19834,16 +19809,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringNotContainsString\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: test/classes/Controllers/Database/StructureControllerTest.php
-
-		-
-			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
-			count: 1
-			path: test/classes/Controllers/Import/ImportControllerTest.php
-
-		-
-			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
-			count: 2
-			path: test/classes/Controllers/NavigationControllerTest.php
 
 		-
 			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, mixed given\\.$#"
@@ -19916,21 +19881,6 @@ parameters:
 			path: test/classes/Controllers/Server/VariablesControllerTest.php
 
 		-
-			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
-			count: 2
-			path: test/classes/Controllers/Sql/EnumValuesControllerTest.php
-
-		-
-			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
-			count: 2
-			path: test/classes/Controllers/Sql/SetValuesControllerTest.php
-
-		-
-			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
-			count: 1
-			path: test/classes/Controllers/Table/OperationsControllerTest.php
-
-		-
 			message: "#^Property PhpMyAdmin\\\\Config\\:\\:\\$settings \\(array\\{PmaAbsoluteUri\\: string, AuthLog\\: string, AuthLogSuccess\\: bool, PmaNoRelation_DisableWarning\\: bool, SuhosinDisableWarning\\: bool, LoginCookieValidityDisableWarning\\: bool, ReservedWordDisableWarning\\: bool, TranslationWarningThreshold\\: int, \\.\\.\\.\\}\\) does not accept array\\{PmaAbsoluteUri\\: string, AuthLog\\: string, AuthLogSuccess\\: bool, PmaNoRelation_DisableWarning\\: bool, SuhosinDisableWarning\\: bool, LoginCookieValidityDisableWarning\\: bool, ReservedWordDisableWarning\\: bool, TranslationWarningThreshold\\: int, \\.\\.\\.\\}\\.$#"
 			count: 1
 			path: test/classes/Controllers/Table/OperationsControllerTest.php
@@ -19962,11 +19912,6 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method PhpMyAdmin\\\\DatabaseInterface\\:\\:expects\\(\\)\\.$#"
-			count: 1
-			path: test/classes/Controllers/Table/SearchControllerTest.php
-
-		-
-			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
 			count: 1
 			path: test/classes/Controllers/Table/SearchControllerTest.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4509,7 +4509,6 @@
     </MixedReturnStatement>
     <PossiblyInvalidArgument>
       <code>$postKey</code>
-      <code>$postKey</code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidArrayOffset>
       <code>$path[$depth - 1]</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -51,7 +51,6 @@
             compression: 'none'|'zip'|'gzip',
             conn_error: string,
             ConfigFile: PhpMyAdmin\Config\ConfigFile,
-            containerBuilder: Symfony\Component\DependencyInjection\ContainerBuilder,
             csv_columns: bool,
             csv_enclosed: string,
             csv_escaped: string,

--- a/src/Controllers/Table/ReplaceController.php
+++ b/src/Controllers/Table/ReplaceController.php
@@ -49,6 +49,10 @@ final class ReplaceController extends AbstractController
         private Transformations $transformations,
         private Relation $relation,
         private DatabaseInterface $dbi,
+        private readonly SqlController $sqlController,
+        private readonly DatabaseSqlController $databaseSqlController,
+        private readonly ChangeController $changeController,
+        private readonly TableSqlController $tableSqlController,
     ) {
         parent::__construct($response, $template);
     }
@@ -475,44 +479,25 @@ final class ReplaceController extends AbstractController
     private function moveBackToCallingScript(string $gotoInclude, ServerRequest $request): void
     {
         $GLOBALS['active_page'] = $gotoInclude;
-        $container = Core::getContainerBuilder();
         if ($gotoInclude === '/sql') {
-            /** @var SqlController $controller */
-            $controller = $container->get(SqlController::class);
-            $controller($request);
+            ($this->sqlController)($request);
 
             return;
         }
 
         if ($gotoInclude === '/database/sql') {
-            /** @var DatabaseSqlController $controller */
-            $controller = $container->get(DatabaseSqlController::class);
-            $controller($request);
-
-            return;
-        }
-
-        if ($gotoInclude === '/table/change') {
-            /** @var ChangeController $controller */
-            $controller = $container->get(ChangeController::class);
-            $controller($request);
+            ($this->databaseSqlController)($request);
 
             return;
         }
 
         if ($gotoInclude === '/table/sql') {
-            /** @var TableSqlController $controller */
-            $controller = $container->get(TableSqlController::class);
-            $controller($request);
+            ($this->tableSqlController)($request);
 
             return;
         }
 
-        /**
-         * Load target page.
-         */
-        /** @psalm-suppress UnresolvableInclude */
-        require ROOT_PATH . Core::securePath($gotoInclude);
+        ($this->changeController)($request);
     }
 
     /**

--- a/src/Controllers/Table/SqlController.php
+++ b/src/Controllers/Table/SqlController.php
@@ -24,7 +24,7 @@ use function htmlspecialchars;
 /**
  * Table SQL executor
  */
-final class SqlController extends AbstractController
+class SqlController extends AbstractController
 {
     public function __construct(
         ResponseRenderer $response,

--- a/src/Core.php
+++ b/src/Core.php
@@ -57,6 +57,8 @@ use const FILTER_VALIDATE_IP;
  */
 class Core
 {
+    public static ContainerBuilder|null $containerBuilder = null;
+
     /**
      * Removes insecure parts in a path; used before include() or
      * require() when a part of the path comes from an insecure source
@@ -762,18 +764,15 @@ class Core
 
     public static function getContainerBuilder(): ContainerBuilder
     {
-        $containerBuilder = $GLOBALS['containerBuilder'] ?? null;
-        if ($containerBuilder instanceof ContainerBuilder) {
-            return $containerBuilder;
+        if (self::$containerBuilder !== null) {
+            return self::$containerBuilder;
         }
 
-        $containerBuilder = new ContainerBuilder();
-        $loader = new PhpFileLoader($containerBuilder, new FileLocator(ROOT_PATH . 'app'));
+        self::$containerBuilder = new ContainerBuilder();
+        $loader = new PhpFileLoader(self::$containerBuilder, new FileLocator(ROOT_PATH . 'app'));
         $loader->load('services_loader.php');
 
-        $GLOBALS['containerBuilder'] = $containerBuilder;
-
-        return $containerBuilder;
+        return self::$containerBuilder;
     }
 
     public static function populateRequestWithEncryptedQueryParams(ServerRequest $request): ServerRequest

--- a/src/Core.php
+++ b/src/Core.php
@@ -560,7 +560,6 @@ class Core
      */
     public static function setPostAsGlobal(array $postPatterns): void
     {
-        $container = self::getContainerBuilder();
         foreach (array_keys($_POST) as $postKey) {
             foreach ($postPatterns as $onePostPattern) {
                 if (! preg_match($onePostPattern, $postKey)) {
@@ -568,7 +567,6 @@ class Core
                 }
 
                 $GLOBALS[$postKey] = $_POST[$postKey];
-                $container->setParameter($postKey, $GLOBALS[$postKey]);
             }
         }
     }

--- a/src/Http/Middleware/CurrentServerGlobalSetting.php
+++ b/src/Http/Middleware/CurrentServerGlobalSetting.php
@@ -38,7 +38,5 @@ final class CurrentServerGlobalSetting implements MiddlewareInterface
         $server = $config->selectServer($serverParamFromRequest);
         $GLOBALS['server'] = $server;
         $GLOBALS['urlParams']['server'] = $server;
-        $container->setParameter('server', $server);
-        $container->setParameter('url_params', $GLOBALS['urlParams']);
     }
 }

--- a/src/Http/Middleware/DatabaseAndTableSetting.php
+++ b/src/Http/Middleware/DatabaseAndTableSetting.php
@@ -44,6 +44,5 @@ final class DatabaseAndTableSetting implements MiddlewareInterface
 
         $GLOBALS['urlParams']['db'] = $GLOBALS['db'];
         $GLOBALS['urlParams']['table'] = $GLOBALS['table'];
-        $container->setParameter('url_params', $GLOBALS['urlParams']);
     }
 }

--- a/src/Http/Middleware/SqlQueryGlobalSetting.php
+++ b/src/Http/Middleware/SqlQueryGlobalSetting.php
@@ -38,6 +38,5 @@ final class SqlQueryGlobalSetting implements MiddlewareInterface
         }
 
         $GLOBALS['sql_query'] = $sqlQuery;
-        $container->setParameter('sql_query', $sqlQuery);
     }
 }

--- a/src/Http/Middleware/UrlParamsSetting.php
+++ b/src/Http/Middleware/UrlParamsSetting.php
@@ -10,7 +10,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 final class UrlParamsSetting implements MiddlewareInterface
 {
@@ -20,27 +19,21 @@ final class UrlParamsSetting implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $container = Core::getContainerBuilder();
-
         $GLOBALS['urlParams'] = [];
-        $container->setParameter('url_params', $GLOBALS['urlParams']);
 
-        $this->setGotoAndBackGlobals($container);
+        $this->setGotoAndBackGlobals();
 
         return $handler->handle($request);
     }
 
-    private function setGotoAndBackGlobals(ContainerInterface $container): void
+    private function setGotoAndBackGlobals(): void
     {
         // Holds page that should be displayed.
         $GLOBALS['goto'] = '';
-        $container->setParameter('goto', $GLOBALS['goto']);
 
         if (isset($_REQUEST['goto']) && Core::checkPageValidity($_REQUEST['goto'])) {
             $GLOBALS['goto'] = $_REQUEST['goto'];
             $GLOBALS['urlParams']['goto'] = $GLOBALS['goto'];
-            $container->setParameter('goto', $GLOBALS['goto']);
-            $container->setParameter('url_params', $GLOBALS['urlParams']);
         } else {
             if ($this->config->issetCookie('goto')) {
                 $this->config->removeCookie('goto');
@@ -52,7 +45,6 @@ final class UrlParamsSetting implements MiddlewareInterface
         if (isset($_REQUEST['back']) && Core::checkPageValidity($_REQUEST['back'])) {
             // Returning page.
             $GLOBALS['back'] = $_REQUEST['back'];
-            $container->setParameter('back', $GLOBALS['back']);
 
             return;
         }

--- a/test/classes/AbstractTestCase.php
+++ b/test/classes/AbstractTestCase.php
@@ -87,30 +87,28 @@ abstract class AbstractTestCase extends TestCase
         Cache::purge();
 
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
-    }
-
-    protected function loadContainerBuilder(): void
-    {
-        $GLOBALS['containerBuilder'] = Core::getContainerBuilder();
+        Core::$containerBuilder = null;
     }
 
     protected function loadDbiIntoContainerBuilder(): void
     {
-        $GLOBALS['containerBuilder']->set(DatabaseInterface::class, DatabaseInterface::getInstance());
-        $GLOBALS['containerBuilder']->setAlias('dbi', DatabaseInterface::class);
+        $containerBuilder = Core::getContainerBuilder();
+        $containerBuilder->set(DatabaseInterface::class, DatabaseInterface::getInstance());
+        $containerBuilder->setAlias('dbi', DatabaseInterface::class);
     }
 
     protected function loadResponseIntoContainerBuilder(): void
     {
         $response = new ResponseRenderer();
-        $GLOBALS['containerBuilder']->set(ResponseRenderer::class, $response);
-        $GLOBALS['containerBuilder']->setAlias('response', ResponseRenderer::class);
+        $containerBuilder = Core::getContainerBuilder();
+        $containerBuilder->set(ResponseRenderer::class, $response);
+        $containerBuilder->setAlias('response', ResponseRenderer::class);
     }
 
     protected function getResponseHtmlResult(): string
     {
         /** @var ResponseRenderer $response */
-        $response = $GLOBALS['containerBuilder']->get(ResponseRenderer::class);
+        $response = Core::getContainerBuilder()->get(ResponseRenderer::class);
 
         return $response->getHTMLResult();
     }
@@ -119,7 +117,7 @@ abstract class AbstractTestCase extends TestCase
     protected function getResponseJsonResult(): array
     {
         /** @var ResponseRenderer $response */
-        $response = $GLOBALS['containerBuilder']->get(ResponseRenderer::class);
+        $response = Core::getContainerBuilder()->get(ResponseRenderer::class);
 
         return $response->getJSONResult();
     }
@@ -127,7 +125,7 @@ abstract class AbstractTestCase extends TestCase
     protected function assertResponseWasNotSuccessfull(): void
     {
         /** @var ResponseRenderer $response */
-        $response = $GLOBALS['containerBuilder']->get(ResponseRenderer::class);
+        $response = Core::getContainerBuilder()->get(ResponseRenderer::class);
 
         $this->assertFalse($response->hasSuccessState(), 'expected the request to fail');
     }
@@ -135,7 +133,7 @@ abstract class AbstractTestCase extends TestCase
     protected function assertResponseWasSuccessfull(): void
     {
         /** @var ResponseRenderer $response */
-        $response = $GLOBALS['containerBuilder']->get(ResponseRenderer::class);
+        $response = Core::getContainerBuilder()->get(ResponseRenderer::class);
 
         $this->assertTrue($response->hasSuccessState(), 'expected the request not to fail');
     }
@@ -199,6 +197,7 @@ abstract class AbstractTestCase extends TestCase
      */
     protected function tearDown(): void
     {
+        Core::$containerBuilder = null;
         DatabaseInterface::$instance = null;
         Config::$instance = null;
         (new ReflectionProperty(Template::class, 'twig'))->setValue(null, null);

--- a/test/classes/ApplicationTest.php
+++ b/test/classes/ApplicationTest.php
@@ -19,11 +19,9 @@ final class ApplicationTest extends AbstractTestCase
 {
     public function testInit(): void
     {
-        $GLOBALS['containerBuilder'] = null;
         $application = Core::getContainerBuilder()->get(Application::class);
         self::assertInstanceOf(Application::class, $application);
         self::assertSame($application, Application::init());
-        $GLOBALS['containerBuilder'] = null;
     }
 
     #[BackupStaticProperties(true)]

--- a/test/classes/Controllers/Database/MultiTableQuery/TablesControllerTest.php
+++ b/test/classes/Controllers/Database/MultiTableQuery/TablesControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Controllers\Database\MultiTableQuery;
 
 use PhpMyAdmin\Controllers\Database\MultiTableQuery\TablesController;
+use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -28,8 +29,6 @@ class TablesControllerTest extends AbstractTestCase
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;
 
-        parent::loadContainerBuilder();
-
         parent::loadDbiIntoContainerBuilder();
 
         $GLOBALS['server'] = 1;
@@ -43,7 +42,7 @@ class TablesControllerTest extends AbstractTestCase
         $_GET['db'] = 'test';
 
         /** @var TablesController $multiTableQueryController */
-        $multiTableQueryController = $GLOBALS['containerBuilder']->get(TablesController::class);
+        $multiTableQueryController = Core::getContainerBuilder()->get(TablesController::class);
         $request = $this->createStub(ServerRequest::class);
         $request->method('getQueryParam')->willReturn($_GET['tables'], $_GET['db']);
         $multiTableQueryController($request);

--- a/test/classes/Controllers/Database/StructureControllerTest.php
+++ b/test/classes/Controllers/Database/StructureControllerTest.php
@@ -379,9 +379,6 @@ class StructureControllerTest extends AbstractTestCase
         $GLOBALS['db'] = 'testdb';
         $GLOBALS['table'] = 'mytable';
 
-        $GLOBALS['containerBuilder']->setParameter('db', $GLOBALS['db']);
-        $GLOBALS['containerBuilder']->setParameter('table', $GLOBALS['table']);
-
         /** @var StructureController $structureController */
         $structureController = $GLOBALS['containerBuilder']->get(StructureController::class);
 

--- a/test/classes/Controllers/Database/StructureControllerTest.php
+++ b/test/classes/Controllers/Database/StructureControllerTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\Database\StructureController;
+use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\DbTableExists;
 use PhpMyAdmin\Http\ServerRequest;
@@ -372,15 +373,13 @@ class StructureControllerTest extends AbstractTestCase
      */
     public function testGetValuesForMroongaTable(): void
     {
-        parent::loadContainerBuilder();
-
         parent::loadDbiIntoContainerBuilder();
 
         $GLOBALS['db'] = 'testdb';
         $GLOBALS['table'] = 'mytable';
 
         /** @var StructureController $structureController */
-        $structureController = $GLOBALS['containerBuilder']->get(StructureController::class);
+        $structureController = Core::getContainerBuilder()->get(StructureController::class);
 
         $this->assertSame(
             [[], '', '', 0],

--- a/test/classes/Controllers/Export/ExportControllerTest.php
+++ b/test/classes/Controllers/Export/ExportControllerTest.php
@@ -36,7 +36,6 @@ class ExportControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->loadContainerBuilder();
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/test/classes/Controllers/Import/ImportControllerTest.php
+++ b/test/classes/Controllers/Import/ImportControllerTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Tests\Controllers\Import;
 
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\Import\ImportController;
+use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -30,8 +31,6 @@ class ImportControllerTest extends AbstractTestCase
 
     public function testIndexParametrized(): void
     {
-        parent::loadContainerBuilder();
-
         parent::loadDbiIntoContainerBuilder();
 
         parent::setLanguage();
@@ -82,7 +81,7 @@ class ImportControllerTest extends AbstractTestCase
         );
 
         /** @var ImportController $importController */
-        $importController = $GLOBALS['containerBuilder']->get(ImportController::class);
+        $importController = Core::getContainerBuilder()->get(ImportController::class);
         $this->dummyDbi->addSelectDb('pma_test');
         $this->dummyDbi->addSelectDb('pma_test');
         $importController($request);

--- a/test/classes/Controllers/NavigationControllerTest.php
+++ b/test/classes/Controllers/NavigationControllerTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Tests\Controllers;
 
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\NavigationController;
+use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -32,8 +33,6 @@ class NavigationControllerTest extends AbstractTestCase
 
     public function testIndex(): void
     {
-        parent::loadContainerBuilder();
-
         parent::loadDbiIntoContainerBuilder();
 
         parent::setLanguage();
@@ -125,7 +124,7 @@ class NavigationControllerTest extends AbstractTestCase
         );
 
         /** @var NavigationController $navigationController */
-        $navigationController = $GLOBALS['containerBuilder']->get(NavigationController::class);
+        $navigationController = Core::getContainerBuilder()->get(NavigationController::class);
         $_POST['full'] = '1';
 
         $request = $this->createStub(ServerRequest::class);
@@ -184,8 +183,6 @@ class NavigationControllerTest extends AbstractTestCase
 
     public function testIndexWithPosAndValue(): void
     {
-        parent::loadContainerBuilder();
-
         parent::loadDbiIntoContainerBuilder();
 
         parent::setLanguage();
@@ -277,7 +274,7 @@ class NavigationControllerTest extends AbstractTestCase
         );
 
         /** @var NavigationController $navigationController */
-        $navigationController = $GLOBALS['containerBuilder']->get(NavigationController::class);
+        $navigationController = Core::getContainerBuilder()->get(NavigationController::class);
         $_POST['full'] = '1';
 
         $request = $this->createStub(ServerRequest::class);

--- a/test/classes/Controllers/Normalization/MainControllerTest.php
+++ b/test/classes/Controllers/Normalization/MainControllerTest.php
@@ -34,8 +34,6 @@ class MainControllerTest extends AbstractTestCase
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;
 
-        parent::loadContainerBuilder();
-
         parent::loadDbiIntoContainerBuilder();
 
         $GLOBALS['server'] = 1;

--- a/test/classes/Controllers/Sql/EnumValuesControllerTest.php
+++ b/test/classes/Controllers/Sql/EnumValuesControllerTest.php
@@ -52,8 +52,6 @@ class EnumValuesControllerTest extends AbstractTestCase
             ['curr_value', null, 'b&c'],
         ]);
 
-        $GLOBALS['containerBuilder']->setParameter('db', $GLOBALS['db']);
-        $GLOBALS['containerBuilder']->setParameter('table', $GLOBALS['table']);
         /** @var EnumValuesController $sqlController */
         $sqlController = $GLOBALS['containerBuilder']->get(EnumValuesController::class);
         $sqlController($request);
@@ -95,8 +93,6 @@ class EnumValuesControllerTest extends AbstractTestCase
             ['curr_value', null, 'b&c'],
         ]);
 
-        $GLOBALS['containerBuilder']->setParameter('db', $GLOBALS['db']);
-        $GLOBALS['containerBuilder']->setParameter('table', $GLOBALS['table']);
         /** @var EnumValuesController $sqlController */
         $sqlController = $GLOBALS['containerBuilder']->get(EnumValuesController::class);
         $sqlController($request);

--- a/test/classes/Controllers/Sql/EnumValuesControllerTest.php
+++ b/test/classes/Controllers/Sql/EnumValuesControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Controllers\Sql;
 
 use PhpMyAdmin\Controllers\Sql\EnumValuesController;
+use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -25,8 +26,6 @@ class EnumValuesControllerTest extends AbstractTestCase
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;
-
-        parent::loadContainerBuilder();
 
         parent::loadDbiIntoContainerBuilder();
 
@@ -53,7 +52,7 @@ class EnumValuesControllerTest extends AbstractTestCase
         ]);
 
         /** @var EnumValuesController $sqlController */
-        $sqlController = $GLOBALS['containerBuilder']->get(EnumValuesController::class);
+        $sqlController = Core::getContainerBuilder()->get(EnumValuesController::class);
         $sqlController($request);
 
         $this->assertResponseWasNotSuccessfull();
@@ -94,7 +93,7 @@ class EnumValuesControllerTest extends AbstractTestCase
         ]);
 
         /** @var EnumValuesController $sqlController */
-        $sqlController = $GLOBALS['containerBuilder']->get(EnumValuesController::class);
+        $sqlController = Core::getContainerBuilder()->get(EnumValuesController::class);
         $sqlController($request);
 
         $this->assertResponseWasSuccessfull();

--- a/test/classes/Controllers/Sql/SetValuesControllerTest.php
+++ b/test/classes/Controllers/Sql/SetValuesControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Controllers\Sql;
 
 use PhpMyAdmin\Controllers\Sql\SetValuesController;
+use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -25,8 +26,6 @@ class SetValuesControllerTest extends AbstractTestCase
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;
-
-        parent::loadContainerBuilder();
 
         parent::loadDbiIntoContainerBuilder();
 
@@ -54,7 +53,7 @@ class SetValuesControllerTest extends AbstractTestCase
         $GLOBALS['table'] = 'enums';
 
         /** @var SetValuesController $sqlController */
-        $sqlController = $GLOBALS['containerBuilder']->get(SetValuesController::class);
+        $sqlController = Core::getContainerBuilder()->get(SetValuesController::class);
         $sqlController($request);
 
         $this->assertResponseWasNotSuccessfull();
@@ -96,7 +95,7 @@ class SetValuesControllerTest extends AbstractTestCase
         $GLOBALS['table'] = 'enums';
 
         /** @var SetValuesController $sqlController */
-        $sqlController = $GLOBALS['containerBuilder']->get(SetValuesController::class);
+        $sqlController = Core::getContainerBuilder()->get(SetValuesController::class);
         $sqlController($request);
 
         $this->assertResponseWasSuccessfull();

--- a/test/classes/Controllers/Sql/SetValuesControllerTest.php
+++ b/test/classes/Controllers/Sql/SetValuesControllerTest.php
@@ -53,8 +53,6 @@ class SetValuesControllerTest extends AbstractTestCase
         $GLOBALS['db'] = 'cvv';
         $GLOBALS['table'] = 'enums';
 
-        $GLOBALS['containerBuilder']->setParameter('db', $GLOBALS['db']);
-        $GLOBALS['containerBuilder']->setParameter('table', $GLOBALS['table']);
         /** @var SetValuesController $sqlController */
         $sqlController = $GLOBALS['containerBuilder']->get(SetValuesController::class);
         $sqlController($request);
@@ -97,8 +95,6 @@ class SetValuesControllerTest extends AbstractTestCase
         $GLOBALS['db'] = 'cvv';
         $GLOBALS['table'] = 'enums';
 
-        $GLOBALS['containerBuilder']->setParameter('db', $GLOBALS['db']);
-        $GLOBALS['containerBuilder']->setParameter('table', $GLOBALS['table']);
         /** @var SetValuesController $sqlController */
         $sqlController = $GLOBALS['containerBuilder']->get(SetValuesController::class);
         $sqlController($request);

--- a/test/classes/Controllers/Table/ExportControllerTest.php
+++ b/test/classes/Controllers/Table/ExportControllerTest.php
@@ -27,7 +27,6 @@ class ExportControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->loadContainerBuilder();
         DatabaseInterface::$instance = $this->createDatabaseInterface();
     }
 

--- a/test/classes/Controllers/Table/OperationsControllerTest.php
+++ b/test/classes/Controllers/Table/OperationsControllerTest.php
@@ -47,9 +47,6 @@ class OperationsControllerTest extends AbstractTestCase
         $this->loadDbiIntoContainerBuilder();
         $this->loadResponseIntoContainerBuilder();
 
-        $GLOBALS['containerBuilder']->setParameter('db', 'test_db');
-        $GLOBALS['containerBuilder']->setParameter('table', 'test_table');
-
         $this->dummyDbi->addResult(
             'SELECT `SCHEMA_NAME` FROM `INFORMATION_SCHEMA`.`SCHEMATA`',
             [['test_db']],

--- a/test/classes/Controllers/Table/OperationsControllerTest.php
+++ b/test/classes/Controllers/Table/OperationsControllerTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\Tests\Controllers\Table;
 use PhpMyAdmin\Charsets;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\Table\OperationsController;
+use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\Factory\ServerRequestFactory;
 use PhpMyAdmin\StorageEngine;
@@ -26,7 +27,6 @@ class OperationsControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->loadContainerBuilder();
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;
@@ -121,7 +121,7 @@ class OperationsControllerTest extends AbstractTestCase
             ->withQueryParams(['db' => 'test_db', 'table' => 'test_table']);
 
         /** @var OperationsController $controller */
-        $controller = $GLOBALS['containerBuilder']->get(OperationsController::class);
+        $controller = Core::getContainerBuilder()->get(OperationsController::class);
         $controller($request);
 
         $this->assertEquals($expectedOutput, $this->getResponseHtmlResult());

--- a/test/classes/Controllers/Table/ReplaceControllerTest.php
+++ b/test/classes/Controllers/Table/ReplaceControllerTest.php
@@ -11,8 +11,11 @@ use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
+use PhpMyAdmin\Controllers\Database\SqlController as DatabaseSqlController;
 use PhpMyAdmin\Controllers\Sql\SqlController;
+use PhpMyAdmin\Controllers\Table\ChangeController;
 use PhpMyAdmin\Controllers\Table\ReplaceController;
+use PhpMyAdmin\Controllers\Table\SqlController as TableSqlController;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\FileListing;
 use PhpMyAdmin\Http\ServerRequest;
@@ -26,7 +29,6 @@ use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionProperty;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 #[CoversClass(ReplaceController::class)]
 class ReplaceControllerTest extends AbstractTestCase
@@ -99,14 +101,6 @@ class ReplaceControllerTest extends AbstractTestCase
         $transformations = new Transformations();
         $template = new Template();
         $response = new ResponseRenderer();
-        $replaceController = new ReplaceController(
-            $response,
-            $template,
-            new InsertEdit($dbi, $relation, $transformations, new FileListing(), $template),
-            $transformations,
-            $relation,
-            $dbi,
-        );
 
         $pageSettings = $this->createStub(PageSettings::class);
         $bookmarkRepository = new BookmarkRepository($dbi, $relation);
@@ -127,8 +121,19 @@ class ReplaceControllerTest extends AbstractTestCase
             $pageSettings,
             $bookmarkRepository,
         );
-        $GLOBALS['containerBuilder'] = $this->createStub(ContainerBuilder::class);
-        $GLOBALS['containerBuilder']->method('get')->willReturn($sqlController);
+
+        $replaceController = new ReplaceController(
+            $response,
+            $template,
+            new InsertEdit($dbi, $relation, $transformations, new FileListing(), $template),
+            $transformations,
+            $relation,
+            $dbi,
+            $sqlController,
+            self::createStub(DatabaseSqlController::class),
+            self::createStub(ChangeController::class),
+            self::createStub(TableSqlController::class),
+        );
 
         $GLOBALS['goto'] = 'index.php?route=/sql';
         $dummyDbi->addSelectDb('my_db');
@@ -155,12 +160,16 @@ class ReplaceControllerTest extends AbstractTestCase
         ]);
 
         $replaceController = new ReplaceController(
-            $this->createStub(ResponseRenderer::class),
-            $this->createStub(Template::class),
-            $this->createStub(InsertEdit::class),
-            $this->createStub(Transformations::class),
-            $this->createStub(Relation::class),
-            $this->createStub(DatabaseInterface::class),
+            self::createStub(ResponseRenderer::class),
+            self::createStub(Template::class),
+            self::createStub(InsertEdit::class),
+            self::createStub(Transformations::class),
+            self::createStub(Relation::class),
+            self::createStub(DatabaseInterface::class),
+            self::createStub(SqlController::class),
+            self::createStub(DatabaseSqlController::class),
+            self::createStub(ChangeController::class),
+            self::createStub(TableSqlController::class),
         );
 
         /** @var array $result */

--- a/test/classes/Controllers/Table/SearchControllerTest.php
+++ b/test/classes/Controllers/Table/SearchControllerTest.php
@@ -125,7 +125,6 @@ class SearchControllerTest extends AbstractTestCase
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;
-        $this->loadContainerBuilder();
 
         parent::loadDbiIntoContainerBuilder();
 
@@ -154,7 +153,7 @@ class SearchControllerTest extends AbstractTestCase
         );
 
         /** @var SearchController $ctrl */
-        $ctrl = $GLOBALS['containerBuilder']->get(SearchController::class);
+        $ctrl = Core::getContainerBuilder()->get(SearchController::class);
 
         $_POST['db'] = 'PMA';
         $_POST['table'] = 'PMA_BookMark';

--- a/test/classes/Controllers/Table/SearchControllerTest.php
+++ b/test/classes/Controllers/Table/SearchControllerTest.php
@@ -153,9 +153,6 @@ class SearchControllerTest extends AbstractTestCase
             ],
         );
 
-        $GLOBALS['containerBuilder']->setParameter('db', 'PMA');
-        $GLOBALS['containerBuilder']->setParameter('table', 'PMA_BookMark');
-
         /** @var SearchController $ctrl */
         $ctrl = $GLOBALS['containerBuilder']->get(SearchController::class);
 

--- a/test/classes/CoreTest.php
+++ b/test/classes/CoreTest.php
@@ -737,4 +737,14 @@ class CoreTest extends AbstractTestCase
 
         self::assertSame('', Core::getEnv('PHPMYADMIN_GET_ENV_TEST'));
     }
+
+    public function testGetContainerBuilder(): void
+    {
+        Core::$containerBuilder = null;
+        $containerBuilder = Core::getContainerBuilder();
+        self::assertSame($containerBuilder, Core::getContainerBuilder());
+        Core::$containerBuilder = null;
+        self::assertNotSame($containerBuilder, Core::getContainerBuilder());
+        Core::$containerBuilder = null;
+    }
 }

--- a/test/classes/Export/OptionsTest.php
+++ b/test/classes/Export/OptionsTest.php
@@ -24,8 +24,6 @@ class OptionsTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->loadContainerBuilder();
-
         parent::setLanguage();
 
         parent::setGlobalConfig();

--- a/test/classes/Http/Middleware/UrlParamsSettingTest.php
+++ b/test/classes/Http/Middleware/UrlParamsSettingTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Http\Middleware;
+
+use PhpMyAdmin\Config;
+use PhpMyAdmin\Http\Middleware\UrlParamsSetting;
+use PhpMyAdmin\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+#[CoversClass(UrlParamsSetting::class)]
+final class UrlParamsSettingTest extends AbstractTestCase
+{
+    public function testProcess(): void
+    {
+        $GLOBALS['urlParams'] = null;
+        $GLOBALS['goto'] = null;
+        $GLOBALS['back'] = null;
+        $_REQUEST['goto'] = 'index.php?route=/';
+        $_REQUEST['back'] = 'index.php?route=/';
+
+        $request = self::createStub(ServerRequestInterface::class);
+        $response = self::createStub(ResponseInterface::class);
+        $handler = self::createMock(RequestHandlerInterface::class);
+        $handler->method('handle')->with($request)->willReturn($response);
+
+        $urlParamsSetting = new UrlParamsSetting(self::createStub(Config::class));
+        self::assertSame($response, $urlParamsSetting->process($request, $handler));
+        /** @psalm-suppress TypeDoesNotContainType */
+        self::assertSame('index.php?route=/', $GLOBALS['goto']);
+        /** @psalm-suppress TypeDoesNotContainType */
+        self::assertSame('index.php?route=/', $GLOBALS['back']);
+        /** @psalm-suppress TypeDoesNotContainType */
+        self::assertSame(['goto' => 'index.php?route=/'], $GLOBALS['urlParams']);
+    }
+}

--- a/test/classes/PluginsTest.php
+++ b/test/classes/PluginsTest.php
@@ -20,7 +20,6 @@ class PluginsTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->loadContainerBuilder();
         DatabaseInterface::$instance = $this->createDatabaseInterface();
 
         parent::loadDbiIntoContainerBuilder();

--- a/test/classes/TableTest.php
+++ b/test/classes/TableTest.php
@@ -1435,7 +1435,6 @@ class TableTest extends AbstractTestCase
                 'utf8mb4_unicode_ci',
             ]);
 
-        $this->loadContainerBuilder();
         $this->loadDbiIntoContainerBuilder();
 
         $GLOBALS['sql_query'] = '';

--- a/test/classes/TemplateTest.php
+++ b/test/classes/TemplateTest.php
@@ -37,8 +37,6 @@ class TemplateTest extends AbstractTestCase
      */
     public function testGetTwigEnvironment(): void
     {
-        $this->loadContainerBuilder();
-
         $config = Config::getInstance();
         $config->settings['environment'] = 'production';
         $twig = Template::getTwigEnvironment(null);

--- a/test/classes/Tracking/TrackerTest.php
+++ b/test/classes/Tracking/TrackerTest.php
@@ -30,7 +30,6 @@ class TrackerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->loadContainerBuilder();
         DatabaseInterface::$instance = $this->createDatabaseInterface();
 
         parent::loadDbiIntoContainerBuilder();


### PR DESCRIPTION
Removes ContainerBuilder::setParameter() calls. These parameters are only written, but never used.