### PR TITLE
Remove last uses of escapeString

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,13 +121,8 @@ parameters:
 			path: src/Advisory/Advisor.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: src/Bookmarks/Bookmark.php
-
-		-
-			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:escapeString\\(\\) expects string, mixed given\\.$#"
-			count: 1
+			message: "#^Parameter \\#2 \\$replace of function str_replace expects array\\|string, mixed given\\.$#"
+			count: 2
 			path: src/Bookmarks/Bookmark.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6441,6 +6441,11 @@ parameters:
 			path: src/CreateAddField.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/CreateAddField.php
+
+		-
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 2
 			path: src/CreateAddField.php
@@ -6487,11 +6492,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$partition of method PhpMyAdmin\\\\CreateAddField\\:\\:getPartitionDefinition\\(\\) expects array, mixed given\\.$#"
-			count: 2
-			path: src/CreateAddField.php
-
-		-
-			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:escapeString\\(\\) expects string, mixed given\\.$#"
 			count: 2
 			path: src/CreateAddField.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10506,6 +10506,11 @@ parameters:
 			path: src/Operations.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Operations.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 9
 			path: src/Operations.php
@@ -10533,11 +10538,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$query of method PhpMyAdmin\\\\DatabaseInterface\\:\\:query\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
-			path: src/Operations.php
-
-		-
-			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:escapeString\\(\\) expects string, mixed given\\.$#"
-			count: 2
 			path: src/Operations.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -40,12 +40,13 @@
     </MixedAssignment>
   </file>
   <file src="src/Bookmarks/Bookmark.php">
-    <DeprecatedMethod>
-      <code>escapeString</code>
-    </DeprecatedMethod>
     <MixedArgument>
-      <code>$variables[$i]</code>
+      <code>$var</code>
+      <code>$var</code>
     </MixedArgument>
+    <MixedAssignment>
+      <code>$var</code>
+    </MixedAssignment>
     <PossiblyUnusedMethod>
       <code>getDatabase</code>
     </PossiblyUnusedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5125,7 +5125,6 @@
       <code><![CDATA[$this->connections[$connectionType]]]></code>
       <code><![CDATA[$this->connections[$connectionType]]]></code>
       <code><![CDATA[$this->connections[$connectionType]]]></code>
-      <code><![CDATA[$this->connections[$connectionType]]]></code>
       <code><![CDATA[$this->versionComment]]></code>
       <code><![CDATA[$this->versionString]]></code>
     </MixedArgument>
@@ -13830,8 +13829,6 @@
   <file src="tests/classes/Dbal/DbiDummyTest.php">
     <DeprecatedMethod>
       <code>Config::getInstance()</code>
-      <code>escapeString</code>
-      <code>escapeString</code>
     </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code>errorData</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7452,10 +7452,6 @@
     </RedundantCast>
   </file>
   <file src="src/Operations.php">
-    <DeprecatedMethod>
-      <code>escapeString</code>
-      <code>escapeString</code>
-    </DeprecatedMethod>
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['auto_increment']]]></code>
     </InvalidArrayOffset>
@@ -7573,23 +7569,19 @@
     <PossiblyInvalidArgument>
       <code><![CDATA[$_POST['comment']]]></code>
       <code><![CDATA[$_POST['db_collation']]]></code>
-      <code><![CDATA[$_POST['new_auto_increment']]]></code>
       <code><![CDATA[$_POST['prev_comment']]]></code>
       <code><![CDATA[$_POST['tbl_collation']]]></code>
       <code><![CDATA[$_POST['what']]]></code>
       <code><![CDATA[$copyMode ?? 'data']]></code>
-      <code>$newRowFormat</code>
       <code>$newRowFormat</code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast>
       <code><![CDATA[$_POST['comment']]]></code>
       <code><![CDATA[$_POST['db_collation']]]></code>
-      <code><![CDATA[$_POST['new_auto_increment']]]></code>
       <code><![CDATA[$_POST['prev_comment']]]></code>
       <code><![CDATA[$_POST['tbl_collation']]]></code>
       <code><![CDATA[$_POST['what']]]></code>
       <code><![CDATA[$copyMode ?? 'data']]></code>
