### PR TITLE
Refactoring of getTablesFull and Query/Cache

### DIFF
--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -1576,6 +1576,7 @@ return [
                 '$transformations' => '@transformations',
                 '$relation' => '@relation',
                 '$dbi' => '@dbi',
+                '$dbTableExists' => '@' . DbTableExists::class,
             ],
         ],
         UserPasswordController::class => [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6986,16 +6986,6 @@ parameters:
 			path: src/Database/Designer/Common.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function mb_strtoupper expects string, int\\|string given\\.$#"
-			count: 2
-			path: src/Database/Designer/Common.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function mb_strtoupper expects string, int\\|string\\|null given\\.$#"
-			count: 2
-			path: src/Database/Designer/Common.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function rawurlencode expects string, mixed given\\.$#"
 			count: 4
 			path: src/Database/Designer/Common.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13641,6 +13641,11 @@ parameters:
 			path: src/Profiling.php
 
 		-
+			message: "#^Cannot access offset string on mixed\\.$#"
+			count: 1
+			path: src/Query/Cache.php
+
+		-
 			message: "#^Cannot access offset 'CHARACTER_MAXIMUM…' on mixed\\.$#"
 			count: 1
 			path: src/Query/Compatibility.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3407,7 +3407,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 10
+			count: 9
 			path: src/Controllers/Operations/TableController.php
 
 		-
@@ -5972,7 +5972,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 4
+			count: 2
 			path: src/Controllers/Table/StructureController.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13641,11 +13641,6 @@ parameters:
 			path: src/Profiling.php
 
 		-
-			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 1
-			path: src/Query/Cache.php
-
-		-
 			message: "#^Cannot access offset 'CHARACTER_MAXIMUM…' on mixed\\.$#"
 			count: 1
 			path: src/Query/Compatibility.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6886,16 +6886,6 @@ parameters:
 			path: src/Database/Designer/Common.php
 
 		-
-			message: "#^Cannot access offset 'ENGINE' on mixed\\.$#"
-			count: 5
-			path: src/Database/Designer/Common.php
-
-		-
-			message: "#^Cannot access offset 'TABLE_NAME' on mixed\\.$#"
-			count: 2
-			path: src/Database/Designer/Common.php
-
-		-
 			message: "#^Cannot access offset 'constraint' on mixed\\.$#"
 			count: 1
 			path: src/Database/Designer/Common.php
@@ -6996,8 +6986,13 @@ parameters:
 			path: src/Database/Designer/Common.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function mb_strtoupper expects string, mixed given\\.$#"
-			count: 4
+			message: "#^Parameter \\#1 \\$string of function mb_strtoupper expects string, int\\|string given\\.$#"
+			count: 2
+			path: src/Database/Designer/Common.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function mb_strtoupper expects string, int\\|string\\|null given\\.$#"
+			count: 2
 			path: src/Database/Designer/Common.php
 
 		-
@@ -7006,12 +7001,12 @@ parameters:
 			path: src/Database/Designer/Common.php
 
 		-
-			message: "#^Parameter \\#2 \\$table of method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getDisplayField\\(\\) expects string, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$table of method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getDisplayField\\(\\) expects string, int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Database/Designer/Common.php
 
 		-
-			message: "#^Parameter \\#2 \\$tableName of class PhpMyAdmin\\\\Database\\\\Designer\\\\DesignerTable constructor expects string, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$tableName of class PhpMyAdmin\\\\Database\\\\Designer\\\\DesignerTable constructor expects string, int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Database/Designer/Common.php
 
@@ -7366,6 +7361,11 @@ parameters:
 			path: src/Database/Search.php
 
 		-
+			message: "#^Binary operation \"\\+\" between int\\|string\\|null and int\\|string\\|null results in an error\\.$#"
+			count: 3
+			path: src/DatabaseInterface.php
+
+		-
 			message: "#^Binary operation \"\\+\" between string\\|null and string\\|null results in an error\\.$#"
 			count: 1
 			path: src/DatabaseInterface.php
@@ -7381,28 +7381,13 @@ parameters:
 			path: src/DatabaseInterface.php
 
 		-
-			message: "#^Cannot access offset 'Data_length' on mixed\\.$#"
-			count: 3
-			path: src/DatabaseInterface.php
-
-		-
-			message: "#^Cannot access offset 'Engine' on mixed\\.$#"
-			count: 1
-			path: src/DatabaseInterface.php
-
-		-
-			message: "#^Cannot access offset 'Index_length' on mixed\\.$#"
-			count: 3
-			path: src/DatabaseInterface.php
-
-		-
-			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 1
-			path: src/DatabaseInterface.php
-
-		-
 			message: "#^Cannot access offset string\\|null on mixed\\.$#"
 			count: 3
+			path: src/DatabaseInterface.php
+
+		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
 			path: src/DatabaseInterface.php
 
 		-
@@ -7501,7 +7486,7 @@ parameters:
 			path: src/DatabaseInterface.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function strtolower expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function strtolower expects string, int\\|string given\\.$#"
 			count: 1
 			path: src/DatabaseInterface.php
 
@@ -13666,26 +13651,6 @@ parameters:
 			path: src/Profiling.php
 
 		-
-			message: "#^Cannot access offset 'AUTO_INCREMENT' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'AVG_ROW_LENGTH' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'Auto_increment' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'Avg_row_length' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
 			message: "#^Cannot access offset 'CHARACTER_MAXIMUM…' on mixed\\.$#"
 			count: 1
 			path: src/Query/Compatibility.php
@@ -13697,16 +13662,6 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'CHARACTER_SET_NAME' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'CHECKSUM' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'CHECK_TIME' on mixed\\.$#"
 			count: 1
 			path: src/Query/Compatibility.php
 
@@ -13741,52 +13696,12 @@ parameters:
 			path: src/Query/Compatibility.php
 
 		-
-			message: "#^Cannot access offset 'CREATE_OPTIONS' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'CREATE_TIME' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'Check_time' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'Checksum' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
 			message: "#^Cannot access offset 'Collation' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Query/Compatibility.php
 
 		-
 			message: "#^Cannot access offset 'Comment' on mixed\\.$#"
-			count: 3
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'Create_options' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'Create_time' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'DATA_FREE' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'DATA_LENGTH' on mixed\\.$#"
 			count: 1
 			path: src/Query/Compatibility.php
 
@@ -13796,33 +13711,13 @@ parameters:
 			path: src/Query/Compatibility.php
 
 		-
-			message: "#^Cannot access offset 'Data_free' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'Data_length' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
 			message: "#^Cannot access offset 'Default' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'ENGINE' on mixed\\.$#"
 			count: 1
 			path: src/Query/Compatibility.php
 
 		-
 			message: "#^Cannot access offset 'EXTRA' on mixed\\.$#"
 			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'Engine' on mixed\\.$#"
-			count: 5
 			path: src/Query/Compatibility.php
 
 		-
@@ -13836,32 +13731,12 @@ parameters:
 			path: src/Query/Compatibility.php
 
 		-
-			message: "#^Cannot access offset 'INDEX_LENGTH' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
 			message: "#^Cannot access offset 'IS_NULLABLE' on mixed\\.$#"
 			count: 1
 			path: src/Query/Compatibility.php
 
 		-
-			message: "#^Cannot access offset 'Index_length' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
 			message: "#^Cannot access offset 'Key' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'MAX_DATA_LENGTH' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'Max_data_length' on mixed\\.$#"
 			count: 1
 			path: src/Query/Compatibility.php
 
@@ -13872,11 +13747,6 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'NUMERIC_SCALE' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'Name' on mixed\\.$#"
 			count: 1
 			path: src/Query/Compatibility.php
 
@@ -13901,87 +13771,27 @@ parameters:
 			path: src/Query/Compatibility.php
 
 		-
-			message: "#^Cannot access offset 'ROW_FORMAT' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'Row_format' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'Rows' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
 			message: "#^Cannot access offset 'TABLE_CATALOG' on mixed\\.$#"
 			count: 1
 			path: src/Query/Compatibility.php
 
 		-
-			message: "#^Cannot access offset 'TABLE_COLLATION' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'TABLE_COMMENT' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
 			message: "#^Cannot access offset 'TABLE_NAME' on mixed\\.$#"
-			count: 2
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'TABLE_ROWS' on mixed\\.$#"
 			count: 1
 			path: src/Query/Compatibility.php
 
 		-
 			message: "#^Cannot access offset 'TABLE_SCHEMA' on mixed\\.$#"
-			count: 2
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'TABLE_TYPE' on mixed\\.$#"
-			count: 3
+			count: 1
 			path: src/Query/Compatibility.php
 
 		-
 			message: "#^Cannot access offset 'Type' on mixed\\.$#"
-			count: 4
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'UPDATE_TIME' on mixed\\.$#"
 			count: 1
 			path: src/Query/Compatibility.php
 
 		-
-			message: "#^Cannot access offset 'Update_time' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'VERSION' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Cannot access offset 'Version' on mixed\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Query\\\\Compatibility\\:\\:getISCompatForGetTablesFull\\(\\) should return array\\<array\\> but returns array\\.$#"
-			count: 1
-			path: src/Query/Compatibility.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function strtoupper expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function strtoupper expects string, \\(int\\|string\\) given\\.$#"
 			count: 1
 			path: src/Query/Compatibility.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10492,11 +10492,6 @@
       <code>getUploadStatus</code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="src/Query/Cache.php">
-    <MixedArrayAssignment>
-      <code><![CDATA[$this->tableCache[$db][$table][$key]]]></code>
-    </MixedArrayAssignment>
-  </file>
   <file src="src/Query/Compatibility.php">
     <MixedArrayAccess>
       <code><![CDATA[$columns[$columnName]['Collation']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4770,16 +4770,9 @@
       <code>$oneField</code>
       <code><![CDATA[$oneKey['constraint']]]></code>
       <code><![CDATA[$oneKey['ref_index_list'][$index]]]></code>
-      <code><![CDATA[$oneTable['TABLE_NAME']]]></code>
-      <code><![CDATA[$oneTable['TABLE_NAME']]]></code>
       <code><![CDATA[$origData['settings_data']]]></code>
       <code>$tab</code>
-      <code><![CDATA[$tables[$t1]['ENGINE']]]></code>
-      <code><![CDATA[$tables[$t1]['ENGINE'] ?? '']]></code>
-      <code><![CDATA[$tables[$t2]['ENGINE']]]></code>
-      <code><![CDATA[$tables[$t2]['ENGINE'] ?? '']]></code>
       <code><![CDATA[$value['foreign_field']]]></code>
-      <code><![CDATA[is_string($oneTable['ENGINE']) ? $oneTable['ENGINE'] : '']]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$oneKey['constraint']]]></code>
@@ -4788,12 +4781,6 @@
       <code><![CDATA[$oneKey['ref_index_list']]]></code>
       <code><![CDATA[$oneKey['ref_index_list'][$index]]]></code>
       <code><![CDATA[$oneKey['ref_table_name']]]></code>
-      <code><![CDATA[$oneTable['ENGINE']]]></code>
-      <code><![CDATA[$oneTable['ENGINE']]]></code>
-      <code><![CDATA[$oneTable['TABLE_NAME']]]></code>
-      <code><![CDATA[$oneTable['TABLE_NAME']]]></code>
-      <code><![CDATA[$tables[$t1]['ENGINE']]]></code>
-      <code><![CDATA[$tables[$t2]['ENGINE']]]></code>
       <code><![CDATA[$value['foreign_db']]]></code>
       <code><![CDATA[$value['foreign_field']]]></code>
       <code><![CDATA[$value['foreign_table']]]></code>
@@ -4809,7 +4796,6 @@
       <code>$index</code>
       <code>$oneField</code>
       <code>$oneKey</code>
-      <code>$oneTable</code>
       <code>$origData</code>
       <code>$tab</code>
       <code>$value</code>
@@ -4825,7 +4811,13 @@
       <code><![CDATA[$_POST['t_x'][$key]]]></code>
       <code><![CDATA[$_POST['t_y'][$key]]]></code>
       <code>$db</code>
+      <code><![CDATA[$oneTable['TABLE_NAME']]]></code>
+      <code><![CDATA[$oneTable['TABLE_NAME']]]></code>
       <code>$tab</code>
+      <code><![CDATA[$tables[$t1]['ENGINE']]]></code>
+      <code><![CDATA[$tables[$t1]['ENGINE'] ?? '']]></code>
+      <code><![CDATA[$tables[$t2]['ENGINE']]]></code>
+      <code><![CDATA[$tables[$t2]['ENGINE'] ?? '']]></code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidArrayOffset>
       <code><![CDATA[$_POST['t_db'][$key]]]></code>
@@ -5195,7 +5187,6 @@
     <MixedArgument>
       <code>$a</code>
       <code>$b</code>
-      <code><![CDATA[$tableData[$sortBy] ?? '']]></code>
       <code><![CDATA[$this->connections[$connectionType]]]></code>
       <code><![CDATA[$this->connections[$connectionType]]]></code>
       <code><![CDATA[$this->connections[$connectionType]]]></code>
@@ -5219,10 +5210,6 @@
     <MixedArrayAccess>
       <code>$resultTarget[$row[$keyIndex]]</code>
       <code>$resultTarget[]</code>
-      <code>$tableData[$sortBy]</code>
-      <code><![CDATA[$tableData['Data_length']]]></code>
-      <code><![CDATA[$tableData['Engine']]]></code>
-      <code><![CDATA[$tableData['Index_length']]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
       <code>$resultTarget[$row[$keyIndex]]</code>
@@ -5241,9 +5228,6 @@
       <code>$resultTarget</code>
       <code>$resultTarget</code>
       <code>$resultTarget</code>
-      <code>$tableData</code>
-      <code>$tableData</code>
-      <code>$tableData</code>
       <code><![CDATA[$this->versionComment]]></code>
       <code><![CDATA[$this->versionString]]></code>
     </MixedAssignment>
@@ -5255,7 +5239,6 @@
     <MixedOperand>
       <code><![CDATA[$a['Data_length']]]></code>
       <code><![CDATA[$b['Data_length']]]></code>
-      <code><![CDATA[$tableData['Data_length']]]></code>
     </MixedOperand>
     <MixedReturnStatement>
       <code>$resultRows</code>
@@ -5289,9 +5272,16 @@
     <NullableReturnStatement>
       <code>$user</code>
     </NullableReturnStatement>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$tableData[$sortBy] ?? '']]></code>
