### PR TITLE
Fix bug with numeric table names

### DIFF
--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -25,6 +25,7 @@ use PhpMyAdmin\Utils\SessionCache;
 
 use function __;
 use function array_column;
+use function array_combine;
 use function array_diff;
 use function array_keys;
 use function array_map;
@@ -595,11 +596,15 @@ class DatabaseInterface implements DbalInterface
                 }
 
                 if ($sortValues) {
+                    // See https://stackoverflow.com/a/32461188 for the explanation of below hack
+                    $keys = array_keys($each_tables);
                     if ($sort_order === 'DESC') {
-                        array_multisort($sortValues, SORT_DESC, $each_tables);
+                        array_multisort($sortValues, SORT_DESC, $each_tables, $keys);
                     } else {
-                        array_multisort($sortValues, SORT_ASC, $each_tables);
+                        array_multisort($sortValues, SORT_ASC, $each_tables, $keys);
                     }
+
+                    $each_tables = array_combine($keys, $each_tables);
                 }
 
                 // cleanup the temporary sort array

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2756,6 +2756,16 @@ parameters:
 			path: libraries/classes/DatabaseInterface.php
 
 		-
+			message: "#^Parameter \\#1 \\$eachTables of static method PhpMyAdmin\\\\Query\\\\Compatibility\\:\\:getISCompatForGetTablesFull\\(\\) expects array, array\\|false given\\.$#"
+			count: 1
+			path: libraries/classes/DatabaseInterface.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of function array_slice expects array, array\\|false given\\.$#"
+			count: 1
+			path: libraries/classes/DatabaseInterface.php
+
+		-
 			message: "#^Parameter \\#1 \\$link of method PhpMyAdmin\\\\DatabaseInterface\\:\\:affectedRows\\(\\) expects int, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3056,14 +3056,9 @@
     </TypeDoesNotContainType>
   </file>
   <file src="libraries/classes/Controllers/Table/ChartController.php">
-    <InvalidArgument occurrences="2">
-      <code>$rows</code>
+    <InvalidArgument occurrences="1">
       <code>$start</code>
     </InvalidArgument>
-    <InvalidScalarArgument occurrences="2">
-      <code>$_REQUEST['pos']</code>
-      <code>$_REQUEST['session_max_rows']</code>
-    </InvalidScalarArgument>
     <MixedArgument occurrences="7">
       <code>$db</code>
       <code>$db</code>
@@ -3079,6 +3074,11 @@
     <MixedAssignment occurrences="1">
       <code>$url_params['db']</code>
     </MixedAssignment>
+    <PossiblyInvalidArgument occurrences="3">
+      <code>$_REQUEST['pos']</code>
+      <code>$_REQUEST['session_max_rows']</code>
+      <code>$rows</code>
+    </PossiblyInvalidArgument>
     <PossiblyInvalidOperand occurrences="4">
       <code>$_REQUEST['pos']</code>
       <code>$_REQUEST['pos']</code>

--- a/test/classes/DatabaseInterfaceTest.php
+++ b/test/classes/DatabaseInterfaceTest.php
@@ -14,6 +14,8 @@ use PhpMyAdmin\SystemDatabase;
 use PhpMyAdmin\Utils\SessionCache;
 use stdClass;
 
+use function array_keys;
+
 /**
  * @covers \PhpMyAdmin\DatabaseInterface
  */
@@ -581,6 +583,23 @@ class DatabaseInterfaceTest extends AbstractTestCase
 
         $actual = $this->dbi->getTablesFull('test_db');
         $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetTablesFullBug18913(): void
+    {
+        $GLOBALS['cfg']['Server']['DisableIS'] = true;
+        $GLOBALS['cfg']['NaturalOrder'] = false;
+
+        $expected = ['0', '1', '42'];
+
+        $this->dummyDbi->addResult('SHOW TABLE STATUS FROM `test_db_bug_18913`', [
+            ['0', ''],
+            ['1', ''],
+            ['42', ''],
+        ], ['Name', 'Engine']);
+
+        $actual = $this->dbi->getTablesFull('test_db_bug_18913');
+        $this->assertEquals($expected, array_keys($actual));
     }
 
     /**


### PR DESCRIPTION
The bug happens in 5.2 also but it only became apparent after my recent refactoring. 

To trigger this bug:
1. DisableIS = true
2. Create a DB with two tables: `0`, `42`. 
3. Open `/database/structure` and see PMA crash. 

The bug happens because of a little-known quirk of `array_multisort` that renames the numerical keys. 