-      <code>$newRowFormat</code>
       <code>$newRowFormat</code>
     </PossiblyInvalidCast>
     <PossiblyInvalidOperand>
@@ -7611,6 +7603,9 @@
     <RedundantCondition>
       <code>$copyMode</code>
     </RedundantCondition>
+    <RiskyCast>
+      <code><![CDATA[$_POST['new_auto_increment']]]></code>
+    </RiskyCast>
     <TypeDoesNotContainNull>
       <code><![CDATA['data']]></code>
     </TypeDoesNotContainNull>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4381,10 +4381,6 @@
     </UnsupportedReferenceUsage>
   </file>
   <file src="src/CreateAddField.php">
-    <DeprecatedMethod>
-      <code>escapeString</code>
-      <code>escapeString</code>
-    </DeprecatedMethod>
     <MixedArgument>
       <code><![CDATA[$_POST['field_name'][$column['col_index']]]]></code>
       <code><![CDATA[$_POST['field_name'][$i]]]></code>
@@ -4394,9 +4390,7 @@
       <code>$index</code>
       <code>$index</code>
       <code><![CDATA[$index['Index_comment']]]></code>
-      <code><![CDATA[$index['Key_block_size']]]></code>
       <code><![CDATA[$index['Key_name']]]></code>
-      <code><![CDATA[$index['Parser']]]></code>
       <code>$partition</code>
       <code>$subpartition</code>
     </MixedArgument>
@@ -4430,6 +4424,7 @@
     </MixedAssignment>
     <MixedOperand>
       <code><![CDATA[$column['size']]]></code>
+      <code><![CDATA[$index['Parser']]]></code>
       <code><![CDATA[$partition['comment']]]></code>
       <code><![CDATA[$partition['data_directory']]]></code>
       <code><![CDATA[$partition['engine']]]></code>