+    </PossiblyInvalidArgument>
     <PossiblyInvalidArrayOffset>
       <code>$row[$value]</code>
     </PossiblyInvalidArrayOffset>
+    <PossiblyInvalidOperand>
+      <code><![CDATA[$tableData['Data_length']]]></code>
+      <code><![CDATA[$tableData['Index_length']]]></code>
+    </PossiblyInvalidOperand>
     <PossiblyNullArrayOffset>
       <code>$resultTarget</code>
       <code>$resultTarget</code>
@@ -5304,6 +5294,8 @@
       <code><![CDATA[$row['Index_length']]]></code>
       <code><![CDATA[$row['Max_data_length']]]></code>
       <code><![CDATA[$row['Rows']]]></code>
+      <code><![CDATA[$tableData['Data_length']]]></code>
+      <code><![CDATA[$tableData['Index_length']]]></code>
     </PossiblyNullOperand>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$_SERVER['SCRIPT_NAME']]]></code>
@@ -10520,9 +10512,6 @@
     </UnsupportedPropertyReferenceUsage>
   </file>
   <file src="src/Query/Compatibility.php">
-    <MixedArgument>
-      <code><![CDATA[$eachTables[$tableName]['Comment'] ?? '']]></code>
-    </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$columns[$columnName]['Collation']]]></code>
       <code><![CDATA[$columns[$columnName]['Comment']]]></code>
