### PR TITLE
Optimize navigation

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9701,37 +9701,17 @@ parameters:
 			path: src/Navigation/NavigationTree.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of class PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeEvent constructor expects string, mixed given\\.$#"
-			count: 1
-			path: src/Navigation/NavigationTree.php
-
-		-
-			message: "#^Parameter \\#1 \\$name of class PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeFunction constructor expects string, mixed given\\.$#"
-			count: 1
-			path: src/Navigation/NavigationTree.php
-
-		-
 			message: "#^Parameter \\#1 \\$name of class PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeIndex constructor expects string, mixed given\\.$#"
 			count: 1
 			path: src/Navigation/NavigationTree.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of class PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeProcedure constructor expects string, mixed given\\.$#"
-			count: 1
-			path: src/Navigation/NavigationTree.php
-
-		-
 			message: "#^Parameter \\#1 \\$name of class PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeTable constructor expects string, mixed given\\.$#"
-			count: 2
+			count: 1
 			path: src/Navigation/NavigationTree.php
 
 		-
 			message: "#^Parameter \\#1 \\$name of class PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeTrigger constructor expects string, mixed given\\.$#"
-			count: 1
-			path: src/Navigation/NavigationTree.php
-
-		-
-			message: "#^Parameter \\#1 \\$name of class PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeView constructor expects string, mixed given\\.$#"
 			count: 1
 			path: src/Navigation/NavigationTree.php
 
@@ -9869,6 +9849,11 @@ parameters:
 			message: "#^Parameter \\#2 \\$value of method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeColumn\\:\\:getTruncateValue\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Navigation/Nodes/NodeColumn.php
+
+		-
+			message: "#^Method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeDatabase\\:\\:getData\\(\\) should return array\\<string\\> but returns array\\.$#"
+			count: 1
+			path: src/Navigation/Nodes/NodeDatabase.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeDatabase\\:\\:getEventCount\\(\\) should return int but returns int\\|string\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9891,13 +9891,8 @@ parameters:
 			path: src/Navigation/Nodes/NodeDatabase.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(mixed, mixed\\)\\: int, 'strnatcasecmp' given\\.$#"
-			count: 3
-			path: src/Navigation/Nodes/NodeDatabase.php
-
-		-
-			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(string\\|null, string\\|null\\)\\: int, 'strnatcasecmp' given\\.$#"
-			count: 3
+			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(mixed, mixed\\)\\: int, Closure\\(string, string\\)\\: int\\<\\-1, 1\\> given\\.$#"
+			count: 1
 			path: src/Navigation/Nodes/NodeDatabase.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9881,7 +9881,7 @@ parameters:
 			path: src/Navigation/Nodes/ObjectFetcher.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\ObjectFetcher\\:\\:getTablesOrViews\\(\\) should return array\\<string\\> but returns array\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\ObjectFetcher\\:\\:getTablesAndViews\\(\\) should return array\\<array\\{name\\: string, type\\: string\\}\\> but returns array\\.$#"
 			count: 1
 			path: src/Navigation/Nodes/ObjectFetcher.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9851,36 +9851,6 @@ parameters:
 			path: src/Navigation/Nodes/NodeColumn.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeDatabase\\:\\:getData\\(\\) should return array\\<string\\> but returns array\\.$#"
-			count: 1
-			path: src/Navigation/Nodes/NodeDatabase.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeDatabase\\:\\:getEventCount\\(\\) should return int but returns int\\|string\\.$#"
-			count: 1
-			path: src/Navigation/Nodes/NodeDatabase.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeDatabase\\:\\:getFunctionCount\\(\\) should return int but returns int\\|string\\.$#"
-			count: 1
-			path: src/Navigation/Nodes/NodeDatabase.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeDatabase\\:\\:getProcedureCount\\(\\) should return int but returns int\\|string\\.$#"
-			count: 1
-			path: src/Navigation/Nodes/NodeDatabase.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeDatabase\\:\\:getTableOrViewCount\\(\\) should return int but returns int\\|string\\.$#"
-			count: 1
-			path: src/Navigation/Nodes/NodeDatabase.php
-
-		-
-			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(mixed, mixed\\)\\: int, Closure\\(string, string\\)\\: int\\<\\-1, 1\\> given\\.$#"
-			count: 1
-			path: src/Navigation/Nodes/NodeDatabase.php
-
-		-
 			message: "#^Cannot access property \\$realName on PhpMyAdmin\\\\Navigation\\\\Nodes\\\\Node\\|false\\.$#"
 			count: 1
 			path: src/Navigation/Nodes/NodeDatabaseChild.php
@@ -9899,6 +9869,21 @@ parameters:
 			message: "#^Parameter \\#1 \\$columnSpecification of static method PhpMyAdmin\\\\Util\\:\\:extractColumnSpec\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Navigation/Nodes/NodeTable.php
+
+		-
+			message: "#^Method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\ObjectFetcher\\:\\:getEventsFromDb\\(\\) should return array\\<string\\> but returns array\\.$#"
+			count: 1
+			path: src/Navigation/Nodes/ObjectFetcher.php
+
+		-
+			message: "#^Method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\ObjectFetcher\\:\\:getRoutines\\(\\) should return array\\<string\\> but returns array\\.$#"
+			count: 1
+			path: src/Navigation/Nodes/ObjectFetcher.php
+
+		-
+			message: "#^Method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\ObjectFetcher\\:\\:getTablesOrViews\\(\\) should return array\\<string\\> but returns array\\.$#"
+			count: 1
+			path: src/Navigation/Nodes/ObjectFetcher.php
 
 		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14794,6 +14794,14 @@
       <code>[]</code>
     </InvalidPropertyAssignmentValue>
   </file>
+  <file src="tests/classes/Navigation/Nodes/ObjectFetcherTest.php">
+    <DeprecatedMethod>
+      <code>Config::getInstance()</code>
+      <code>Config::getInstance()</code>
+      <code>Config::getInstance()</code>
+      <code>Config::getInstance()</code>
+    </DeprecatedMethod>
+  </file>
   <file src="tests/classes/NormalizationTest.php">
     <DeprecatedMethod>
       <code>Config::getInstance()</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7550,7 +7550,7 @@
       <code><![CDATA[$this->dbi->fetchResult($query)]]></code>
       <code><![CDATA[$this->dbi->fetchResult($query)]]></code>
       <code><![CDATA[$this->dbi->fetchResult($query)]]></code>
-      <code>string[]</code>
+      <code>array{name:string, type:string}[]</code>
       <code>string[]</code>
       <code>string[]</code>
     </MixedReturnTypeCoercion>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5386,7 +5386,7 @@
     </InvalidReturnType>
     <MixedReturnTypeCoercion>
       <code><![CDATA[array<array-key, string|null>]]></code>
-      <code><![CDATA[array_column($this->result->fetch_all(), 0)]]></code>
+      <code>array_column($result, $column)</code>
       <code><![CDATA[array_column($this->result->fetch_all(), 1, 0)]]></code>
       <code><![CDATA[list<string|null>]]></code>
     </MixedReturnTypeCoercion>
@@ -15520,6 +15520,11 @@
     <InvalidReturnType>
       <code><![CDATA[array<array-key, string|null>]]></code>
     </InvalidReturnType>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[array_column($this->fetchAllAssoc(), $column)]]></code>
