### PR TITLE
Fix creation of no-password user

### DIFF
--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -3103,7 +3103,7 @@ class Privileges
             if ($_POST['pred_password'] === 'keep') {
                 $createUserReal = sprintf($createUserStmt, $slashedPassword);
             } elseif ($_POST['pred_password'] === 'none') {
-                $createUserReal = sprintf($createUserStmt, '');
+                $createUserReal = sprintf($createUserStmt, "''");
             } else {
                 if (
                     ! ((Compatibility::isMariaDb() && $isMariaDBPwdPluginActive)
@@ -3124,7 +3124,7 @@ class Privileges
             // and pre-5.2.0 MariaDB versions
             $passwordSetReal = sprintf($passwordSetStmt, $slashedUsername, $slashedHostname, $slashedPassword);
         } elseif ($_POST['pred_password'] === 'none') {
-            $passwordSetReal = sprintf($passwordSetStmt, $slashedUsername, $slashedHostname, '');
+            $passwordSetReal = sprintf($passwordSetStmt, $slashedUsername, $slashedHostname, "''");
         } else {
             $hashedPassword = $this->getHashedPassword($_POST['pma_pw']);
             $passwordSetReal = sprintf($passwordSetStmt, $slashedUsername, $slashedHostname, $hashedPassword);


### PR DESCRIPTION
Here's another issue I've caused that I have just found. Previously if "no password" was selected then the SQL would set the password to an empty string. While refactoring, I missed the quotes and broke the resulting SQL. 