### PR TITLE
Fix creation of mocks in unit tests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16406,21 +16406,6 @@ parameters:
 			path: tests/classes/Controllers/Server/VariablesControllerTest.php
 
 		-
-			message: "#^Call to an undefined method PhpMyAdmin\\\\DatabaseInterface\\:\\:expects\\(\\)\\.$#"
-			count: 4
-			path: tests/classes/Controllers/Table/RelationControllerTest.php
-
-		-
-			message: "#^Cannot call method method\\(\\) on mixed\\.$#"
-			count: 4
-			path: tests/classes/Controllers/Table/RelationControllerTest.php
-
-		-
-			message: "#^Cannot call method willReturn\\(\\) on mixed\\.$#"
-			count: 4
-			path: tests/classes/Controllers/Table/RelationControllerTest.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$result has no value type specified in iterable type array\\.$#"
 			count: 2
 			path: tests/classes/Controllers/Table/ReplaceControllerTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16446,21 +16446,6 @@ parameters:
 			path: tests/classes/Controllers/Table/SearchControllerTest.php
 
 		-
-			message: "#^Call to an undefined method PhpMyAdmin\\\\Http\\\\ServerRequest&PHPUnit\\\\Framework\\\\MockObject\\\\Stub\\:\\:expects\\(\\)\\.$#"
-			count: 1
-			path: tests/classes/Controllers/Triggers/IndexControllerTest.php
-
-		-
-			message: "#^Cannot call method method\\(\\) on mixed\\.$#"
-			count: 1
-			path: tests/classes/Controllers/Triggers/IndexControllerTest.php
-
-		-
-			message: "#^Cannot call method willReturn\\(\\) on mixed\\.$#"
-			count: 1
-			path: tests/classes/Controllers/Triggers/IndexControllerTest.php
-
-		-
 			message: "#^Cannot access offset 'arr' on mixed\\.$#"
 			count: 5
 			path: tests/classes/CoreTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16486,11 +16486,6 @@ parameters:
 			path: tests/classes/Crypto/CryptoTest.php
 
 		-
-			message: "#^Call to an undefined method PhpMyAdmin\\\\DatabaseInterface\\:\\:expects\\(\\)\\.$#"
-			count: 10
-			path: tests/classes/Database/CentralColumnsTest.php
-
-		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array\\<string\\> will always evaluate to true\\.$#"
 			count: 1
 			path: tests/classes/Database/CentralColumnsTest.php
@@ -16498,26 +16493,6 @@ parameters:
 		-
 			message: "#^Cannot access offset 0 on mixed\\.$#"
 			count: 1
-			path: tests/classes/Database/CentralColumnsTest.php
-
-		-
-			message: "#^Cannot call method method\\(\\) on mixed\\.$#"
-			count: 10
-			path: tests/classes/Database/CentralColumnsTest.php
-
-		-
-			message: "#^Cannot call method willReturn\\(\\) on mixed\\.$#"
-			count: 9
-			path: tests/classes/Database/CentralColumnsTest.php
-
-		-
-			message: "#^Cannot call method willReturnOnConsecutiveCalls\\(\\) on mixed\\.$#"
-			count: 1
-			path: tests/classes/Database/CentralColumnsTest.php
-
-		-
-			message: "#^Cannot call method with\\(\\) on mixed\\.$#"
-			count: 7
 			path: tests/classes/Database/CentralColumnsTest.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16411,26 +16411,6 @@ parameters:
 			path: tests/classes/Controllers/Table/ReplaceControllerTest.php
 
 		-
-			message: "#^Call to an undefined method PhpMyAdmin\\\\DatabaseInterface\\:\\:expects\\(\\)\\.$#"
-			count: 1
-			path: tests/classes/Controllers/Table/SearchControllerTest.php
-
-		-
-			message: "#^Cannot call method method\\(\\) on mixed\\.$#"
-			count: 1
-			path: tests/classes/Controllers/Table/SearchControllerTest.php
-
-		-
-			message: "#^Cannot call method willReturn\\(\\) on mixed\\.$#"
-			count: 1
-			path: tests/classes/Controllers/Table/SearchControllerTest.php
-
-		-
-			message: "#^Cannot call method with\\(\\) on mixed\\.$#"
-			count: 1
-			path: tests/classes/Controllers/Table/SearchControllerTest.php
-
-		-
 			message: "#^Cannot access offset 'arr' on mixed\\.$#"
 			count: 5
 			path: tests/classes/CoreTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17386,11 +17386,6 @@ parameters:
 			path: tests/classes/Stubs/ResponseRenderer.php
 
 		-
