### PR TITLE
Remove $GLOBALS['active_page']

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1709,7 +1709,6 @@
       <code>Config::getInstance()</code>
     </DeprecatedMethod>
     <InvalidArrayOffset>
-      <code><![CDATA[$GLOBALS['active_page']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
       <code><![CDATA[$GLOBALS['export_type']]]></code>
       <code><![CDATA[$GLOBALS['save_filename']]]></code>
@@ -1756,7 +1755,6 @@
       <code><![CDATA[$_SESSION['tmpval']['aliases']]]></code>
     </MixedArrayAssignment>
     <MixedAssignment>
-      <code><![CDATA[$GLOBALS['active_page']]]></code>
       <code><![CDATA[$GLOBALS['charset']]]></code>
       <code><![CDATA[$GLOBALS['codegen_format']]]></code>
       <code><![CDATA[$GLOBALS['codegen_structure_or_data']]]></code>
@@ -2012,7 +2010,6 @@
       <code>$importPlugin == null</code>
     </DocblockTypeContradiction>
     <InvalidArrayOffset>
-      <code><![CDATA[$GLOBALS['active_page']]]></code>
       <code><![CDATA[$GLOBALS['ajax_reload']]]></code>
       <code><![CDATA[$GLOBALS['charset_conversion']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
@@ -2069,7 +2066,6 @@
       <code><![CDATA[$_SESSION['Import_message']['message']]]></code>
     </MixedArrayAssignment>
     <MixedAssignment>
-      <code><![CDATA[$GLOBALS['active_page']]]></code>
       <code><![CDATA[$GLOBALS['ajax_reload']]]></code>
       <code><![CDATA[$GLOBALS['charset_conversion']]]></code>
       <code><![CDATA[$GLOBALS['charset_of_file']]]></code>
@@ -3196,7 +3192,6 @@
   </file>
   <file src="src/Controllers/Table/AddFieldController.php">
     <InvalidArrayOffset>
-      <code><![CDATA[$GLOBALS['active_page']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
     </InvalidArrayOffset>
     <MixedArgument>
@@ -3206,7 +3201,6 @@
       <code><![CDATA[$_POST['field_transformation_options'][$fieldindex]]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code><![CDATA[$GLOBALS['active_page']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
     </MixedAssignment>
     <PossiblyInvalidArgument>
@@ -3276,11 +3270,9 @@
   </file>
   <file src="src/Controllers/Table/ChangeRowsController.php">
     <InvalidArrayOffset>
-      <code><![CDATA[$GLOBALS['active_page']]]></code>
       <code><![CDATA[$GLOBALS['where_clause']]]></code>
     </InvalidArrayOffset>
     <MixedAssignment>
-      <code><![CDATA[$GLOBALS['active_page']]]></code>
       <code><![CDATA[$GLOBALS['where_clause']]]></code>
       <code>$rowsToDelete</code>
     </MixedAssignment>
@@ -3365,7 +3357,6 @@
       <code><![CDATA[$_REQUEST['pos']]]></code>
     </InvalidArgument>
     <InvalidArrayOffset>
-      <code><![CDATA[$GLOBALS['active_page']]]></code>
       <code><![CDATA[$GLOBALS['disp_message']]]></code>
       <code><![CDATA[$GLOBALS['disp_query']]]></code>
     </InvalidArrayOffset>
@@ -3376,7 +3367,6 @@
       <code>$row</code>
     </MixedArgument>
     <MixedAssignment>
-      <code><![CDATA[$GLOBALS['active_page']]]></code>
       <code><![CDATA[$GLOBALS['disp_message']]]></code>
       <code><![CDATA[$GLOBALS['disp_query']]]></code>
       <code><![CDATA[$GLOBALS['sql_query']]]></code>
@@ -3438,12 +3428,10 @@
   </file>
   <file src="src/Controllers/Table/ExportRowsController.php">
     <InvalidArrayOffset>
-      <code><![CDATA[$GLOBALS['active_page']]]></code>
       <code><![CDATA[$GLOBALS['single_table']]]></code>
       <code><![CDATA[$GLOBALS['where_clause']]]></code>
     </InvalidArrayOffset>
     <MixedAssignment>
-      <code><![CDATA[$GLOBALS['active_page']]]></code>
       <code><![CDATA[$GLOBALS['single_table']]]></code>
       <code><![CDATA[$GLOBALS['where_clause']]]></code>
     </MixedAssignment>
@@ -3679,7 +3667,6 @@
       <code>$insertErrors</code>
     </InvalidArgument>
     <InvalidArrayOffset>
-      <code><![CDATA[$GLOBALS['active_page']]]></code>
       <code><![CDATA[$GLOBALS['disp_message']]]></code>
       <code><![CDATA[$GLOBALS['disp_query']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
@@ -3729,7 +3716,6 @@
       <code>$mimeMap[$columnName]</code>
     </MixedArrayOffset>
     <MixedAssignment>
-      <code><![CDATA[$GLOBALS['active_page']]]></code>
       <code><![CDATA[$GLOBALS['disp_message']]]></code>
       <code><![CDATA[$GLOBALS['disp_query']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>

--- a/src/Controllers/Export/ExportController.php
+++ b/src/Controllers/Export/ExportController.php
@@ -61,7 +61,6 @@ final class ExportController extends AbstractController
         $GLOBALS['table_select'] ??= null;
         $GLOBALS['time_start'] ??= null;
         $GLOBALS['charset'] ??= null;
-        $GLOBALS['active_page'] ??= null;
         $GLOBALS['table_data'] ??= null;
 
         /** @var array<string, string> $postParams */
@@ -300,7 +299,6 @@ final class ExportController extends AbstractController
                     $GLOBALS['message'] = Message::error(
                         __('No tables found in database.'),
                     );
-                    $GLOBALS['active_page'] = Url::getFromRoute('/database/export');
                     /** @var DatabaseExportController $controller */
                     $controller = ContainerBuilder::getContainer()->get(DatabaseExportController::class);
                     $controller($request);

--- a/src/Controllers/Import/ImportController.php
+++ b/src/Controllers/Import/ImportController.php
@@ -94,7 +94,6 @@ final class ImportController extends AbstractController
         $GLOBALS['import_file_name'] ??= null;
         $GLOBALS['import_notice'] ??= null;
         $GLOBALS['read_multiply'] ??= null;
-        $GLOBALS['active_page'] ??= null;
 
         $GLOBALS['charset_of_file'] = $request->getParsedBodyParam('charset_of_file');
         $GLOBALS['format'] = $request->getParsedBodyParam('format', '');
@@ -773,7 +772,6 @@ final class ImportController extends AbstractController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', Message::error($GLOBALS['msg']));
         } else {
-            $GLOBALS['active_page'] = $GLOBALS['goto'];
             /** @psalm-suppress UnresolvableInclude */
             include ROOT_PATH . $GLOBALS['goto'];
         }

--- a/src/Controllers/Table/AddFieldController.php
+++ b/src/Controllers/Table/AddFieldController.php
@@ -50,7 +50,6 @@ class AddFieldController extends AbstractController
     {
         $GLOBALS['errorUrl'] ??= null;
         $GLOBALS['message'] ??= null;
-        $GLOBALS['active_page'] ??= null;
 
         /** @var string|null $numberOfFields */
         $numberOfFields = $request->getParsedBodyParam('num_fields');
@@ -182,8 +181,6 @@ class AddFieldController extends AbstractController
 
             return;
         }
-
-        $GLOBALS['active_page'] = Url::getFromRoute('/table/structure');
 
         $this->addScriptFiles(['vendor/jquery/jquery.uitablefilter.js']);
 

--- a/src/Controllers/Table/ChangeRowsController.php
+++ b/src/Controllers/Table/ChangeRowsController.php
@@ -8,7 +8,6 @@ use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
-use PhpMyAdmin\Url;
 
 use function __;
 use function array_values;
@@ -26,7 +25,6 @@ final class ChangeRowsController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['active_page'] ??= null;
         $GLOBALS['where_clause'] ??= null;
 
         $rowsToDelete = $request->getParsedBodyParam('rows_to_delete');
@@ -49,8 +47,6 @@ final class ChangeRowsController extends AbstractController
         if (is_array($rowsToDelete)) {
             $GLOBALS['where_clause'] = array_values($rowsToDelete);
         }
-
-        $GLOBALS['active_page'] = Url::getFromRoute('/table/change');
 
         ($this->changeController)($request);
     }

--- a/src/Controllers/Table/DeleteRowsController.php
+++ b/src/Controllers/Table/DeleteRowsController.php
@@ -16,7 +16,6 @@ use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Sql;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Transformations;
-use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
 use PhpMyAdmin\Utils\ForeignKey;
 
@@ -38,7 +37,6 @@ final class DeleteRowsController extends AbstractController
         $GLOBALS['goto'] ??= null;
         $GLOBALS['disp_message'] ??= null;
         $GLOBALS['disp_query'] ??= null;
-        $GLOBALS['active_page'] ??= null;
 
         $multBtn = $_POST['mult_btn'] ?? '';
         $selected = $_POST['selected'] ?? [];
@@ -82,8 +80,6 @@ final class DeleteRowsController extends AbstractController
         if ($request->hasBodyParam('original_sql_query')) {
             $GLOBALS['sql_query'] = $request->getParsedBodyParam('original_sql_query', '');
         }
-
-        $GLOBALS['active_page'] = Url::getFromRoute('/sql');
 
         $this->response->addHTML($sql->executeQueryAndSendQueryResponse(
             null,

--- a/src/Controllers/Table/ExportRowsController.php
+++ b/src/Controllers/Table/ExportRowsController.php
@@ -8,7 +8,6 @@ use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
-use PhpMyAdmin\Url;
 
 use function __;
 use function array_values;
@@ -26,7 +25,6 @@ final class ExportRowsController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['active_page'] ??= null;
         $GLOBALS['single_table'] ??= null;
         $GLOBALS['where_clause'] ??= null;
 
@@ -48,8 +46,6 @@ final class ExportRowsController extends AbstractController
         if (isset($_POST['rows_to_delete']) && is_array($_POST['rows_to_delete'])) {
             $GLOBALS['where_clause'] = array_values($_POST['rows_to_delete']);
         }
-
-        $GLOBALS['active_page'] = Url::getFromRoute('/table/export');
 
         ($this->exportController)($request);
     }

--- a/src/Controllers/Table/ReplaceController.php
+++ b/src/Controllers/Table/ReplaceController.php
@@ -68,7 +68,6 @@ final class ReplaceController extends AbstractController
 
         $GLOBALS['errorUrl'] ??= null;
         $GLOBALS['unsaved_values'] ??= null;
-        $GLOBALS['active_page'] ??= null;
         $GLOBALS['disp_query'] ??= null;
         $GLOBALS['disp_message'] ??= null;
         $GLOBALS['query'] ??= null;
@@ -478,7 +477,6 @@ final class ReplaceController extends AbstractController
 
     private function moveBackToCallingScript(string $gotoInclude, ServerRequest $request): void
     {
-        $GLOBALS['active_page'] = $gotoInclude;
         if ($gotoInclude === '/sql') {
             ($this->sqlController)($request);
 

--- a/src/Controllers/Table/Structure/BrowseController.php
+++ b/src/Controllers/Table/Structure/BrowseController.php
@@ -11,7 +11,6 @@ use PhpMyAdmin\ParseAnalyze;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Sql;
 use PhpMyAdmin\Template;
-use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
 
 use function __;
@@ -44,7 +43,6 @@ final class BrowseController extends AbstractController
      */
     private function displayTableBrowseForSelectedColumns(string $goto): void
     {
-        $GLOBALS['active_page'] = Url::getFromRoute('/sql');
         $fields = [];
         foreach ($_POST['selected_fld'] as $sval) {
             $fields[] = Util::backquote($sval);

--- a/tests/classes/Controllers/Table/ChangeRowsControllerTest.php
+++ b/tests/classes/Controllers/Table/ChangeRowsControllerTest.php
@@ -23,7 +23,6 @@ class ChangeRowsControllerTest extends AbstractTestCase
 
         DatabaseInterface::$instance = $this->createDatabaseInterface();
         Current::$server = 2;
-        $GLOBALS['active_page'] = null;
         $GLOBALS['where_clause'] = null;
         $_POST = [];
     }
@@ -38,8 +37,6 @@ class ChangeRowsControllerTest extends AbstractTestCase
 
         (new ChangeRowsController(new ResponseRenderer(), new Template(), $mock))($request);
 
-        /** @psalm-suppress InvalidArrayOffset */
-        $this->assertSame('index.php?route=/table/change&server=2&lang=en', $GLOBALS['active_page']);
         /** @psalm-suppress InvalidArrayOffset */
         $this->assertSame([], $GLOBALS['where_clause']);
     }
@@ -58,8 +55,6 @@ class ChangeRowsControllerTest extends AbstractTestCase
         $this->assertSame(['message' => 'No row selected.'], $response->getJSONResult());
         $this->assertFalse($response->hasSuccessState());
         /** @psalm-suppress InvalidArrayOffset */
-        $this->assertNull($GLOBALS['active_page']);
-        /** @psalm-suppress InvalidArrayOffset */
         $this->assertNull($GLOBALS['where_clause']);
     }
 
@@ -73,8 +68,6 @@ class ChangeRowsControllerTest extends AbstractTestCase
 
         (new ChangeRowsController(new ResponseRenderer(), new Template(), $mock))($request);
 
-        /** @psalm-suppress InvalidArrayOffset */
-        $this->assertSame('index.php?route=/table/change&server=2&lang=en', $GLOBALS['active_page']);
         /** @psalm-suppress InvalidArrayOffset */
         $this->assertSame(['row1', 'row2'], $GLOBALS['where_clause']);
     }

--- a/tests/classes/Controllers/Table/ExportRowsControllerTest.php
+++ b/tests/classes/Controllers/Table/ExportRowsControllerTest.php
@@ -23,7 +23,6 @@ class ExportRowsControllerTest extends AbstractTestCase
 
         DatabaseInterface::$instance = $this->createDatabaseInterface();
         Current::$server = 2;
-        $GLOBALS['active_page'] = null;
         $GLOBALS['single_table'] = null;
         $GLOBALS['where_clause'] = null;
         $_POST = [];
@@ -42,8 +41,6 @@ class ExportRowsControllerTest extends AbstractTestCase
             $controller,
         ))($this->createStub(ServerRequest::class));
 
-        /** @psalm-suppress InvalidArrayOffset */
-        $this->assertSame('index.php?route=/table/export&server=2&lang=en', $GLOBALS['active_page']);
         /** @psalm-suppress InvalidArrayOffset */
         $this->assertTrue($GLOBALS['single_table']);
         /** @psalm-suppress InvalidArrayOffset */
@@ -67,8 +64,6 @@ class ExportRowsControllerTest extends AbstractTestCase
         $this->assertSame(['message' => 'No row selected.'], $response->getJSONResult());
         $this->assertFalse($response->hasSuccessState());
         /** @psalm-suppress InvalidArrayOffset */
-        $this->assertNull($GLOBALS['active_page']);
-        /** @psalm-suppress InvalidArrayOffset */
         $this->assertNull($GLOBALS['single_table']);
         /** @psalm-suppress InvalidArrayOffset */
         $this->assertNull($GLOBALS['where_clause']);
@@ -88,8 +83,6 @@ class ExportRowsControllerTest extends AbstractTestCase
             $controller,
         ))($this->createStub(ServerRequest::class));
 
-        /** @psalm-suppress InvalidArrayOffset */
-        $this->assertSame('index.php?route=/table/export&server=2&lang=en', $GLOBALS['active_page']);
         /** @psalm-suppress InvalidArrayOffset */
         $this->assertTrue($GLOBALS['single_table']);
         /** @psalm-suppress InvalidArrayOffset */


### PR DESCRIPTION
This global was used only in tests. It was used to check whether the controller redirected to another one. We have an expectation for this in every test, so this assertion shouldn't be necessary. 