@@ -10533,24 +10522,6 @@
       <code><![CDATA[$columns[$columnName]['Null']]]></code>
       <code><![CDATA[$columns[$columnName]['Privileges']]]></code>
       <code><![CDATA[$columns[$columnName]['Type']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Auto_increment']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Avg_row_length']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Check_time']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Checksum']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Collation']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Comment']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Create_options']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Create_time']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Data_free']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Data_length']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Engine']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Index_length']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Max_data_length']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Name']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Row_format']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Rows']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Update_time']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['Version']]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
       <code><![CDATA[$columns[$columnName]['CHARACTER_MAXIMUM_LENGTH']]]></code>
@@ -10563,19 +10534,14 @@
       <code><![CDATA[$columns[$columnName]['TABLE_CATALOG']]]></code>
       <code><![CDATA[$columns[$columnName]['TABLE_NAME']]]></code>
       <code><![CDATA[$columns[$columnName]['TABLE_SCHEMA']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['TABLE_SCHEMA']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['TABLE_TYPE']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['TABLE_TYPE']]]></code>
-      <code><![CDATA[$eachTables[$tableName]['TABLE_TYPE']]]></code>
     </MixedArrayAssignment>
     <MixedAssignment>
       <code>$colCollation</code>
       <code>$colType</code>
     </MixedAssignment>
