### PR TITLE
Fix import of empty tables from MediaWiki

### DIFF
--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -1125,6 +1125,10 @@ class Import
             $numCols = count($tables[$i][self::COL_NAMES]);
             $numRows = count($tables[$i][self::ROWS]);
 
+            if ($numRows === 0) {
+                break;
+            }
+
             $tempSQLStr = 'INSERT INTO ' . Util::backquote($dbName) . '.'
                 . Util::backquote($tables[$i][self::TBL_NAME]) . ' (';
 

--- a/libraries/classes/Plugins/Import/ImportMediawiki.php
+++ b/libraries/classes/Plugins/Import/ImportMediawiki.php
@@ -302,8 +302,10 @@ class ImportMediawiki extends ImportPlugin
             // Set the table name
             $this->setTableName($table[0]);
 
-            // Set generic names for table headers if they don't exist
-            $this->setTableHeaders($table[1], $table[2][0]);
+            // Set generic names for table headers if they don't exist and the table has some data
+            if ($table[2] !== []) {
+                $this->setTableHeaders($table[1], $table[2][0]);
+            }
 
             // Create the tables array to be used in Import::buildSql()
             $tables = [];

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3056,14 +3056,9 @@
     </TypeDoesNotContainType>
   </file>
   <file src="libraries/classes/Controllers/Table/ChartController.php">
-    <InvalidArgument occurrences="2">
-      <code>$rows</code>
+    <InvalidArgument occurrences="1">
       <code>$start</code>
     </InvalidArgument>
-    <InvalidScalarArgument occurrences="2">
-      <code>$_REQUEST['pos']</code>
-      <code>$_REQUEST['session_max_rows']</code>
-    </InvalidScalarArgument>
     <MixedArgument occurrences="7">
       <code>$db</code>
       <code>$db</code>
@@ -3079,6 +3074,11 @@
     <MixedAssignment occurrences="1">
       <code>$url_params['db']</code>
     </MixedAssignment>
+    <PossiblyInvalidArgument occurrences="3">
+      <code>$_REQUEST['pos']</code>
+      <code>$_REQUEST['session_max_rows']</code>
+      <code>$rows</code>
+    </PossiblyInvalidArgument>
     <PossiblyInvalidOperand occurrences="4">
       <code>$_REQUEST['pos']</code>
       <code>$_REQUEST['pos']</code>
@@ -16133,7 +16133,8 @@
     </TypeDoesNotContainType>
   </file>
   <file src="test/classes/Plugins/Import/ImportMediawikiTest.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument occurrences="2">
+      <code>$import_notice</code>
       <code>$import_notice</code>
     </MixedArgument>
   </file>

--- a/test/classes/Plugins/Import/ImportMediawikiTest.php
+++ b/test/classes/Plugins/Import/ImportMediawikiTest.php
@@ -125,4 +125,51 @@ class ImportMediawikiTest extends AbstractTestCase
         $this->assertStringContainsString('Edit settings for `pma_bookmarktest`', $import_notice);
         $this->assertTrue($GLOBALS['finished']);
     }
+
+    /**
+     * Test for doImport
+     *
+     * @group medium
+     */
+    public function testDoImportWithEmptyTable(): void
+    {
+        //$import_notice will show the import detail result
+        global $import_notice;
+
+        //Mock DBI
+        $dbi = $this->getMockBuilder(DatabaseInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $GLOBALS['dbi'] = $dbi;
+
+        $importHandle = new File('test/test_data/__slashes.mediawiki');
+        $importHandle->open();
+
+        //Test function called
+        $this->object->doImport($importHandle);
+
+        // If import successfully, PMA will show all databases and
+        // tables imported as following HTML Page
+        /*
+           The following structures have either been created or altered. Here you
+           can:
+           View a structure's contents by clicking on its name
+           Change any of its settings by clicking the corresponding "Options" link
+           Edit structure by following the "Structure" link
+
+           mediawiki_DB (Options)
+           pma_bookmarktest (Structure) (Options)
+        */
+
+        //asset that all databases and tables are imported
+        $this->assertStringContainsString(
+            'The following structures have either been created or altered.',
+            $import_notice
+        );
+        $this->assertStringContainsString('Go to database: `mediawiki_DB`', $import_notice);
+        $this->assertStringContainsString('Edit settings for `mediawiki_DB`', $import_notice);
+        $this->assertStringContainsString('Go to table: `empty`', $import_notice);
+        $this->assertStringContainsString('Edit settings for `empty`', $import_notice);
+        $this->assertTrue($GLOBALS['finished']);
+    }
 }

--- a/test/test_data/__slashes.mediawiki
+++ b/test/test_data/__slashes.mediawiki
@@ -1,0 +1,12 @@
+
+<!--
+Table data for `empty`
+-->
+
+{| class="wikitable sortable" style="text-align:center;"
+|+'''empty'''
+|-
+ ! \'table
+ ! \\column
+|}
+


### PR DESCRIPTION
Fixes #18930

This is a minimal fix. It should allow importing empty tables, although I am not sure how correct the whole thing is. 