--- a/src/Bookmarks/Bookmark.php
+++ b/src/Bookmarks/Bookmark.php
@@ -137,10 +137,7 @@ class Bookmark
         // replace variable placeholders with values
         $numberOfVariables = $this->getVariableCount();
         for ($i = 1; $i <= $numberOfVariables; $i++) {
-            $var = '';
-            if (! empty($variables[$i])) {
-                $var = $this->dbi->escapeString($variables[$i]);
-            }
+            $var = $variables[$i] ?? '';
 
             $query = str_replace('[VARIABLE' . $i . ']', $var, $query);
             // backward compatibility

--- a/src/CreateAddField.php
+++ b/src/CreateAddField.php
@@ -165,8 +165,7 @@ class CreateAddField
         $sqlQuery .= ' (' . implode(', ', $indexFields) . ')';
 
         if ($index['Key_block_size']) {
-            $sqlQuery .= ' KEY_BLOCK_SIZE = '
-                 . $this->dbi->escapeString($index['Key_block_size']);
+            $sqlQuery .= ' KEY_BLOCK_SIZE = ' . (int) $index['Key_block_size'];
         }
 
         // specifying index type is allowed only for primary, unique and index only
@@ -179,7 +178,7 @@ class CreateAddField
         }
 
         if ($index['Index_choice'] === 'FULLTEXT' && $index['Parser']) {
-            $sqlQuery .= ' WITH PARSER ' . $this->dbi->escapeString($index['Parser']);
+            $sqlQuery .= ' WITH PARSER ' . $index['Parser'];
         }
 
         if ($index['Index_comment']) {

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -1879,25 +1879,6 @@ class DatabaseInterface implements DbalInterface
     }
 
     /**
-     * returns properly escaped string for use in MySQL queries
-     *
-     * @deprecated Use {@see quoteString()} instead.
-     *
-     * @param string $str string to be escaped
-     * @psalm-param ConnectionType $connectionType
-     *
-     * @return string a MySQL escaped string
-     */
-    public function escapeString(string $str, int $connectionType = Connection::TYPE_USER): string
-    {
-        if (isset($this->connections[$connectionType])) {
-            return $this->extension->escapeString($this->connections[$connectionType], $str);
-        }
-
-        return $str;
-    }
-
-    /**
      * Returns properly escaped string for use in MySQL LIKE clauses.
      * This method escapes only _, %, and /. It does not escape quotes or any other characters.
      *

--- a/src/Dbal/DbalInterface.php
+++ b/src/Dbal/DbalInterface.php
@@ -564,18 +564,6 @@ interface DbalInterface
     public function quoteString(string $str, int $connectionType = Connection::TYPE_USER): string;
 
     /**
-     * returns properly escaped string for use in MySQL queries
-     *
-     * @deprecated Use {@see quoteString()} instead.
-     *
-     * @param string $str string to be escaped
-     * @psalm-param ConnectionType $connectionType
-     *
-     * @return string a MySQL escaped string
-     */
-    public function escapeString(string $str, int $connectionType = Connection::TYPE_USER): string;
-
-    /**
      * Returns properly escaped string for use in MySQL LIKE clauses.
      * This method escapes only _, %, and /. It does not escape quotes or any other characters.
      *

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -18,6 +18,7 @@ use function __;
 use function array_merge;
 use function count;
 use function explode;
+use function in_array;
 use function is_scalar;
 use function is_string;
 use function mb_strtolower;
@@ -677,8 +678,7 @@ class Operations
             || $_POST['new_auto_increment'] !== $GLOBALS['auto_increment'])
             && $_POST['new_auto_increment'] !== $_POST['hidden_auto_increment']
         ) {
-            $tableAlters[] = 'auto_increment = '
-                . $this->dbi->escapeString($_POST['new_auto_increment']);
+            $tableAlters[] = 'auto_increment = ' . (int) $_POST['new_auto_increment'];
         }
 
         if (! empty($_POST['new_row_format'])) {
@@ -686,11 +686,10 @@ class Operations
             $newRowFormatLower = mb_strtolower($newRowFormat);
             if (
                 $pmaTable->isEngine(['MYISAM', 'ARIA', 'INNODB', 'PBXT'])
-                && ($rowFormat === ''
-                || $newRowFormatLower !== mb_strtolower($rowFormat))
+                && ($rowFormat === '' || $newRowFormatLower !== mb_strtolower($rowFormat))
+                && in_array($newRowFormat, ['DEFAULT', 'DYNAMIC', 'FIXED', 'COMPRESSED', 'REDUNDANT', 'COMPACT'], true)
             ) {
-                $tableAlters[] = 'ROW_FORMAT = '
-                    . $this->dbi->escapeString($newRowFormat);
+                $tableAlters[] = 'ROW_FORMAT = ' . $newRowFormat;
             }
         }
 

--- a/tests/classes/Dbal/DbiDummyTest.php
+++ b/tests/classes/Dbal/DbiDummyTest.php
@@ -112,19 +112,4 @@ class DbiDummyTest extends AbstractTestCase
             ],
         ];
     }
-
-    /**
-     * Test for string escaping
-     */
-    public function testEscapeString(): void
-    {
-        $this->assertEquals(
-            'a',
-            $this->dbi->escapeString('a'),
-        );
-        $this->assertEquals(
-            'a\\\'',
-            $this->dbi->escapeString('a\''),
-        );
-    }
 }


### PR DESCRIPTION
I tackle the remaining usages in the following ways:
- `auto_increment` and `KEY_BLOCK_SIZE` should always be integers so I cast them to int
- `ROW_FORMAT` can only be one of selected keywords. I added a whitelist. 
- `Parser` is a user-provided name of the parser. It's neither a string nor a keyword. It's a dynamic part of SQL so it cannot be escaped by PMA. 
- Bookmark's variables should probably be untouched by PMA. The user may provide an integer, string, SQL, or anything else as a value. We cannot escape it and treating it as a string is limiting users. This is a change in the functionality. Users now must provide properly formatted strings as values when executing bookmarks. 