### PR TITLE
Refactoring getStatusInfo() and Cache

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15452,7 +15452,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 6
+			count: 7
 			path: src/Table/Table.php
 
 		-
@@ -15608,11 +15608,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 2
-			path: src/Table/Table.php
-
-		-
-			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
-			count: 1
 			path: src/Table/Table.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3371,11 +3371,6 @@ parameters:
 			path: src/Controllers/Operations/DatabaseController.php
 
 		-
-			message: "#^Cannot access offset 'Row_format' on mixed\\.$#"
-			count: 1
-			path: src/Controllers/Operations/TableController.php
-
-		-
 			message: "#^Cannot access offset 'back' on mixed\\.$#"
 			count: 2
 			path: src/Controllers/Operations/TableController.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1591,11 +1591,6 @@ parameters:
 			path: src/Controllers/Database/DataDictionaryController.php
 
 		-
-			message: "#^Cannot cast mixed to string\\.$#"
-			count: 1
-			path: src/Controllers/Database/DataDictionaryController.php
-
-		-
 			message: "#^Cannot access offset 'dbName' on mixed\\.$#"
 			count: 2
 			path: src/Controllers/Database/DesignerController.php
@@ -5891,58 +5886,28 @@ parameters:
 			path: src/Controllers/Table/Structure/SaveController.php
 
 		-
+			message: "#^Binary operation \"\\+\" between int\\|non\\-falsy\\-string and int\\|non\\-falsy\\-string results in an error\\.$#"
+			count: 4
+			path: src/Controllers/Table/StructureController.php
+
+		-
+			message: "#^Binary operation \"\\-\" between mixed and int\\|string results in an error\\.$#"
+			count: 1
+			path: src/Controllers/Table/StructureController.php
+
+		-
+			message: "#^Binary operation \"/\" between mixed and int\\|string\\|null results in an error\\.$#"
+			count: 1
+			path: src/Controllers/Table/StructureController.php
+
+		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
 			path: src/Controllers/Table/StructureController.php
 
 		-
-			message: "#^Cannot access offset 'Check_time' on mixed\\.$#"
-			count: 1
-			path: src/Controllers/Table/StructureController.php
-
-		-
-			message: "#^Cannot access offset 'Create_time' on mixed\\.$#"
-			count: 1
-			path: src/Controllers/Table/StructureController.php
-
-		-
-			message: "#^Cannot access offset 'Data_free' on mixed\\.$#"
-			count: 1
-			path: src/Controllers/Table/StructureController.php
-
-		-
-			message: "#^Cannot access offset 'Data_length' on mixed\\.$#"
-			count: 7
-			path: src/Controllers/Table/StructureController.php
-
-		-
-			message: "#^Cannot access offset 'Index_length' on mixed\\.$#"
-			count: 2
-			path: src/Controllers/Table/StructureController.php
-
-		-
-			message: "#^Cannot access offset 'Name' on mixed\\.$#"
-			count: 1
-			path: src/Controllers/Table/StructureController.php
-
-		-
-			message: "#^Cannot access offset 'Rows' on mixed\\.$#"
-			count: 1
-			path: src/Controllers/Table/StructureController.php
-
-		-
-			message: "#^Cannot access offset 'Type' on mixed\\.$#"
-			count: 1
-			path: src/Controllers/Table/StructureController.php
-
-		-
-			message: "#^Cannot access offset 'Update_time' on mixed\\.$#"
-			count: 1
-			path: src/Controllers/Table/StructureController.php
-
-		-
 			message: "#^Cannot use array destructuring on array\\<int, string\\>\\|null\\.$#"
-			count: 1
+			count: 4
 			path: src/Controllers/Table/StructureController.php
 
 		-
@@ -5956,28 +5921,18 @@ parameters:
 			path: src/Controllers/Table/StructureController.php
 
 		-
-			message: "#^Parameter \\#1 \\$datetime of function strtotime expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$datetime of function strtotime expects string, int\\|string given\\.$#"
 			count: 3
 			path: src/Controllers/Table/StructureController.php
 
 		-
-			message: "#^Parameter \\#1 \\$showTableName of method PhpMyAdmin\\\\Table\\\\Table\\:\\:getNumRows\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Controllers/Table/StructureController.php
-
-		-
-			message: "#^Parameter \\#1 \\$timestamp of static method PhpMyAdmin\\\\Util\\:\\:localisedDate\\(\\) expects int, \\(int\\|false\\) given\\.$#"
+			message: "#^Parameter \\#1 \\$timestamp of static method PhpMyAdmin\\\\Util\\:\\:localisedDate\\(\\) expects int, int\\|false given\\.$#"
 			count: 3
-			path: src/Controllers/Table/StructureController.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of static method PhpMyAdmin\\\\Util\\:\\:formatByteDown\\(\\) expects float\\|int\\|string\\|null, \\(array\\|float\\|int\\) given\\.$#"
-			count: 2
 			path: src/Controllers/Table/StructureController.php
 
 		-
 			message: "#^Parameter \\#1 \\$value of static method PhpMyAdmin\\\\Util\\:\\:formatByteDown\\(\\) expects float\\|int\\|string\\|null, mixed given\\.$#"
-			count: 3
+			count: 4
 			path: src/Controllers/Table/StructureController.php
 
 		-
@@ -13016,26 +12971,6 @@ parameters:
 			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
 
 		-
