### PR TITLE
Fix wrong param name in Account locking controllers

### DIFF
--- a/src/Controllers/Server/Privileges/AccountLockController.php
+++ b/src/Controllers/Server/Privileges/AccountLockController.php
@@ -17,7 +17,7 @@ use function __;
 
 final class AccountLockController extends AbstractController
 {
-    public function __construct(ResponseRenderer $response, Template $template, private AccountLocking $model)
+    public function __construct(ResponseRenderer $response, Template $template, private AccountLocking $accountLocking)
     {
         parent::__construct($response, $template);
     }
@@ -34,7 +34,7 @@ final class AccountLockController extends AbstractController
         $hostName = $request->getParsedBodyParam('hostname');
 
         try {
-            $this->model->lock($userName, $hostName);
+            $this->accountLocking->lock($userName, $hostName);
         } catch (Throwable $exception) {
             $this->response->setStatusCode(StatusCodeInterface::STATUS_BAD_REQUEST);
             $this->response->setRequestStatus(false);

--- a/src/Controllers/Server/Privileges/AccountUnlockController.php
+++ b/src/Controllers/Server/Privileges/AccountUnlockController.php
@@ -17,7 +17,7 @@ use function __;
 
 final class AccountUnlockController extends AbstractController
 {
-    public function __construct(ResponseRenderer $response, Template $template, private AccountLocking $model)
+    public function __construct(ResponseRenderer $response, Template $template, private AccountLocking $accountLocking)
     {
         parent::__construct($response, $template);
     }
@@ -34,7 +34,7 @@ final class AccountUnlockController extends AbstractController
         $hostName = $request->getParsedBodyParam('hostname');
 
         try {
-            $this->model->unlock($userName, $hostName);
+            $this->accountLocking->unlock($userName, $hostName);
         } catch (Throwable $exception) {
             $this->response->setStatusCode(StatusCodeInterface::STATUS_BAD_REQUEST);
             $this->response->setRequestStatus(false);


### PR DESCRIPTION
It took us 6 months to notice that this controller stopped working. Fixes #18954. Nice catch. 