### PR TITLE
Refactor getDbInfo() and getTablesWhenOpen()

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -12399,10 +12399,6 @@
     <PossiblyNullArgument>
       <code>$value</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayOffset>
-      <code>$sotCache</code>
-      <code>$tables</code>
-    </PossiblyNullArrayOffset>
     <RedundantCast>
       <code><![CDATA[(string) $_REQUEST['tbl_group']]]></code>
       <code><![CDATA[(string) $_REQUEST['tbl_group']]]></code>

--- a/src/Controllers/Database/ExportController.php
+++ b/src/Controllers/Database/ExportController.php
@@ -22,6 +22,7 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function array_merge;
+use function count;
 use function is_array;
 
 final class ExportController extends AbstractController
@@ -77,7 +78,8 @@ final class ExportController extends AbstractController
 
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/database/export');
 
-        [$GLOBALS['tables'], $GLOBALS['num_tables']] = Util::getDbInfo($request, Current::$database, false);
+        [$GLOBALS['tables']] = Util::getDbInfo($request, Current::$database, false);
+        $GLOBALS['num_tables'] = count($GLOBALS['tables']);
 
         // exit if no tables in db found
         if ($GLOBALS['num_tables'] < 1) {

--- a/src/Controllers/Database/StructureController.php
+++ b/src/Controllers/Database/StructureController.php
@@ -98,10 +98,10 @@ class StructureController extends AbstractController
      */
     private function getDatabaseInfo(ServerRequest $request): void
     {
-        [$tables, $numTables, $totalNumTables] = Util::getDbInfo($request, Current::$database);
+        [$tables, $totalNumTables] = Util::getDbInfo($request, Current::$database);
 
         $this->tables = $tables;
-        $this->numTables = $numTables;
+        $this->numTables = count($tables);
         $this->position = Util::getTableListPosition($request, Current::$database);
         $this->totalNumTables = $totalNumTables;
 

--- a/src/Controllers/Database/TrackingController.php
+++ b/src/Controllers/Database/TrackingController.php
@@ -22,6 +22,7 @@ use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
 
 use function __;
+use function count;
 use function htmlspecialchars;
 use function sprintf;
 
@@ -73,7 +74,7 @@ class TrackingController extends AbstractController
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/table/tracking');
         $GLOBALS['urlParams']['back'] = Url::getFromRoute('/database/tracking');
 
-        [, $numTables] = Util::getDbInfo($request, Current::$database);
+        $numTables = count(Util::getDbInfo($request, Current::$database)[0]);
         $isSystemSchema = Utilities::isSystemSchema(Current::$database);
 
         if ($request->hasBodyParam('delete_tracking') && $request->hasBodyParam('table')) {

--- a/src/Util.php
+++ b/src/Util.php
@@ -1791,7 +1791,7 @@ class Util
      *
      * @return mixed[] list of tables
      */
-    public static function getTablesWhenOpen(string $db, ResultInterface $dbInfoResult): array
+    private static function getTablesWhenOpen(string $db, ResultInterface $dbInfoResult): array
     {
         $sotCache = [];
         $tables = [];

--- a/src/Util.php
+++ b/src/Util.php
@@ -1658,7 +1658,7 @@ class Util
      * Gets the list of tables in the current db and information about these tables if possible.
      *
      * @return array<int, array|int>
-     * @psalm-return array{array, int, int}
+     * @psalm-return array{array, int}
      */
     public static function getDbInfo(ServerRequest $request, string $db, bool $isResultLimited = true): array
     {
@@ -1765,12 +1765,9 @@ class Util
             );
         }
 
-        $numTables = count($tables);
-
         return [
             $tables,
-            $numTables,
-            $totalNumTables ?? $numTables, // needed for proper working of the MaxTableList feature
+            $totalNumTables ?? count($tables), // needed for proper working of the MaxTableList feature
         ];
     }
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -1743,8 +1743,7 @@ class Util
                 // all tables in db
                 // - get the total number of tables
                 //  (needed for proper working of the MaxTableList feature)
-                $tables = $dbi->getTables($db);
-                $totalNumTables = count($tables);
+                $totalNumTables = count($dbi->getTables($db));
                 if ($isResultLimited) {
                     // fetch the details for a possible limited subset
                     $limitOffset = self::getTableListPosition($request, $db);
@@ -1755,7 +1754,7 @@ class Util
             // We must use union operator here instead of array_merge to preserve numerical keys
             $tables = $groupTable + $dbi->getTablesFull(
                 $db,
-                $groupWithSeparator !== false ? $groupWithSeparator : $tables,
+                $groupWithSeparator !== false ? $groupWithSeparator : '',
                 $groupWithSeparator !== false,
                 $limitOffset,
                 $limitCount,

--- a/tests/classes/Stubs/DbiDummy.php
+++ b/tests/classes/Stubs/DbiDummy.php
@@ -2115,7 +2115,7 @@ class DbiDummy implements DbiExtension
                 ],
             ],
             [
-                'query' => "SHOW TABLE STATUS FROM `world` WHERE `Name` IN ('City', 'Country', 'CountryLanguage')",
+                'query' => 'SHOW TABLE STATUS FROM `world`',
                 'columns' => [
                     'Name',
                     'Engine',

--- a/tests/classes/UtilTest.php
+++ b/tests/classes/UtilTest.php
@@ -1496,7 +1496,7 @@ SQL;
             'TABLE_COMMENT' => '',
             'TABLE_TYPE' => 'BASE TABLE',
         ];
-        $expected = [['test_table' => $tableInfo], 1, 1];
+        $expected = [['test_table' => $tableInfo], 1];
         $actual = Util::getDbInfo($this->createStub(ServerRequest::class), 'test_db');
         $this->assertSame($expected, $actual);
     }


### PR DESCRIPTION
Does anyone know how I can trigger the functionality in `getDbInfo` with `NavigationTreeTableSeparator`? I enabled this in config but it doesn't seem to reach this breakpoint. 