-			message: "#^Cannot access offset 'Check_time' on mixed\\.$#"
-			count: 1
-			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
-
-		-
-			message: "#^Cannot access offset 'Comment' on mixed\\.$#"
-			count: 1
-			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
-
-		-
-			message: "#^Cannot access offset 'Create_time' on mixed\\.$#"
-			count: 1
-			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
-
-		-
-			message: "#^Cannot access offset 'Update_time' on mixed\\.$#"
-			count: 1
-			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
-
-		-
 			message: "#^Cannot access offset 'foreign_field' on mixed\\.$#"
 			count: 1
 			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
@@ -13091,7 +13026,7 @@ parameters:
 			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
 
 		-
-			message: "#^Parameter \\#1 \\$datetime of function strtotime expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$datetime of function strtotime expects string, int\\|string given\\.$#"
 			count: 3
 			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
 
@@ -13101,7 +13036,7 @@ parameters:
 			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
 
 		-
-			message: "#^Parameter \\#1 \\$timestamp of static method PhpMyAdmin\\\\Util\\:\\:localisedDate\\(\\) expects int, \\(int\\|false\\) given\\.$#"
+			message: "#^Parameter \\#1 \\$timestamp of static method PhpMyAdmin\\\\Util\\:\\:localisedDate\\(\\) expects int, int\\|false given\\.$#"
 			count: 3
 			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
 
@@ -15452,31 +15387,31 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to int\\.$#"
-			count: 2
+			count: 1
 			path: src/Table/Table.php
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
-			count: 3
+			count: 2
 			path: src/Table/Table.php
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 19
+			count: 18
 			path: src/Table/Table.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Table\\\\Table\\:\\:getAutoIncrement\\(\\) should return string but returns mixed\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Table\\\\Table\\:\\:getAutoIncrement\\(\\) should return string but returns int\\|string\\.$#"
 			count: 1
 			path: src/Table/Table.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Table\\\\Table\\:\\:getCollation\\(\\) should return string but returns mixed\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Table\\\\Table\\:\\:getCollation\\(\\) should return string but returns int\\|string\\.$#"
 			count: 1
 			path: src/Table/Table.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Table\\\\Table\\:\\:getComment\\(\\) should return string but returns mixed\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Table\\\\Table\\:\\:getComment\\(\\) should return string but returns int\\|string\\.$#"
 			count: 1
 			path: src/Table/Table.php
 
@@ -15627,7 +15562,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$string of function explode expects string, mixed given\\.$#"
-			count: 3
+			count: 2
 			path: src/Table/Table.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15447,12 +15447,12 @@ parameters:
 
 		-
 			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 7
+			count: 6
 			path: src/Table/Table.php
 
 		-
 			message: "#^Cannot cast mixed to int\\.$#"
-			count: 4
+			count: 2
 			path: src/Table/Table.php
 
 		-
@@ -15602,7 +15602,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
-			count: 2
+			count: 1
 			path: src/Table/Table.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15467,7 +15467,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 20
+			count: 19
 			path: src/Table/Table.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11592,7 +11592,6 @@
       <code><![CDATA[$GLOBALS['sql_auto_increments']]]></code>
       <code><![CDATA[$GLOBALS['sql_indexes']]]></code>
       <code><![CDATA[$_POST['constraint_name'][$masterFieldMd5]]]></code>
-      <code>$cachedResult</code>
       <code>$column</code>
       <code>$column</code>
       <code><![CDATA[$column['Extra']]]></code>
@@ -11641,7 +11640,6 @@
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code><![CDATA[$_SESSION['tmpval']['table_uiprefs'][$serverId][$this->dbName][$this->name]]]></code>
-      <code>$cachedResult[$info]</code>
       <code><![CDATA[$column['Extra']]]></code>
       <code><![CDATA[$column['Extra']]]></code>
       <code><![CDATA[$column['Field']]]></code>
@@ -11700,8 +11698,6 @@
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
       <code>$altered</code>
       <code>$altered</code>
-      <code>$cachedResult</code>
-      <code>$cachedResult</code>
       <code>$column</code>
       <code>$column</code>
       <code>$column</code>
@@ -11727,7 +11723,6 @@
       <code>$refDbName</code>
       <code>$ret[]</code>
       <code>$row</code>
-      <code>$rowCount</code>
       <code>$tableAutoIncrement</code>
       <code>$tableCollation</code>
       <code>$tableComment</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2400,15 +2400,12 @@
       <code>$tableAlters</code>
       <code>is_array($partitionNames) ? $partitionNames : []</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess>
-      <code><![CDATA[$showTable['Row_format']]]></code>
-    </MixedArrayAccess>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['auto_increment']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
       <code><![CDATA[$GLOBALS['message_to_show']]]></code>
