### PR TITLE
Remove mb_str* functions when used in bool context

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7741,13 +7741,8 @@ parameters:
 			path: src/Display/Results.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function mb_strpos expects string, mixed given\\.$#"
-			count: 2
-			path: src/Display/Results.php
-
-		-
 			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, mixed given\\.$#"
-			count: 1
+			count: 3
 			path: src/Display/Results.php
 
 		-
@@ -8156,11 +8151,6 @@ parameters:
 			path: src/Export/Export.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\<0, max\\>\\|false given\\.$#"
-			count: 2
-			path: src/Export/Export.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
 			count: 1
 			path: src/Export/Export.php
@@ -8227,11 +8217,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in &&, bool\\|int\\<0, max\\>\\|string given on the right side\\.$#"
-			count: 1
-			path: src/Export/Options.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\<0, max\\>\\|false given\\.$#"
 			count: 1
 			path: src/Export/Options.php
 
@@ -10796,11 +10781,6 @@ parameters:
 			path: src/Plugins.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, int\\<0, max\\>\\|false given\\.$#"
-			count: 2
-			path: src/Plugins.php
-
-		-
 			message: "#^Parameter \\#1 \\$link of static method PhpMyAdmin\\\\Html\\\\MySQLDocumentation\\:\\:show\\(\\) expects string, mixed given\\.$#"
 			count: 2
 			path: src/Plugins.php
@@ -11601,11 +11581,6 @@ parameters:
 			path: src/Plugins/Export/ExportSql.php
 
 		-
-			message: "#^Casting to int something that's already int\\<1, max\\>\\.$#"
-			count: 1
-			path: src/Plugins/Export/ExportSql.php
-
-		-
 			message: "#^Casting to string something that's already string\\.$#"
 			count: 2
 			path: src/Plugins/Export/ExportSql.php
@@ -11626,11 +11601,6 @@ parameters:
 			path: src/Plugins/Export/ExportSql.php
 
 		-
-			message: "#^Only booleans are allowed in an elseif condition, int\\<0, max\\>\\|false given\\.$#"
-			count: 2
-			path: src/Plugins/Export/ExportSql.php
-
-		-
 			message: "#^Only booleans are allowed in an elseif condition, mixed given\\.$#"
 			count: 1
 			path: src/Plugins/Export/ExportSql.php
@@ -11638,11 +11608,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an if condition, bool\\|null given\\.$#"
 			count: 1
-			path: src/Plugins/Export/ExportSql.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\<0, max\\>\\|false given\\.$#"
-			count: 2
 			path: src/Plugins/Export/ExportSql.php
 
 		-
@@ -11676,7 +11641,7 @@ parameters:
 			path: src/Plugins/Export/ExportSql.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function mb_strpos expects string, string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, string\\|null given\\.$#"
 			count: 3
 			path: src/Plugins/Export/ExportSql.php
 
@@ -15153,11 +15118,6 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 3
-			path: src/Table/Search.php
-
-		-
-			message: "#^Only booleans are allowed in \\|\\|, int\\<0, max\\>\\|false given on the right side\\.$#"
-			count: 1
 			path: src/Table/Search.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -462,17 +462,12 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
-			count: 3
+			count: 2
 			path: src/Config.php
 
 		-
 			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
 			count: 6
-			path: src/Config.php
-
-		-
-			message: "#^Only booleans are allowed in an elseif condition, string\\|false given\\.$#"
-			count: 4
 			path: src/Config.php
 
 		-
@@ -487,7 +482,7 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
-			count: 4
+			count: 2
 			path: src/Config.php
 
 		-
@@ -511,7 +506,7 @@ parameters:
 			path: src/Config.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function mb_strstr expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, mixed given\\.$#"
 			count: 1
 			path: src/Config.php
 
@@ -8991,11 +8986,6 @@ parameters:
 			path: src/Html/Generator.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
-			count: 1
-			path: src/Html/Generator.php
-
-		-
 			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
 			count: 1
 			path: src/Html/Generator.php
@@ -9007,7 +8997,7 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
-			count: 3
+			count: 1
 			path: src/Html/Generator.php
 
 		-
@@ -9586,11 +9576,6 @@ parameters:
 			path: src/InsertEdit.php
 
 		-
-			message: "#^Only booleans are allowed in &&, string\\|false given on the right side\\.$#"
-			count: 2
-			path: src/InsertEdit.php
-
-		-
 			message: "#^Only booleans are allowed in &&, string\\|null given on the left side\\.$#"
 			count: 1
 			path: src/InsertEdit.php
@@ -9611,22 +9596,12 @@ parameters:
 			path: src/InsertEdit.php
 
 		-
-			message: "#^Only booleans are allowed in an elseif condition, string\\|false given\\.$#"
-			count: 1
-			path: src/InsertEdit.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, array\\<array\\<int\\|string, array\\<array\\<string\\>\\|bool\\|int\\|string\\>\\|bool\\|int\\|string\\|null\\>\\|bool\\|int\\|string\\>\\|bool\\|int\\|string given\\.$#"
 			count: 1
 			path: src/InsertEdit.php
 
 		-
 			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 1
-			path: src/InsertEdit.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
 			count: 1
 			path: src/InsertEdit.php
 
@@ -9952,11 +9927,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
-			count: 1
-			path: src/Menu.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
 			count: 1
 			path: src/Menu.php
 
