### PR TITLE
Add role based auth for MySQL 8.x and compatibles

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6756,11 +6756,6 @@ parameters:
 			path: src/DatabaseInterface.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
-			count: 2
-			path: src/DatabaseInterface.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
 			count: 2
 			path: src/DatabaseInterface.php

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -1517,11 +1517,7 @@ class DatabaseInterface implements DbalInterface
         if (! $hasGrantPrivilege) {
             foreach ($this->getCurrentRolesAndHost() as [$role, $roleHost]) {
                 $query = QueryGenerator::getInformationSchemaDataForGranteeRequest($role, $roleHost ?? '');
-                $result = $this->tryQuery($query);
-
-                if ($result) {
-                    $hasGrantPrivilege = (bool) $result->numRows();
-                }
+                $hasGrantPrivilege = (bool) $this->fetchValue($query);
 
                 if ($hasGrantPrivilege) {
                     break;
@@ -1568,11 +1564,7 @@ class DatabaseInterface implements DbalInterface
         if (! $hasCreatePrivilege) {
             foreach ($this->getCurrentRolesAndHost() as [$role, $roleHost]) {
                 $query = QueryGenerator::getInformationSchemaDataForCreateRequest($role, $roleHost ?? '');
-                $result = $this->tryQuery($query);
-
-                if ($result) {
-                    $hasCreatePrivilege = (bool) $result->numRows();
-                }
+                $hasCreatePrivilege = (bool) $this->fetchValue($query);
 
                 if ($hasCreatePrivilege) {
                     break;


### PR DESCRIPTION
### Description

On MySQL 8.x engine implement a role based granting system. That system is used as default grant on AWS RDS Aurora MySQL where I hit this problem that I report on this issue https://github.com/phpmyadmin/phpmyadmin/issues/18782

As describe on MySQL 8.x documentation the roles maybe multiple and can be switched on runtime with `SET ROLE` command, that's why I implement it on that way and without any cache.

This PR is the first step to implement the new role based system and start to be compatible with this kind of grant system.

This changes may implemented also on phpMyAdmin 5.2 version.

### Testing

create a role and add that role to a test user without any grant; that user must create databases and add/change/revoke grants
MySQL
```
CREATE ROLE `rds_superuser_role`;
GRANT ALL PRIVILEGES ON *.* TO 'rds_superuser_role'@'%' WITH GRANT OPTION;
CREATE ROLE `rds_null_role`;
GRANT USAGE ON *.* TO 'rds_null_role'@'%';
CREATE USER 'testbug'@'%' IDENTIFIED BY 'testbug';
GRANT USAGE ON *.* TO 'testbug'@'%';
GRANT `rds_superuser_role`@`%` TO 'testbug'@'%';
GRANT `rds_null_role`@`%` TO 'testbug'@'%';
SET DEFAULT ROLE 'rds_superuser_role', 'rds_null_role' TO 'testbug'@'%';
```
MariaDB
```
CREATE ROLE `rds_superuser_role`;
GRANT ALL PRIVILEGES ON *.* TO 'rds_superuser_role' WITH GRANT OPTION;
CREATE ROLE `rds_null_role`;
GRANT USAGE ON *.* TO 'rds_null_role';
CREATE USER 'testbug'@'%' IDENTIFIED BY 'testbug';
GRANT USAGE ON *.* TO 'testbug'@'%';
GRANT `rds_superuser_role` TO 'testbug'@'%';
GRANT `rds_null_role` TO 'testbug'@'%';
SET DEFAULT ROLE 'rds_superuser_role' FOR 'testbug'@'%';
```

refs: 
general reference of roles starting from MySQL 8.x https://dev.mysql.com/doc/refman/8.0/en/roles.html
multiple roles allowed at the same time https://dev.mysql.com/doc/refman/8.0/en/information-functions.html#function_current-role
`SET ROLE` command https://dev.mysql.com/doc/refman/8.0/en/set-role.html
MariaDB docs for roles https://mariadb.com/kb/en/roles_overview/
MariaDB syntax to add role and set as default https://mariadb.com/kb/en/set-default-role/