-    <MixedReturnTypeCoercion>
-      <code>$eachTables</code>
-      <code>mixed[][]</code>
-    </MixedReturnTypeCoercion>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$eachTables[$tableName]['Comment'] ?? '']]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Query/Utilities.php">
     <DeprecatedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2424,7 +2424,6 @@
       <code><![CDATA[$GLOBALS['auto_increment']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
       <code><![CDATA[$GLOBALS['message_to_show']]]></code>
-      <code>$rereadInfo</code>
       <code>$showTable</code>
       <code>$showTable</code>
     </MixedAssignment>
@@ -4146,8 +4145,6 @@
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
       <code>$attributes[$rownum]</code>
-      <code>$rereadInfo</code>
-      <code>$showTable</code>
       <code>$showTable</code>
     </MixedAssignment>
     <MixedOperand>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4814,10 +4814,6 @@
       <code><![CDATA[$oneTable['TABLE_NAME']]]></code>
       <code><![CDATA[$oneTable['TABLE_NAME']]]></code>
       <code>$tab</code>
-      <code><![CDATA[$tables[$t1]['ENGINE']]]></code>
-      <code><![CDATA[$tables[$t1]['ENGINE'] ?? '']]></code>
-      <code><![CDATA[$tables[$t2]['ENGINE']]]></code>
-      <code><![CDATA[$tables[$t2]['ENGINE'] ?? '']]></code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidArrayOffset>
       <code><![CDATA[$_POST['t_db'][$key]]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14108,7 +14108,6 @@
   <file src="tests/classes/Export/OptionsTest.php">
     <DeprecatedMethod>
       <code>Config::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$config->settings]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10493,12 +10493,9 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="src/Query/Cache.php">
-    <MixedAssignment>
-      <code>$loc[array_shift($contentPath)]</code>
-    </MixedAssignment>
-    <UnsupportedPropertyReferenceUsage>
-      <code><![CDATA[$loc = &$this->tableCache]]></code>
-    </UnsupportedPropertyReferenceUsage>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->tableCache[$db][$table][$key]]]></code>
+    </MixedArrayAssignment>
   </file>
   <file src="src/Query/Compatibility.php">
     <MixedArrayAccess>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10493,14 +10493,7 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="src/Query/Cache.php">