@@ -15691,11 +15661,6 @@ parameters:
 			path: src/Tracking/Tracker.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
-			count: 1
-			path: src/Tracking/Tracker.php
-
-		-
 			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:quoteString\\(\\) expects string, mixed given\\.$#"
 			count: 2
 			path: src/Tracking/Tracker.php
@@ -15762,16 +15727,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Tracking\\\\Tracking\\:\\:getHtmlForDataManipulationStatements\\(\\) should return string but returns mixed\\.$#"
-			count: 1
-			path: src/Tracking/Tracking.php
-
-		-
-			message: "#^Only booleans are allowed in \\|\\|, string\\|false given on the left side\\.$#"
-			count: 1
-			path: src/Tracking/Tracking.php
-
-		-
-			message: "#^Only booleans are allowed in \\|\\|, string\\|false given on the right side\\.$#"
 			count: 1
 			path: src/Tracking/Tracking.php
 
@@ -16697,16 +16652,16 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
-			count: 3
-			path: tests/classes/ConfigTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$haystack of function mb_strstr expects string, array\\<string\\> given\\.$#"
 			count: 1
 			path: tests/classes/ConfigTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function mb_strstr expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, array\\<string\\> given\\.$#"
+			count: 1
+			path: tests/classes/ConfigTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, mixed given\\.$#"
 			count: 1
 			path: tests/classes/ConfigTest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1086,6 +1086,11 @@ parameters:
 			path: src/Config/Validator.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function str_starts_with expects string, mixed given\\.$#"
+			count: 1
+			path: src/Config/Validator.php
+
+		-
 			message: "#^Parameter \\#1 \\$host of static method PhpMyAdmin\\\\Config\\\\Validator\\:\\:testDBConnection\\(\\) expects string, mixed given\\.$#"
 			count: 2
 			path: src/Config/Validator.php
@@ -1102,7 +1107,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function mb_substr expects string, mixed given\\.$#"
-			count: 2
+			count: 1
 			path: src/Config/Validator.php
 
 		-
@@ -14101,6 +14106,11 @@ parameters:
 			path: src/Server/Privileges.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function str_starts_with expects string, string\\|null given\\.$#"
+			count: 3
+			path: src/Server/Privileges.php
+
+		-
 			message: "#^Parameter \\#1 \\$name of method PhpMyAdmin\\\\Server\\\\Privileges\\:\\:escapeGrantWildcards\\(\\) expects string, array\\<int, string\\>\\|string\\|true\\|null given\\.$#"
 			count: 1
 			path: src/Server/Privileges.php
@@ -14153,11 +14163,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$string of function mb_substr expects string, mixed given\\.$#"
 			count: 1
-			path: src/Server/Privileges.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function mb_substr expects string, string\\|null given\\.$#"
-			count: 3
 			path: src/Server/Privileges.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -12931,9 +12931,6 @@
       <code><![CDATA[$config->settings['Server']]]></code>
       <code><![CDATA[$config->settings['Server']]]></code>
     </InvalidArrayOffset>
-    <InvalidCast>
-      <code>$v</code>
-    </InvalidCast>
     <MixedArgument>
       <code><![CDATA[$gdNfo['GD Version']]]></code>
     </MixedArgument>
@@ -12949,6 +12946,9 @@
     <RedundantConditionGivenDocblockType>
       <code>assertIsArray</code>
     </RedundantConditionGivenDocblockType>
+    <TypeDoesNotContainType>
+      <code><![CDATA[str_contains($v, '2.')]]></code>
+    </TypeDoesNotContainType>
   </file>
   <file src="tests/classes/ConsoleTest.php">
     <DeprecatedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5812,6 +5812,9 @@
     <PossiblyNullArgument>
       <code><![CDATA[$GLOBALS['file_handle']]]></code>
     </PossiblyNullArgument>
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$error['message']]]></code>
+    </PossiblyNullArrayAccess>
     <RedundantCondition>
       <code>mb_strtolower($userExtension) !== $requiredExtension</code>
       <code>mb_strtolower($userExtension) !== $requiredExtension</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10847,8 +10847,6 @@
       <code><![CDATA[$dbRights[$row['User']]]]></code>
       <code>$groupAssignment</code>
       <code>$row</code>
-      <code>$row</code>
-      <code>$row</code>
     </PossiblyNullArrayOffset>
     <PossiblyNullOperand>
       <code>$alterUserQuery</code>

--- a/src/CheckUserPrivileges.php
+++ b/src/CheckUserPrivileges.php
@@ -10,7 +10,6 @@ namespace PhpMyAdmin;
 use PhpMyAdmin\Query\Utilities;
 use PhpMyAdmin\Utils\SessionCache;
 
-use function mb_strpos;
 use function mb_substr;
 use function preg_match;
 use function preg_replace;