+      <code><![CDATA[array_column($this->result, $column)]]></code>
+      <code><![CDATA[list<string|null>]]></code>
+    </MixedReturnTypeCoercion>
     <PossiblyUnusedReturnValue>
       <code>bool</code>
     </PossiblyUnusedReturnValue>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7506,41 +7506,9 @@
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
-      <code>Config::getInstance()</code>
-      <code>Config::getInstance()</code>
-      <code>Config::getInstance()</code>
-      <code>Config::getInstance()</code>
-      <code>Config::getInstance()</code>
-      <code>Config::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
-    <InvalidReturnStatement>
-      <code><![CDATA[$dbi->queryAndGetNumRows($query)]]></code>
-      <code><![CDATA[$dbi->queryAndGetNumRows($query)]]></code>
-      <code><![CDATA[$dbi->queryAndGetNumRows($query)]]></code>
-      <code><![CDATA[$dbi->queryAndGetNumRows($query)]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code>int</code>
-      <code>int</code>
-      <code>int</code>
-      <code>int</code>
-    </InvalidReturnType>
-    <MixedArgumentTypeCoercion>
-      <code>usort($retval, strnatcasecmp(...))</code>
-    </MixedArgumentTypeCoercion>
-    <MixedReturnTypeCoercion>
-      <code>$retval</code>
-      <code>string[]</code>
-    </MixedReturnTypeCoercion>
   </file>
   <file src="src/Navigation/Nodes/NodeDatabaseChild.php">
     <PossiblyInvalidPropertyFetch>
@@ -7576,6 +7544,16 @@
     <PossiblyUnusedProperty>
       <code>$secondIcon</code>
     </PossiblyUnusedProperty>
+  </file>
+  <file src="src/Navigation/Nodes/ObjectFetcher.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->dbi->fetchResult($query)]]></code>
+      <code><![CDATA[$this->dbi->fetchResult($query)]]></code>
+      <code><![CDATA[$this->dbi->fetchResult($query)]]></code>
+      <code>string[]</code>
+      <code>string[]</code>
+      <code>string[]</code>
+    </MixedReturnTypeCoercion>
   </file>
   <file src="src/Normalization.php">
     <DeprecatedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7332,11 +7332,6 @@
       <code>$item</code>
       <code>$item</code>
       <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
       <code>$path</code>
       <code>$path[0]</code>
       <code>$path[0]</code>
@@ -7360,7 +7355,6 @@
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$db</code>
-      <code>$item</code>
       <code>$item</code>
       <code>$part</code>
       <code>$path</code>
@@ -7543,6 +7537,10 @@
     <MixedArgumentTypeCoercion>
       <code>usort($retval, strnatcasecmp(...))</code>
     </MixedArgumentTypeCoercion>
+    <MixedReturnTypeCoercion>
+      <code>$retval</code>
+      <code>string[]</code>
+    </MixedReturnTypeCoercion>
   </file>
   <file src="src/Navigation/Nodes/NodeDatabaseChild.php">
     <PossiblyInvalidPropertyFetch>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.21.0@04ba9358e3f7d14a9dc3edd4e814a9d51d8c637f">
+<files psalm-version="5.21.1@8c473e2437be8b6a8fd8f630f0f11a16b114c494">
   <file src="app/services_loader.php">
     <MixedArgument>
       <code>$argumentName</code>
@@ -7517,6 +7517,7 @@
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
+      <code>Config::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
@@ -7527,11 +7528,6 @@
       <code>DatabaseInterface::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
-    <InvalidArgument>
-      <code><![CDATA[usort($retval, 'strnatcasecmp')]]></code>
-      <code><![CDATA[usort($retval, 'strnatcasecmp')]]></code>
-      <code><![CDATA[usort($retval, 'strnatcasecmp')]]></code>
-    </InvalidArgument>
     <InvalidReturnStatement>
       <code><![CDATA[$dbi->queryAndGetNumRows($query)]]></code>
       <code><![CDATA[$dbi->queryAndGetNumRows($query)]]></code>
@@ -7545,9 +7541,7 @@
       <code>int</code>
     </InvalidReturnType>
     <MixedArgumentTypeCoercion>
-      <code><![CDATA[usort($retval, 'strnatcasecmp')]]></code>
-      <code><![CDATA[usort($retval, 'strnatcasecmp')]]></code>
-      <code><![CDATA[usort($retval, 'strnatcasecmp')]]></code>
+      <code>usort($retval, strnatcasecmp(...))</code>
     </MixedArgumentTypeCoercion>
   </file>
   <file src="src/Navigation/Nodes/NodeDatabaseChild.php">

--- a/src/Dbal/MysqliResult.php
+++ b/src/Dbal/MysqliResult.php
@@ -19,6 +19,7 @@ use function is_bool;
 use function is_string;
 
 use const MYSQLI_ASSOC;
+use const MYSQLI_NUM;
 
 /**
  * Extension independent database result
@@ -121,12 +122,12 @@ final class MysqliResult implements ResultInterface
     }
 
     /**
-     * Returns values from the first column of each row
+     * Returns values from the selected column of each row
      *
      * @return array<int, string|null>
      * @psalm-return list<string|null>
      */
-    public function fetchAllColumn(): array
+    public function fetchAllColumn(int|string $column = 0): array
     {
         if ($this->result === null) {
             return [];
@@ -135,7 +136,9 @@ final class MysqliResult implements ResultInterface
         // This function should return all rows, not only the remaining rows
         $this->result->data_seek(0);
 
-        return array_column($this->result->fetch_all(), 0);
+        $result = is_string($column) ? $this->result->fetch_all(MYSQLI_ASSOC) : $this->result->fetch_all(MYSQLI_NUM);
+
+        return array_column($result, $column);
     }
 
     /**

--- a/src/Dbal/ResultInterface.php
+++ b/src/Dbal/ResultInterface.php
@@ -56,12 +56,12 @@ interface ResultInterface extends IteratorAggregate
     public function fetchAllAssoc(): array;
 
     /**
-     * Returns values from the first column of each row
+     * Returns values from the selected column of each row
      *
      * @return array<int, string|null>
      * @psalm-return list<string|null>
      */
-    public function fetchAllColumn(): array;
+    public function fetchAllColumn(int|string $column = 0): array;
 
     /**
      * Returns values as single dimensional array where the key is the first column

--- a/src/Navigation/Nodes/NodeDatabase.php
+++ b/src/Navigation/Nodes/NodeDatabase.php
@@ -258,7 +258,7 @@ class NodeDatabase extends Node
      * @param int    $pos          The offset of the list within the results
      * @param string $searchClause A string used to filter the results of the query
      *
-     * @return mixed[]
+     * @return string[]
      */
     public function getData(
         RelationParameters $relationParameters,

--- a/src/Navigation/Nodes/NodeDatabase.php
+++ b/src/Navigation/Nodes/NodeDatabase.php
@@ -452,9 +452,7 @@ class NodeDatabase extends Node
         $retval = [];
         $handle = $dbi->tryQuery($query);
         if ($handle !== false) {
-            while ($arr = $handle->fetchAssoc()) {
-                $retval[] = $arr['Name'];
-            }
+            $retval = $handle->fetchAllColumn('Name');
         }
 
         return $retval;
@@ -526,9 +524,7 @@ class NodeDatabase extends Node
         $retval = [];
         $handle = $dbi->tryQuery($query);
         if ($handle !== false) {
-            while ($arr = $handle->fetchAssoc()) {
-                $retval[] = $arr['Name'];
-            }
+            $retval = $handle->fetchAllColumn('Name');
         }
 
         return $retval;

--- a/src/Navigation/Nodes/NodeDatabase.php
+++ b/src/Navigation/Nodes/NodeDatabase.php
@@ -19,6 +19,7 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function array_slice;
+use function count;
 use function in_array;
 use function strnatcasecmp;
 use function substr;
@@ -38,6 +39,8 @@ class NodeDatabase extends Node
 
     /** @var int[][] $presenceCounts */
     private array $presenceCounts = [];
+
+    private ObjectFetcher $objectFetcher;
 
     /**
      * Initialises the class
@@ -61,6 +64,8 @@ class NodeDatabase extends Node
 
         $this->classes = 'database';
         $this->urlParamName = 'db';
+
+        $this->objectFetcher = new ObjectFetcher(DatabaseInterface::getInstance(), Config::getInstance());
     }
 
     /**
@@ -76,176 +81,13 @@ class NodeDatabase extends Node
     public function getPresence(string $type = '', string $searchClause = ''): int
     {
         return $this->presenceCounts[$type][$searchClause] ??= match ($type) {
-            'tables' => $this->getTableCount($searchClause),
-            'views' => $this->getViewCount($searchClause),
-            'procedures' => $this->getProcedureCount($searchClause),
-            'functions' => $this->getFunctionCount($searchClause),
-            'events' => $this->getEventCount($searchClause),
+            'tables' => count($this->objectFetcher->getTables($this->realName, $searchClause)),
+            'views' => count($this->objectFetcher->getViews($this->realName, $searchClause)),
+            'procedures' => count($this->objectFetcher->getProcedures($this->realName, $searchClause)),
+            'functions' => count($this->objectFetcher->getFunctions($this->realName, $searchClause)),
+            'events' => count($this->objectFetcher->getEvents($this->realName, $searchClause)),
             default => 0,
         };
-    }
-
-    /**
-     * Returns the number of tables or views present inside this database
-     *
-     * @param string $which        tables|views
-     * @param string $searchClause A string used to filter the results of
-     *                             the query
-     */
-    private function getTableOrViewCount(string $which, string $searchClause): int
-    {
-        $condition = $which === 'tables' ? 'IN' : 'NOT IN';
-
-        $dbi = DatabaseInterface::getInstance();
-        if (! Config::getInstance()->selectedServer['DisableIS']) {
-            $query = 'SELECT COUNT(*) ';
-            $query .= 'FROM `INFORMATION_SCHEMA`.`TABLES` ';
-            $query .= 'WHERE `TABLE_SCHEMA`=' . $dbi->quoteString($this->realName) . ' ';
-            $query .= 'AND `TABLE_TYPE` ' . $condition . "('BASE TABLE', 'SYSTEM VERSIONED') ";
-            if ($searchClause !== '') {
-                $query .= 'AND ' . $this->getWhereClauseForSearch($searchClause, 'TABLE_NAME');
-            }
-
-            return (int) $dbi->fetchValue($query);
-        }
-
-        $query = 'SHOW FULL TABLES FROM ';
-        $query .= Util::backquote($this->realName);
-        $query .= ' WHERE `Table_type` ' . $condition . "('BASE TABLE', 'SYSTEM VERSIONED') ";
-        if ($searchClause !== '') {
-            $query .= 'AND ' . $this->getWhereClauseForSearch($searchClause, 'Tables_in_' . $this->realName);
-        }
-
-        return $dbi->queryAndGetNumRows($query);
-    }
-
-    /**
-     * Returns the number of tables present inside this database
-     *
-     * @param string $searchClause A string used to filter the results of
-     *                             the query
-     */
-    private function getTableCount(string $searchClause): int
-    {
-        return $this->getTableOrViewCount('tables', $searchClause);
-    }
-
-    /**
-     * Returns the number of views present inside this database
-     *
-     * @param string $searchClause A string used to filter the results of
-     *                             the query
-     */
-    private function getViewCount(string $searchClause): int
-    {
-        return $this->getTableOrViewCount('views', $searchClause);
-    }
-
-    /**
-     * Returns the number of procedures present inside this database
-     *
-     * @param string $searchClause A string used to filter the results of
-     *                             the query
-     */
-    private function getProcedureCount(string $searchClause): int
-    {
-        $dbi = DatabaseInterface::getInstance();
-        if (! Config::getInstance()->selectedServer['DisableIS']) {
-            $query = 'SELECT COUNT(*) ';
-            $query .= 'FROM `INFORMATION_SCHEMA`.`ROUTINES` ';
-            $query .= 'WHERE `ROUTINE_SCHEMA` '
-                . Util::getCollateForIS() . '=' . $dbi->quoteString($this->realName);
-            $query .= "AND `ROUTINE_TYPE`='PROCEDURE' ";
-            if ($searchClause !== '') {
-                $query .= 'AND ' . $this->getWhereClauseForSearch($searchClause, 'ROUTINE_NAME');
-            }
-
-            return (int) $dbi->fetchValue($query);
-        }
-
-        $query = 'SHOW PROCEDURE STATUS WHERE `Db`=' . $dbi->quoteString($this->realName) . ' ';
-        if ($searchClause !== '') {
-            $query .= 'AND ' . $this->getWhereClauseForSearch($searchClause, 'Name');
-        }
-
-        return $dbi->queryAndGetNumRows($query);
-    }
-
-    /**
-     * Returns the number of functions present inside this database
-     *
-     * @param string $searchClause A string used to filter the results of
-     *                             the query
-     */
-    private function getFunctionCount(string $searchClause): int
-    {
-        $dbi = DatabaseInterface::getInstance();
-        if (! Config::getInstance()->selectedServer['DisableIS']) {
-            $query = 'SELECT COUNT(*) ';
-            $query .= 'FROM `INFORMATION_SCHEMA`.`ROUTINES` ';
-            $query .= 'WHERE `ROUTINE_SCHEMA` '
-                . Util::getCollateForIS() . '=' . $dbi->quoteString($this->realName) . ' ';
-            $query .= "AND `ROUTINE_TYPE`='FUNCTION' ";
-            if ($searchClause !== '') {
-                $query .= 'AND ' . $this->getWhereClauseForSearch($searchClause, 'ROUTINE_NAME');
-            }
-
-            return (int) $dbi->fetchValue($query);
-        }
-
-        $query = 'SHOW FUNCTION STATUS WHERE `Db`=' . $dbi->quoteString($this->realName) . ' ';
-        if ($searchClause !== '') {
-            $query .= 'AND ' . $this->getWhereClauseForSearch($searchClause, 'Name');
-        }
-
-        return $dbi->queryAndGetNumRows($query);
-    }
-
-    /**
-     * Returns the number of events present inside this database
-     *
-     * @param string $searchClause A string used to filter the results of
-     *                             the query
-     */
-    private function getEventCount(string $searchClause): int
-    {
-        $dbi = DatabaseInterface::getInstance();
-        if (! Config::getInstance()->selectedServer['DisableIS']) {
-            $query = 'SELECT COUNT(*) ';
-            $query .= 'FROM `INFORMATION_SCHEMA`.`EVENTS` ';
-            $query .= 'WHERE `EVENT_SCHEMA` '
-                . Util::getCollateForIS() . '=' . $dbi->quoteString($this->realName) . ' ';
-            if ($searchClause !== '') {
-                $query .= 'AND ' . $this->getWhereClauseForSearch($searchClause, 'EVENT_NAME');
-            }
-
-            return (int) $dbi->fetchValue($query);
-        }
-
-        $query = 'SHOW EVENTS FROM ' . Util::backquote($this->realName) . ' ';
-        if ($searchClause !== '') {
-            $query .= 'WHERE ' . $this->getWhereClauseForSearch($searchClause, 'Name');
-        }
-
-        return $dbi->queryAndGetNumRows($query);
-    }
-
-    /**
-     * Returns the WHERE clause for searching inside a database
-     *
-     * @param string $searchClause A string used to filter the results of the query
-     * @param string $columnName   Name of the column in the result set to match
-     *
-     * @return string WHERE clause for searching
-     */
-    private function getWhereClauseForSearch(
-        string $searchClause,
-        string $columnName,
-    ): string {
-        $dbi = DatabaseInterface::getInstance();
-
-        return Util::backquote($columnName) . ' LIKE '
-            . $dbi->quoteString('%' . $dbi->escapeMysqlWildcards($searchClause) . '%');
     }
 
     /**
@@ -267,11 +109,11 @@ class NodeDatabase extends Node
         string $searchClause = '',
     ): array {
         $retval = match ($type) {
-            'tables' => $this->getTables($pos, $searchClause),
-            'views' => $this->getViews($pos, $searchClause),
-            'procedures' => $this->getProcedures($pos, $searchClause),
-            'functions' => $this->getFunctions($pos, $searchClause),
-            'events' => $this->getEvents($pos, $searchClause),
+            'tables' => $this->objectFetcher->getTables($this->realName, $searchClause),
+            'views' => $this->objectFetcher->getViews($this->realName, $searchClause),
+            'procedures' => $this->objectFetcher->getProcedures($this->realName, $searchClause),
+            'functions' => $this->objectFetcher->getFunctions($this->realName, $searchClause),
+            'events' => $this->objectFetcher->getEvents($this->realName, $searchClause),
             default => [],
         };
 
@@ -331,203 +173,6 @@ class NodeDatabase extends Node
         }
 
         return $hiddenItems;
-    }
-
-    /**
-     * Returns the list of tables or views inside this database
-     *
-     * @param string $which        tables|views
-     * @param int    $pos          The offset of the list within the results
-     * @param string $searchClause A string used to filter the results of the query
-     *
-     * @return mixed[]
-     */
-    private function getTablesOrViews(string $which, int $pos, string $searchClause): array
-    {
-        $condition = $which === 'tables' ? 'IN' : 'NOT IN';
-
-        $config = Config::getInstance();
-        $dbi = DatabaseInterface::getInstance();
-        if (! $config->selectedServer['DisableIS']) {
-            $query = 'SELECT `TABLE_NAME` AS `name` ';
-            $query .= 'FROM `INFORMATION_SCHEMA`.`TABLES` ';
-            $query .= 'WHERE `TABLE_SCHEMA`=' . $dbi->quoteString($this->realName) . ' ';
-            $query .= 'AND `TABLE_TYPE` ' . $condition . "('BASE TABLE', 'SYSTEM VERSIONED') ";
-            if ($searchClause !== '') {
-                $query .= 'AND `TABLE_NAME` LIKE ';
-                $query .= $dbi->quoteString(
-                    '%' . $dbi->escapeMysqlWildcards($searchClause) . '%',
-                );
-            }
-
-            $query .= 'ORDER BY `TABLE_NAME` ASC ';
-
-            return $dbi->fetchResult($query);
-        }
-
-        $query = ' SHOW FULL TABLES FROM ';
-        $query .= Util::backquote($this->realName);
-        $query .= ' WHERE `Table_type` ' . $condition . "('BASE TABLE', 'SYSTEM VERSIONED') ";
-        if ($searchClause !== '') {
-            $query .= 'AND ' . Util::backquote('Tables_in_' . $this->realName);
-            $query .= ' LIKE ' . $dbi->quoteString(
-                '%' . $dbi->escapeMysqlWildcards($searchClause) . '%',
-            );
-        }
-
-        $retval = [];
-        $handle = $dbi->tryQuery($query);
-        if ($handle !== false) {
-            $retval = $handle->fetchAllColumn();
-        }
-
-        return $retval;
-    }
-
-    /**
-     * Returns the list of tables inside this database
-     *
-     * @param int    $pos          The offset of the list within the results
-     * @param string $searchClause A string used to filter the results of the query
-     *
-     * @return mixed[]
-     */
-    private function getTables(int $pos, string $searchClause): array
-    {
-        return $this->getTablesOrViews('tables', $pos, $searchClause);
-    }
-
-    /**
-     * Returns the list of views inside this database
-     *
-     * @param int    $pos          The offset of the list within the results
-     * @param string $searchClause A string used to filter the results of the query
-     *
-     * @return mixed[]
-     */
-    private function getViews(int $pos, string $searchClause): array
-    {
-        return $this->getTablesOrViews('views', $pos, $searchClause);
-    }
-
-    /**
-     * Returns the list of procedures or functions inside this database
-     *
-     * @param string $routineType  PROCEDURE|FUNCTION
-     * @param int    $pos          The offset of the list within the results
-     * @param string $searchClause A string used to filter the results of the query
-     *
-     * @return mixed[]
-     */
-    private function getRoutines(string $routineType, int $pos, string $searchClause): array
-    {
-        $config = Config::getInstance();
-        $dbi = DatabaseInterface::getInstance();
-        if (! $config->selectedServer['DisableIS']) {
-            $query = 'SELECT `ROUTINE_NAME` AS `name` ';
-            $query .= 'FROM `INFORMATION_SCHEMA`.`ROUTINES` ';
-            $query .= 'WHERE `ROUTINE_SCHEMA` '
-                . Util::getCollateForIS() . '=' . $dbi->quoteString($this->realName);
-            $query .= "AND `ROUTINE_TYPE`='" . $routineType . "' ";
-            if ($searchClause !== '') {
-                $query .= 'AND `ROUTINE_NAME` LIKE ';
-                $query .= $dbi->quoteString(
-                    '%' . $dbi->escapeMysqlWildcards($searchClause) . '%',
-                );
-            }
-
-            $query .= 'ORDER BY `ROUTINE_NAME` ASC ';
-
-            return $dbi->fetchResult($query);
-        }
-
-        $query = 'SHOW ' . $routineType . ' STATUS WHERE `Db`=' . $dbi->quoteString($this->realName) . ' ';
-        if ($searchClause !== '') {
-            $query .= 'AND `Name` LIKE ';
-            $query .= $dbi->quoteString(
-                '%' . $dbi->escapeMysqlWildcards($searchClause) . '%',
-            );
-        }
-
-        $retval = [];
-        $handle = $dbi->tryQuery($query);
-        if ($handle !== false) {
-            $retval = $handle->fetchAllColumn('Name');
-        }
-
-        return $retval;
-    }
-
-    /**
-     * Returns the list of procedures inside this database
-     *
-     * @param int    $pos          The offset of the list within the results
-     * @param string $searchClause A string used to filter the results of the query
-     *
-     * @return mixed[]
-     */
-    private function getProcedures(int $pos, string $searchClause): array
-    {
-        return $this->getRoutines('PROCEDURE', $pos, $searchClause);
-    }
-
-    /**
-     * Returns the list of functions inside this database
-     *
-     * @param int    $pos          The offset of the list within the results
-     * @param string $searchClause A string used to filter the results of the query
-     *
-     * @return mixed[]
-     */
-    private function getFunctions(int $pos, string $searchClause): array
-    {
-        return $this->getRoutines('FUNCTION', $pos, $searchClause);
-    }
-
-    /**
-     * Returns the list of events inside this database
-     *
-     * @param int    $pos          The offset of the list within the results
-     * @param string $searchClause A string used to filter the results of the query
-     *
-     * @return mixed[]
-     */
-    private function getEvents(int $pos, string $searchClause): array
-    {
-        $config = Config::getInstance();
-        $dbi = DatabaseInterface::getInstance();
-        if (! $config->selectedServer['DisableIS']) {
-            $query = 'SELECT `EVENT_NAME` AS `name` ';
-            $query .= 'FROM `INFORMATION_SCHEMA`.`EVENTS` ';
-            $query .= 'WHERE `EVENT_SCHEMA` '
-                . Util::getCollateForIS() . '=' . $dbi->quoteString($this->realName) . ' ';
-            if ($searchClause !== '') {
-                $query .= 'AND `EVENT_NAME` LIKE ';
-                $query .= $dbi->quoteString(
-                    '%' . $dbi->escapeMysqlWildcards($searchClause) . '%',
-                );
-            }
-
-            $query .= 'ORDER BY `EVENT_NAME` ASC ';
-
-            return $dbi->fetchResult($query);
-        }
-
-        $query = 'SHOW EVENTS FROM ' . Util::backquote($this->realName) . ' ';
-        if ($searchClause !== '') {
-            $query .= 'WHERE `Name` LIKE ';
-            $query .= $dbi->quoteString(
-                '%' . $dbi->escapeMysqlWildcards($searchClause) . '%',
-            );
-        }
-
-        $retval = [];
-        $handle = $dbi->tryQuery($query);
-        if ($handle !== false) {
-            $retval = $handle->fetchAllColumn('Name');
-        }
-
-        return $retval;
     }
 
     /**

--- a/src/Navigation/Nodes/NodeDatabase.php
+++ b/src/Navigation/Nodes/NodeDatabase.php
@@ -20,6 +20,7 @@ use PhpMyAdmin\Util;
 use function __;
 use function array_slice;
 use function in_array;
+use function strnatcasecmp;
 use function substr;
 use function usort;
 
@@ -274,6 +275,15 @@ class NodeDatabase extends Node
             default => [],
         };
 
+        $config = Config::getInstance();
+        $maxItems = $config->settings['MaxNavigationItems'];
+
+        if ($config->settings['NaturalOrder']) {
+            usort($retval, strnatcasecmp(...));
+        }
+
+        $retval = array_slice($retval, $pos, $maxItems);
+
         // Remove hidden items so that they are not displayed in navigation tree
         if ($relationParameters->navigationItemsHidingFeature !== null) {
             $hiddenItems = $this->getHiddenItems($relationParameters, substr($type, 0, -1));
@@ -337,7 +347,6 @@ class NodeDatabase extends Node
         $condition = $which === 'tables' ? 'IN' : 'NOT IN';
 
         $config = Config::getInstance();
-        $maxItems = $config->settings['MaxNavigationItems'];
         $dbi = DatabaseInterface::getInstance();
         if (! $config->selectedServer['DisableIS']) {
             $query = 'SELECT `TABLE_NAME` AS `name` ';
@@ -352,13 +361,8 @@ class NodeDatabase extends Node
             }
 
             $query .= 'ORDER BY `TABLE_NAME` ASC ';
-            $retval = $dbi->fetchResult($query);
 
-            if ($config->settings['NaturalOrder']) {
-                usort($retval, 'strnatcasecmp');
-            }
-
-            return array_slice($retval, $pos, $maxItems);
+            return $dbi->fetchResult($query);
         }
 
         $query = ' SHOW FULL TABLES FROM ';
@@ -377,11 +381,7 @@ class NodeDatabase extends Node
             $retval = $handle->fetchAllColumn();
         }
 
-        if ($config->settings['NaturalOrder']) {
-            usort($retval, 'strnatcasecmp');
-        }
-
-        return array_slice($retval, $pos, $maxItems);
+        return $retval;
     }
 
     /**
@@ -422,7 +422,6 @@ class NodeDatabase extends Node
     private function getRoutines(string $routineType, int $pos, string $searchClause): array
     {
         $config = Config::getInstance();
-        $maxItems = $config->settings['MaxNavigationItems'];
         $dbi = DatabaseInterface::getInstance();
         if (! $config->selectedServer['DisableIS']) {
             $query = 'SELECT `ROUTINE_NAME` AS `name` ';
@@ -438,13 +437,8 @@ class NodeDatabase extends Node
             }
 
             $query .= 'ORDER BY `ROUTINE_NAME` ASC ';
-            $retval = $dbi->fetchResult($query);
 
-            if ($config->settings['NaturalOrder']) {
-                usort($retval, 'strnatcasecmp');
-            }
-
-            return array_slice($retval, $pos, $maxItems);
+            return $dbi->fetchResult($query);
         }
 
         $query = 'SHOW ' . $routineType . ' STATUS WHERE `Db`=' . $dbi->quoteString($this->realName) . ' ';
@@ -463,11 +457,7 @@ class NodeDatabase extends Node
             }
         }
 
-        if ($config->settings['NaturalOrder']) {
-            usort($retval, 'strnatcasecmp');
-        }
-
-        return array_slice($retval, $pos, $maxItems);
+        return $retval;
     }
 
     /**
@@ -507,7 +497,6 @@ class NodeDatabase extends Node
     private function getEvents(int $pos, string $searchClause): array
     {
         $config = Config::getInstance();
-        $maxItems = $config->settings['MaxNavigationItems'];
         $dbi = DatabaseInterface::getInstance();
         if (! $config->selectedServer['DisableIS']) {
             $query = 'SELECT `EVENT_NAME` AS `name` ';
@@ -522,13 +511,8 @@ class NodeDatabase extends Node
             }
 
             $query .= 'ORDER BY `EVENT_NAME` ASC ';
-            $retval = $dbi->fetchResult($query);
 
-            if ($config->settings['NaturalOrder']) {
-                usort($retval, 'strnatcasecmp');
-            }
-
-            return array_slice($retval, $pos, $maxItems);
+            return $dbi->fetchResult($query);
         }
 
         $query = 'SHOW EVENTS FROM ' . Util::backquote($this->realName) . ' ';
@@ -547,11 +531,7 @@ class NodeDatabase extends Node
             }
         }
 
-        if ($config->settings['NaturalOrder']) {
-            usort($retval, 'strnatcasecmp');
-        }
-
-        return array_slice($retval, $pos, $maxItems);
+        return $retval;
     }
 
     /**

--- a/src/Navigation/Nodes/ObjectFetcher.php
+++ b/src/Navigation/Nodes/ObjectFetcher.php
@@ -119,7 +119,7 @@ class ObjectFetcher
                 $query .= $this->dbi->quoteString('%' . $this->dbi->escapeMysqlWildcards($searchClause) . '%');
             }
 
-            $query .= ' ORDER BY `EVENT_NAME` ASC ';
+            $query .= ' ORDER BY `EVENT_NAME` ASC';
 
             return $this->dbi->fetchResult($query);
         }
@@ -179,7 +179,7 @@ class ObjectFetcher
                 $query .= $this->dbi->quoteString('%' . $this->dbi->escapeMysqlWildcards($searchClause) . '%');
             }
 
-            $query .= ' ORDER BY `TABLE_NAME` ASC ';
+            $query .= ' ORDER BY `TABLE_NAME` ASC';
 
             return $this->dbi->fetchResult($query);
         }
@@ -187,7 +187,7 @@ class ObjectFetcher
         $query = 'SHOW FULL TABLES FROM ';
         $query .= Util::backquote($realName);
         if ($searchClause !== '') {
-            $query .= 'AND ' . Util::backquote('Tables_in_' . $realName) . ' LIKE ';
+            $query .= ' WHERE ' . Util::backquote('Tables_in_' . $realName) . ' LIKE ';
             $query .= $this->dbi->quoteString('%' . $this->dbi->escapeMysqlWildcards($searchClause) . '%');
         }
 
@@ -216,15 +216,14 @@ class ObjectFetcher
         if (! $this->config->selectedServer['DisableIS']) {
             $query = 'SELECT `ROUTINE_NAME` AS `name` ';
             $query .= 'FROM `INFORMATION_SCHEMA`.`ROUTINES` ';
-            $query .= 'WHERE `ROUTINE_SCHEMA` '
-                . Util::getCollateForIS() . '=' . $this->dbi->quoteString($realName);
-            $query .= "AND `ROUTINE_TYPE`='" . $routineType . "' ";
+            $query .= 'WHERE `ROUTINE_SCHEMA` ' . Util::getCollateForIS() . '=' . $this->dbi->quoteString($realName);
+            $query .= " AND `ROUTINE_TYPE`='" . $routineType . "'";
             if ($searchClause !== '') {
-                $query .= 'AND `ROUTINE_NAME` LIKE ';
+                $query .= ' AND `ROUTINE_NAME` LIKE ';
                 $query .= $this->dbi->quoteString('%' . $this->dbi->escapeMysqlWildcards($searchClause) . '%');
             }
 
-            $query .= 'ORDER BY `ROUTINE_NAME` ASC ';
+            $query .= ' ORDER BY `ROUTINE_NAME` ASC';
 
             return $this->dbi->fetchResult($query);
         }

--- a/src/Navigation/Nodes/ObjectFetcher.php
+++ b/src/Navigation/Nodes/ObjectFetcher.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Navigation\Nodes;
+
+use PhpMyAdmin\Config;
+use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Util;
+
+class ObjectFetcher
+{
+    /** @var string[]|null */
+    private array|null $tables = null;
+    /** @var string[]|null */
+    private array|null $views = null;
+    /** @var string[]|null */
+    private array|null $procedures = null;
+    /** @var string[]|null */
+    private array|null $functions = null;
+    /** @var string[]|null */
+    private array|null $events = null;
+
+    public function __construct(private DatabaseInterface $dbi, private Config $config)
+    {
+    }
+
+    /**
+     * Returns the list of tables inside this database
+     *
+     * @param string $searchClause A string used to filter the results of the query
+     *
+     * @return string[]
+     */
+    public function getTables(string $realName, string $searchClause): array
+    {
+        if ($this->tables !== null) {
+            return $this->tables;
+        }
+
+        return $this->tables = $this->getTablesOrViews('tables', $realName, $searchClause);
+    }
+
+    /**
+     * Returns the list of views inside this database
+     *
+     * @param string $searchClause A string used to filter the results of the query
+     *
+     * @return string[]
+     */
+    public function getViews(string $realName, string $searchClause): array
+    {
+        if ($this->views !== null) {
+            return $this->views;
+        }
+
+        return $this->views = $this->getTablesOrViews('views', $realName, $searchClause);
+    }
+
+    /**
+     * Returns the list of procedures inside this database
+     *
+     * @param string $searchClause A string used to filter the results of the query
+     *
+     * @return string[]
+     */
+    public function getProcedures(string $realName, string $searchClause): array
+    {
+        if ($this->procedures !== null) {
+            return $this->procedures;
+        }
+
+        return $this->procedures = $this->getRoutines('PROCEDURE', $realName, $searchClause);
+    }
+
+    /**
+     * Returns the list of functions inside this database
+     *
+     * @param string $searchClause A string used to filter the results of the query
+     *
+     * @return string[]
+     */
+    public function getFunctions(string $realName, string $searchClause): array
+    {
+        if ($this->functions !== null) {
+            return $this->functions;
+        }
+
+        return $this->functions = $this->getRoutines('FUNCTION', $realName, $searchClause);
+    }
+
+    /**
+     * Returns the list of events inside this database
+     *
+     * @param string $searchClause A string used to filter the results of the query
+     *
+     * @return string[]
+     */
+    public function getEvents(string $realName, string $searchClause): array
+    {
+        if ($this->events !== null) {
+            return $this->events;
+        }
+
+        return $this->events = $this->getEventsFromDb($realName, $searchClause);
+    }
+
+    /** @return string[] */
+    private function getEventsFromDb(string $realName, string $searchClause): array
+    {
+        if (! $this->config->selectedServer['DisableIS']) {
+            $query = 'SELECT `EVENT_NAME` AS `name` ';
+            $query .= 'FROM `INFORMATION_SCHEMA`.`EVENTS` ';
+            $query .= 'WHERE `EVENT_SCHEMA` ' . Util::getCollateForIS() . '=' . $this->dbi->quoteString($realName);
+            if ($searchClause !== '') {
+                $query .= ' AND `EVENT_NAME` LIKE ';
+                $query .= $this->dbi->quoteString('%' . $this->dbi->escapeMysqlWildcards($searchClause) . '%');
+            }
+
+            $query .= ' ORDER BY `EVENT_NAME` ASC ';
+
+            return $this->dbi->fetchResult($query);
+        }
+
+        $query = 'SHOW EVENTS FROM ' . Util::backquote($realName);
+        if ($searchClause !== '') {
+            $query .= ' WHERE `Name` LIKE ';
+            $query .= $this->dbi->quoteString('%' . $this->dbi->escapeMysqlWildcards($searchClause) . '%');
+        }
+
+        $retval = [];
+        $handle = $this->dbi->tryQuery($query);
+        if ($handle !== false) {
+            /** @var string[] $retval */
+            $retval = $handle->fetchAllColumn('Name');
+        }
+
+        return $retval;
+    }
+
+    /**
+     * Returns the list of tables or views inside this database
+     *
+     * @param string $which        tables|views
+     * @param string $searchClause A string used to filter the results of the query
+     *
+     * @return string[]
+     */
+    private function getTablesOrViews(string $which, string $realName, string $searchClause): array
+    {
+        $condition = $which === 'tables' ? 'IN' : 'NOT IN';
+
+        if (! $this->config->selectedServer['DisableIS']) {
+            $query = 'SELECT `TABLE_NAME` AS `name` ';
+            $query .= 'FROM `INFORMATION_SCHEMA`.`TABLES` ';
+            $query .= 'WHERE `TABLE_SCHEMA`=' . $this->dbi->quoteString($realName);
+            $query .= ' AND `TABLE_TYPE` ' . $condition . "('BASE TABLE', 'SYSTEM VERSIONED') ";
+            if ($searchClause !== '') {
+                $query .= ' AND `TABLE_NAME` LIKE ';
+                $query .= $this->dbi->quoteString('%' . $this->dbi->escapeMysqlWildcards($searchClause) . '%');
+            }
+
+            $query .= ' ORDER BY `TABLE_NAME` ASC ';
+
+            return $this->dbi->fetchResult($query);
+        }
+
+        $query = ' SHOW FULL TABLES FROM ';
+        $query .= Util::backquote($realName);
+        $query .= ' WHERE `Table_type` ' . $condition . "('BASE TABLE', 'SYSTEM VERSIONED') ";
+        if ($searchClause !== '') {
+            $query .= 'AND ' . Util::backquote('Tables_in_' . $realName) . ' LIKE ';
+            $query .= $this->dbi->quoteString('%' . $this->dbi->escapeMysqlWildcards($searchClause) . '%');
+        }
+
+        $retval = [];
+        $handle = $this->dbi->tryQuery($query);
+        if ($handle !== false) {
+            /** @var string[] $retval */
+            $retval = $handle->fetchAllColumn();
+        }
+
+        return $retval;
+    }
+
+    /**
+     * Returns the list of procedures or functions inside this database
+     *
+     * @param string $routineType  PROCEDURE|FUNCTION
+     * @param string $searchClause A string used to filter the results of the query
+     *
+     * @return string[]
+     */
+    private function getRoutines(string $routineType, string $realName, string $searchClause): array
+    {
+        if (! $this->config->selectedServer['DisableIS']) {
+            $query = 'SELECT `ROUTINE_NAME` AS `name` ';
+            $query .= 'FROM `INFORMATION_SCHEMA`.`ROUTINES` ';
+            $query .= 'WHERE `ROUTINE_SCHEMA` '
+                . Util::getCollateForIS() . '=' . $this->dbi->quoteString($realName);
+            $query .= "AND `ROUTINE_TYPE`='" . $routineType . "' ";
+            if ($searchClause !== '') {
+                $query .= 'AND `ROUTINE_NAME` LIKE ';
+                $query .= $this->dbi->quoteString('%' . $this->dbi->escapeMysqlWildcards($searchClause) . '%');
+            }
+
+            $query .= 'ORDER BY `ROUTINE_NAME` ASC ';
+
+            return $this->dbi->fetchResult($query);
+        }
+
+        $query = 'SHOW ' . $routineType . ' STATUS WHERE `Db`=' . $this->dbi->quoteString($realName);
+        if ($searchClause !== '') {
+            $query .= ' AND `Name` LIKE ';
+            $query .= $this->dbi->quoteString('%' . $this->dbi->escapeMysqlWildcards($searchClause) . '%');
+        }
+
+        $retval = [];
+        $handle = $this->dbi->tryQuery($query);
+        if ($handle !== false) {
+            /** @var string[] $retval */
+            $retval = $handle->fetchAllColumn('Name');
+        }
+
+        return $retval;
+    }
+}

--- a/tests/classes/Controllers/NavigationControllerTest.php
+++ b/tests/classes/Controllers/NavigationControllerTest.php
@@ -90,36 +90,31 @@ class NavigationControllerTest extends AbstractTestCase
         );
 
         $this->dummyDbi->addResult(
-            'SELECT COUNT(*) FROM `INFORMATION_SCHEMA`.`TABLES` WHERE `TABLE_SCHEMA`=\'air-balloon_burner_dev2\''
-            . ' AND `TABLE_TYPE` IN(\'BASE TABLE\', \'SYSTEM VERSIONED\')',
-            [[0]],
-        );
-
-        $this->dummyDbi->addResult(
-            'SELECT COUNT(*) FROM `INFORMATION_SCHEMA`.`TABLES` WHERE `TABLE_SCHEMA`=\'air-balloon_burner_dev2\''
-            . ' AND `TABLE_TYPE` NOT IN(\'BASE TABLE\', \'SYSTEM VERSIONED\')',
-            [[0]],
+            'SELECT `TABLE_NAME` AS `name`, `TABLE_TYPE` AS `type` FROM `INFORMATION_SCHEMA`.`TABLES`'
+            . ' WHERE `TABLE_SCHEMA`=\'air-balloon_burner_dev2\' ORDER BY `TABLE_NAME` ASC',
+            [],
         );
 
         $this->dummyDbi->addResult('SELECT @@lower_case_table_names', [['0']]);
 
         $this->dummyDbi->addResult(
-            'SELECT COUNT(*) FROM `INFORMATION_SCHEMA`.`ROUTINES` WHERE '
-            . '`ROUTINE_SCHEMA` COLLATE utf8_bin=\'air-balloon_burner_dev2\' AND `ROUTINE_TYPE`=\'FUNCTION\'',
-            [[0]],
+            'SELECT `ROUTINE_NAME` AS `name` FROM `INFORMATION_SCHEMA`.`ROUTINES` WHERE '
+            . '`ROUTINE_SCHEMA` COLLATE utf8_bin=\'air-balloon_burner_dev2\' AND `ROUTINE_TYPE`=\'FUNCTION\' '
+            . 'ORDER BY `ROUTINE_NAME` ASC',
+            [],
         );
 
         $this->dummyDbi->addResult(
-            'SELECT COUNT(*) FROM `INFORMATION_SCHEMA`.`ROUTINES`'
-            . ' WHERE `ROUTINE_SCHEMA` COLLATE utf8_bin=\'air-balloon_burner_dev2\''
-            . 'AND `ROUTINE_TYPE`=\'PROCEDURE\'',
-            [[0]],
+            'SELECT `ROUTINE_NAME` AS `name` FROM `INFORMATION_SCHEMA`.`ROUTINES` WHERE '
+            . '`ROUTINE_SCHEMA` COLLATE utf8_bin=\'air-balloon_burner_dev2\' AND `ROUTINE_TYPE`=\'PROCEDURE\' '
+            . 'ORDER BY `ROUTINE_NAME` ASC',
+            [],
         );
 
         $this->dummyDbi->addResult(
-            'SELECT COUNT(*) FROM `INFORMATION_SCHEMA`.`EVENTS`'
-            . ' WHERE `EVENT_SCHEMA` COLLATE utf8_bin=\'air-balloon_burner_dev2\'',
-            [[0]],
+            'SELECT `EVENT_NAME` AS `name` FROM `INFORMATION_SCHEMA`.`EVENTS`'
+            . ' WHERE `EVENT_SCHEMA` COLLATE utf8_bin=\'air-balloon_burner_dev2\' ORDER BY `EVENT_NAME` ASC',
+            [],
         );
 
         $responseRenderer = new ResponseRenderer();
@@ -245,35 +240,31 @@ class NavigationControllerTest extends AbstractTestCase
         );
 
         $this->dummyDbi->addResult(
-            'SELECT COUNT(*) FROM `INFORMATION_SCHEMA`.`TABLES` WHERE `TABLE_SCHEMA`=\'air-balloon_burner_dev2\''
-            . ' AND `TABLE_TYPE` IN(\'BASE TABLE\', \'SYSTEM VERSIONED\')',
-            [[0]],
-        );
-
-        $this->dummyDbi->addResult(
-            'SELECT COUNT(*) FROM `INFORMATION_SCHEMA`.`TABLES` WHERE `TABLE_SCHEMA`=\'air-balloon_burner_dev2\''
-            . ' AND `TABLE_TYPE` NOT IN(\'BASE TABLE\', \'SYSTEM VERSIONED\')',
-            [[0]],
+            'SELECT `TABLE_NAME` AS `name`, `TABLE_TYPE` AS `type` FROM `INFORMATION_SCHEMA`.`TABLES`'
+            . ' WHERE `TABLE_SCHEMA`=\'air-balloon_burner_dev2\' ORDER BY `TABLE_NAME` ASC',
+            [],
         );
 
         $this->dummyDbi->addResult('SELECT @@lower_case_table_names', [['0']]);
 
         $this->dummyDbi->addResult(
-            'SELECT COUNT(*) FROM `INFORMATION_SCHEMA`.`ROUTINES` WHERE '
-            . '`ROUTINE_SCHEMA` COLLATE utf8_bin=\'air-balloon_burner_dev2\' AND `ROUTINE_TYPE`=\'FUNCTION\'',
-            [[0]],
+            'SELECT `ROUTINE_NAME` AS `name` FROM `INFORMATION_SCHEMA`.`ROUTINES` WHERE '
+            . '`ROUTINE_SCHEMA` COLLATE utf8_bin=\'air-balloon_burner_dev2\' AND `ROUTINE_TYPE`=\'FUNCTION\' '
+            . 'ORDER BY `ROUTINE_NAME` ASC',
+            [],
         );
 
         $this->dummyDbi->addResult(
-            'SELECT COUNT(*) FROM `INFORMATION_SCHEMA`.`EVENTS` WHERE'
-            . ' `EVENT_SCHEMA` COLLATE utf8_bin=\'air-balloon_burner_dev2\'',
-            [[0]],
+            'SELECT `EVENT_NAME` AS `name` FROM `INFORMATION_SCHEMA`.`EVENTS` WHERE'
+            . ' `EVENT_SCHEMA` COLLATE utf8_bin=\'air-balloon_burner_dev2\' ORDER BY `EVENT_NAME` ASC',
+            [],
         );
 
         $this->dummyDbi->addResult(
-            'SELECT COUNT(*) FROM `INFORMATION_SCHEMA`.`ROUTINES` WHERE '
-            . '`ROUTINE_SCHEMA` COLLATE utf8_bin=\'air-balloon_burner_dev2\'AND `ROUTINE_TYPE`=\'PROCEDURE\'',
-            [[0]],
+            'SELECT `ROUTINE_NAME` AS `name` FROM `INFORMATION_SCHEMA`.`ROUTINES` WHERE '
+            . '`ROUTINE_SCHEMA` COLLATE utf8_bin=\'air-balloon_burner_dev2\' AND `ROUTINE_TYPE`=\'PROCEDURE\' '
+            . 'ORDER BY `ROUTINE_NAME` ASC',
+            [],
         );
 
         $responseRenderer = new ResponseRenderer();