-    <MixedArrayOffset>
-      <code>$loc[$key]</code>
-      <code>$loc[$key]</code>
-      <code>$loc[array_shift($contentPath)]</code>
-    </MixedArrayOffset>
     <MixedAssignment>
-      <code>$key</code>
-      <code>$loc</code>
       <code>$loc[array_shift($contentPath)]</code>
     </MixedAssignment>
     <UnsupportedPropertyReferenceUsage>

--- a/src/Controllers/Operations/TableController.php
+++ b/src/Controllers/Operations/TableController.php
@@ -118,8 +118,7 @@ class TableController extends AbstractController
          */
         $this->dbi->selectDb(Current::$database);
 
-        $rereadInfo = $pmaTable->getStatusInfo();
-        $showTable = $pmaTable->getStatusInfo(null, ! empty($rereadInfo));
+        $showTable = $pmaTable->getStatusInfo();
         if ($pmaTable->isView()) {
             $tableIsAView = true;
             $tableStorageEngine = __('View');
@@ -328,7 +327,7 @@ class TableController extends AbstractController
             // a change, clear the cache
             $this->dbi->getCache()->clearTableCache();
             $this->dbi->selectDb(Current::$database);
-            $showTable = $pmaTable->getStatusInfo(null, true);
+            $showTable = $pmaTable->getStatusInfo(forceRead: true);
             if ($pmaTable->isView()) {
                 $tableIsAView = true;
                 $tableStorageEngine = __('View');

--- a/src/Controllers/Operations/ViewController.php
+++ b/src/Controllers/Operations/ViewController.php
@@ -98,7 +98,7 @@ class ViewController extends AbstractController
                 $result = true;
                 Current::$table = $tableObject->getName();
                 /* Force reread after rename */
-                $tableObject->getStatusInfo(null, true);
+                $this->dbi->getCache()->clearTableCache();
                 $GLOBALS['reload'] = true;
             } else {
                 $message->addText($tableObject->getLastError());

--- a/src/Controllers/Table/StructureController.php
+++ b/src/Controllers/Table/StructureController.php
@@ -69,8 +69,6 @@ class StructureController extends AbstractController
         $GLOBALS['errorUrl'] ??= null;
 
         $this->dbi->selectDb(Current::$database);
-        $rereadInfo = $this->tableObj->getStatusInfo(null, true);
-        $showTable = $this->tableObj->getStatusInfo(null, ! empty($rereadInfo));
 
         $this->pageSettings->init('TableStructure');
         $this->response->addHTML($this->pageSettings->getErrorHTML());
@@ -141,7 +139,6 @@ class StructureController extends AbstractController
             $columnsWithIndex,
             $isSystemSchema,
             $request->getRoute(),
-            $showTable,
         ));
     }
 
@@ -161,7 +158,6 @@ class StructureController extends AbstractController
         array $columnsWithIndex,
         bool $isSystemSchema,
         string $route,