-			message: "#^Call to an undefined method PhpMyAdmin\\\\DatabaseInterface\\:\\:expects\\(\\)\\.$#"
-			count: 4
-			path: tests/classes/Table/TableTest.php
-
-		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpMyAdmin\\\\\\\\Table\\\\\\\\Table' and PhpMyAdmin\\\\Table\\\\Table will always evaluate to true\\.$#"
 			count: 1
 			path: tests/classes/Table/TableTest.php
@@ -17398,21 +17393,6 @@ parameters:
 		-
 			message: "#^Cannot access offset 'SCHEMA_TABLES' on mixed\\.$#"
 			count: 1
-			path: tests/classes/Table/TableTest.php
-
-		-
-			message: "#^Cannot call method method\\(\\) on mixed\\.$#"
-			count: 4
-			path: tests/classes/Table/TableTest.php
-
-		-
-			message: "#^Cannot call method willReturn\\(\\) on mixed\\.$#"
-			count: 2
-			path: tests/classes/Table/TableTest.php
-
-		-
-			message: "#^Cannot call method willReturnMap\\(\\) on mixed\\.$#"
-			count: 2
 			path: tests/classes/Table/TableTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13084,10 +13084,6 @@
   <file src="tests/classes/Controllers/Server/VariablesControllerTest.php">
     <DeprecatedMethod>
       <code>Config::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
     <MixedArrayAccess>
       <code>$formattedValue</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13238,27 +13238,7 @@
   <file src="tests/classes/Controllers/Table/RelationControllerTest.php">
     <DeprecatedMethod>
       <code>Config::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
-    <MixedMethodCall>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-    </MixedMethodCall>
-    <UndefinedMethod>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-    </UndefinedMethod>
   </file>
   <file src="tests/classes/Controllers/Table/ReplaceControllerTest.php">
     <DeprecatedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13407,15 +13407,6 @@
   <file src="tests/classes/Database/CentralColumnsTest.php">
     <DeprecatedMethod>
       <code>Config::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$config->settings]]></code>
@@ -13437,50 +13428,9 @@
     <MixedAssignment>
       <code>$listDetailCols</code>
     </MixedAssignment>
-    <MixedMethodCall>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturnOnConsecutiveCalls</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-    </MixedMethodCall>
     <RedundantCondition>
       <code>assertIsArray</code>
     </RedundantCondition>
-    <UndefinedMethod>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-    </UndefinedMethod>
   </file>
   <file src="tests/classes/Database/Designer/CommonTest.php">
     <DeprecatedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13248,16 +13248,7 @@
   <file src="tests/classes/Controllers/Table/SearchControllerTest.php">
     <DeprecatedMethod>
       <code>Config::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
-    <MixedMethodCall>
-      <code>method</code>
-      <code>willReturn</code>
-      <code>with</code>
-    </MixedMethodCall>
-    <UndefinedMethod>
-      <code>expects</code>
-    </UndefinedMethod>
   </file>
   <file src="tests/classes/Controllers/Table/SqlControllerTest.php">
     <DeprecatedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13338,16 +13338,9 @@
     <MixedAssignment>
       <code>$output</code>
     </MixedAssignment>
-    <MixedMethodCall>
-      <code>method</code>
-      <code>willReturn</code>
-    </MixedMethodCall>
     <PossiblyUnusedMethod>
       <code>providerGetDataFromRequest</code>
     </PossiblyUnusedMethod>
-    <UndefinedInterfaceMethod>
-      <code>expects</code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="tests/classes/CoreTest.php">
     <DeprecatedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14937,25 +14937,6 @@
     <DeprecatedMethod>
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['sql_drop_table']]]></code>
@@ -14965,25 +14946,9 @@
       <code>$sql</code>
       <code>$sql</code>
     </MixedAssignment>
-    <MixedMethodCall>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturnMap</code>
-      <code>willReturnMap</code>
-    </MixedMethodCall>
     <PossiblyUnusedMethod>
       <code>dataValidateName</code>
     </PossiblyUnusedMethod>
