### PR TITLE
Refactor relation

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16667,7 +16667,7 @@ parameters:
 
 		-
 			message: "#^Property PhpMyAdmin\\\\Config\\:\\:\\$selectedServer \\(array\\{host\\: string, port\\: string, socket\\: string, ssl\\: bool, ssl_key\\: string\\|null, ssl_cert\\: string\\|null, ssl_ca\\: string\\|null, ssl_ca_path\\: string\\|null, \\.\\.\\.\\}\\) does not accept array\\{\\}\\.$#"
-			count: 6
+			count: 5
 			path: tests/classes/ConfigStorage/RelationTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -12782,7 +12782,6 @@
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
-      <code>Config::getInstance()</code>
     </DeprecatedMethod>
     <DocblockTypeContradiction>
       <code>assertSame</code>
@@ -12872,28 +12871,6 @@
       <code><![CDATA[$config->selectedServer]]></code>
       <code><![CDATA[$config->selectedServer]]></code>
       <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code><![CDATA[$config->selectedServer]]></code>
-      <code>[]</code>
       <code>[]</code>
       <code>[]</code>
       <code>[]</code>
@@ -12913,7 +12890,6 @@
       <code>assertSame</code>
     </RedundantConditionGivenDocblockType>
     <TypeDoesNotContainType>
-      <code>assertSame</code>
       <code>assertSame</code>
       <code>assertSame</code>
       <code>assertSame</code>