--- a/tests/classes/Dbal/MysqliResultTest.php
+++ b/tests/classes/Dbal/MysqliResultTest.php
@@ -10,6 +10,9 @@ use PhpMyAdmin\Dbal\MysqliResult;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
+use const MYSQLI_ASSOC;
+use const MYSQLI_NUM;
+
 #[CoversClass(DbiMysqli::class)]
 class MysqliResultTest extends AbstractTestCase
 {
@@ -62,5 +65,25 @@ class MysqliResultTest extends AbstractTestCase
         $result = new MysqliResult($mysqliResult);
 
         self::assertTrue($result->seek($offset));
+    }
+
+    /**
+     * Test for fetchAllColumn
+     */
+    public function testFetchAllColumn(): void
+    {
+        $mysqliResult = self::createMock(mysqli_result::class);
+        $mysqliResult->expects(self::exactly(3))
+            ->method('fetch_all')
+            ->willReturnMap([
+                [MYSQLI_ASSOC, [['foo' => 'bar']]],
+                [MYSQLI_NUM, [['baz', 'foobar']]],
+            ]);
+
+        $result = new MysqliResult($mysqliResult);
+
+        self::assertSame(['baz'], $result->fetchAllColumn());
+        self::assertSame(['foobar'], $result->fetchAllColumn(1));
+        self::assertSame(['bar'], $result->fetchAllColumn('foo'));
     }
 }