-      <code>$showTable</code>
-      <code>$showTable</code>
+      <code>$rowFormat</code>
+      <code>$rowFormat</code>
     </MixedAssignment>
   </file>
   <file src="src/Controllers/Operations/ViewController.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2404,8 +2404,6 @@
       <code><![CDATA[$GLOBALS['auto_increment']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
       <code><![CDATA[$GLOBALS['message_to_show']]]></code>
-      <code>$rowFormat</code>
-      <code>$rowFormat</code>
     </MixedAssignment>
   </file>
   <file src="src/Controllers/Operations/ViewController.php">
@@ -4087,47 +4085,34 @@
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
     </InvalidArrayOffset>
-    <MixedArgument>
-      <code><![CDATA[$showTable['Check_time']]]></code>
-      <code><![CDATA[$showTable['Create_time']]]></code>
-      <code><![CDATA[$showTable['Data_free']]]></code>
-      <code><![CDATA[$showTable['Data_length']]]></code>
-      <code><![CDATA[$showTable['Data_length']
-                + $showTable['Index_length']]]></code>
-      <code><![CDATA[$showTable['Data_length']
-                + $showTable['Index_length']
-                - $showTable['Data_free']]]></code>
-      <code><![CDATA[$showTable['Data_length'] + $showTable['Index_length']]]></code>
-      <code><![CDATA[$showTable['Index_length']]]></code>
-      <code><![CDATA[$showTable['Name']]]></code>
-      <code><![CDATA[$showTable['Update_time']]]></code>
-      <code><![CDATA[($showTable['Data_length']
-                + $showTable['Index_length'])
-                / $showTable['Rows']]]></code>
-    </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$showTable['Name']]]></code>
-      <code><![CDATA[$showTable['Rows']]]></code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment>
-      <code><![CDATA[$showTable['Data_length']]]></code>
-      <code><![CDATA[$showTable['Index_length']]]></code>
-    </MixedArrayAssignment>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
       <code>$attributes[$rownum]</code>
-      <code>$showTable</code>
     </MixedAssignment>
     <MixedOperand>
       <code><![CDATA[$displayedFields[$rownum]->icon]]></code>
       <code><![CDATA[$displayedFields[$rownum]->icon]]></code>
-      <code><![CDATA[$showTable['Data_length']]]></code>
-      <code><![CDATA[$showTable['Data_length']
-                + $showTable['Index_length']]]></code>
-      <code><![CDATA[$showTable['Index_length']]]></code>
-      <code><![CDATA[$showTable['Index_length']]]></code>
-      <code><![CDATA[$showTable['Index_length']]]></code>
     </MixedOperand>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$showTable['Check_time']]]></code>
