### PR TITLE
Add role based auth for MySQL 8.x and compatibles

### DIFF
--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -1809,7 +1809,7 @@ class DatabaseInterface implements DbalInterface
 
         if (! $hasGrantPrivilege && $roles !== null) {
             foreach ($roles as [$role, $roleHost]) {
-                $query = QueryGenerator::getInformationSchemaDataForGranteeRequest($role, $roleHost);
+                $query = QueryGenerator::getInformationSchemaDataForGranteeRequest($role, $roleHost ?? '');
                 $result = $this->tryQuery($query);
 
                 if ($result) {
@@ -1868,7 +1868,7 @@ class DatabaseInterface implements DbalInterface
 
         if (! $hasCreatePrivilege && $roles !== null) {
             foreach ($roles as [$role, $roleHost]) {
-                $query = QueryGenerator::getInformationSchemaDataForCreateRequest($role, $roleHost);
+                $query = QueryGenerator::getInformationSchemaDataForCreateRequest($role, $roleHost ?? '');
                 $result = $this->tryQuery($query);
 
                 if ($result) {

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -122,8 +122,8 @@ class DatabaseInterface implements DbalInterface
     /** @var array Current user and host cache */
     private $currentUser;
 
-    /** @var array Current role and host cache */
-    private $currentRoleAndHost;
+    /** @var array<int, array<int, string>>|null Current role and host cache */
+    private $currentRoleAndHost = null;
 
     /** @var string|null lower_case_table_names value cache */
     private $lowerCaseTableNames = null;

--- a/libraries/classes/Query/Generator.php
+++ b/libraries/classes/Query/Generator.php
@@ -223,13 +223,20 @@ class Generator
 
     public static function getInformationSchemaDataForCreateRequest(string $user, string $host): string
     {
+        // second part of query is for MariaDB that not show roles inside INFORMATION_SCHEMA db
         return 'SELECT 1 FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES` '
             . "WHERE `PRIVILEGE_TYPE` = 'CREATE USER' AND "
-            . "'''" . $user . "''@''" . $host . "''' LIKE `GRANTEE` LIMIT 1";
+            . "'''" . $user . "''@''" . $host . "''' LIKE `GRANTEE`"
+            . ' UNION '
+            . 'SELECT 1 FROM mysql.user '
+            . "WHERE `create_user_priv` = 'Y' COLLATE utf8mb4_general_ci AND "
+            . "'" . $user . "' LIKE `User` AND '' LIKE `Host`"
+            . ' LIMIT 1';
     }
 
     public static function getInformationSchemaDataForGranteeRequest(string $user, string $host): string
     {
+        // second part of query is for MariaDB that not show roles inside INFORMATION_SCHEMA db
         return 'SELECT 1 FROM ('
             . 'SELECT `GRANTEE`, `IS_GRANTABLE` FROM '
             . '`INFORMATION_SCHEMA`.`COLUMN_PRIVILEGES` UNION '
@@ -240,7 +247,12 @@ class Generator
             . 'SELECT `GRANTEE`, `IS_GRANTABLE` FROM '
             . '`INFORMATION_SCHEMA`.`USER_PRIVILEGES`) t '
             . "WHERE `IS_GRANTABLE` = 'YES' AND "
-            . "'''" . $user . "''@''" . $host . "''' LIKE `GRANTEE` LIMIT 1";
+            . "'''" . $user . "''@''" . $host . "''' LIKE `GRANTEE` "
+            . ' UNION '
+            . 'SELECT 1 FROM mysql.user '
+            . "WHERE `create_user_priv` = 'Y' COLLATE utf8mb4_general_ci AND "
+            . "'" . $user . "' LIKE `User` AND '' LIKE `Host`"
+            . 'LIMIT 1';
     }
 
     public static function getInformationSchemaForeignKeyConstraintsRequest(

--- a/libraries/classes/Query/Generator.php
+++ b/libraries/classes/Query/Generator.php
@@ -252,7 +252,7 @@ class Generator
             . 'SELECT 1 FROM mysql.user '
             . "WHERE `create_user_priv` = 'Y' COLLATE utf8mb4_general_ci AND "
             . "'" . $user . "' LIKE `User` AND '' LIKE `Host`"
-            . 'LIMIT 1';
+            . ' LIMIT 1';
     }
 
     public static function getInformationSchemaForeignKeyConstraintsRequest(

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -1266,6 +1266,7 @@ class Util
         SessionCache::remove('is_createuser');
         SessionCache::remove('is_grantuser');
         SessionCache::remove('mysql_cur_user');
+        SessionCache::remove('mysql_cur_role');
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2676,6 +2676,16 @@ parameters:
 			path: libraries/classes/DatabaseInterface.php
 
 		-
+			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:getCurrentRoles\\(\\) should return array\\<int, array\\<int, string\\>\\> but returns array\\<int, string\\>\\.$#"
+			count: 1
+			path: libraries/classes/DatabaseInterface.php
+
+		-
+			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:getCurrentRoles\\(\\) should return array\\<int, array\\<int, string\\>\\> but returns mixed\\.$#"
+			count: 1
+			path: libraries/classes/DatabaseInterface.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:getCurrentUser\\(\\) should return string but returns mixed\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php
@@ -2751,6 +2761,11 @@ parameters:
 			path: libraries/classes/DatabaseInterface.php
 
 		-
+			message: "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(array\\<int, string\\>\\)\\: mixed\\)\\|null, Closure\\(string\\)\\: non\\-empty\\-array\\<int, string\\> given\\.$#"
+			count: 1
+			path: libraries/classes/DatabaseInterface.php
+
+		-
 			message: "#^Parameter \\#1 \\$eachTables of static method PhpMyAdmin\\\\Query\\\\Compatibility\\:\\:getISCompatForGetTablesFull\\(\\) expects array, array\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php
@@ -2793,6 +2808,11 @@ parameters:
 		-
 			message: "#^Property PhpMyAdmin\\\\DatabaseInterface\\:\\:\\$links type has no value type specified in iterable type array\\.$#"
 			count: 1
+			path: libraries/classes/DatabaseInterface.php
+
+		-
+			message: "#^Variable \\$roleHost on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 2
 			path: libraries/classes/DatabaseInterface.php
 
 		-
@@ -9724,6 +9744,11 @@ parameters:
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Database\\\\TriggersTest\\:\\:testGetEditorFormEdit\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/Database/TriggersTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with array\\<string\\> and array\\<int, array\\<int, string\\>\\> will always evaluate to false\\.$#"
+			count: 1
+			path: test/classes/DatabaseInterfaceTest.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\DatabaseInterfaceTest\\:\\:currentUserData\\(\\) return type has no value type specified in iterable type array\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5727,12 +5727,15 @@
     </PossiblyNullArrayAccess>
   </file>
   <file src="libraries/classes/DatabaseInterface.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction occurrences="3">
       <code>$this-&gt;extension === null</code>
+      <code>''</code>
+      <code>''</code>
     </DocblockTypeContradiction>
     <EmptyArrayAccess occurrences="1">
       <code>$result_target[]</code>
     </EmptyArrayAccess>
+    <InvalidArgument occurrences="1"/>
     <InvalidOperand occurrences="6">
       <code>$row['Data_free']</code>
       <code>$row['Data_length']</code>
@@ -5741,7 +5744,8 @@
       <code>$row['Max_data_length']</code>
       <code>$row['Rows']</code>
     </InvalidOperand>
-    <InvalidReturnStatement occurrences="1">
+    <InvalidReturnStatement occurrences="2">
+      <code>$role</code>
       <code>$this-&gt;extension-&gt;getProtoInfo($this-&gt;links[$link])</code>
     </InvalidReturnStatement>
     <InvalidReturnType occurrences="1">
@@ -5895,8 +5899,9 @@
       <code>$trigger['TRIGGER_NAME']</code>
       <code>$warningsCount</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType occurrences="3">
       <code>array</code>
+      <code>array&lt;int, array&lt;int, string&gt;&gt;</code>
       <code>string</code>
     </MixedInferredReturnType>
     <MixedOperand occurrences="6">
@@ -5910,7 +5915,8 @@
     <MixedPropertyFetch occurrences="1">
       <code>$this-&gt;links[$link]-&gt;warning_count</code>
     </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement occurrences="3">
+      <code>SessionCache::get('mysql_cur_role')</code>
       <code>SessionCache::get('mysql_cur_user')</code>
       <code>reset($columns)</code>
     </MixedReturnStatement>
@@ -5918,8 +5924,9 @@
       <code>$this-&gt;fetchResult($sql, null, 'Field', $link)</code>
       <code>string[]</code>
     </MixedReturnTypeCoercion>
-    <NullableReturnStatement occurrences="2">
+    <NullableReturnStatement occurrences="3">
       <code>$user</code>
+      <code>SessionCache::get('mysql_cur_role')</code>
       <code>SessionCache::get('mysql_cur_user')</code>
     </NullableReturnStatement>
     <PossiblyInvalidArrayOffset occurrences="1">
@@ -5944,6 +5951,10 @@
       <code>$databases[$database_name]['SCHEMA_TABLES']</code>
       <code>$databases[$database_name]['SCHEMA_TABLE_ROWS']</code>
     </PossiblyUndefinedArrayOffset>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$roleHost</code>
+      <code>$roleHost</code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="libraries/classes/DbTableExists.php">
     <MixedArgument occurrences="2">
@@ -15307,16 +15318,18 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/classes/DatabaseInterfaceTest.php">
-    <MixedArgumentTypeCoercion occurrences="3">
+    <MixedArgumentTypeCoercion occurrences="4">
+      <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgumentTypeCoercion>
-    <MixedInferredReturnType occurrences="4">
+    <MixedInferredReturnType occurrences="5">
       <code>array</code>
       <code>array</code>
       <code>array</code>
       <code>array</code>
+      <code>mixed[]</code>
     </MixedInferredReturnType>
   </file>
   <file src="test/classes/Dbal/DbiDummyTest.php">

--- a/test/classes/DatabaseInterfaceTest.php
+++ b/test/classes/DatabaseInterfaceTest.php
@@ -116,11 +116,9 @@ class DatabaseInterfaceTest extends AbstractTestCase
     /**
      * Tests for DBI::getCurrentRole() method.
      *
-     * @param string           $version         version
-     * @param bool             $isRoleSupported isRoleSupported
-     * @param string[][]|false $value           value
-     * @param string[]|null    $string          string
-     * @param string[][]|null  $expected        expected result
+     * @param string[][]|false $value
+     * @param string[]         $string
+     * @param string[][]       $expected
      *
      * @dataProvider currentRolesData
      */
@@ -128,8 +126,8 @@ class DatabaseInterfaceTest extends AbstractTestCase
         string $version,
         bool $isRoleSupported,
         $value,
-        $string,
-        $expected,
+        array $string,
+        array $expected
     ): void {
         $this->dbi->setVersion(['@@version' => $version]);
 
@@ -139,9 +137,9 @@ class DatabaseInterfaceTest extends AbstractTestCase
             $this->dummyDbi->addResult('SELECT CURRENT_ROLE();', $value);
         }
 
-        $this->assertEquals($expected, $this->dbi->getCurrentRolesAndHost());
+        self::assertSame($expected, $this->dbi->getCurrentRolesAndHost());
 
-        $this->assertEquals($string, $this->dbi->getCurrentRoles());
+        self::assertSame($string, $this->dbi->getCurrentRoles());
 
         $this->assertAllQueriesConsumed();
     }
@@ -154,8 +152,8 @@ class DatabaseInterfaceTest extends AbstractTestCase
     public static function currentRolesData(): array
     {
         return [
-            ['10.4.99-MariaDB', false, false, null, null],
-            ['5.7.35 - MySQL Community Server (GPL)', false, false, null, null],
+            ['10.4.99-MariaDB', false, false, [], []],
+            ['5.7.35 - MySQL Community Server (GPL)', false, false, [], []],
             [
                 '8.0.0 - MySQL Community Server - GPL',
                 true,

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -582,7 +582,9 @@ class DbiDummy implements DbiExtension
             [
                 'query' => 'SELECT 1 FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES`'
                     . " WHERE `PRIVILEGE_TYPE` = 'CREATE USER'"
-                    . " AND '''pma_test''@''localhost''' LIKE `GRANTEE` LIMIT 1",
+                    . " AND '''pma_test''@''localhost''' LIKE `GRANTEE`"
+                    . " UNION SELECT 1 FROM mysql.user WHERE `create_user_priv` = 'Y' COLLATE utf8mb4_general_ci"
+                    . " AND 'pma_test' LIKE `User` AND '' LIKE `Host` LIMIT 1",
                 'result' => [['1']],
             ],
             [
@@ -595,7 +597,9 @@ class DbiDummy implements DbiExtension
                     . ' UNION SELECT `GRANTEE`, `IS_GRANTABLE`'
                     . ' FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES`) t'
                     . " WHERE `IS_GRANTABLE` = 'YES'"
-                    . " AND '''pma_test''@''localhost''' LIKE `GRANTEE` LIMIT 1",
+                    . " AND '''pma_test''@''localhost''' LIKE `GRANTEE`"
+                    . " UNION SELECT 1 FROM mysql.user WHERE `create_user_priv` = 'Y' COLLATE utf8mb4_general_ci"
+                    . " AND 'pma_test' LIKE `User` AND '' LIKE `Host` LIMIT 1",
                 'result' => [['1']],
             ],
             [


### PR DESCRIPTION
### Description

On MySQL 8.x engine implement a role based granting system. That system is used as default grant on AWS RDS Aurora MySQL where I hit this problem that I report on this issue https://github.com/phpmyadmin/phpmyadmin/issues/18782

As describe on MySQL 8.x documentation the roles maybe multiple and can be switched on runtime with `SET ROLE` command, that's why I implement it on that way and without any cache.

This PR is the first step to implement the new role based system and start to be compatible with this kind of grant system.

This changes may implemented also on phpMyAdmin 5.2 version.

### Testing

create a role and add that role to a test user without any grant; that user must create databases and add/change/revoke grants
```sql
CREATE ROLE `rds_superuser_role`;
GRANT ALL PRIVILEGES ON *.* TO 'rds_superuser_role'@'%' WITH GRANT OPTION;
CREATE USER 'testbug'@'%' IDENTIFIED BY 'testbug';
GRANT USAGE ON *.* TO 'testbug'@'%';
GRANT `rds_superuser_role`@`%` TO 'testbug'@'%';
SET DEFAULT ROLE 'rds_superuser_role' TO 'testbug'@'%';
```

refs:
general reference of roles starting from MySQL 8.x https://dev.mysql.com/doc/refman/8.0/en/roles.html
multiple roles allowed at the same time https://dev.mysql.com/doc/refman/8.0/en/information-functions.html#function_current-role
`SET ROLE` command https://dev.mysql.com/doc/refman/8.0/en/set-role.html