--- a/tests/classes/Navigation/Nodes/ObjectFetcherTest.php
+++ b/tests/classes/Navigation/Nodes/ObjectFetcherTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Navigation\Nodes;
+
+use PhpMyAdmin\Config;
+use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Navigation\Nodes\ObjectFetcher;
+use PhpMyAdmin\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(ObjectFetcher::class)]
+class ObjectFetcherTest extends AbstractTestCase
+{
+    public function testGetDataIS(): void
+    {
+        $config = Config::getInstance();
+        $config->selectedServer['DisableIS'] = false;
+
+        $dummyDbi = $this->createDbiDummy();
+        $dummyDbi->removeDefaultResults();
+        $dbi = $this->createDatabaseInterface($dummyDbi);
+        DatabaseInterface::$instance = $dbi;
+
+        $dummyDbi->addResult('SELECT @@lower_case_table_names', [['0']]);
+
+        $dummyDbi->addResult(
+            'SELECT `TABLE_NAME` AS `name`, `TABLE_TYPE` AS `type` FROM `INFORMATION_SCHEMA`.`TABLES`'
+            . ' WHERE `TABLE_SCHEMA`=\'default\' ORDER BY `TABLE_NAME` ASC',
+            [
+                ['test_table', 'BASE TABLE'],
+                ['test_view', 'VIEW'],
+            ],
+            ['name', 'type'],
+        );
+
+        $dummyDbi->addResult(
+            'SELECT `ROUTINE_NAME` AS `name` FROM `INFORMATION_SCHEMA`.`ROUTINES` WHERE '
+            . '`ROUTINE_SCHEMA` COLLATE utf8_bin=\'default\' AND `ROUTINE_TYPE`=\'FUNCTION\' '
+            . 'ORDER BY `ROUTINE_NAME` ASC',
+            [['test_function']],
+            ['name'],
+        );
+
+        $dummyDbi->addResult(
+            'SELECT `EVENT_NAME` AS `name` FROM `INFORMATION_SCHEMA`.`EVENTS` WHERE'
+            . ' `EVENT_SCHEMA` COLLATE utf8_bin=\'default\' ORDER BY `EVENT_NAME` ASC',
+            [['test_event']],
+            ['name'],
+        );
+
+        $dummyDbi->addResult(
+            'SELECT `ROUTINE_NAME` AS `name` FROM `INFORMATION_SCHEMA`.`ROUTINES` WHERE '
+            . '`ROUTINE_SCHEMA` COLLATE utf8_bin=\'default\' AND `ROUTINE_TYPE`=\'PROCEDURE\' '
+            . 'ORDER BY `ROUTINE_NAME` ASC',
+            [['test_procedure']],
+            ['name'],
+        );
+
+        $objectFetcher = new ObjectFetcher($dbi, $config);
+
+        $tables = $objectFetcher->getTables('default', '');
+        self::assertSame(['test_table'], $tables);
+
+        $views = $objectFetcher->getViews('default', '');
+        self::assertSame(['test_view'], $views);
+
+        $functions = $objectFetcher->getFunctions('default', '');
+        self::assertSame(['test_function'], $functions);
+
+        $events = $objectFetcher->getEvents('default', '');
+        self::assertSame(['test_event'], $events);
+
+        $procedures = $objectFetcher->getProcedures('default', '');
+        self::assertSame(['test_procedure'], $procedures);
+
+        $dummyDbi->assertAllQueriesConsumed();
+    }
+
+    public function testGetDataISWithSearchClause(): void
+    {
+        $config = Config::getInstance();
+        $config->selectedServer['DisableIS'] = false;
+
+        $dummyDbi = $this->createDbiDummy();
+        $dummyDbi->removeDefaultResults();
+        $dbi = $this->createDatabaseInterface($dummyDbi);
+        DatabaseInterface::$instance = $dbi;
+
+        $dummyDbi->addResult('SELECT @@lower_case_table_names', [['0']]);
+
+        $dummyDbi->addResult(
+            'SELECT `TABLE_NAME` AS `name`, `TABLE_TYPE` AS `type` FROM `INFORMATION_SCHEMA`.`TABLES`'
+            . ' WHERE `TABLE_SCHEMA`=\'default\' AND `TABLE_NAME` LIKE \'%abc%\' ORDER BY `TABLE_NAME` ASC',
+            [
+                ['test_table', 'BASE TABLE'],
+                ['test_view', 'VIEW'],
+            ],
+            ['name', 'type'],
+        );
+
+        $dummyDbi->addResult(
+            'SELECT `ROUTINE_NAME` AS `name` FROM `INFORMATION_SCHEMA`.`ROUTINES` WHERE '
+            . '`ROUTINE_SCHEMA` COLLATE utf8_bin=\'default\' AND `ROUTINE_TYPE`=\'FUNCTION\' '
+            . "AND `ROUTINE_NAME` LIKE '%abc%' "
+            . 'ORDER BY `ROUTINE_NAME` ASC',
+            [['test_function']],
+            ['name'],
+        );
+
+        $dummyDbi->addResult(
+            'SELECT `EVENT_NAME` AS `name` FROM `INFORMATION_SCHEMA`.`EVENTS` WHERE'
+            . ' `EVENT_SCHEMA` COLLATE utf8_bin=\'default\' AND `EVENT_NAME` LIKE \'%abc%\' ORDER BY `EVENT_NAME` ASC',
+            [['test_event']],
+            ['name'],
+        );
+
+        $dummyDbi->addResult(
+            'SELECT `ROUTINE_NAME` AS `name` FROM `INFORMATION_SCHEMA`.`ROUTINES` WHERE '
+            . '`ROUTINE_SCHEMA` COLLATE utf8_bin=\'default\' AND `ROUTINE_TYPE`=\'PROCEDURE\' '
+            . "AND `ROUTINE_NAME` LIKE '%abc%' "
+            . 'ORDER BY `ROUTINE_NAME` ASC',
+            [['test_procedure']],
+            ['name'],
+        );
+
+        $objectFetcher = new ObjectFetcher($dbi, $config);
+
+        $tables = $objectFetcher->getTables('default', 'abc');
+        self::assertSame(['test_table'], $tables);
+
+        $views = $objectFetcher->getViews('default', 'abc');
+        self::assertSame(['test_view'], $views);
+
+        $functions = $objectFetcher->getFunctions('default', 'abc');
+        self::assertSame(['test_function'], $functions);
+
+        $events = $objectFetcher->getEvents('default', 'abc');
+        self::assertSame(['test_event'], $events);
+
+        $procedures = $objectFetcher->getProcedures('default', 'abc');
+        self::assertSame(['test_procedure'], $procedures);
+
+        $dummyDbi->assertAllQueriesConsumed();
+    }
+
+    public function testGetDataNonIS(): void
+    {
+        $config = Config::getInstance();
+        $config->selectedServer['DisableIS'] = true;
+
+        $dummyDbi = $this->createDbiDummy();
+        $dummyDbi->removeDefaultResults();
+        $dbi = $this->createDatabaseInterface($dummyDbi);
+
+        $dummyDbi->addResult(
+            'SHOW FULL TABLES FROM `default`',
+            [
+                ['test_table', 'BASE TABLE'],
+                ['test_view', 'VIEW'],
+            ],
+        );
+
+        $dummyDbi->addResult(
+            'SHOW FUNCTION STATUS WHERE `Db`=\'default\'',
+            [['test_function']],
+            ['Name'],
+        );
+
+        $dummyDbi->addResult(
+            'SHOW EVENTS FROM `default`',
+            [['test_event']],
+            ['Name'],
+        );
+
+        $dummyDbi->addResult(
+            'SHOW PROCEDURE STATUS WHERE `Db`=\'default\'',
+            [['test_procedure']],
+            ['Name'],
+        );
+
+        $objectFetcher = new ObjectFetcher($dbi, $config);
+
+        $tables = $objectFetcher->getTables('default', '');
+        self::assertSame(['test_table'], $tables);
+
+        $views = $objectFetcher->getViews('default', '');
+        self::assertSame(['test_view'], $views);
+
+        $functions = $objectFetcher->getFunctions('default', '');
+        self::assertSame(['test_function'], $functions);
+
+        $events = $objectFetcher->getEvents('default', '');
+        self::assertSame(['test_event'], $events);
+
+        $procedures = $objectFetcher->getProcedures('default', '');
+        self::assertSame(['test_procedure'], $procedures);
+
+        $dummyDbi->assertAllQueriesConsumed();
+    }
+
+    public function testGetDataWithSearchQuery(): void
+    {
+        $config = Config::getInstance();
+        $config->selectedServer['DisableIS'] = true;
+
+        $dummyDbi = $this->createDbiDummy();
+        $dummyDbi->removeDefaultResults();
+        $dbi = $this->createDatabaseInterface($dummyDbi);
+
+        $dummyDbi->addResult(
+            'SHOW FULL TABLES FROM `default` WHERE `Tables_in_default` LIKE \'%abc%\'',
+            [
+                ['test_table', 'BASE TABLE'],
+                ['test_view', 'VIEW'],
+            ],
+        );
+
+        $dummyDbi->addResult(
+            'SHOW FUNCTION STATUS WHERE `Db`=\'default\' AND `Name` LIKE \'%abc%\'',
+            [['test_function']],
+            ['Name'],
+        );
+
+        $dummyDbi->addResult(
+            'SHOW EVENTS FROM `default` WHERE `Name` LIKE \'%abc%\'',
+            [['test_event']],
+            ['Name'],
+        );
+
+        $dummyDbi->addResult(
+            'SHOW PROCEDURE STATUS WHERE `Db`=\'default\' AND `Name` LIKE \'%abc%\'',
+            [['test_procedure']],
+            ['Name'],
+        );
+
+        $objectFetcher = new ObjectFetcher($dbi, $config);
+
+        $tables = $objectFetcher->getTables('default', 'abc');
+        self::assertSame(['test_table'], $tables);
+
+        $views = $objectFetcher->getViews('default', 'abc');
+        self::assertSame(['test_view'], $views);
+
+        $functions = $objectFetcher->getFunctions('default', 'abc');
+        self::assertSame(['test_function'], $functions);
+
+        $events = $objectFetcher->getEvents('default', 'abc');
+        self::assertSame(['test_event'], $events);
+
+        $procedures = $objectFetcher->getProcedures('default', 'abc');
+        self::assertSame(['test_procedure'], $procedures);
+
+        $dummyDbi->assertAllQueriesConsumed();
+    }
+}