@@ -38,7 +37,7 @@ class CheckUserPrivileges
         if (
             $showGrants->grants !== 'ALL'
             && $showGrants->grants !== 'ALL PRIVILEGES'
-            && (mb_strpos($showGrants->grants, 'SELECT, INSERT, UPDATE, DELETE') === false)
+            && ! str_contains($showGrants->grants, 'SELECT, INSERT, UPDATE, DELETE')
         ) {
             return;
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -39,7 +39,6 @@ use function is_numeric;
 use function is_readable;
 use function is_string;
 use function is_writable;
-use function mb_strstr;
 use function mb_strtolower;
 use function md5;
 use function min;
@@ -53,6 +52,7 @@ use function realpath;
 use function rtrim;
 use function setcookie;
 use function sprintf;
+use function str_contains;
 use function str_ends_with;
 use function stripos;
 use function strtolower;
@@ -187,15 +187,15 @@ class Config
      */
     private function setClientPlatform(string $userAgent): void
     {
-        if (mb_strstr($userAgent, 'Win')) {
+        if (str_contains($userAgent, 'Win')) {
             $this->set('PMA_USR_OS', 'Win');
-        } elseif (mb_strstr($userAgent, 'Mac')) {
+        } elseif (str_contains($userAgent, 'Mac')) {
             $this->set('PMA_USR_OS', 'Mac');
-        } elseif (mb_strstr($userAgent, 'Linux')) {
+        } elseif (str_contains($userAgent, 'Linux')) {
             $this->set('PMA_USR_OS', 'Linux');
-        } elseif (mb_strstr($userAgent, 'Unix')) {
+        } elseif (str_contains($userAgent, 'Unix')) {
             $this->set('PMA_USR_OS', 'Unix');
-        } elseif (mb_strstr($userAgent, 'OS/2')) {
+        } elseif (str_contains($userAgent, 'OS/2')) {
             $this->set('PMA_USR_OS', 'OS/2');
         } else {
             $this->set('PMA_USR_OS', 'Other');
@@ -254,7 +254,7 @@ class Config
             $this->set('PMA_USR_BROWSER_AGENT', 'SAFARI');
             // Firefox
         } elseif (
-            ! mb_strstr($httpUserAgent, 'compatible')
+            ! str_contains($httpUserAgent, 'compatible')
             && preg_match('@Firefox/([\w.]+)@', $httpUserAgent, $logVersion)
         ) {
             $this->set('PMA_USR_BROWSER_VER', $logVersion[1]);
@@ -296,7 +296,7 @@ class Config
 
         if (function_exists('gd_info')) {
             $gdInfo = gd_info();
-            if (mb_strstr($gdInfo['GD Version'], '2.')) {
+            if (str_contains($gdInfo['GD Version'], '2.')) {
                 $this->set('PMA_IS_GD2', 1);
 
                 return;

--- a/src/Config/Form.php
+++ b/src/Config/Form.php
@@ -17,10 +17,10 @@ use function is_bool;
 use function is_int;
 use function is_string;
 use function ltrim;
-use function mb_strpos;
 use function mb_strrpos;
 use function mb_substr;
 use function str_replace;
+use function str_starts_with;
 use function trigger_error;
 
 use const E_USER_ERROR;
@@ -233,7 +233,7 @@ class Form
     protected function readTypes(): void
     {
         foreach ($this->fields as $name => $path) {
-            if (mb_strpos((string) $name, ':group:') === 0) {
+            if (str_starts_with((string) $name, ':group:')) {
                 $this->fieldsTypes[$name] = 'group';
                 continue;
             }
@@ -265,7 +265,7 @@ class Form
                 continue;
             }
 
-            if (mb_strpos($name, ':group:') !== 0) {
+            if (! str_starts_with($name, ':group:')) {
                 continue;
             }
 

--- a/src/Config/FormDisplay.php
+++ b/src/Config/FormDisplay.php
@@ -35,7 +35,9 @@ use function mb_substr;
 use function preg_match;
 use function settype;
 use function sprintf;
+use function str_ends_with;
 use function str_replace;
+use function str_starts_with;
 use function trigger_error;
 use function trim;
 
@@ -396,9 +398,9 @@ class FormDisplay
         // detect password fields
         if (
             $type === 'text'
-            && (mb_substr($translatedPath, -9) === '-password'
-               || mb_substr($translatedPath, -4) === 'pass'
-               || mb_substr($translatedPath, -4) === 'Pass')
+            && (str_ends_with($translatedPath, '-password')
+               || str_ends_with($translatedPath, 'pass')
+               || str_ends_with($translatedPath, 'Pass'))
         ) {
             $type = 'password';
         }
@@ -711,8 +713,7 @@ class FormDisplay
      */
     public function getDocLink(string $path): string
     {
-        $test = mb_substr($path, 0, 6);
-        if ($test === 'Import' || $test === 'Export') {
+        if (str_starts_with($path, 'Import') || str_starts_with($path, 'Export')) {
             return '';
         }
 

--- a/src/Config/Validator.php
+++ b/src/Config/Validator.php
@@ -35,6 +35,7 @@ use function preg_match;
 use function preg_replace;
 use function sprintf;
 use function str_replace;
+use function str_starts_with;
 use function trim;
 
 use const FILTER_FLAG_IPV4;
@@ -90,7 +91,7 @@ class Validator
                 }
 
                 for ($i = 1, $nb = count($uv); $i < $nb; $i++) {
-                    if (mb_substr($uv[$i], 0, 6) !== 'value:') {
+                    if (! str_starts_with($uv[$i], 'value:')) {
                         continue;
                     }
 

--- a/src/Controllers/Operations/TableController.php
+++ b/src/Controllers/Operations/TableController.php
@@ -34,10 +34,10 @@ use function count;
 use function implode;
 use function is_array;
 use function is_string;
-use function mb_strstr;
 use function mb_strtolower;
 use function mb_strtoupper;
 use function preg_replace;
+use function str_contains;
 use function strlen;
 use function urldecode;
 
@@ -439,8 +439,8 @@ class TableController extends AbstractController
         }
 
         $comment = '';
-        if (mb_strstr($showComment, '; InnoDB free') === false) {
-            if (mb_strstr($showComment, 'InnoDB free') === false) {
+        if (! str_contains($showComment, '; InnoDB free')) {
+            if (! str_contains($showComment, 'InnoDB free')) {
                 // only user entered comment
                 $comment = $showComment;
             }

--- a/src/Controllers/Table/Structure/SaveController.php
+++ b/src/Controllers/Table/Structure/SaveController.php
@@ -28,8 +28,8 @@ use function count;
 use function implode;
 use function in_array;
 use function is_array;
-use function mb_strpos;
 use function sprintf;
+use function str_contains;
 use function strlen;
 
 final class SaveController extends AbstractController
@@ -101,7 +101,7 @@ final class SaveController extends AbstractController
             // find the remembered sort expression
             $sortedCol = $this->tableObj->getUiProp(Table::PROP_SORTED_COLUMN);
             // if the old column name is part of the remembered sort expression
-            if (mb_strpos((string) $sortedCol, Util::backquote($_POST['field_orig'][$i])) !== false) {
+            if (str_contains((string) $sortedCol, Util::backquote($_POST['field_orig'][$i]))) {
                 // delete the whole remembered sort expression
                 $this->tableObj->removeUiProp(Table::PROP_SORTED_COLUMN);
             }

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -59,7 +59,6 @@ use function json_encode;
 use function max;
 use function mb_check_encoding;
 use function mb_strlen;
-use function mb_strpos;
 use function mb_strtolower;
 use function mb_strtoupper;
 use function mb_substr;
@@ -1456,11 +1455,8 @@ class Results
         // Another query to test this:
         // SELECT p.*, FROM_UNIXTIME(p.temps) FROM mytable AS p
         // (and try clicking on each column's header twice)
-        $noSortTable = $sortTable === '' || mb_strpos(
-            $sortExpressionNoDirection[$indexInExpression],
-            $sortTable,
-        ) === false;
-        $noOpenParenthesis = mb_strpos($sortExpressionNoDirection[$indexInExpression], '(') === false;
+        $noSortTable = $sortTable === '' || ! str_contains($sortExpressionNoDirection[$indexInExpression], $sortTable);
+        $noOpenParenthesis = ! str_contains($sortExpressionNoDirection[$indexInExpression], '(');
         if ($sortTable !== '' && $noSortTable && $noOpenParenthesis) {
             $newSortExpressionNoDirection = $sortTable
                 . $sortExpressionNoDirection[$indexInExpression];

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -418,8 +418,7 @@ class Results
 
         $bIsProcessList = isset($which[1]);
         if ($bIsProcessList) {
-            $str = ' ' . strtoupper($which[1]);
-            $bIsProcessList = strpos($str, 'PROCESSLIST') > 0;
+            $bIsProcessList = str_contains(strtoupper($which[1]), 'PROCESSLIST');
         }
 
         return $displayParts->with([
@@ -2080,9 +2079,7 @@ class Results
             );
 
             if (isset($which[1])) {
-                $str = ' ' . strtoupper($which[1]);
-                $isShowProcessList = strpos($str, 'PROCESSLIST') > 0;
-                if ($isShowProcessList) {
+                if (str_contains(strtoupper($which[1]), 'PROCESSLIST')) {
                     $mediaTypeMap['..Info'] = [
                         'mimetype' => 'Text_Plain',
                         'transformation' => 'output/Text_Plain_Sql.php',
@@ -3773,8 +3770,7 @@ class Results
                 $transformationPlugin->getMIMESubtype(),
                 'Octetstream',
             );
-            $posMimeText = strpos($transformationPlugin->getMIMEType(), 'Text');
-            if ($posMimeOctetstream || $posMimeText !== false) {
+            if ($posMimeOctetstream || str_contains($transformationPlugin->getMIMEType(), 'Text')) {
                 // Applying Transformations on hex string of binary data
                 // seems more appropriate
                 $result = pack('H*', bin2hex($content));

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -47,12 +47,12 @@ use function is_numeric;
 use function is_string;
 use function is_writable;
 use function mb_strlen;
-use function mb_strpos;
 use function mb_strtolower;
 use function mb_substr;
 use function ob_list_handlers;
 use function preg_match;
 use function preg_replace;
+use function str_contains;
 use function strlen;
 use function strtolower;
 use function substr;
@@ -83,7 +83,7 @@ class Export
     public function shutdown(): void
     {
         $error = error_get_last();
-        if ($error == null || ! mb_strpos($error['message'], 'execution time')) {
+        if ($error === null || ! str_contains($error['message'], 'execution time')) {
             return;
         }
 
@@ -567,7 +567,7 @@ class Export
 
         // Walk over databases
         foreach ($this->dbi->getDatabaseList() as $currentDb) {
-            if (! isset($tmpSelect) || ! mb_strpos(' ' . $tmpSelect, '|' . $currentDb . '|')) {
+            if (! isset($tmpSelect) || ! str_contains(' ' . $tmpSelect, '|' . $currentDb . '|')) {
                 continue;
             }
 

--- a/src/Export/Options.php
+++ b/src/Export/Options.php
@@ -20,7 +20,7 @@ use function function_exists;
 use function in_array;
 use function is_array;
 use function is_string;
-use function mb_strpos;
+use function str_contains;
 use function urldecode;
 
 final class Options
@@ -73,7 +73,7 @@ final class Options
                     $isSelected = true;
                 }
             } elseif ($tmpSelect !== '') {
-                if (mb_strpos(' ' . $tmpSelect, '|' . $currentDb . '|')) {
+                if (str_contains(' ' . $tmpSelect, '|' . $currentDb . '|')) {
                     $isSelected = true;
                 }
             } else {

--- a/src/Html/Generator.php
+++ b/src/Html/Generator.php
@@ -44,7 +44,6 @@ use function is_array;
 use function is_string;
 use function json_encode;
 use function mb_strlen;
-use function mb_strstr;
 use function mb_strtolower;
 use function mb_substr;
 use function nl2br;
@@ -765,7 +764,7 @@ class Generator
 
         // For security reasons, if the MySQL refuses the connection, the query
         // is hidden so no details are revealed.
-        if ($sqlQuery !== '' && ! mb_strstr($sqlQuery, 'connect')) {
+        if ($sqlQuery !== '' && ! str_contains($sqlQuery, 'connect')) {
             // Static analysis errors.
             if ($errors !== []) {
                 $errorMessage .= '<p><strong>' . __('Static analysis:')
@@ -791,7 +790,7 @@ class Generator
             $formattedSqlToLower = mb_strtolower($formattedSql);
 
             // TODO: Show documentation for all statement types.
-            if (mb_strstr($formattedSqlToLower, 'select')) {
+            if (str_contains($formattedSqlToLower, 'select')) {
                 // please show me help to the error on select
                 $errorMessage .= MySQLDocumentation::show('SELECT');
             }
@@ -867,7 +866,7 @@ class Generator
         }
 
         if ($backUrl !== '') {
-            if (mb_strstr($backUrl, '?')) {
+            if (str_contains($backUrl, '?')) {
                 $backUrl .= '&amp;no_history=true';
             } else {
                 $backUrl .= '?no_history=true';

--- a/src/InsertEdit.php
+++ b/src/InsertEdit.php
@@ -31,7 +31,6 @@ use function json_encode;
 use function max;
 use function mb_stripos;
 use function mb_strlen;
-use function mb_strstr;
 use function min;
 use function password_hash;
 use function preg_match;
@@ -344,9 +343,9 @@ class InsertEdit
         array $foreignData,
     ): string {
         $foreigner = $this->relation->searchColumnInForeigners($foreigners, $column->field);
-        if (mb_strstr($column->trueType, 'enum')) {
+        if (str_contains($column->trueType, 'enum')) {
             $nullifyCode = mb_strlen($column->type) > 20 ? '1' : '2';
-        } elseif (mb_strstr($column->trueType, 'set')) {
+        } elseif (str_contains($column->trueType, 'set')) {
             $nullifyCode = '3';
         } elseif ($foreigner && $foreignData['foreign_link'] == false) {
             // foreign key in a drop-down
@@ -399,7 +398,7 @@ class InsertEdit
             $textareaCols = $config->settings['CharTextareaCols'];
             $extractedColumnspec = Util::extractColumnSpec($column->type);
             $maxlength = $extractedColumnspec['spec_in_brackets'];
-        } elseif ($config->settings['LongtextDoubleTextarea'] && mb_strstr($column->pmaType, 'longtext')) {
+        } elseif ($config->settings['LongtextDoubleTextarea'] && str_contains($column->pmaType, 'longtext')) {
             $textAreaRows = $config->settings['TextareaRows'] * 2;
             $textareaCols = $config->settings['TextareaCols'] * 2;
         }
@@ -1779,7 +1778,7 @@ class InsertEdit
                 $textAreaRows = max($config->settings['CharTextareaRows'], 7);
                 $textareaCols = $config->settings['CharTextareaCols'];
                 $maxlength = $extractedColumnspec['spec_in_brackets'];
-            } elseif ($config->settings['LongtextDoubleTextarea'] && mb_strstr($column->pmaType, 'longtext')) {
+            } elseif ($config->settings['LongtextDoubleTextarea'] && str_contains($column->pmaType, 'longtext')) {
                 $textAreaRows = $config->settings['TextareaRows'] * 2;
                 $textareaCols = $config->settings['TextareaCols'] * 2;
             }

--- a/src/IpAllowDeny.php
+++ b/src/IpAllowDeny.php
@@ -15,11 +15,11 @@ use function hash_equals;
 use function hexdec;
 use function inet_pton;
 use function ip2long;
-use function mb_strpos;
 use function mb_strtolower;
 use function mb_substr;
 use function min;
 use function preg_match;
+use function str_contains;
 use function str_replace;
 use function substr_replace;
 
@@ -36,7 +36,7 @@ class IpAllowDeny
      */
     public function ipMaskTest(string $testRange, string $ipToTest): bool
     {
-        if (mb_strpos($testRange, ':') > -1 || mb_strpos($ipToTest, ':') > -1) {
+        if (str_contains($testRange, ':') || str_contains($ipToTest, ':')) {
             // assume IPv6
             return $this->ipv6MaskTest($testRange, $ipToTest);
         }
@@ -130,8 +130,8 @@ class IpAllowDeny
         $testRange = mb_strtolower($testRange);
         $ipToTest = mb_strtolower($ipToTest);
 
-        $isCidr = mb_strpos($testRange, '/') > -1;
-        $isRange = mb_strpos($testRange, '[') > -1;
+        $isCidr = str_contains($testRange, '/');
+        $isRange = str_contains($testRange, '[');
         $isSingle = ! $isCidr && ! $isRange;
 
         $ipHex = bin2hex((string) inet_pton($ipToTest));

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -19,9 +19,9 @@ use function array_intersect_key;
 use function count;
 use function in_array;
 use function mb_strpos;
-use function mb_strstr;
 use function mb_substr;
 use function preg_replace;
+use function str_contains;
 
 /**
  * Class for generating the top menu
@@ -168,7 +168,7 @@ class Menu
                     $table['comment'] = $tableObj->getComment();
                 }
 
-                if (mb_strstr($table['comment'], '; InnoDB free')) {
+                if (str_contains($table['comment'], '; InnoDB free')) {
                     $table['comment'] = (string) preg_replace('@; InnoDB free:.*?$@', '', $table['comment']);
                 }
             } else {

--- a/src/Mime.php
+++ b/src/Mime.php
@@ -11,7 +11,6 @@ namespace PhpMyAdmin;
 
 use function chr;
 use function mb_strlen;
-use function mb_substr;
 use function str_starts_with;
 
 /**
@@ -35,7 +34,7 @@ class Mime
             return 'image/gif';
         }
 
-        if ($len >= 4 && mb_substr($test, 0, 4, '8bit') === "\x89PNG") {
+        if ($len >= 4 && str_starts_with($test, "\x89PNG")) {
             return 'image/png';
         }
 

--- a/src/Navigation/Navigation.php
+++ b/src/Navigation/Navigation.php
@@ -28,9 +28,8 @@ use function __;
 use function count;
 use function defined;
 use function file_exists;
-use function is_bool;
 use function parse_url;
-use function strpos;
+use function str_contains;
 use function trim;
 
 use const PHP_URL_HOST;
@@ -74,10 +73,9 @@ class Navigation
 
             if ($config->settings['NavigationLogoLinkWindow'] === 'main') {
                 if (empty(parse_url($logo['link'], PHP_URL_HOST))) {
-                    $hasStartChar = strpos($logo['link'], '?');
                     $logo['link'] .= Url::getCommon(
                         [],
-                        is_bool($hasStartChar) ? '?' : Url::getArgSeparator(),
+                        ! str_contains($logo['link'], '?') ? '?' : Url::getArgSeparator(),
                     );
                     // Internal link detected
                     $logo['attributes'] = '';

--- a/src/Plugins.php
+++ b/src/Plugins.php
@@ -31,13 +31,13 @@ use function count;
 use function htmlspecialchars;
 use function is_array;
 use function is_subclass_of;
-use function mb_strpos;
 use function mb_strtolower;
 use function mb_strtoupper;
 use function mb_substr;
 use function method_exists;
 use function preg_match_all;
 use function sprintf;
+use function str_contains;
 use function str_replace;
 use function str_starts_with;
 use function strcasecmp;
@@ -303,7 +303,7 @@ class Plugins
         $properties = null;
         if (! $isSubgroup) {
             // for subgroup headers
-            if (mb_strpos($propertyGroup::class, 'PropertyItem')) {
+            if (str_contains($propertyGroup::class, 'PropertyItem')) {
                 $properties = [$propertyGroup];
             } else {
                 // for main groups
@@ -336,7 +336,7 @@ class Plugins
             foreach ($properties as $propertyItem) {
                 $propertyClass = $propertyItem::class;
                 // if the property is a subgroup, we deal with it recursively
-                if (mb_strpos($propertyClass, 'Subgroup')) {
+                if (str_contains($propertyClass, 'Subgroup')) {
                     // for subgroups
                     // each subgroup can have a header, which may also be a form element
                     /** @var OptionsPropertyItem|null $subgroupHeader */

--- a/src/Plugins/Export/ExportSql.php
+++ b/src/Plugins/Export/ExportSql.php
@@ -52,6 +52,7 @@ use function preg_quote;
 use function preg_replace;
 use function preg_split;
 use function sprintf;
+use function str_contains;
 use function str_repeat;
 use function str_replace;
 use function strtotime;
@@ -825,7 +826,7 @@ class ExportSql extends ExportPlugin
         $createQuery = 'CREATE DATABASE IF NOT EXISTS '
             . Util::backquoteCompat($dbAlias, $compat, $this->useSqlBackquotes);
         $collation = DatabaseInterface::getInstance()->getDbCollation($db);
-        if (mb_strpos($collation, '_')) {
+        if (str_contains($collation, '_')) {
             $createQuery .= ' DEFAULT CHARACTER SET '
                 . mb_substr(
                     $collation,
@@ -1413,11 +1414,11 @@ class ExportSql extends ExportPlugin
 
             // Convert end of line chars to one that we want (note that MySQL
             // doesn't return query it will accept in all cases)
-            if (mb_strpos($createQuery, "(\r\n ")) {
+            if (str_contains($createQuery, "(\r\n ")) {
                 $createQuery = str_replace("\r\n", "\n", $createQuery);
-            } elseif (mb_strpos($createQuery, "(\n ")) {
+            } elseif (str_contains($createQuery, "(\n ")) {
                 $createQuery = str_replace("\n", "\n", $createQuery);
-            } elseif (mb_strpos($createQuery, "(\r ")) {
+            } elseif (str_contains($createQuery, "(\r ")) {
                 $createQuery = str_replace("\r", "\n", $createQuery);
             }
 

--- a/src/Plugins/Export/Helpers/TableProperty.php
+++ b/src/Plugins/Export/Helpers/TableProperty.php
@@ -10,6 +10,7 @@ use function htmlspecialchars;
 use function mb_strpos;
 use function mb_substr;
 use function str_replace;
+use function str_starts_with;
 use function strlen;
 use function trim;
 
@@ -103,35 +104,35 @@ class TableProperty
      */
     public function getDotNetPrimitiveType(): string
     {
-        if (mb_strpos($this->type, 'int') === 0) {
+        if (str_starts_with($this->type, 'int')) {
             return 'int';
         }
 
-        if (mb_strpos($this->type, 'longtext') === 0) {
+        if (str_starts_with($this->type, 'longtext')) {
             return 'string';
         }
 
-        if (mb_strpos($this->type, 'long') === 0) {
+        if (str_starts_with($this->type, 'long')) {
             return 'long';
         }
 
-        if (mb_strpos($this->type, 'char') === 0) {
+        if (str_starts_with($this->type, 'char')) {
             return 'string';
         }
 
-        if (mb_strpos($this->type, 'varchar') === 0) {
+        if (str_starts_with($this->type, 'varchar')) {
             return 'string';
         }
 
-        if (mb_strpos($this->type, 'text') === 0) {
+        if (str_starts_with($this->type, 'text')) {
             return 'string';
         }
 
-        if (mb_strpos($this->type, 'tinyint') === 0) {
+        if (str_starts_with($this->type, 'tinyint')) {
             return 'bool';
         }
 
-        if (mb_strpos($this->type, 'datetime') === 0) {
+        if (str_starts_with($this->type, 'datetime')) {
             return 'DateTime';
         }
 
@@ -145,35 +146,35 @@ class TableProperty
      */
     public function getDotNetObjectType(): string
     {
-        if (mb_strpos($this->type, 'int') === 0) {
+        if (str_starts_with($this->type, 'int')) {
             return 'Int32';
         }
 
-        if (mb_strpos($this->type, 'longtext') === 0) {
+        if (str_starts_with($this->type, 'longtext')) {
             return 'String';
         }
 
-        if (mb_strpos($this->type, 'long') === 0) {
+        if (str_starts_with($this->type, 'long')) {
             return 'Long';
         }
 
-        if (mb_strpos($this->type, 'char') === 0) {
+        if (str_starts_with($this->type, 'char')) {
             return 'String';
         }
 
-        if (mb_strpos($this->type, 'varchar') === 0) {
+        if (str_starts_with($this->type, 'varchar')) {
             return 'String';
         }
 
-        if (mb_strpos($this->type, 'text') === 0) {
+        if (str_starts_with($this->type, 'text')) {
             return 'String';
         }
 
-        if (mb_strpos($this->type, 'tinyint') === 0) {
+        if (str_starts_with($this->type, 'tinyint')) {
             return 'Boolean';
         }
 
-        if (mb_strpos($this->type, 'datetime') === 0) {
+        if (str_starts_with($this->type, 'datetime')) {
             return 'DateTime';
         }
 

--- a/src/Plugins/Import/ImportMediawiki.php
+++ b/src/Plugins/Import/ImportMediawiki.php
@@ -18,7 +18,6 @@ use function __;
 use function count;
 use function explode;
 use function mb_strlen;
-use function mb_strpos;
 use function mb_substr;
 use function preg_match;
 use function str_contains;
@@ -545,7 +544,7 @@ class ImportMediawiki extends ImportPlugin
      */
     private function getCellContent(string $cell, string $colStartChar): string
     {
-        if (mb_strpos($cell, $colStartChar) === 0) {
+        if (str_starts_with($cell, $colStartChar)) {
             return trim(mb_substr($cell, 1));
         }
 

--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -57,6 +57,7 @@ use function range;
 use function sprintf;
 use function str_contains;
 use function str_replace;
+use function str_starts_with;
 use function strnatcasecmp;
 use function strtr;
 use function trim;
@@ -476,9 +477,9 @@ class Privileges
 
                 $res = $this->dbi->query($sqlQuery);
                 while ($row1 = $res->fetchRow()) {
-                    if (mb_substr($row1[0], 0, 4) === 'max_') {
+                    if (str_starts_with($row1[0], 'max_')) {
                         $row[$row1[0]] = 0;
-                    } elseif (mb_substr($row1[0], 0, 5) === 'x509_' || mb_substr($row1[0], 0, 4) === 'ssl_') {
+                    } elseif (str_starts_with($row1[0], 'x509_') || str_starts_with($row1[0], 'ssl_')) {
                         $row[$row1[0]] = '';
                     } else {
                         $row[$row1[0]] = 'N';

--- a/src/Table/Search.php
+++ b/src/Table/Search.php
@@ -13,7 +13,6 @@ use function explode;
 use function implode;
 use function in_array;
 use function is_array;
-use function mb_strpos;
 use function preg_match;
 use function str_contains;
 use function str_replace;
@@ -163,7 +162,7 @@ final class Search
             // strings to numbers and numbers to strings as necessary
             // during the comparison
             $needsQuoting = preg_match('@char|binary|blob|text|set|date|time|year|uuid@i', $types)
-                || mb_strpos(' ' . $funcType, 'LIKE');
+                || str_contains($funcType, 'LIKE');
 
             // LIKE %...%
             if ($funcType === 'LIKE %...%') {

--- a/src/Tracking/Tracker.php
+++ b/src/Tracking/Tracker.php
@@ -37,8 +37,6 @@ use function trim;
 
 /**
  * This class tracks changes on databases, tables and views.
- *
- * @todo use stristr instead of strstr
  */
 class Tracker
 {

--- a/src/Tracking/Tracker.php
+++ b/src/Tracking/Tracker.php
@@ -27,12 +27,12 @@ use PhpMyAdmin\SqlParser\Statements\UpdateStatement;
 use PhpMyAdmin\Util;
 
 use function intval;
-use function mb_strstr;
 use function preg_quote;
 use function preg_replace;
 use function serialize;
 use function sprintf;
 use function str_ends_with;
+use function str_starts_with;
 use function trim;
 
 /**
@@ -546,7 +546,7 @@ class Tracker
     public static function handleQuery(string $query): void
     {
         // If query is marked as untouchable, leave
-        if (mb_strstr($query, '/*NOTRACK*/')) {
+        if (str_starts_with($query, '/*NOTRACK*/')) {
             return;
         }
 

--- a/src/Tracking/Tracking.php
+++ b/src/Tracking/Tracking.php
@@ -37,6 +37,7 @@ use function mb_substr;
 use function preg_replace;
 use function rtrim;
 use function sprintf;
+use function str_contains;
 use function strtotime;
 use function trim;
 
@@ -593,8 +594,8 @@ class Tracking
         $dropCreateStatements = $trackedData->ddlog[0]['statement'];
 
         if (
-            mb_strstr($trackedData->ddlog[0]['statement'], 'DROP TABLE')
-            || mb_strstr($trackedData->ddlog[0]['statement'], 'DROP VIEW')
+            str_contains($trackedData->ddlog[0]['statement'], 'DROP TABLE')
+            || str_contains($trackedData->ddlog[0]['statement'], 'DROP VIEW')
         ) {
             $dropCreateStatements .= $trackedData->ddlog[1]['statement'];
         }

--- a/src/Util.php
+++ b/src/Util.php
@@ -63,6 +63,7 @@ use function set_time_limit;
 use function sort;
 use function sprintf;
 use function str_contains;
+use function str_ends_with;
 use function str_getcsv;
 use function str_pad;
 use function str_replace;
@@ -146,7 +147,7 @@ class Util
         }
 
         foreach ($quotes as $quote) {
-            if (mb_substr($quotedString, 0, 1) === $quote && mb_substr($quotedString, -1, 1) === $quote) {
+            if (str_starts_with($quotedString, $quote) && str_ends_with($quotedString, $quote)) {
                 // replace escaped quotes
                 return str_replace($quote . $quote, $quote, mb_substr($quotedString, 1, -1));
             }
@@ -821,7 +822,7 @@ class Util
     public static function userDir(string $dir): string
     {
         // add trailing slash
-        if (mb_substr($dir, -1) !== '/') {
+        if (! str_ends_with($dir, '/')) {
             $dir .= '/';
         }
 

--- a/tests/classes/ConfigTest.php
+++ b/tests/classes/ConfigTest.php
@@ -22,7 +22,6 @@ use function file_put_contents;
 use function fileperms;
 use function function_exists;
 use function gd_info;
-use function mb_strstr;
 use function md5;
 use function ob_end_clean;
 use function ob_get_contents;
@@ -30,6 +29,7 @@ use function ob_start;
 use function phpinfo;
 use function preg_match;
 use function realpath;
+use function str_contains;
 use function strip_tags;
 use function stristr;
 use function sys_get_temp_dir;
@@ -279,7 +279,7 @@ PHP;
         if (function_exists('gd_info')) {
             $this->object->checkGd2();
             $gdNfo = gd_info();
-            if (mb_strstr($gdNfo['GD Version'], '2.')) {
+            if (str_contains($gdNfo['GD Version'], '2.')) {
                 $this->assertEquals(
                     1,
                     $this->object->get('PMA_IS_GD2'),
@@ -304,7 +304,8 @@ PHP;
             return;
         }
 
-        if (mb_strstr($v, '2.')) {
+        // TODO: The variable $v clearly is incorrect. Was this meant to be $a?
+        if (str_contains($v, '2.')) {
             $this->assertEquals(
                 1,
                 $this->object->get('PMA_IS_GD2'),


### PR DESCRIPTION
As far as I know, if they operate on UTF-8 strings, then they are equivalent to their non-mb counterparts. As of PHP 8.0 we have nice functions that are better suited for boolean conditions. 