+      <code><![CDATA[$showTable['Create_time']]]></code>
+      <code><![CDATA[$showTable['Update_time']]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidOperand>
+      <code><![CDATA[$showTable['Data_free']]]></code>
+      <code><![CDATA[$showTable['Data_length']]]></code>
+      <code><![CDATA[$showTable['Data_length']]]></code>
+      <code><![CDATA[$showTable['Data_length']]]></code>
+      <code><![CDATA[$showTable['Data_length']]]></code>
+      <code><![CDATA[$showTable['Index_length']]]></code>
+      <code><![CDATA[$showTable['Index_length']]]></code>
+      <code><![CDATA[$showTable['Index_length']]]></code>
+      <code><![CDATA[$showTable['Index_length']]]></code>
+      <code><![CDATA[$showTable['Rows']]]></code>
+    </PossiblyInvalidOperand>
+    <PossiblyNullOperand>
+      <code><![CDATA[$showTable['Rows']]]></code>
+    </PossiblyNullOperand>
   </file>
   <file src="src/Controllers/Table/TrackingController.php">
     <DeprecatedMethod>
@@ -5529,7 +5514,6 @@
       <code>$query</code>
       <code>$rel</code>
       <code>$relationalDisplay</code>
-      <code>$tableCreateTime</code>
       <code>$value</code>
     </MixedAssignment>
     <MixedInferredReturnType>
@@ -9806,9 +9790,6 @@
       <code><![CDATA[$oneKey['ref_table_name']]]></code>
       <code><![CDATA[$rel['foreign_field']]]></code>
       <code><![CDATA[$rel['foreign_table']]]></code>
-      <code><![CDATA[$showTable['Check_time']]]></code>
-      <code><![CDATA[$showTable['Create_time']]]></code>
-      <code><![CDATA[$showTable['Update_time']]]></code>
       <code>$table</code>
       <code>$table</code>
       <code>$table</code>
@@ -9831,10 +9812,6 @@
       <code><![CDATA[$rel['foreign_field']]]></code>
       <code><![CDATA[$rel['foreign_table']]]></code>
       <code><![CDATA[$rel['foreign_table']]]></code>
-      <code><![CDATA[$showTable['Check_time']]]></code>
-      <code><![CDATA[$showTable['Comment']]]></code>
-      <code><![CDATA[$showTable['Create_time']]]></code>
-      <code><![CDATA[$showTable['Update_time']]]></code>
       <code><![CDATA[$this->pdf->customLinks['RT']['-']]]></code>
       <code><![CDATA[$this->pdf->customLinks['doc'][$foreigner['foreign_table']]]]></code>
       <code><![CDATA[$this->pdf->customLinks['doc'][$table]]]></code>
@@ -9872,8 +9849,6 @@
       <code>$oneField</code>
       <code>$oneKey</code>
       <code>$rel</code>
-      <code>$showComment</code>
-      <code>$showTable</code>
       <code>$table</code>
       <code>$table</code>
       <code>$type</code>
@@ -9884,12 +9859,14 @@
       <code><![CDATA[$foreigner['foreign_table']]]></code>
       <code><![CDATA[$foreigner['on_delete']]]></code>
       <code><![CDATA[$foreigner['on_update']]]></code>
-      <code>$showComment</code>
       <code>$table</code>
       <code>$table</code>
     </MixedOperand>
     <PossiblyInvalidArgument>
       <code><![CDATA[$_REQUEST['pdf_table_order']]]></code>
+      <code><![CDATA[$showTable['Check_time']]]></code>
+      <code><![CDATA[$showTable['Create_time']]]></code>
+      <code><![CDATA[$showTable['Update_time']]]></code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast>
       <code><![CDATA[$_REQUEST['pdf_orientation']]]></code>
@@ -11588,6 +11565,16 @@
       <code><![CDATA[$GLOBALS['sql_auto_increments']]]></code>
       <code><![CDATA[$GLOBALS['sql_indexes']]]></code>
     </InvalidArrayOffset>
+    <InvalidReturnStatement>
+      <code><![CDATA[$tableAutoIncrement ?? '']]></code>
+      <code><![CDATA[$this->getStatusInfo('TABLE_COLLATION') ?? '']]></code>
+      <code><![CDATA[$this->getStatusInfo('TABLE_COMMENT') ?? '']]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code>string</code>
+      <code>string</code>
+      <code>string</code>
+    </InvalidReturnType>
     <MixedArgument>
       <code><![CDATA[$GLOBALS['sql_auto_increments']]]></code>
       <code><![CDATA[$GLOBALS['sql_indexes']]]></code>
@@ -11627,7 +11614,6 @@
       <code><![CDATA[$optionsArray[$existrelForeign[$masterFieldMd5]['on_update'] ?? ''] ?? null]]></code>
       <code><![CDATA[$options['expr']]]></code>
       <code><![CDATA[$row['Type']]]></code>
-      <code>$tableOptions</code>
       <code><![CDATA[$this->uiprefs[$property]]]></code>
       <code><![CDATA[$this->uiprefs[$property]]]></code>
       <code>$value</code>
@@ -11703,7 +11689,6 @@
       <code>$column</code>
       <code><![CDATA[$columns[$row['Field']]]]></code>
       <code>$constraintName</code>
-      <code>$currCreateTime</code>
       <code>$eachCol</code>
       <code>$foreignDb</code>
       <code>$foreignDb</code>
@@ -11723,23 +11708,12 @@
       <code>$refDbName</code>
       <code>$ret[]</code>
       <code>$row</code>
-      <code>$tableAutoIncrement</code>
-      <code>$tableCollation</code>
-      <code>$tableComment</code>
-      <code>$tableNumRowInfo</code>
-      <code>$tableOptions</code>
-      <code>$tableRowFormat</code>
-      <code>$tableStorageEngine</code>
-      <code>$type</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
     <MixedInferredReturnType>
       <code>mixed[]</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string</code>
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
@@ -11760,11 +11734,6 @@
       <code><![CDATA[$altered->options]]></code>
     </MixedPropertyFetch>
     <MixedReturnStatement>
-      <code><![CDATA[$tableAutoIncrement ?? '']]></code>
-      <code><![CDATA[$tableAutoIncrement ?? '']]></code>
-      <code><![CDATA[$tableCollation ?? '']]></code>
-      <code><![CDATA[$tableCollation ?? '']]></code>
-      <code>$tableComment</code>
       <code><![CDATA[end($this->errors)]]></code>
       <code><![CDATA[end($this->messages)]]></code>
       <code>json_decode($value, true)</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11596,7 +11596,6 @@
       <code><![CDATA[$GLOBALS['sql_indexes']]]></code>
       <code><![CDATA[$_POST['constraint_name'][$masterFieldMd5]]]></code>
       <code>$cachedResult</code>
-      <code>$cachedResult</code>
       <code>$column</code>
       <code>$column</code>
       <code><![CDATA[$column['Extra']]]></code>
@@ -11645,6 +11644,7 @@
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code><![CDATA[$_SESSION['tmpval']['table_uiprefs'][$serverId][$this->dbName][$this->name]]]></code>
+      <code>$cachedResult[$info]</code>
       <code><![CDATA[$column['Extra']]]></code>
       <code><![CDATA[$column['Extra']]]></code>
       <code><![CDATA[$column['Field']]]></code>

--- a/src/Controllers/Import/ImportController.php
+++ b/src/Controllers/Import/ImportController.php
@@ -112,12 +112,6 @@ final class ImportController extends AbstractController
         // default values
         $GLOBALS['reload'] = false;
 
-        // Use to identify current cycle is executing
-        // a multiquery statement or stored routine
-        if (! isset($_SESSION['is_multi_query'])) {
-            $_SESSION['is_multi_query'] = false;
-        }
-
         $GLOBALS['ajax_reload'] = [];
         $GLOBALS['import_text'] = '';
         // Are we just executing plain query or sql file?
@@ -678,9 +672,7 @@ final class ImportController extends AbstractController
         }
 
         if ($GLOBALS['go_sql']) {
-            if ($queriesToBeExecuted !== []) {
-                $_SESSION['is_multi_query'] = true;
-            } else {
+            if ($queriesToBeExecuted === []) {
                 $queriesToBeExecuted = [$GLOBALS['sql_query']];
             }
 

--- a/src/Controllers/Operations/TableController.php
+++ b/src/Controllers/Operations/TableController.php
@@ -118,7 +118,7 @@ class TableController extends AbstractController
          */
         $this->dbi->selectDb(Current::$database);
 
-        $showTable = $pmaTable->getStatusInfo();
+        $rowFormat = $pmaTable->getStatusInfo('Row_format');
         if ($pmaTable->isView()) {
             $tableIsAView = true;
             $tableStorageEngine = __('View');
@@ -327,7 +327,7 @@ class TableController extends AbstractController
             // a change, clear the cache
             $this->dbi->getCache()->clearTableCache();
             $this->dbi->selectDb(Current::$database);
-            $showTable = $pmaTable->getStatusInfo(forceRead: true);
+            $rowFormat = $pmaTable->getStatusInfo('Row_format');
             if ($pmaTable->isView()) {
                 $tableIsAView = true;
                 $tableStorageEngine = __('View');
@@ -501,7 +501,7 @@ class TableController extends AbstractController
             'collations' => $collations,
             'tbl_collation' => $tableCollation,
             'row_formats' => $possibleRowFormats[$tableStorageEngine] ?? [],
-            'row_format_current' => $showTable['Row_format'],
+            'row_format_current' => $rowFormat,
             'has_auto_increment' => $hasAutoIncrement,
             'auto_increment' => $GLOBALS['auto_increment'],
             'has_pack_keys' => $hasPackKeys,

--- a/src/Controllers/Table/StructureController.php
+++ b/src/Controllers/Table/StructureController.php
@@ -48,7 +48,7 @@ use function strtotime;
  */
 class StructureController extends AbstractController
 {
-    protected readonly Table $tableObj;
+    private readonly Table $tableObj;
 
     public function __construct(
         ResponseRenderer $response,
@@ -150,7 +150,7 @@ class StructureController extends AbstractController
      * @param (string|int)[] $columnsWithIndex       Columns with index
      * @psalm-param non-empty-string $route
      */
-    protected function displayStructure(
+    private function displayStructure(
         RelationParameters $relationParameters,
         array $columnsWithUniqueIndex,
         Index|null $primaryIndex,
@@ -292,7 +292,7 @@ class StructureController extends AbstractController
     /**
      * Get HTML snippet for display table statistics
      */
-    protected function getTableStats(
+    private function getTableStats(
         bool $isSystemSchema,
         bool $tableIsAView,
         string $tableStorageEngine,

--- a/src/Controllers/Table/StructureController.php
+++ b/src/Controllers/Table/StructureController.php
@@ -38,7 +38,6 @@ use stdClass;
 
 use function __;
 use function in_array;
-use function is_string;
 use function str_contains;
 use function strtotime;
 
@@ -300,11 +299,6 @@ class StructureController extends AbstractController
         // Clear the cache as some table information might have gotten changed due to the user action.
         $this->dbi->getCache()->clearTableCache();
         $showTable = $this->tableObj->getStatusInfo();
-        $tableInfoNunRows = $this->tableObj->getNumRows($showTable['Name']);
-
-        if (is_string($showTable)) {
-            $showTable = [];
-        }
 
         if (empty($showTable['Data_length'])) {
             $showTable['Data_length'] = 0;
@@ -353,7 +347,7 @@ class StructureController extends AbstractController
 
         $avgSize = '';
         $avgUnit = '';
-        if ($tableInfoNunRows > 0) {
+        if ($this->tableObj->getNumRows() > 0) {
             [$avgSize, $avgUnit] = Util::formatByteDown(
                 ($showTable['Data_length']
                 + $showTable['Index_length'])
@@ -393,7 +387,6 @@ class StructureController extends AbstractController
             'db' => Current::$database,
             'table' => Current::$table,
             'showtable' => $showTable,
-            'table_info_num_rows' => $tableInfoNunRows,
             'tbl_is_view' => $tableIsAView,
             'db_is_system_schema' => $isSystemSchema,
             'tbl_storage_engine' => $tableStorageEngine,

--- a/src/Controllers/Table/StructureController.php
+++ b/src/Controllers/Table/StructureController.php
@@ -297,7 +297,9 @@ class StructureController extends AbstractController
         bool $tableIsAView,
         string $tableStorageEngine,
     ): string {
-        $showTable = $this->dbi->getTable(Current::$database, Current::$table)->getStatusInfo(forceRead: true);
+        // Clear the cache as some table information might have gotten changed due to the user action.
+        $this->dbi->getCache()->clearTableCache();
+        $showTable = $this->tableObj->getStatusInfo();
         $tableInfoNunRows = $this->tableObj->getNumRows($showTable['Name']);
 
         if (is_string($showTable)) {

--- a/src/Plugins/Schema/Pdf/PdfRelationSchema.php
+++ b/src/Plugins/Schema/Pdf/PdfRelationSchema.php
@@ -537,11 +537,7 @@ class PdfRelationSchema extends ExportRelationSchema
                 $mimeMap = $this->transformations->getMime($this->db->getName(), $table, true);
             }
 
-            /**
-             * Gets table information
-             */
-            $showTable = $dbi->getTable($this->db->getName(), $table)
-                ->getStatusInfo();
+            $showTable = $dbi->getTable($this->db->getName(), $table)->getStatusInfo();
             $showComment = $showTable['Comment'] ?? '';
             $createTime = isset($showTable['Create_time'])
                 ? Util::localisedDate(

--- a/src/Query/Cache.php
+++ b/src/Query/Cache.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Query;
 
-use PhpMyAdmin\Util;
-
 /**
  * Handles caching results
  */
@@ -46,14 +44,19 @@ class Cache
     /**
      * Get a cached value from table cache.
      *
-     * @param (int|string)[] $contentPath Array of the name of the target value
-     * @param mixed          $default     Return value on cache miss
+     * @param T $key
      *
-     * @return mixed cached value or default
+     * @return (T is null ? (string|int|null)[] : (string|int|null))|null
+     *
+     * @template T of string|null
      */
-    public function getCachedTableContent(array $contentPath, mixed $default = null): mixed
+    public function getCachedTableContent(string $db, string $table, string|null $key = null): array|string|int|null
     {
-        return Util::getValueByKey($this->tableCache, $contentPath, $default);
+        if ($key === null) {
+            return $this->tableCache[$db][$table] ?? null;
+        }
+
+        return $this->tableCache[$db][$table][$key] ?? null;
     }
 
     public function clearTableCache(): void

--- a/src/Sql.php
+++ b/src/Sql.php
@@ -1088,7 +1088,6 @@ class Sql
             );
         }
 
-        $_SESSION['is_multi_query'] = false;
         $displayResultsObject->setProperties(
             $unlimNumRows,
             $this->dbi->getFieldsMeta($result),

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -273,21 +273,18 @@ class Table implements Stringable
      * Returns full table status info, or specific if $info provided
      * this info is collected from information_schema
      *
-     * @param string|null $info      specific information to be fetched
-     * @param bool        $forceRead read new rather than serving from cache
+     * @param string|null $info specific information to be fetched
      *
      * @todo DatabaseInterface::getTablesFull needs to be merged
      * somehow into this class or at least better documented
      */
-    public function getStatusInfo(
-        string|null $info = null,
-        bool $forceRead = false,
-    ): mixed {
+    public function getStatusInfo(string|null $info = null): mixed
+    {
         $cachedResult = $this->dbi->getCache()->getCachedTableContent([$this->dbName, $this->name]);
 
         // sometimes there is only one entry (ExactRows) so
         // we have to get the table's details
-        if ($cachedResult === null || $forceRead || count($cachedResult) === 1) {
+        if ($cachedResult === null || count($cachedResult) === 1) {
             $this->dbi->getTablesFull($this->dbName, $this->name);
             $cachedResult = $this->dbi->getCache()->getCachedTableContent([$this->dbName, $this->name]);
         }

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -218,7 +218,7 @@ class Table implements Stringable
 
         // use cached data or load information with SHOW command
         if (
-            $this->dbi->getCache()->getCachedTableContent([$this->dbName, $this->name]) != null
+            $this->dbi->getCache()->getCachedTableContent($this->dbName, $this->name) !== null
             || Config::getInstance()->selectedServer['DisableIS']
         ) {
             $type = $this->getStatusInfo('TABLE_TYPE');
@@ -280,13 +280,13 @@ class Table implements Stringable
      */
     public function getStatusInfo(string|null $info = null): mixed
     {
-        $cachedResult = $this->dbi->getCache()->getCachedTableContent([$this->dbName, $this->name]);
+        $cachedResult = $this->dbi->getCache()->getCachedTableContent($this->dbName, $this->name);
 
         // sometimes there is only one entry (ExactRows) so
         // we have to get the table's details
         if ($cachedResult === null || count($cachedResult) === 1) {
             $this->dbi->getTablesFull($this->dbName, $this->name);
-            $cachedResult = $this->dbi->getCache()->getCachedTableContent([$this->dbName, $this->name]);
+            $cachedResult = $this->dbi->getCache()->getCachedTableContent($this->dbName, $this->name);
         }
 
         if ($cachedResult === null) {
@@ -664,7 +664,7 @@ class Table implements Stringable
         $isView = $this->isView();
         $cache = $this->dbi->getCache();
 
-        $exactRowsCached = $cache->getCachedTableContent([$this->dbName, $this->name, 'ExactRows']);
+        $exactRowsCached = $cache->getCachedTableContent($this->dbName, $this->name, 'ExactRows');
         if ($exactRowsCached !== null) {
             return (int) $exactRowsCached;
         }
@@ -672,11 +672,11 @@ class Table implements Stringable
         $rowCount = null;
 
         if (! $forceExact) {
-            if (($cache->getCachedTableContent([$this->dbName, $this->name, 'Rows']) === null) && ! $isView) {
+            if (($cache->getCachedTableContent($this->dbName, $this->name, 'Rows') === null) && ! $isView) {
                 $this->dbi->getTablesFull($this->dbName, $this->name);
             }
 
-            $rowCount = $cache->getCachedTableContent([$this->dbName, $this->name, 'Rows']);
+            $rowCount = $cache->getCachedTableContent($this->dbName, $this->name, 'Rows');
         }
 
         // for a VIEW, $row_count is always false at this point

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -314,7 +314,7 @@ class Table implements Stringable
      */
     public function getStorageEngine(): string
     {
-        $tableStorageEngine = $this->getStatusInfo('ENGINE', false);
+        $tableStorageEngine = $this->getStatusInfo('ENGINE');
 
         return strtoupper((string) $tableStorageEngine);
     }
@@ -326,7 +326,7 @@ class Table implements Stringable
      */
     public function getComment(): string
     {
-        $tableComment = $this->getStatusInfo('TABLE_COMMENT', false);
+        $tableComment = $this->getStatusInfo('TABLE_COMMENT');
         if ($tableComment === false) {
             return '';
         }
@@ -341,7 +341,7 @@ class Table implements Stringable
      */
     public function getCollation(): string
     {
-        $tableCollation = $this->getStatusInfo('TABLE_COLLATION', false);
+        $tableCollation = $this->getStatusInfo('TABLE_COLLATION');
         if ($tableCollation === false) {
             return '';
         }
@@ -356,7 +356,7 @@ class Table implements Stringable
      */
     public function getNumRows(string $showTableName): int
     {
-        $tableNumRowInfo = $this->getStatusInfo('TABLE_ROWS', false);
+        $tableNumRowInfo = $this->getStatusInfo('TABLE_ROWS');
         if ($tableNumRowInfo === false) {
             $tableNumRowInfo = $this->dbi->getTable($this->dbName, $showTableName)
             ->countRecords(true);
@@ -372,7 +372,7 @@ class Table implements Stringable
      */
     public function getRowFormat(): string
     {
-        $tableRowFormat = $this->getStatusInfo('ROW_FORMAT', false);
+        $tableRowFormat = $this->getStatusInfo('ROW_FORMAT');
 
         return is_string($tableRowFormat) ? $tableRowFormat : '';
     }
@@ -384,7 +384,7 @@ class Table implements Stringable
      */
     public function getAutoIncrement(): string
     {
-        $tableAutoIncrement = $this->getStatusInfo('AUTO_INCREMENT', false);
+        $tableAutoIncrement = $this->getStatusInfo('AUTO_INCREMENT');
 
         return $tableAutoIncrement ?? '';
     }
@@ -396,7 +396,7 @@ class Table implements Stringable
      */
     public function getCreateOptions(): array
     {
-        $tableOptions = $this->getStatusInfo('CREATE_OPTIONS', false);
+        $tableOptions = $this->getStatusInfo('CREATE_OPTIONS');
         $createOptionsTmp = empty($tableOptions) ? [] : explode(' ', $tableOptions);
         $createOptions = [];
         // export create options by its name as variables into global namespace

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -34,7 +34,6 @@ use PhpMyAdmin\Util;
 use Stringable;
 
 use function __;
-use function array_key_exists;
 use function array_keys;
 use function array_map;
 use function array_merge;
@@ -64,10 +63,7 @@ use function strtolower;
 use function strtoupper;
 use function substr;
 use function substr_compare;
-use function trigger_error;
 use function trim;
-
-use const E_USER_WARNING;
 
 /**
  * Handles everything related to tables
@@ -277,9 +273,8 @@ class Table implements Stringable
      * Returns full table status info, or specific if $info provided
      * this info is collected from information_schema
      *
-     * @param string|null $info         specific information to be fetched
-     * @param bool        $forceRead    read new rather than serving from cache
-     * @param bool        $disableError if true, disables error message
+     * @param string|null $info      specific information to be fetched
+     * @param bool        $forceRead read new rather than serving from cache
      *
      * @todo DatabaseInterface::getTablesFull needs to be merged
      * somehow into this class or at least better documented
@@ -287,7 +282,6 @@ class Table implements Stringable
     public function getStatusInfo(
         string|null $info = null,
         bool $forceRead = false,
-        bool $disableError = false,
     ): mixed {
         $cachedResult = $this->dbi->getCache()->getCachedTableContent([$this->dbName, $this->name]);
 
@@ -309,18 +303,6 @@ class Table implements Stringable
             return $cachedResult;
         }
 
-        // array_key_exists allows for null values
-        if (! array_key_exists($info, $cachedResult)) {
-            if (! $disableError) {
-                trigger_error(
-                    __('Unknown table status:') . ' ' . $info,
-                    E_USER_WARNING,
-                );
-            }
-
-            return false;
-        }
-
         return $cachedResult[$info];
     }
 
@@ -332,7 +314,7 @@ class Table implements Stringable
      */
     public function getStorageEngine(): string
     {
-        $tableStorageEngine = $this->getStatusInfo('ENGINE', false, true);
+        $tableStorageEngine = $this->getStatusInfo('ENGINE', false);
 
         return strtoupper((string) $tableStorageEngine);
     }
@@ -344,7 +326,7 @@ class Table implements Stringable
      */
     public function getComment(): string
     {
-        $tableComment = $this->getStatusInfo('TABLE_COMMENT', false, true);
+        $tableComment = $this->getStatusInfo('TABLE_COMMENT', false);
         if ($tableComment === false) {
             return '';
         }
@@ -359,7 +341,7 @@ class Table implements Stringable
      */
     public function getCollation(): string
     {
-        $tableCollation = $this->getStatusInfo('TABLE_COLLATION', false, true);
+        $tableCollation = $this->getStatusInfo('TABLE_COLLATION', false);
         if ($tableCollation === false) {
             return '';
         }
@@ -374,7 +356,7 @@ class Table implements Stringable
      */
     public function getNumRows(string $showTableName): int
     {
-        $tableNumRowInfo = $this->getStatusInfo('TABLE_ROWS', false, true);
+        $tableNumRowInfo = $this->getStatusInfo('TABLE_ROWS', false);
         if ($tableNumRowInfo === false) {
             $tableNumRowInfo = $this->dbi->getTable($this->dbName, $showTableName)
             ->countRecords(true);
@@ -390,7 +372,7 @@ class Table implements Stringable
      */
     public function getRowFormat(): string
     {
-        $tableRowFormat = $this->getStatusInfo('ROW_FORMAT', false, true);
+        $tableRowFormat = $this->getStatusInfo('ROW_FORMAT', false);
 
         return is_string($tableRowFormat) ? $tableRowFormat : '';
     }
@@ -402,7 +384,7 @@ class Table implements Stringable
      */
     public function getAutoIncrement(): string
     {
-        $tableAutoIncrement = $this->getStatusInfo('AUTO_INCREMENT', false, true);
+        $tableAutoIncrement = $this->getStatusInfo('AUTO_INCREMENT', false);
 
         return $tableAutoIncrement ?? '';
     }
@@ -414,7 +396,7 @@ class Table implements Stringable
      */
     public function getCreateOptions(): array
     {
-        $tableOptions = $this->getStatusInfo('CREATE_OPTIONS', false, true);
+        $tableOptions = $this->getStatusInfo('CREATE_OPTIONS', false);
         $createOptionsTmp = empty($tableOptions) ? [] : explode(' ', $tableOptions);
         $createOptions = [];
         // export create options by its name as variables into global namespace

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -289,10 +289,6 @@ class Table implements Stringable
         bool $forceRead = false,
         bool $disableError = false,
     ): mixed {
-        if (! empty($_SESSION['is_multi_query'])) {
-            $disableError = true;
-        }
-
         $cachedResult = $this->dbi->getCache()->getCachedTableContent([$this->dbName, $this->name]);
 
         // sometimes there is only one entry (ExactRows) so

--- a/tests/classes/Table/TableTest.php
+++ b/tests/classes/Table/TableTest.php
@@ -1446,7 +1446,7 @@ class TableTest extends AbstractTestCase
         $extension = new DbiDummy();
         $dbi = new DatabaseInterface($extension);
         $tblObject = new Table($targetTable, $targetDb, $dbi);
-        $tblObject->getStatusInfo(null, true);
+        $tblObject->getStatusInfo(null);
         $expect = 'DBIDUMMY';
         $tblStorageEngine = $dbi->getTable($targetDb, $targetTable)->getStorageEngine();
         $this->assertEquals($expect, $tblStorageEngine);
@@ -1462,7 +1462,7 @@ class TableTest extends AbstractTestCase
         $extension = new DbiDummy();
         $dbi = new DatabaseInterface($extension);
         $tblObject = new Table($targetTable, $targetDb, $dbi);
-        $tblObject->getStatusInfo(null, true);
+        $tblObject->getStatusInfo(null);
         $expect = 'Test comment for "table1" in \'pma_test\'';
         $showComment = $dbi->getTable($targetDb, $targetTable)->getComment();
         $this->assertEquals($expect, $showComment);
@@ -1478,7 +1478,7 @@ class TableTest extends AbstractTestCase
         $extension = new DbiDummy();
         $dbi = new DatabaseInterface($extension);
         $tblObject = new Table($targetTable, $targetDb, $dbi);
-        $tblObject->getStatusInfo(null, true);
+        $tblObject->getStatusInfo(null);
         $expect = 'utf8mb4_general_ci';
         $tblCollation = $dbi->getTable($targetDb, $targetTable)->getCollation();
         $this->assertEquals($expect, $tblCollation);
@@ -1494,7 +1494,7 @@ class TableTest extends AbstractTestCase
         $extension = new DbiDummy();
         $dbi = new DatabaseInterface($extension);
         $tblObject = new Table($targetTable, $targetDb, $dbi);
-        $tblObject->getStatusInfo(null, true);
+        $tblObject->getStatusInfo(null);
         $expect = 'Redundant';
         $rowFormat = $dbi->getTable($targetDb, $targetTable)->getRowFormat();
         $this->assertEquals($expect, $rowFormat);
@@ -1510,7 +1510,7 @@ class TableTest extends AbstractTestCase
         $extension = new DbiDummy();
         $dbi = new DatabaseInterface($extension);
         $tblObject = new Table($targetTable, $targetDb, $dbi);
-        $tblObject->getStatusInfo(null, true);
+        $tblObject->getStatusInfo(null);
         $expect = '5';
         $autoIncrement = $dbi->getTable($targetDb, $targetTable)->getAutoIncrement();
         $this->assertEquals($expect, $autoIncrement);
@@ -1526,7 +1526,7 @@ class TableTest extends AbstractTestCase
         $extension = new DbiDummy();
         $dbi = new DatabaseInterface($extension);
         $tblObject = new Table($targetTable, $targetDb, $dbi);
-        $tblObject->getStatusInfo(null, true);
+        $tblObject->getStatusInfo(null);
         $expect = ['pack_keys' => 'DEFAULT', 'row_format' => 'REDUNDANT'];
         $createOptions = $dbi->getTable($targetDb, $targetTable)->getCreateOptions();
         $this->assertEquals($expect, $createOptions);


### PR DESCRIPTION
Hopefully, this doesn't break anything. I removed `trigger_error` as mentioned in https://github.com/phpmyadmin/phpmyadmin/pull/18856#issuecomment-1868440684 The SESSION stuff didn't seem to have any purpose and I hope it's just something from the past. Either way, it should not be inside this method. 

The `$forceRead` param doesn't seem necessary to me as it makes more sense to just clear the cache. 

I have propagated the type hints and changed the sentinel value to be `null`. 