-        mixed $showTable,
     ): string {
         if ($this->tableObj->isView()) {
             $tableIsAView = true;
@@ -193,7 +189,7 @@ class StructureController extends AbstractController
         // Get valid statistics whatever is the table type
         if ($config->settings['ShowStats']) {
             //get table stats in HTML format
-            $tablestats = $this->getTableStats($isSystemSchema, $tableIsAView, $tableStorageEngine, $showTable);
+            $tablestats = $this->getTableStats($isSystemSchema, $tableIsAView, $tableStorageEngine);
             //returning the response in JSON format to be used by Ajax
             $this->response->addJSON('tableStat', $tablestats);
         }
@@ -300,14 +296,9 @@ class StructureController extends AbstractController
         bool $isSystemSchema,
         bool $tableIsAView,
         string $tableStorageEngine,
-        mixed $showTable,
     ): string {
+        $showTable = $this->dbi->getTable(Current::$database, Current::$table)->getStatusInfo(forceRead: true);
         $tableInfoNunRows = $this->tableObj->getNumRows($showTable['Name']);
-
-        if (empty($showTable)) {
-            $showTable = $this->dbi->getTable(Current::$database, Current::$table)
-                ->getStatusInfo(null, true);
-        }
 
         if (is_string($showTable)) {
             $showTable = [];

--- a/src/Database/Designer/Common.php
+++ b/src/Database/Designer/Common.php
@@ -26,7 +26,6 @@ use function is_array;
 use function is_string;
 use function json_decode;
 use function json_encode;
-use function mb_strtoupper;
 use function rawurlencode;
 
 /**
@@ -507,13 +506,11 @@ class Common
         string $db1,
         string $db2,
     ): array {
-        $tables = $this->dbi->getTablesFull($db1, $t1);
-        $typeT1 = mb_strtoupper($tables[$t1]['ENGINE'] ?? '');
-        $tables = $this->dbi->getTablesFull($db2, $t2);
-        $typeT2 = mb_strtoupper($tables[$t2]['ENGINE'] ?? '');
+        $typeT1 = Table::get($t1, $db1, $this->dbi)->getStorageEngine();
+        $typeT2 = Table::get($t2, $db2, $this->dbi)->getStorageEngine();
 
         // native foreign key
-        if (ForeignKey::isSupported($typeT1) && ForeignKey::isSupported($typeT2) && $typeT1 === $typeT2) {
+        if (ForeignKey::isSupported($typeT1) && $typeT1 === $typeT2) {
             // relation exists?
             $existRelForeign = $this->relation->getForeigners($db2, $t2, '', 'foreign');
             $foreigner = $this->relation->searchColumnInForeigners($existRelForeign, $f2);
@@ -624,12 +621,10 @@ class Common
         [$db1, $t1] = explode('.', $t1);
         [$db2, $t2] = explode('.', $t2);
 
-        $tables = $this->dbi->getTablesFull($db1, $t1);
-        $typeT1 = mb_strtoupper($tables[$t1]['ENGINE']);
-        $tables = $this->dbi->getTablesFull($db2, $t2);
-        $typeT2 = mb_strtoupper($tables[$t2]['ENGINE']);
+        $typeT1 = Table::get($t1, $db1, $this->dbi)->getStorageEngine();
+        $typeT2 = Table::get($t2, $db2, $this->dbi)->getStorageEngine();
 
-        if (ForeignKey::isSupported($typeT1) && ForeignKey::isSupported($typeT2) && $typeT1 === $typeT2) {
+        if (ForeignKey::isSupported($typeT1) && $typeT1 === $typeT2) {
             // InnoDB
             $existRelForeign = $this->relation->getForeigners($db2, $t2, '', 'foreign');
             $foreigner = $this->relation->searchColumnInForeigners($existRelForeign, $f2);

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -360,7 +360,7 @@ class DatabaseInterface implements DbalInterface
      * @param string|null    $tableType    whether table or view
      * @psalm-param ConnectionType $connectionType
      *
-     * @return mixed[]           list of tables in given db(s)
+     * @return (string|int|null)[][]           list of tables in given db(s)
      *
      * @todo    move into Table
      */
@@ -426,7 +426,7 @@ class DatabaseInterface implements DbalInterface
                 $sql .= ' LIMIT ' . $limitCount . ' OFFSET ' . $limitOffset;
             }
 
-            /** @var mixed[][][] $tables */
+            /** @var (string|int|null)[][][] $tables */
             $tables = $this->fetchResult(
                 $sql,
                 ['TABLE_SCHEMA', 'TABLE_NAME'],
@@ -534,6 +534,7 @@ class DatabaseInterface implements DbalInterface
                 }
             }
 
+            /** @var (string|int|null)[][] $eachTables */
             $eachTables = $this->fetchResult($sql, 'Name', null, $connectionType);
 
             // here, we check for Mroonga engine and compute the good data_length and index_length

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -1081,11 +1081,8 @@ class Results
 
         [$columnOrder, $columnVisibility] = $this->getColumnParams($statementInfo);
 
-        $tableCreateTime = '';
         $table = new Table($this->table, $this->db, $this->dbi);
-        if (! $table->isView()) {
-            $tableCreateTime = $this->dbi->getTable($this->db, $this->table)->getStatusInfo('Create_time');
-        }
+        $tableCreateTime = ! $table->isView() ? $table->getStatusInfo('Create_time') : '';
 
         return [
             'order' => $columnOrder,

--- a/src/Query/Cache.php
+++ b/src/Query/Cache.php
@@ -11,14 +11,14 @@ use PhpMyAdmin\Util;
  */
 class Cache
 {
-    /** @var mixed[][] Table data cache */
+    /** @var (string|int|null)[][][] Table data cache */
     private array $tableCache = [];
 
     /**
      * Caches table data so Table does not require to issue
      * SHOW TABLE STATUS again
      *
-     * @param mixed[][] $tables information for tables of some databases
+     * @param (string|int|null)[][] $tables information for tables of some databases
      */
     public function cacheTableData(string $database, array $tables): void
     {

--- a/src/Query/Cache.php
+++ b/src/Query/Cache.php
@@ -42,18 +42,12 @@ class Cache
     /**
      * Set an item in table cache using dot notation.
      *
-     * @param mixed[]|null $contentPath Array with the target path
-     * @param mixed        $value       Target value
+     * @param string[] $contentPath Array with the target path
+     * @param mixed    $value       Target value
      */
-    public function cacheTableContent(array|null $contentPath, mixed $value): void
+    public function cacheTableContent(array $contentPath, mixed $value): void
     {
         $loc = &$this->tableCache;
-
-        if (! isset($contentPath)) {
-            $loc = $value;
-
-            return;
-        }
 
         while (count($contentPath) > 1) {
             $key = array_shift($contentPath);

--- a/src/Query/Cache.php
+++ b/src/Query/Cache.php
@@ -6,10 +6,6 @@ namespace PhpMyAdmin\Query;
 
 use PhpMyAdmin\Util;
 
-use function array_shift;
-use function count;
-use function is_array;
-
 /**
  * Handles caching results
  */
@@ -40,30 +36,11 @@ class Cache
     }
 
     /**
-     * Set an item in table cache using dot notation.
-     *
-     * @param string[] $contentPath Array with the target path
-     * @param mixed    $value       Target value
+     * Set an item in the cache
      */
-    public function cacheTableContent(array $contentPath, mixed $value): void
+    public function cacheTableValue(string $db, string $table, string $key, string|int|null $value): void
     {
-        $loc = &$this->tableCache;
-
-        while (count($contentPath) > 1) {
-            $key = array_shift($contentPath);
-
-            // If the key doesn't exist at this depth, we will just create an empty
-            // array to hold the next value, allowing us to create the arrays to hold
-            // final values at the correct depth. Then we'll keep digging into the
-            // array.
-            if (! isset($loc[$key]) || ! is_array($loc[$key])) {
-                $loc[$key] = [];
-            }
-
-            $loc = &$loc[$key];
-        }
-
-        $loc[array_shift($contentPath)] = $value;
+        $this->tableCache[$db][$table][$key] = $value;
     }
 
     /**

--- a/src/Query/Compatibility.php
+++ b/src/Query/Compatibility.php
@@ -21,9 +21,9 @@ use function substr;
 class Compatibility
 {
     /**
-     * @param mixed[] $eachTables
+     * @param (string|int|null)[][] $eachTables
      *
-     * @return mixed[][]
+     * @return (string|int|null)[][]
      */
     public static function getISCompatForGetTablesFull(array $eachTables, string $eachDatabase): array
     {

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -698,10 +698,7 @@ class Table implements Stringable
 
         if (! $forceExact) {
             if (($cache->getCachedTableContent([$this->dbName, $this->name, 'Rows']) == null) && ! $isView) {
-                $tmpTables = $this->dbi->getTablesFull($this->dbName, $this->name);
-                if (isset($tmpTables[$this->name])) {
-                    $cache->cacheTableContent([$this->dbName, $this->name], $tmpTables[$this->name]);
-                }
+                $this->dbi->getTablesFull($this->dbName, $this->name);
             }
 
             $rowCount = $cache->getCachedTableContent([$this->dbName, $this->name, 'Rows']);

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -697,7 +697,7 @@ class Table implements Stringable
         $rowCount = null;
 
         if (! $forceExact) {
-            if (($cache->getCachedTableContent([$this->dbName, $this->name, 'Rows']) == null) && ! $isView) {
+            if (($cache->getCachedTableContent([$this->dbName, $this->name, 'Rows']) === null) && ! $isView) {
                 $this->dbi->getTablesFull($this->dbName, $this->name);
             }
 

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -736,7 +736,7 @@ class Table implements Stringable
         }
 
         if (is_numeric($rowCount)) {
-            $cache->cacheTableContent([$this->dbName, $this->name, 'ExactRows'], (int) $rowCount);
+            $cache->cacheTableValue($this->dbName, $this->name, 'ExactRows', (int) $rowCount);
 
             return (int) $rowCount;
         }

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -325,7 +325,7 @@ class Table implements Stringable
             return false;
         }
 
-        return $this->dbi->getCache()->getCachedTableContent([$this->dbName, $this->name, $info]);
+        return $cachedResult[$info];
     }
 
     /**

--- a/tests/classes/Export/OptionsTest.php
+++ b/tests/classes/Export/OptionsTest.php
@@ -65,8 +65,6 @@ class OptionsTest extends AbstractTestCase
         $table = 'PMA_test';
         $numTablesStr = '10';
         $unlimNumRowsStr = 'unlim_num_rows_str';
-        //$single_table = "single_table";
-        DatabaseInterface::getInstance()->getCache()->cacheTableContent([$db, $table, 'ENGINE'], 'MERGE');
 
         $columnsInfo = [
             'test_column1' => ['COLUMN_NAME' => 'test_column1'],

--- a/tests/classes/Table/TableTest.php
+++ b/tests/classes/Table/TableTest.php
@@ -949,10 +949,7 @@ class TableTest extends AbstractTestCase
     public function testIsMergeCase2(): void
     {
         $dbi = DatabaseInterface::getInstance();
-        $dbi->getCache()->cacheTableContent(
-            ['PMA', 'PMA_BookMark'],
-            ['ENGINE' => 'MERGE'],
-        );
+        $dbi->getCache()->cacheTableValue('PMA', 'PMA_BookMark', 'ENGINE', 'MERGE');
 
         $tableObj = new Table('PMA_BookMark', 'PMA', $dbi);
         $this->assertTrue(
@@ -966,10 +963,7 @@ class TableTest extends AbstractTestCase
     public function testIsMergeCase3(): void
     {
         $dbi = DatabaseInterface::getInstance();
-        $dbi->getCache()->cacheTableContent(
-            ['PMA', 'PMA_BookMark'],
-            ['ENGINE' => 'MRG_MYISAM'],
-        );
+        $dbi->getCache()->cacheTableValue('PMA', 'PMA_BookMark', 'ENGINE', 'MRG_MYISAM');
 
         $tableObj = new Table('PMA_BookMark', 'PMA', $dbi);
         $this->assertTrue(

--- a/tests/classes/Table/TableTest.php
+++ b/tests/classes/Table/TableTest.php
@@ -936,11 +936,6 @@ class TableTest extends AbstractTestCase
     public function testIsMergeCase1(): void
     {
         $dbi = DatabaseInterface::getInstance();
-        $tableObj = new Table('PMA_BookMark', 'PMA', $dbi);
-        $this->assertEquals(
-            '',
-            $tableObj->isMerge(),
-        );
 
         $tableObj = new Table('PMA_BookMark', 'PMA', $dbi);
         $this->assertFalse(


### PR DESCRIPTION
I've decided to narrow down the type hints because we know that results from DB are either `string` or `null`. The mroonga calculations add `int` as another possible type. The cache may also have `ExactRows` which is an int too. Since we know the exact structure of the array, and by extension the structure of the cache, we can specify narrow type hints. This doesn't help with fetching the values from cache as it can be any part of the cache or the default value, so this remains `mixed`.

All changes in this PR attempt to simplify and clean up usage of `getTablesFull()` results, but there are still many places where the results are used in a complicated and confusing way. In future PRs I will try to untangle it as much as possible. I still have many open questions about how this works. For example, `getStatusInfo()` has param `$disableError`. I don't understand why this function triggers an error and why it can be silenced. It doesn't make any sense to me. 