--- a/tests/classes/Stubs/DbiDummy.php
+++ b/tests/classes/Stubs/DbiDummy.php
@@ -1042,13 +1042,8 @@ class DbiDummy implements DbiExtension
                 ],
             ],
             [
-                'query' => "SHOW FULL TABLES FROM `default` WHERE `Table_type` IN('BASE TABLE', 'SYSTEM VERSIONED')",
+                'query' => 'SHOW FULL TABLES FROM `default`',
                 'result' => [['test1', 'BASE TABLE'], ['test2', 'BASE TABLE']],
-            ],
-            [
-                'query' => 'SHOW FULL TABLES FROM `default` '
-                    . "WHERE `Table_type` NOT IN('BASE TABLE', 'SYSTEM VERSIONED')",
-                'result' => [],
             ],
             [
                 'query' => "SHOW FUNCTION STATUS WHERE `Db`='default'",

--- a/tests/classes/Stubs/DummyResult.php
+++ b/tests/classes/Stubs/DummyResult.php
@@ -156,12 +156,12 @@ class DummyResult implements ResultInterface
     }
 
     /**
-     * Returns values from the first column of each row
+     * Returns values from the selected column of each row
      *
      * @return array<int, string|null>
      * @psalm-return list<string|null>
      */
-    public function fetchAllColumn(): array
+    public function fetchAllColumn(int|string $column = 0): array
     {
         if ($this->result === null) {
             return [];
@@ -170,7 +170,11 @@ class DummyResult implements ResultInterface
         // This function should return all rows, not only the remaining rows
         $this->seek(0);
 
-        return array_column($this->result, 0);
+        if (is_string($column)) {
+            return array_column($this->fetchAllAssoc(), $column);
+        }
+
+        return array_column($this->result, $column);
     }
 
     /**


### PR DESCRIPTION
This PR combines fetching count and records into a single operation and performs a single read from DB for tables and views. 

On my machine with 12k tables, the response time dropped from 5.3s to 2.7s, as measured by xDebug. 

Without xDebug, times measured in the browser:

| DisableIS |  before | after |
| ------------- |:-------------:| -----:|
| true    | 4.9s  | 1.8s |
| false | 4.9s | 1.7s |

Times include sorting with natSort, which adds about 150ms. With xDebug enabled, sorting adds up to 1s.

---

Reading the table `INFORMATION_SCHEMA.TABLES` takes about 1.5s. `SHOW FULL TABLES` is just a simple wrapper for `SELECT` from IS. This table has 2 columns that we want, the first one is the table name and the second is the type. We need to know the type to distinguish between view and normal table. MySQL will take the same amount of time to read from the table whether we want views, tables, or both. It will also take 1.5s to get the count of matching rows. 

The optimization here avoid doing the same thing 3 or 4 times*. Instead of reading the count, views, and tables separately, it makes a single call to DB to read everything into memory. We can filter the results in PHP and then use `count()` to count the records. It feels like this should be worse for performance, but it isn't. Memory is cheap and filling memory is quick. Since the fix I introduced on 5.2, we already read everything into memory anyway. So it was just a matter of reorganizing the code. This means that instead of spending ~4.5s (or 6s) reading from DB, the code spends only ~1.5s. 

\* I tested with a DB with ~12k table but no views. The code read 3 times from DB, but if I had even just a single view it would read 4 times. 

I still need to add unit tests for the new class. 