-    <UndefinedMethod>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-    </UndefinedMethod>
   </file>
   <file src="tests/classes/TemplateTest.php">
     <PossiblyUnusedMethod>

--- a/tests/classes/Controllers/Server/Privileges/AccountLockControllerTest.php
+++ b/tests/classes/Controllers/Server/Privileges/AccountLockControllerTest.php
@@ -19,11 +19,9 @@ use PHPUnit\Framework\MockObject\Stub;
 #[CoversClass(AccountLockController::class)]
 class AccountLockControllerTest extends AbstractTestCase
 {
-    /** @var DatabaseInterface&Stub */
-    private DatabaseInterface $dbiStub;
+    private DatabaseInterface&Stub $dbiStub;
 
-    /** @var ServerRequest&Stub  */
-    private ServerRequest $requestStub;
+    private ServerRequest&Stub $requestStub;
 
     private ResponseRenderer $responseRendererStub;
 

--- a/tests/classes/Controllers/Server/Privileges/AccountUnlockControllerTest.php
+++ b/tests/classes/Controllers/Server/Privileges/AccountUnlockControllerTest.php
@@ -19,11 +19,9 @@ use PHPUnit\Framework\MockObject\Stub;
 #[CoversClass(AccountUnlockController::class)]
 class AccountUnlockControllerTest extends AbstractTestCase
 {
-    /** @var DatabaseInterface&Stub */
-    private DatabaseInterface $dbiStub;
+    private DatabaseInterface&Stub $dbiStub;
 
-    /** @var ServerRequest&Stub  */
-    private ServerRequest $requestStub;
+    private ServerRequest&Stub $requestStub;
 
     private ResponseRenderer $responseRendererStub;
 

--- a/tests/classes/Controllers/Server/VariablesControllerTest.php
+++ b/tests/classes/Controllers/Server/VariablesControllerTest.php
@@ -29,6 +29,8 @@ use function str_replace;
 #[CoversClass(VariablesController::class)]
 class VariablesControllerTest extends AbstractTestCase
 {
+    private DatabaseInterface&MockObject $mockedDbi;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -41,7 +43,7 @@ class VariablesControllerTest extends AbstractTestCase
         Current::$table = 'table';
         Config::getInstance()->selectedServer['DisableIS'] = false;
 
-        $dbi = $this->getMockBuilder(DatabaseInterface::class)
+        $this->mockedDbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -61,10 +63,8 @@ class VariablesControllerTest extends AbstractTestCase
             ['SHOW GLOBAL VARIABLES;', 0, 1, ConnectionType::User, $serverGlobalVariables],
         ];
 
-        $dbi->expects($this->any())->method('fetchResult')
+        $this->mockedDbi->expects($this->any())->method('fetchResult')
             ->willReturnMap($fetchResult);
-
-        DatabaseInterface::$instance = $dbi;
     }
 
     public function testIndex(): void
@@ -73,14 +73,12 @@ class VariablesControllerTest extends AbstractTestCase
 
         $resultStub = $this->createMock(DummyResult::class);
 
-        /** @var MockObject&DatabaseInterface $dbi */
-        $dbi = DatabaseInterface::getInstance();
-        $dbi->expects($this->once())
+        $this->mockedDbi->expects($this->once())
             ->method('tryQuery')
             ->with('SHOW SESSION VARIABLES;')
             ->willReturn($resultStub);
 
-        $controller = new VariablesController($response, new Template(), $dbi);
+        $controller = new VariablesController($response, new Template(), $this->mockedDbi);
 
         $controller($this->createStub(ServerRequest::class));
         $html = $response->getHTMLResult();
@@ -123,7 +121,7 @@ class VariablesControllerTest extends AbstractTestCase
         $controller = new VariablesController(
             ResponseRenderer::getInstance(),
             new Template(),
-            DatabaseInterface::getInstance(),
+            $this->mockedDbi,
         );
 
         $nameForValueByte = 'byte_variable';
@@ -189,7 +187,7 @@ class VariablesControllerTest extends AbstractTestCase
         $controller = new VariablesController(
             ResponseRenderer::getInstance(),
             new Template(),
-            DatabaseInterface::getInstance(),
+            $this->mockedDbi,
         );
 
         $nameForValueByte = 'wsrep_replicated_bytes';
@@ -242,7 +240,7 @@ class VariablesControllerTest extends AbstractTestCase
         $controller = new VariablesController(
             ResponseRenderer::getInstance(),
             new Template(),
-            DatabaseInterface::getInstance(),
+            $this->mockedDbi,
         );
 
         $nameForValueByte = 'wsrep_replicated_bytes';

--- a/tests/classes/Controllers/Table/RelationControllerTest.php
+++ b/tests/classes/Controllers/Table/RelationControllerTest.php
@@ -16,6 +16,7 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseStub;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 
 #[CoversClass(RelationController::class)]
 class RelationControllerTest extends AbstractTestCase
@@ -23,6 +24,8 @@ class RelationControllerTest extends AbstractTestCase
     private ResponseStub $response;
 
     private Template $template;
+
+    private DatabaseInterface&MockObject $dbi;
 
     /**
      * Configures environment
@@ -39,11 +42,9 @@ class RelationControllerTest extends AbstractTestCase
         $_POST['foreignDb'] = 'db';
         $_POST['foreignTable'] = 'table';
 
-        $dbi = $this->getMockBuilder(DatabaseInterface::class)
+        $this->dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
-
-        DatabaseInterface::$instance = $dbi;
 
         $this->response = new ResponseStub();
         $this->template = new Template();
@@ -67,15 +68,14 @@ class RelationControllerTest extends AbstractTestCase
         $tableMock->expects($this->any())->method('getColumns')
             ->willReturn($viewColumns);
 
-        $dbi = DatabaseInterface::getInstance();
-        $dbi->expects($this->any())->method('getTable')
+        $this->dbi->expects($this->any())->method('getTable')
             ->willReturn($tableMock);
 
         $ctrl = new RelationController(
             $this->response,
             $this->template,
-            new Relation($dbi),
-            $dbi,
+            new Relation($this->dbi),
+            $this->dbi,
         );
 
         $ctrl->getDropdownValueForTable();
@@ -101,15 +101,14 @@ class RelationControllerTest extends AbstractTestCase
         $tableMock->expects($this->any())->method('getIndexedColumns')
             ->willReturn($indexedColumns);
 
-        $dbi = DatabaseInterface::getInstance();
-        $dbi->expects($this->any())->method('getTable')
+        $this->dbi->expects($this->any())->method('getTable')
             ->willReturn($tableMock);
 
         $ctrl = new RelationController(
             $this->response,
             $this->template,
-            new Relation($dbi),
-            $dbi,
+            new Relation($this->dbi),
+            $this->dbi,
         );
 
         $ctrl->getDropdownValueForTable();
@@ -126,8 +125,7 @@ class RelationControllerTest extends AbstractTestCase
     {
         $resultStub = $this->createMock(DummyResult::class);
 
-        $dbi = DatabaseInterface::getInstance();
-        $dbi->expects($this->exactly(1))
+        $this->dbi->expects($this->exactly(1))
             ->method('query')
             ->willReturn($resultStub);
 
@@ -140,8 +138,8 @@ class RelationControllerTest extends AbstractTestCase
         $ctrl = new RelationController(
             $this->response,
             $this->template,
-            new Relation($dbi),
-            $dbi,
+            new Relation($this->dbi),
+            $this->dbi,
         );
 
         $_POST['foreign'] = 'true';
@@ -162,8 +160,7 @@ class RelationControllerTest extends AbstractTestCase
     {
         $resultStub = $this->createMock(DummyResult::class);
 
-        $dbi = DatabaseInterface::getInstance();
-        $dbi->expects($this->exactly(1))
+        $this->dbi->expects($this->exactly(1))
             ->method('query')
             ->willReturn($resultStub);
 
@@ -174,8 +171,8 @@ class RelationControllerTest extends AbstractTestCase
         $ctrl = new RelationController(
             $this->response,
             $this->template,
-            new Relation($dbi),
-            $dbi,
+            new Relation($this->dbi),
+            $this->dbi,
         );
 
         $_POST['foreign'] = 'false';

--- a/tests/classes/Controllers/Triggers/IndexControllerTest.php
+++ b/tests/classes/Controllers/Triggers/IndexControllerTest.php
@@ -279,7 +279,7 @@ HTML;
             new DbTableExists($dbi),
         );
 
-        $request = $this->createStub(ServerRequest::class);
+        $request = $this->createMock(ServerRequest::class);
         $request->expects($this->any())
             ->method('getParsedBodyParam')
             ->willReturn('foo');

--- a/tests/classes/Gis/GisGeometryTest.php
+++ b/tests/classes/Gis/GisGeometryTest.php
@@ -15,8 +15,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[CoversClass(GisGeometry::class)]
 class GisGeometryTest extends AbstractTestCase
 {
-    /** @var GisGeometry&MockObject */
-    protected GisGeometry $object;
+    protected GisGeometry&MockObject $object;
 
     /**
      * Sets up the fixture, for example, opens a network connection.

--- a/tests/classes/Navigation/Nodes/NodeDatabaseChildTest.php
+++ b/tests/classes/Navigation/Nodes/NodeDatabaseChildTest.php
@@ -19,12 +19,7 @@ use ReflectionProperty;
 #[CoversClass(NodeDatabase::class)]
 class NodeDatabaseChildTest extends AbstractTestCase
 {
-    /**
-     * Mock of NodeDatabaseChild
-     *
-     * @var NodeDatabaseChild&MockObject
-     */
-    protected NodeDatabaseChild $object;
+    protected NodeDatabaseChild&MockObject $object;
 
     /**
      * Sets up the fixture.

--- a/tests/classes/Properties/Options/OptionsPropertyGroupTest.php
+++ b/tests/classes/Properties/Options/OptionsPropertyGroupTest.php
@@ -13,8 +13,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[CoversClass(OptionsPropertyGroup::class)]
 class OptionsPropertyGroupTest extends AbstractTestCase
 {
-    /** @var OptionsPropertyGroup&MockObject */
-    protected OptionsPropertyGroup $stub;
+    protected OptionsPropertyGroup&MockObject $stub;
 
     /**
      * Configures global environment.

--- a/tests/classes/Properties/Options/OptionsPropertyItemTest.php
+++ b/tests/classes/Properties/Options/OptionsPropertyItemTest.php
@@ -12,8 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[CoversClass(OptionsPropertyItem::class)]
 class OptionsPropertyItemTest extends AbstractTestCase
 {
-    /** @var OptionsPropertyItem&MockObject */
-    protected OptionsPropertyItem $stub;
+    protected OptionsPropertyItem&MockObject $stub;
 
     /**
      * Configures global environment.

--- a/tests/classes/Properties/Options/OptionsPropertyOneItemTest.php
+++ b/tests/classes/Properties/Options/OptionsPropertyOneItemTest.php
@@ -12,8 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[CoversClass(OptionsPropertyOneItem::class)]
 class OptionsPropertyOneItemTest extends AbstractTestCase
 {
-    /** @var OptionsPropertyOneItem&MockObject  */
-    protected OptionsPropertyOneItem $stub;
+    protected OptionsPropertyOneItem&MockObject $stub;
 
     /**
      * Configures global environment.

--- a/tests/classes/Properties/PropertyItemTest.php
+++ b/tests/classes/Properties/PropertyItemTest.php
@@ -12,8 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[CoversClass(PropertyItem::class)]
 class PropertyItemTest extends AbstractTestCase
 {
-    /** @var PropertyItem&MockObject */
-    protected PropertyItem $stub;
+    protected PropertyItem&MockObject $stub;
 
     /**
      * Configures global environment.

--- a/tests/classes/StorageEngineTest.php
+++ b/tests/classes/StorageEngineTest.php
@@ -35,8 +35,7 @@ class StorageEngineTest extends AbstractTestCase
 
     protected DbiDummy $dummyDbi;
 
-    /** @var StorageEngine&MockObject */
-    protected StorageEngine $object;
+    protected StorageEngine&MockObject $object;
 
     /**
      * Sets up the fixture, for example, opens a network connection.

--- a/tests/classes/TypesByDatabaseVersionTest.php
+++ b/tests/classes/TypesByDatabaseVersionTest.php
@@ -13,8 +13,7 @@ use PHPUnit\Framework\MockObject\Stub;
 #[CoversClass(Types::class)]
 class TypesByDatabaseVersionTest extends AbstractTestCase
 {
-    /** @var DatabaseInterface&Stub */
-    private DatabaseInterface $dbiStub;
+    private DatabaseInterface&Stub $dbiStub;
 
     protected Types $object;
 


### PR DESCRIPTION
They are technically identical. The only difference is that `createMock` registers the created mock, but I don't know what exactly this means. This change helps with code navigation in IDEs. 
s/createStub/createMock/