--- a/src/ConfigStorage/Relation.php
+++ b/src/ConfigStorage/Relation.php
@@ -247,7 +247,6 @@ class Relation
             || $config->selectedServer['pmadb'] === ''
             || ! $this->dbi->selectDb($config->selectedServer['pmadb'], Connection::TYPE_CONTROL)
         ) {
-            // No server selected -> no bookmark table
             $config->selectedServer['pmadb'] = '';
 
             return $relationParams;
@@ -256,22 +255,13 @@ class Relation
         $relationParams['user'] = $config->selectedServer['user'];
         $relationParams['db'] = $config->selectedServer['pmadb'];
 
-        //  Now I just check if all tables that i need are present so I can for
-        //  example enable relations but not pdf...
-        //  I was thinking of checking if they have all required columns but I
-        //  fear it might be too slow
-
         $relationParamsFilled = $this->fillRelationParamsWithTableNames($relationParams);
 
         if ($relationParamsFilled === null) {
-            // query failed ... ?
             return $relationParams;
         }
 
-        // Filling did success
-        $relationParams = $relationParamsFilled;
-
-        $relationParams = $this->checkTableAccess($relationParams);
+        $relationParams = $this->checkTableAccess($relationParamsFilled);
 
         $allWorks = true;
         foreach ($workToTable as $work => $table) {

--- a/src/ConfigStorage/Relation.php
+++ b/src/ConfigStorage/Relation.php
@@ -81,34 +81,22 @@ class Relation
     private function checkTableAccess(array $relationParams): array
     {
         if (isset($relationParams['relation'], $relationParams['table_info'])) {
-            if ($this->canAccessStorageTable((string) $relationParams['table_info'])) {
-                $relationParams['displaywork'] = true;
-            }
+            $relationParams['displaywork'] = true;
         }
 
         if (isset($relationParams['table_coords'], $relationParams['pdf_pages'])) {
-            if ($this->canAccessStorageTable((string) $relationParams['table_coords'])) {
-                if ($this->canAccessStorageTable((string) $relationParams['pdf_pages'])) {
-                    $relationParams['pdfwork'] = true;
-                }
-            }
+            $relationParams['pdfwork'] = true;
         }
 
         if (isset($relationParams['column_info'])) {
-            if ($this->canAccessStorageTable((string) $relationParams['column_info'])) {
-                $relationParams['commwork'] = true;
-                // phpMyAdmin 4.3+
-                // Check for input transformations upgrade.
-                $relationParams['mimework'] = $this->tryUpgradeTransformations();
-            }
+            $relationParams['commwork'] = true;
+            // phpMyAdmin 4.3+
+            // Check for input transformations upgrade.
+            $relationParams['mimework'] = $this->tryUpgradeTransformations();
         }
 
         if (isset($relationParams['users'], $relationParams['usergroups'])) {
-            if ($this->canAccessStorageTable((string) $relationParams['users'])) {
-                if ($this->canAccessStorageTable((string) $relationParams['usergroups'])) {
-                    $relationParams['menuswork'] = true;
-                }
-            }
+            $relationParams['menuswork'] = true;
         }
 
         $settings = [
@@ -129,10 +117,6 @@ class Relation
 
         foreach ($settings as $setingName => $worksKey) {
             if (! isset($relationParams[$setingName])) {
-                continue;
-            }
-
-            if (! $this->canAccessStorageTable((string) $relationParams[$setingName])) {
                 continue;
             }
 
@@ -293,18 +277,6 @@ class Relation
         $relationParams['allworks'] = $allWorks;
 
         return $relationParams;
-    }
-
-    /**
-     * Check if the table is accessible
-     *
-     * @param string $tableDbName The table or table.db
-     */
-    public function canAccessStorageTable(string $tableDbName): bool
-    {
-        $result = $this->dbi->tryQueryAsControlUser('SELECT NULL FROM ' . Util::backquote($tableDbName) . ' LIMIT 0');
-
-        return $result !== false;
     }
 
     /**

--- a/src/ConfigStorage/Relation.php
+++ b/src/ConfigStorage/Relation.php
@@ -1513,8 +1513,7 @@ class Relation
 
         $config->selectedServer['pmadb'] = $db;
 
-        //NOTE: I am unsure why we do that, as it defeats the purpose of the session cache
-        // Unset the cache
+        // Unset the cache as new tables might have been added
         self::$cache = null;
         // Fill back the cache
         $this->getRelationParameters();

--- a/src/ConfigStorage/Relation.php
+++ b/src/ConfigStorage/Relation.php
@@ -154,52 +154,50 @@ class Relation
         }
 
         $config = Config::getInstance();
-        $tabQuery = 'SHOW TABLES FROM '
-        . Util::backquote($config->selectedServer['pmadb']);
-        $tableRes = $this->dbi->tryQueryAsControlUser($tabQuery);
-        if ($tableRes === false) {
+        $tables = $this->dbi->getTables($config->selectedServer['pmadb'], Connection::TYPE_CONTROL);
+        if ($tables === []) {
             return null;
         }
 
-        while ($currTable = $tableRes->fetchRow()) {
-            if ($currTable[0] == $config->selectedServer['bookmarktable']) {
-                $relationParams['bookmark'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['relation']) {
-                $relationParams['relation'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['table_info']) {
-                $relationParams['table_info'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['table_coords']) {
-                $relationParams['table_coords'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['column_info']) {
-                $relationParams['column_info'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['pdf_pages']) {
-                $relationParams['pdf_pages'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['history']) {
-                $relationParams['history'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['recent']) {
-                $relationParams['recent'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['favorite']) {
-                $relationParams['favorite'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['table_uiprefs']) {
-                $relationParams['table_uiprefs'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['tracking']) {
-                $relationParams['tracking'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['userconfig']) {
-                $relationParams['userconfig'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['users']) {
-                $relationParams['users'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['usergroups']) {
-                $relationParams['usergroups'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['navigationhiding']) {
-                $relationParams['navigationhiding'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['savedsearches']) {
-                $relationParams['savedsearches'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['central_columns']) {
-                $relationParams['central_columns'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['designer_settings']) {
-                $relationParams['designer_settings'] = (string) $currTable[0];
-            } elseif ($currTable[0] == $config->selectedServer['export_templates']) {
-                $relationParams['export_templates'] = (string) $currTable[0];
+        foreach ($tables as $currTable) {
+            if ($currTable == $config->selectedServer['bookmarktable']) {
+                $relationParams['bookmark'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['relation']) {
+                $relationParams['relation'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['table_info']) {
+                $relationParams['table_info'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['table_coords']) {
+                $relationParams['table_coords'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['column_info']) {
+                $relationParams['column_info'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['pdf_pages']) {
+                $relationParams['pdf_pages'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['history']) {
+                $relationParams['history'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['recent']) {
+                $relationParams['recent'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['favorite']) {
+                $relationParams['favorite'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['table_uiprefs']) {
+                $relationParams['table_uiprefs'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['tracking']) {
+                $relationParams['tracking'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['userconfig']) {
+                $relationParams['userconfig'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['users']) {
+                $relationParams['users'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['usergroups']) {
+                $relationParams['usergroups'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['navigationhiding']) {
+                $relationParams['navigationhiding'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['savedsearches']) {
+                $relationParams['savedsearches'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['central_columns']) {
+                $relationParams['central_columns'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['designer_settings']) {
+                $relationParams['designer_settings'] = $currTable;
+            } elseif ($currTable == $config->selectedServer['export_templates']) {
+                $relationParams['export_templates'] = $currTable;
             }
         }
 

--- a/tests/classes/ConfigStorage/RelationTest.php
+++ b/tests/classes/ConfigStorage/RelationTest.php
@@ -234,7 +234,7 @@ class RelationTest extends AbstractTestCase
         );
 
         $dummyDbi->addResult(
-            'SHOW TABLES FROM `db_pma`',
+            'SHOW TABLES FROM `db_pma`;',
             [['pma__userconfig']],
             ['Tables_in_db_pma'],
         );
@@ -296,7 +296,7 @@ class RelationTest extends AbstractTestCase
         );
 
         $dummyDbi->addResult(
-            'SHOW TABLES FROM `db_pma`',
+            'SHOW TABLES FROM `db_pma`;',
             [['pma__userconfig']],
             ['Tables_in_db_pma'],
         );
@@ -573,7 +573,7 @@ class RelationTest extends AbstractTestCase
         );
 
         $dummyDbi->addResult(
-            'SHOW TABLES FROM `db_pma`',
+            'SHOW TABLES FROM `db_pma`;',
             [
                 ['pma__userconfig'],
                 // This is important as it tricks default existing table detection
@@ -897,7 +897,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addResult('CREATE DATABASE IF NOT EXISTS `phpmyadmin`', true);
 
         $dummyDbi->addResult(
-            'SHOW TABLES FROM `phpmyadmin`',
+            'SHOW TABLES FROM `phpmyadmin`;',
             [],
         );
         $dummyDbi->addSelectDb('phpmyadmin');
@@ -1483,7 +1483,7 @@ class RelationTest extends AbstractTestCase
         );
 
         $dummyDbi->addResult(
-            'SHOW TABLES FROM `phpmyadmin`',
+            'SHOW TABLES FROM `phpmyadmin`;',
             [['pma__userconfig']],
             ['Tables_in_phpmyadmin'],
         );
@@ -1570,7 +1570,7 @@ class RelationTest extends AbstractTestCase
         );
 
         $dummyDbi->addResult(
-            'SHOW TABLES FROM `phpmyadmin`',
+            'SHOW TABLES FROM `phpmyadmin`;',
             [['pma__userconfig']],
             ['Tables_in_phpmyadmin'],
         );
@@ -1656,7 +1656,7 @@ class RelationTest extends AbstractTestCase
         );
 
         $dummyDbi->addResult(
-            'SHOW TABLES FROM `PMA-storage`',
+            'SHOW TABLES FROM `PMA-storage`;',
             [['pma__userconfig_custom', 'pma__usergroups']],
             ['Tables_in_PMA-storage'],
         );
@@ -1681,7 +1681,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->assertAllSelectsConsumed();
 
         $dummyDbi->addResult(
-            'SHOW TABLES FROM `PMA-storage`',
+            'SHOW TABLES FROM `PMA-storage`;',
             [['pma__userconfig_custom', 'pma__usergroups']],
             ['Tables_in_PMA-storage'],
         );
@@ -1766,7 +1766,7 @@ class RelationTest extends AbstractTestCase
             ['Tables_in_PMA-storage'],
         );
         $dummyDbi->addResult(
-            'SHOW TABLES FROM `PMA-storage`',
+            'SHOW TABLES FROM `PMA-storage`;',
             [
                 ['pma__tracking'],
             ],
@@ -1796,7 +1796,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->assertAllSelectsConsumed();
 
         $dummyDbi->addResult(
-            'SHOW TABLES FROM `PMA-storage`',
+            'SHOW TABLES FROM `PMA-storage`;',
             [
                 [
                     'pma__userconfig_custom',
@@ -1888,7 +1888,7 @@ class RelationTest extends AbstractTestCase
         );
 
         $dummyDbi->addResult(
-            'SHOW TABLES FROM `PMA-storage`',
+            'SHOW TABLES FROM `PMA-storage`;',
             [
                 ['pma__favorite_custom'],
             ],

--- a/tests/classes/ConfigStorage/RelationTest.php
+++ b/tests/classes/ConfigStorage/RelationTest.php
@@ -239,7 +239,6 @@ class RelationTest extends AbstractTestCase
             ['Tables_in_db_pma'],
         );
 
-        $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', []);
         $dummyDbi->addSelectDb('db_pma');
 
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
@@ -301,7 +300,6 @@ class RelationTest extends AbstractTestCase
             ['Tables_in_db_pma'],
         );
 
-        $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', []);
         $dummyDbi->addSelectDb('db_pma');
         $dummyDbi->addSelectDb('db_pma');
 
@@ -582,8 +580,6 @@ class RelationTest extends AbstractTestCase
             ],
             ['Tables_in_db_pma'],
         );
-
-        $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', []);
 
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -1488,8 +1484,6 @@ class RelationTest extends AbstractTestCase
             ['Tables_in_phpmyadmin'],
         );
 
-        $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', [], ['NULL']);
-
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         $dummyDbi->addSelectDb('phpmyadmin');
@@ -1501,92 +1495,6 @@ class RelationTest extends AbstractTestCase
         $relationParameters = RelationParameters::fromArray([
             'db' => 'phpmyadmin',
             'userconfigwork' => true,
-            'userconfig' => 'pma__userconfig',
-        ]);
-        $this->assertSame($relationParameters->toArray(), $relation->getRelationParameters()->toArray());
-
-        $this->assertSame([
-            'user' => '',
-            'pmadb' => 'phpmyadmin',
-            'bookmarktable' => '',
-            'relation' => '',
-            'table_info' => '',
-            'table_coords' => '',
-            'column_info' => '',
-            'pdf_pages' => '',
-            'history' => '',
-            'recent' => '',
-            'favorite' => '',
-            'table_uiprefs' => '',
-            'tracking' => '',
-            'userconfig' => 'pma__userconfig',
-            'users' => '',
-            'usergroups' => '',
-            'navigationhiding' => '',
-            'savedsearches' => '',
-            'central_columns' => '',
-            'designer_settings' => '',
-            'export_templates' => '',
-        ], $config->selectedServer);
-
-        $dummyDbi->assertAllQueriesConsumed();
-    }
-
-    public function testInitRelationParamsCacheDefaultDbNameDbExistsFirstServerNotWorkingTable(): void
-    {
-        Current::$database = '';
-        $config = Config::getInstance();
-        $config->selectedServer = [];
-        $config->selectedServer['user'] = '';
-        $config->selectedServer['pmadb'] = '';
-        $config->selectedServer['bookmarktable'] = '';
-        $config->selectedServer['relation'] = '';
-        $config->selectedServer['table_info'] = '';
-        $config->selectedServer['table_coords'] = '';
-        $config->selectedServer['column_info'] = '';
-        $config->selectedServer['pdf_pages'] = '';
-        $config->selectedServer['history'] = '';
-        $config->selectedServer['recent'] = '';
-        $config->selectedServer['favorite'] = '';
-        $config->selectedServer['table_uiprefs'] = '';
-        $config->selectedServer['tracking'] = '';
-        $config->selectedServer['userconfig'] = '';
-        $config->selectedServer['users'] = '';
-        $config->selectedServer['usergroups'] = '';
-        $config->selectedServer['navigationhiding'] = '';
-        $config->selectedServer['savedsearches'] = '';
-        $config->selectedServer['central_columns'] = '';
-        $config->selectedServer['designer_settings'] = '';
-        $config->selectedServer['export_templates'] = '';
-
-        $dummyDbi = $this->createDbiDummy();
-        $dbi = $this->createDatabaseInterface($dummyDbi);
-
-        $dummyDbi->removeDefaultResults();
-        $dummyDbi->addResult(
-            'SHOW TABLES FROM `phpmyadmin`;',
-            [['pma__userconfig']],
-            ['Tables_in_phpmyadmin'],
-        );
-
-        $dummyDbi->addResult(
-            'SHOW TABLES FROM `phpmyadmin`;',
-            [['pma__userconfig']],
-            ['Tables_in_phpmyadmin'],
-        );
-
-        $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', false);
-
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
-
-        $dummyDbi->addSelectDb('phpmyadmin');
-        $relation = new Relation($dbi);
-        $relation->initRelationParamsCache();
-        $dummyDbi->assertAllSelectsConsumed();
-
-        $relationParameters = RelationParameters::fromArray([
-            'db' => 'phpmyadmin',
-            'userconfigwork' => false,
             'userconfig' => 'pma__userconfig',
         ]);
         $this->assertSame($relationParameters->toArray(), $relation->getRelationParameters()->toArray());
@@ -1661,8 +1569,6 @@ class RelationTest extends AbstractTestCase
             ['Tables_in_PMA-storage'],
         );
 
-        $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig_custom` LIMIT 0', [], ['NULL']);
-
         $dummyDbi->addSelectDb('PMA-storage');
 
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
@@ -1685,8 +1591,6 @@ class RelationTest extends AbstractTestCase
             [['pma__userconfig_custom', 'pma__usergroups']],
             ['Tables_in_PMA-storage'],
         );
-
-        $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig_custom` LIMIT 0', [], ['NULL']);
 
         $dummyDbi->addSelectDb('PMA-storage');
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
@@ -1894,8 +1798,6 @@ class RelationTest extends AbstractTestCase
             ],
             ['Tables_in_PMA-storage'],
         );
-
-        $dummyDbi->addResult('SELECT NULL FROM `pma__favorite_custom` LIMIT 0', [], ['NULL']);
 
         $_SESSION['tmpval'] = [];
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);

--- a/tests/classes/Stubs/DbiDummy.php
+++ b/tests/classes/Stubs/DbiDummy.php
@@ -852,7 +852,7 @@ class DbiDummy implements DbiExtension
                 'result' => [['utf8_general_ci']],
             ],
             ['query' => 'SELECT @@collation_database', 'columns' => ['@@collation_database'], 'result' => [['bar']]],
-            ['query' => 'SHOW TABLES FROM `phpmyadmin`', 'result' => []],
+            ['query' => 'SHOW TABLES FROM `phpmyadmin`;', 'result' => []],
             [
                 'query' => 'SELECT tracking_active FROM `pmadb`.`tracking`' .
                     " WHERE db_name = 'pma_test_db'" .


### PR DESCRIPTION
Related to #18710

This removes checks for access to PMA tables. I really don't think we need to do this. If the control user doesn't have the privilege to access them, then `SHOW TABLES` will not list them. I doubt they would be inaccessible for any other reason. This should improve performance on slow systems. 