### PR TITLE
Refactor UserPrivileges to use instance instead of static props

### DIFF
--- a/app/services.php
+++ b/app/services.php
@@ -6,7 +6,6 @@ use PhpMyAdmin\Advisory\Advisor;
 use PhpMyAdmin\Application;
 use PhpMyAdmin\Bookmarks\BookmarkRepository;
 use PhpMyAdmin\BrowseForeigners;
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
@@ -57,6 +56,7 @@ use PhpMyAdmin\Transformations;
 use PhpMyAdmin\Triggers\Triggers;
 use PhpMyAdmin\UserPassword;
 use PhpMyAdmin\UserPreferences;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PhpMyAdmin\Utils\HttpRequest;
 use PhpMyAdmin\VersionInformation;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
@@ -83,7 +83,6 @@ return [
         'config' => ['class' => Config::class, 'factory' => [Config::class, 'getInstance']],
         Config\PageSettings::class => ['class' => Config\PageSettings::class, 'arguments' => ['@user_preferences']],
         'central_columns' => ['class' => CentralColumns::class, 'arguments' => ['@dbi']],
-        'check_user_privileges' => ['class' => CheckUserPrivileges::class, 'arguments' => ['@dbi']],
         'create_add_field' => ['class' => CreateAddField::class, 'arguments' => ['@dbi']],
         'dbi' => ['class' => DatabaseInterface::class, 'factory' => [DatabaseInterface::class, 'getInstance']],
         DbTableExists::class => ['class' => DbTableExists::class, 'arguments' => ['@dbi']],
@@ -220,6 +219,7 @@ return [
             'arguments' => ['@server_privileges', '@' . AuthenticationPluginFactory::class, '@dbi'],
         ],
         'user_preferences' => ['class' => UserPreferences::class, 'arguments' => ['@dbi', '@relation', '@template']],
+        UserPrivilegesFactory::class => ['class' => UserPrivilegesFactory::class, 'arguments' => ['@dbi']],
         'version_information' => ['class' => VersionInformation::class],
         DatabaseInterface::class => 'dbi',
         PhpMyAdmin\FlashMessages::class => 'flash',

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -1009,47 +1009,23 @@ return [
         ],
         Sql\ColumnPreferencesController::class => [
             'class' => Sql\ColumnPreferencesController::class,
-            'arguments' => [
-                '$response' => '@response',
-                '$template' => '@template',
-                '$checkUserPrivileges' => '@check_user_privileges',
-                '$dbi' => '@dbi',
-            ],
+            'arguments' => ['$response' => '@response', '$template' => '@template', '$dbi' => '@dbi'],
         ],
         Sql\DefaultForeignKeyCheckValueController::class => [
             'class' => Sql\DefaultForeignKeyCheckValueController::class,
-            'arguments' => [
-                '$response' => '@response',
-                '$template' => '@template',
-                '$checkUserPrivileges' => '@check_user_privileges',
-            ],
+            'arguments' => ['$response' => '@response', '$template' => '@template'],
         ],
         Sql\EnumValuesController::class => [
             'class' => Sql\EnumValuesController::class,
-            'arguments' => [
-                '$response' => '@response',
-                '$template' => '@template',
-                '$sql' => '@sql',
-                '$checkUserPrivileges' => '@check_user_privileges',
-            ],
+            'arguments' => ['$response' => '@response', '$template' => '@template', '$sql' => '@sql'],
         ],
         Sql\RelationalValuesController::class => [
             'class' => Sql\RelationalValuesController::class,
-            'arguments' => [
-                '$response' => '@response',
-                '$template' => '@template',
-                '$sql' => '@sql',
-                '$checkUserPrivileges' => '@check_user_privileges',
-            ],
+            'arguments' => ['$response' => '@response', '$template' => '@template', '$sql' => '@sql'],
         ],
         Sql\SetValuesController::class => [
             'class' => Sql\SetValuesController::class,
-            'arguments' => [
-                '$response' => '@response',
-                '$template' => '@template',
-                '$sql' => '@sql',
-                '$checkUserPrivileges' => '@check_user_privileges',
-            ],
+            'arguments' => ['$response' => '@response', '$template' => '@template', '$sql' => '@sql'],
         ],
         Sql\SqlController::class => [
             'class' => Sql\SqlController::class,
@@ -1057,7 +1033,6 @@ return [
                 '$response' => '@response',
                 '$template' => '@template',
                 '$sql' => '@sql',
-                '$checkUserPrivileges' => '@check_user_privileges',
                 '$dbi' => '@dbi',
                 '$pageSettings' => '@' . PageSettings::class,
                 '$bookmarkRepository' => '@bookmarkRepository',

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -302,6 +302,7 @@ return [
                 '$template' => '@template',
                 '$operations' => '@operations',
                 '$structureController' => '@' . Database\StructureController::class,
+                '$userPrivilegesFactory' => '@' . UserPrivilegesFactory::class,
             ],
         ],
         Database\Structure\CopyTableWithPrefixController::class => [
@@ -617,6 +618,7 @@ return [
                 '$response' => '@response',
                 '$template' => '@template',
                 '$normalization' => '@normalization',
+                '$userPrivilegesFactory' => '@' . UserPrivilegesFactory::class,
             ],
         ],
         Normalization\CreateNewColumnController::class => [
@@ -625,6 +627,7 @@ return [
                 '$response' => '@response',
                 '$template' => '@template',
                 '$normalization' => '@normalization',
+                '$userPrivilegesFactory' => '@' . UserPrivilegesFactory::class,
             ],
         ],
         Normalization\GetColumnsController::class => [
@@ -768,11 +771,17 @@ return [
                 '$dbi' => '@dbi',
                 '$transformations' => '@transformations',
                 '$relationCleanup' => '@relation_cleanup',
+                '$userPrivilegesFactory' => '@' . UserPrivilegesFactory::class,
             ],
         ],
         Server\DatabasesController::class => [
             'class' => Server\DatabasesController::class,
-            'arguments' => ['$response' => '@response', '$template' => '@template', '$dbi' => '@dbi'],
+            'arguments' => [
+                '$response' => '@response',
+                '$template' => '@template',
+                '$dbi' => '@dbi',
+                '$userPrivilegesFactory' => '@' . UserPrivilegesFactory::class,
+            ],
         ],
         Server\EnginesController::class => [
             'class' => Server\EnginesController::class,
@@ -829,6 +838,7 @@ return [
                 '$template' => '@template',
                 '$relation' => '@relation',
                 '$dbi' => '@dbi',
+                '$userPrivilegesFactory' => '@' . UserPrivilegesFactory::class,
             ],
         ],
         Server\ReplicationController::class => [
@@ -1049,6 +1059,7 @@ return [
                 '$dbi' => '@dbi',
                 '$columnsDefinition' => '@table_columns_definition',
                 '$dbTableExists' => '@' . DbTableExists::class,
+                '$userPrivilegesFactory' => '@' . UserPrivilegesFactory::class,
             ],
         ],
         Table\ChangeController::class => [
@@ -1089,6 +1100,7 @@ return [
                 '$config' => '@config',
                 '$dbi' => '@dbi',
                 '$columnsDefinition' => '@table_columns_definition',
+                '$userPrivilegesFactory' => '@' . UserPrivilegesFactory::class,
             ],
         ],
         Table\DeleteConfirmController::class => [
@@ -1408,6 +1420,7 @@ return [
                 '$template' => '@template',
                 '$dbi' => '@dbi',
                 '$columnsDefinition' => '@table_columns_definition',
+                '$userPrivilegesFactory' => '@' . UserPrivilegesFactory::class,
             ],
         ],
         Table\Structure\FulltextController::class => [
@@ -1457,6 +1470,7 @@ return [
                 '$transformations' => '@transformations',
                 '$dbi' => '@dbi',
                 '$structureController' => '@' . Table\StructureController::class,
+                '$userPrivilegesFactory' => '@' . UserPrivilegesFactory::class,
             ],
         ],
         Table\Structure\SpatialController::class => [

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -44,6 +44,7 @@ use PhpMyAdmin\DbTableExists;
 use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Plugins\AuthenticationPluginFactory;
 use PhpMyAdmin\Theme\ThemeManager;
+use PhpMyAdmin\UserPrivilegesFactory;
 
 return [
     'services' => [
@@ -187,7 +188,7 @@ return [
                 '$response' => '@response',
                 '$template' => '@template',
                 '$operations' => '@operations',
-                '$checkUserPrivileges' => '@check_user_privileges',
+                '$userPrivilegesFactory' => '@' . UserPrivilegesFactory::class,
                 '$relation' => '@relation',
                 '$relationCleanup' => '@relation_cleanup',
                 '$dbi' => '@dbi',
@@ -208,7 +209,7 @@ return [
             'arguments' => [
                 '$response' => '@response',
                 '$template' => '@template',
-                '$checkUserPrivileges' => '@check_user_privileges',
+                '$userPrivilegesFactory' => '@' . UserPrivilegesFactory::class,
                 '$dbi' => '@dbi',
                 '$routines' => '@routines',
                 '$dbTableExists' => '@' . DbTableExists::class,
@@ -1296,7 +1297,7 @@ return [
                 '$response' => '@response',
                 '$template' => '@template',
                 '$operations' => '@operations',
-                '$checkUserPrivileges' => '@check_user_privileges',
+                '$userPrivilegesFactory' => '@' . UserPrivilegesFactory::class,
                 '$relation' => '@relation',
                 '$dbi' => '@dbi',
                 '$dbTableExists' => '@' . DbTableExists::class,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -171,81 +171,6 @@ parameters:
 			path: src/Charsets.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Only booleans are allowed in \\|\\|, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given on the left side\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Only booleans are allowed in \\|\\|, int\\|false given on the right side\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Parameter \\#1 \\$database of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Parameter \\#2 \\$table of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Parameter \\#3 \\$column of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Parameter \\#4 \\$routines of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Parameter \\#5 \\$isReload of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Parameter \\#6 \\$isCreateDatabase of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Parameter \\#7 \\$databaseToCreate of class PhpMyAdmin\\\\UserPrivileges constructor expects string, mixed given\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Parameter \\#8 \\$databasesToTest of class PhpMyAdmin\\\\UserPrivileges constructor expects array\\<string\\>\\|false, mixed given\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$databaseToCreate \\(string\\) does not accept string\\|null\\.$#"
-			count: 2
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$databasesToTest \\(array\\<string\\>\\|false\\) does not accept mixed\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
 			message: "#^Parameter \\#1 \\$source of method PhpMyAdmin\\\\Config\\:\\:loadAndCheck\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Command/CacheWarmupCommand.php
@@ -15119,6 +15044,81 @@ parameters:
 			message: "#^Ternary operator condition is always true\\.$#"
 			count: 1
 			path: src/UserPreferences.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
+			count: 1
+			path: src/UserPrivilegesFactory.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
+			count: 1
+			path: src/UserPrivilegesFactory.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given on the left side\\.$#"
+			count: 1
+			path: src/UserPrivilegesFactory.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, int\\|false given on the right side\\.$#"
+			count: 1
+			path: src/UserPrivilegesFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$database of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
+			count: 1
+			path: src/UserPrivilegesFactory.php
+
+		-
+			message: "#^Parameter \\#2 \\$table of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
+			count: 1
+			path: src/UserPrivilegesFactory.php
+
+		-
+			message: "#^Parameter \\#3 \\$column of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
+			count: 1
+			path: src/UserPrivilegesFactory.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: src/UserPrivilegesFactory.php
+
+		-
+			message: "#^Parameter \\#4 \\$routines of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
+			count: 1
+			path: src/UserPrivilegesFactory.php
+
+		-
+			message: "#^Parameter \\#5 \\$isReload of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
+			count: 1
+			path: src/UserPrivilegesFactory.php
+
+		-
+			message: "#^Parameter \\#6 \\$isCreateDatabase of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
+			count: 1
+			path: src/UserPrivilegesFactory.php
+
+		-
+			message: "#^Parameter \\#7 \\$databaseToCreate of class PhpMyAdmin\\\\UserPrivileges constructor expects string, mixed given\\.$#"
+			count: 1
+			path: src/UserPrivilegesFactory.php
+
+		-
+			message: "#^Parameter \\#8 \\$databasesToTest of class PhpMyAdmin\\\\UserPrivileges constructor expects array\\<string\\>\\|false, mixed given\\.$#"
+			count: 1
+			path: src/UserPrivilegesFactory.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$databaseToCreate \\(string\\) does not accept string\\|null\\.$#"
+			count: 2
+			path: src/UserPrivilegesFactory.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$databasesToTest \\(array\\<string\\>\\|false\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/UserPrivilegesFactory.php
 
 		-
 			message: "#^Binary operation \"\\.\" between bool\\|float\\|int\\|string and array\\<string\\>\\|string\\|false results in an error\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -191,52 +191,57 @@ parameters:
 			path: src/CheckUserPrivileges.php
 
 		-
+			message: "#^Parameter \\#1 \\$database of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
+			count: 1
+			path: src/CheckUserPrivileges.php
+
+		-
+			message: "#^Parameter \\#2 \\$table of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
+			count: 1
+			path: src/CheckUserPrivileges.php
+
+		-
+			message: "#^Parameter \\#3 \\$column of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
+			count: 1
+			path: src/CheckUserPrivileges.php
+
+		-
 			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
 			count: 1
 			path: src/CheckUserPrivileges.php
 
 		-
-			message: "#^Static property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$column \\(bool\\) does not accept mixed\\.$#"
+			message: "#^Parameter \\#4 \\$routines of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
 			count: 1
 			path: src/CheckUserPrivileges.php
 
 		-
-			message: "#^Static property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$database \\(bool\\) does not accept mixed\\.$#"
+			message: "#^Parameter \\#5 \\$isReload of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
 			count: 1
 			path: src/CheckUserPrivileges.php
 
 		-
-			message: "#^Static property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$databaseToCreate \\(string\\) does not accept mixed\\.$#"
+			message: "#^Parameter \\#6 \\$isCreateDatabase of class PhpMyAdmin\\\\UserPrivileges constructor expects bool, mixed given\\.$#"
 			count: 1
 			path: src/CheckUserPrivileges.php
 
 		-
-			message: "#^Static property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$databaseToCreate \\(string\\) does not accept string\\|null\\.$#"
+			message: "#^Parameter \\#7 \\$databaseToCreate of class PhpMyAdmin\\\\UserPrivileges constructor expects string, mixed given\\.$#"
+			count: 1
+			path: src/CheckUserPrivileges.php
+
+		-
+			message: "#^Parameter \\#8 \\$databasesToTest of class PhpMyAdmin\\\\UserPrivileges constructor expects array\\<string\\>\\|false, mixed given\\.$#"
+			count: 1
+			path: src/CheckUserPrivileges.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$databaseToCreate \\(string\\) does not accept string\\|null\\.$#"
 			count: 2
 			path: src/CheckUserPrivileges.php
 
 		-
-			message: "#^Static property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$databasesToTest \\(array\\<string\\>\\|false\\) does not accept mixed\\.$#"
-			count: 2
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Static property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$isCreateDatabase \\(bool\\) does not accept mixed\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Static property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$isReload \\(bool\\) does not accept mixed\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Static property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$routines \\(bool\\) does not accept mixed\\.$#"
-			count: 1
-			path: src/CheckUserPrivileges.php
-
-		-
-			message: "#^Static property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$table \\(bool\\) does not accept mixed\\.$#"
+			message: "#^Property PhpMyAdmin\\\\UserPrivileges\\:\\:\\$databasesToTest \\(array\\<string\\>\\|false\\) does not accept mixed\\.$#"
 			count: 1
 			path: src/CheckUserPrivileges.php
 
@@ -3516,11 +3521,6 @@ parameters:
 			path: src/Controllers/Server/PrivilegesController.php
 
 		-
-			message: "#^Parameter \\#2 \\$initial of method PhpMyAdmin\\\\Server\\\\Privileges\\:\\:getHtmlForUserOverview\\(\\) expects string\\|null, mixed given\\.$#"
-			count: 1
-			path: src/Controllers/Server/PrivilegesController.php
-
-		-
 			message: "#^Parameter \\#2 \\$oldHostname of method PhpMyAdmin\\\\Server\\\\Privileges\\:\\:getDataForChangeOrCopyUser\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/Server/PrivilegesController.php
@@ -3572,6 +3572,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#3 \\$hostname of method PhpMyAdmin\\\\Server\\\\Privileges\\:\\:updatePassword\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controllers/Server/PrivilegesController.php
+
+		-
+			message: "#^Parameter \\#3 \\$initial of method PhpMyAdmin\\\\Server\\\\Privileges\\:\\:getHtmlForUserOverview\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/Server/PrivilegesController.php
 
@@ -6686,11 +6691,6 @@ parameters:
 			path: src/Database/Routines.php
 
 		-
-			message: "#^Parameter \\#2 \\$createRoutine of method PhpMyAdmin\\\\Database\\\\Routines\\:\\:create\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Database/Routines.php
-
-		-
 			message: "#^Parameter \\#2 \\$itemParamDir of method PhpMyAdmin\\\\Database\\\\Routines\\:\\:processParamsAndBuild\\(\\) expects array\\<string\\>, array given\\.$#"
 			count: 1
 			path: src/Database/Routines.php
@@ -6707,6 +6707,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$warnedAboutLength of method PhpMyAdmin\\\\Database\\\\Routines\\:\\:processFunctionSpecificParameters\\(\\) expects bool, mixed given\\.$#"
+			count: 1
+			path: src/Database/Routines.php
+
+		-
+			message: "#^Parameter \\#3 \\$createRoutine of method PhpMyAdmin\\\\Database\\\\Routines\\:\\:create\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Database/Routines.php
 
@@ -9296,17 +9301,17 @@ parameters:
 			path: src/ListDatabase.php
 
 		-
-			message: "#^Parameter \\#1 \\$likeDbName of method PhpMyAdmin\\\\ListDatabase\\:\\:retrieve\\(\\) expects string\\|null, array\\<string\\>\\|bool\\|int\\<0, max\\>\\|string given\\.$#"
-			count: 1
-			path: src/ListDatabase.php
-
-		-
 			message: "#^Parameter \\#1 \\$str of function strtr expects string, array\\<string\\>\\|bool\\|int\\<0, max\\>\\|string given\\.$#"
 			count: 1
 			path: src/ListDatabase.php
 
 		-
 			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(mixed, mixed\\)\\: int, Closure\\(string, string\\)\\: int\\<\\-1, 1\\> given\\.$#"
+			count: 1
+			path: src/ListDatabase.php
+
+		-
+			message: "#^Parameter \\#2 \\$likeDbName of method PhpMyAdmin\\\\ListDatabase\\:\\:retrieve\\(\\) expects string\\|null, array\\<string\\>\\|bool\\|int\\<0, max\\>\\|string given\\.$#"
 			count: 1
 			path: src/ListDatabase.php
 
@@ -9521,11 +9526,6 @@ parameters:
 			path: src/Navigation/NavigationTree.php
 
 		-
-			message: "#^Parameter \\#1 \\$path of method PhpMyAdmin\\\\Navigation\\\\NavigationTree\\:\\:buildPathPart\\(\\) expects array, mixed given\\.$#"
-			count: 1
-			path: src/Navigation/NavigationTree.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
 			count: 1
 			path: src/Navigation/NavigationTree.php
@@ -9541,17 +9541,22 @@ parameters:
 			path: src/Navigation/NavigationTree.php
 
 		-
-			message: "#^Parameter \\#1 \\$table of method PhpMyAdmin\\\\Navigation\\\\NavigationTree\\:\\:addTableContainers\\(\\) expects PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeTable, PhpMyAdmin\\\\Navigation\\\\Nodes\\\\Node given\\.$#"
-			count: 1
-			path: src/Navigation/NavigationTree.php
-
-		-
 			message: "#^Parameter \\#2 \\$needle of function mb_strpos expects string, mixed given\\.$#"
 			count: 1
 			path: src/Navigation/NavigationTree.php
 
 		-
-			message: "#^Parameter \\#2 \\$searchClause of method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeDatabase\\:\\:getPresence\\(\\) expects string, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$path of method PhpMyAdmin\\\\Navigation\\\\NavigationTree\\:\\:buildPathPart\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Navigation/NavigationTree.php
+
+		-
+			message: "#^Parameter \\#2 \\$table of method PhpMyAdmin\\\\Navigation\\\\NavigationTree\\:\\:addTableContainers\\(\\) expects PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeTable, PhpMyAdmin\\\\Navigation\\\\Nodes\\\\Node given\\.$#"
+			count: 1
+			path: src/Navigation/NavigationTree.php
+
+		-
+			message: "#^Parameter \\#3 \\$searchClause of method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\NodeDatabase\\:\\:getPresence\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Navigation/NavigationTree.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -132,16 +132,16 @@
     </PossiblyNullArrayOffset>
   </file>
   <file src="src/CheckUserPrivileges.php">
-    <MixedAssignment>
-      <code>UserPrivileges::$column</code>
-      <code>UserPrivileges::$database</code>
-      <code>UserPrivileges::$databaseToCreate</code>
-      <code>UserPrivileges::$databasesToTest</code>
-      <code>UserPrivileges::$isCreateDatabase</code>
-      <code>UserPrivileges::$isReload</code>
-      <code>UserPrivileges::$routines</code>
-      <code>UserPrivileges::$table</code>
-    </MixedAssignment>
+    <MixedArgument>
+      <code><![CDATA[SessionCache::get('col_priv')]]></code>
+      <code><![CDATA[SessionCache::get('db_priv')]]></code>
+      <code><![CDATA[SessionCache::get('db_to_create')]]></code>
+      <code><![CDATA[SessionCache::get('dbs_to_test')]]></code>
+      <code><![CDATA[SessionCache::get('is_create_db_priv')]]></code>
+      <code><![CDATA[SessionCache::get('is_reload_priv')]]></code>
+      <code><![CDATA[SessionCache::get('proc_priv')]]></code>
+      <code><![CDATA[SessionCache::get('table_priv')]]></code>
+    </MixedArgument>
   </file>
   <file src="src/Command/CacheWarmupCommand.php">
     <DeprecatedMethod>
@@ -1379,6 +1379,9 @@
     </DeprecatedMethod>
   </file>
   <file src="src/Controllers/Database/Structure/CopyTableController.php">
+    <DeprecatedMethod>
+      <code>DatabaseInterface::getInstance()</code>
+    </DeprecatedMethod>
     <MixedArgument>
       <code><![CDATA[$request->getParsedBodyParam('what')]]></code>
     </MixedArgument>
@@ -2053,9 +2056,17 @@
     </MixedAssignment>
   </file>
   <file src="src/Controllers/Normalization/AddNewPrimaryController.php">
+    <DeprecatedMethod>
+      <code>DatabaseInterface::getInstance()</code>
+    </DeprecatedMethod>
     <UnusedParam>
       <code>$request</code>
     </UnusedParam>
+  </file>
+  <file src="src/Controllers/Normalization/CreateNewColumnController.php">
+    <DeprecatedMethod>
+      <code>DatabaseInterface::getInstance()</code>
+    </DeprecatedMethod>
   </file>
   <file src="src/Controllers/Normalization/FirstNormalForm/FirstStepController.php">
     <MixedAssignment>
@@ -6905,15 +6916,9 @@
     </PossiblyNullOperand>
   </file>
   <file src="src/ListDatabase.php">
-    <MixedArgument>
-      <code>$db</code>
-    </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>usort($databaseList, strnatcasecmp(...))</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment>
-      <code>$db</code>
-    </MixedAssignment>
     <UnusedProperty>
       <code>$checkUserPrivileges</code>
     </UnusedProperty>
@@ -6955,6 +6960,7 @@
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
+      <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
     <PossiblyNullArrayOffset>
       <code>$hidden</code>
@@ -7119,7 +7125,6 @@
       <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
     <MixedArgument>
-      <code>$databases</code>
       <code>$db</code>
       <code>$db</code>
       <code>$db</code>
@@ -7127,13 +7132,15 @@
       <code>$db</code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$databases</code>
       <code>$db</code>
       <code>$db</code>
       <code>$db</code>
       <code>$db</code>
       <code>$db</code>
     </MixedAssignment>
+    <PossiblyInvalidArgument>
+      <code>$databases</code>
+    </PossiblyInvalidArgument>
     <PossiblyNullArgument>
       <code>$arr[0]</code>
       <code>$arr[0]</code>
@@ -12407,17 +12414,6 @@
       <code>Config::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
-    <RedundantConditionGivenDocblockType>
-      <code>assertTrue</code>
-      <code>assertTrue</code>
-      <code>assertTrue</code>
-      <code>assertTrue</code>
-      <code>assertTrue</code>
-      <code>assertTrue</code>
-      <code>assertTrue</code>
-      <code>assertTrue</code>
-      <code>assertTrue</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="tests/classes/Command/SetVersionCommandTest.php">
     <PossiblyUnusedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2957,9 +2957,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="src/Controllers/Sql/DefaultForeignKeyCheckValueController.php">
-    <PossiblyUnusedMethod>
-      <code>__construct</code>
-    </PossiblyUnusedMethod>
     <UnusedParam>
       <code>$request</code>
     </UnusedParam>
@@ -6503,7 +6500,6 @@
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1367,9 +1367,6 @@
     </DeprecatedMethod>
   </file>
   <file src="src/Controllers/Database/Structure/CopyTableController.php">
-    <DeprecatedMethod>
-      <code>DatabaseInterface::getInstance()</code>
-    </DeprecatedMethod>
     <MixedArgument>
       <code><![CDATA[$request->getParsedBodyParam('what')]]></code>
     </MixedArgument>
@@ -2044,17 +2041,9 @@
     </MixedAssignment>
   </file>
   <file src="src/Controllers/Normalization/AddNewPrimaryController.php">
-    <DeprecatedMethod>
-      <code>DatabaseInterface::getInstance()</code>
-    </DeprecatedMethod>
     <UnusedParam>
       <code>$request</code>
     </UnusedParam>
-  </file>
-  <file src="src/Controllers/Normalization/CreateNewColumnController.php">
-    <DeprecatedMethod>
-      <code>DatabaseInterface::getInstance()</code>
-    </DeprecatedMethod>
   </file>
   <file src="src/Controllers/Normalization/FirstNormalForm/FirstStepController.php">
     <MixedAssignment>
@@ -6944,7 +6933,6 @@
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
     <PossiblyNullArrayOffset>
       <code>$hidden</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -131,18 +131,6 @@
       <code><![CDATA[self::$collations[$row['Charset']]]]></code>
     </PossiblyNullArrayOffset>
   </file>
-  <file src="src/CheckUserPrivileges.php">
-    <MixedArgument>
-      <code><![CDATA[SessionCache::get('col_priv')]]></code>
-      <code><![CDATA[SessionCache::get('db_priv')]]></code>
-      <code><![CDATA[SessionCache::get('db_to_create')]]></code>
-      <code><![CDATA[SessionCache::get('dbs_to_test')]]></code>
-      <code><![CDATA[SessionCache::get('is_create_db_priv')]]></code>
-      <code><![CDATA[SessionCache::get('is_reload_priv')]]></code>
-      <code><![CDATA[SessionCache::get('proc_priv')]]></code>
-      <code><![CDATA[SessionCache::get('table_priv')]]></code>
-    </MixedArgument>
-  </file>
   <file src="src/Command/CacheWarmupCommand.php">
     <DeprecatedMethod>
       <code>Config::getInstance()</code>
@@ -6916,7 +6904,7 @@
       <code>usort($databaseList, strnatcasecmp(...))</code>
     </MixedArgumentTypeCoercion>
     <UnusedProperty>
-      <code>$checkUserPrivileges</code>
+      <code>$userPrivilegesFactory</code>
     </UnusedProperty>
   </file>
   <file src="src/Menu.php">
@@ -12071,6 +12059,18 @@
       <code>$hasConfig</code>
     </RiskyTruthyFalsyComparison>
   </file>
+  <file src="src/UserPrivilegesFactory.php">
+    <MixedArgument>
+      <code><![CDATA[SessionCache::get('col_priv')]]></code>
+      <code><![CDATA[SessionCache::get('db_priv')]]></code>
+      <code><![CDATA[SessionCache::get('db_to_create')]]></code>
+      <code><![CDATA[SessionCache::get('dbs_to_test')]]></code>
+      <code><![CDATA[SessionCache::get('is_create_db_priv')]]></code>
+      <code><![CDATA[SessionCache::get('is_reload_priv')]]></code>
+      <code><![CDATA[SessionCache::get('proc_priv')]]></code>
+      <code><![CDATA[SessionCache::get('table_priv')]]></code>
+    </MixedArgument>
+  </file>
   <file src="src/Util.php">
     <ArgumentTypeCoercion>
       <code>$separator</code>
@@ -12404,12 +12404,6 @@
     <PossiblyUnusedMethod>
       <code>providerTestBuildDescription</code>
     </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/classes/CheckUserPrivilegesTest.php">
-    <DeprecatedMethod>
-      <code>Config::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
-    </DeprecatedMethod>
   </file>
   <file src="tests/classes/Command/SetVersionCommandTest.php">
     <PossiblyUnusedMethod>
@@ -15281,6 +15275,12 @@
       <code><![CDATA[$_SESSION['userconfig']['db']]]></code>
       <code><![CDATA[$_SESSION['userconfig']['ts']]]></code>
     </MixedArrayAccess>
+  </file>
+  <file src="tests/classes/UserPrivilegesFactoryTest.php">
+    <DeprecatedMethod>
+      <code>Config::getInstance()</code>
+      <code>DatabaseInterface::getInstance()</code>
+    </DeprecatedMethod>
   </file>
   <file src="tests/classes/UtilTest.php">
     <ArgumentTypeCoercion>

--- a/src/Controllers/Database/PrivilegesController.php
+++ b/src/Controllers/Database/PrivilegesController.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Database;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\DatabaseInterface;
@@ -50,9 +49,6 @@ class PrivilegesController extends AbstractController
 
             return;
         }
-
-        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-        $checkUserPrivileges->getPrivileges();
 
         $this->addScriptFiles(['server/privileges.js', 'vendor/zxcvbn-ts.js']);
 

--- a/src/Controllers/Database/RoutinesController.php
+++ b/src/Controllers/Database/RoutinesController.php
@@ -19,7 +19,6 @@ use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
-use PhpMyAdmin\UserPrivileges;
 use PhpMyAdmin\Util;
 
 use function __;
@@ -58,7 +57,7 @@ class RoutinesController extends AbstractController
 
         $type = $_REQUEST['type'] ?? null;
 
-        $this->checkUserPrivileges->getPrivileges();
+        $userPrivileges = $this->checkUserPrivileges->getPrivileges();
 
         $config = Config::getInstance();
         if (! $request->isAjax()) {
@@ -119,7 +118,7 @@ class RoutinesController extends AbstractController
         $GLOBALS['message'] ??= null;
 
         if (! empty($_POST['editor_process_add']) || ! empty($_POST['editor_process_edit'])) {
-            $output = $this->routines->handleRequestCreateOrEdit(Current::$database);
+            $output = $this->routines->handleRequestCreateOrEdit($userPrivileges, Current::$database);
             if ($request->isAjax()) {
                 if (! $GLOBALS['message']->isSuccess()) {
                     $this->response->setRequestStatus(false);
@@ -264,7 +263,7 @@ class RoutinesController extends AbstractController
                     'parameter_rows' => $parameterRows,
                     'charsets' => $charsets,
                     'numeric_options' => $this->routines->numericOptions,
-                    'has_privileges' => UserPrivileges::$routines && UserPrivileges::$isReload,
+                    'has_privileges' => $userPrivileges->routines && $userPrivileges->isReload,
                     'sql_data_access' => $this->routines->sqlDataAccess,
                 ]);
 

--- a/src/Controllers/Database/RoutinesController.php
+++ b/src/Controllers/Database/RoutinesController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers\Database;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
@@ -19,6 +18,7 @@ use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PhpMyAdmin\Util;
 
 use function __;
@@ -39,7 +39,7 @@ class RoutinesController extends AbstractController
     public function __construct(
         ResponseRenderer $response,
         Template $template,
-        private CheckUserPrivileges $checkUserPrivileges,
+        private UserPrivilegesFactory $userPrivilegesFactory,
         private DatabaseInterface $dbi,
         private Routines $routines,
         private readonly DbTableExists $dbTableExists,
@@ -57,7 +57,7 @@ class RoutinesController extends AbstractController
 
         $type = $_REQUEST['type'] ?? null;
 
-        $userPrivileges = $this->checkUserPrivileges->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         $config = Config::getInstance();
         if (! $request->isAjax()) {

--- a/src/Controllers/Database/Structure/CopyTableController.php
+++ b/src/Controllers/Database/Structure/CopyTableController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Database\Structure;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Controllers\Database\StructureController;
 use PhpMyAdmin\Current;
@@ -15,6 +14,7 @@ use PhpMyAdmin\Operations;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Table\Table;
 use PhpMyAdmin\Template;
+use PhpMyAdmin\UserPrivilegesFactory;
 
 final class CopyTableController extends AbstractController
 {
@@ -34,8 +34,8 @@ final class CopyTableController extends AbstractController
         /** @var string $targetDb */
         $targetDb = $request->getParsedBodyParam('target_db');
 
-        $checkUserPrivileges = new CheckUserPrivileges(DatabaseInterface::getInstance());
-        $userPrivileges = $checkUserPrivileges->getPrivileges();
+        $userPrivilegesFactory = new UserPrivilegesFactory(DatabaseInterface::getInstance());
+        $userPrivileges = $userPrivilegesFactory->getPrivileges();
 
         foreach ($selected as $selectedValue) {
             Table::moveCopy(

--- a/src/Controllers/Database/Structure/CopyTableController.php
+++ b/src/Controllers/Database/Structure/CopyTableController.php
@@ -7,7 +7,6 @@ namespace PhpMyAdmin\Controllers\Database\Structure;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Controllers\Database\StructureController;
 use PhpMyAdmin\Current;
-use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Operations;
@@ -23,6 +22,7 @@ final class CopyTableController extends AbstractController
         Template $template,
         private Operations $operations,
         private StructureController $structureController,
+        private readonly UserPrivilegesFactory $userPrivilegesFactory,
     ) {
         parent::__construct($response, $template);
     }
@@ -34,8 +34,7 @@ final class CopyTableController extends AbstractController
         /** @var string $targetDb */
         $targetDb = $request->getParsedBodyParam('target_db');
 
-        $userPrivilegesFactory = new UserPrivilegesFactory(DatabaseInterface::getInstance());
-        $userPrivileges = $userPrivilegesFactory->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         foreach ($selected as $selectedValue) {
             Table::moveCopy(

--- a/src/Controllers/Database/Structure/CopyTableController.php
+++ b/src/Controllers/Database/Structure/CopyTableController.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Database\Structure;
 
+use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Controllers\Database\StructureController;
 use PhpMyAdmin\Current;
+use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Operations;
@@ -32,6 +34,9 @@ final class CopyTableController extends AbstractController
         /** @var string $targetDb */
         $targetDb = $request->getParsedBodyParam('target_db');
 
+        $checkUserPrivileges = new CheckUserPrivileges(DatabaseInterface::getInstance());
+        $userPrivileges = $checkUserPrivileges->getPrivileges();
+
         foreach ($selected as $selectedValue) {
             Table::moveCopy(
                 Current::$database,
@@ -48,7 +53,13 @@ final class CopyTableController extends AbstractController
                 continue;
             }
 
-            $this->operations->adjustPrivilegesCopyTable(Current::$database, $selectedValue, $targetDb, $selectedValue);
+            $this->operations->adjustPrivilegesCopyTable(
+                $userPrivileges,
+                Current::$database,
+                $selectedValue,
+                $targetDb,
+                $selectedValue,
+            );
         }
 
         $GLOBALS['message'] = Message::success();

--- a/src/Controllers/Database/StructureController.php
+++ b/src/Controllers/Database/StructureController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers\Database;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\ConfigStorage\Relation;
@@ -199,9 +198,6 @@ final class StructureController extends AbstractController
 
         $createTable = '';
         if (! $this->dbIsSystemSchema) {
-            $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-            $checkUserPrivileges->getPrivileges();
-
             $createTable = $this->template->render('database/create_table', ['db' => Current::$database]);
         }
 

--- a/src/Controllers/Database/TrackingController.php
+++ b/src/Controllers/Database/TrackingController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Database;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
@@ -134,9 +133,6 @@ class TrackingController extends AbstractController
             $this->response->addHTML('<p>' . __('No tables found in database.') . '</p>' . "\n");
 
             if (! $isSystemSchema) {
-                $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-                $checkUserPrivileges->getPrivileges();
-
                 $this->render('database/create_table', ['db' => Current::$database]);
             }
 

--- a/src/Controllers/HomeController.php
+++ b/src/Controllers/HomeController.php
@@ -7,7 +7,6 @@ namespace PhpMyAdmin\Controllers;
 use Fig\Http\Message\RequestMethodInterface;
 use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Current;
@@ -120,9 +119,6 @@ class HomeController extends AbstractController
             }
 
             if (Current::$server > 0) {
-                $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-                $checkUserPrivileges->getPrivileges();
-
                 $charsets = Charsets::getCharsets($this->dbi, $config->selectedServer['DisableIS']);
                 $collations = Charsets::getCollations($this->dbi, $config->selectedServer['DisableIS']);
                 $charsetsList = [];

--- a/src/Controllers/Normalization/AddNewPrimaryController.php
+++ b/src/Controllers/Normalization/AddNewPrimaryController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Normalization;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
@@ -15,6 +14,7 @@ use PhpMyAdmin\Normalization;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
+use PhpMyAdmin\UserPrivilegesFactory;
 
 final class AddNewPrimaryController extends AbstractController
 {
@@ -25,8 +25,8 @@ final class AddNewPrimaryController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $checkUserPrivileges = new CheckUserPrivileges(DatabaseInterface::getInstance());
-        $userPrivileges = $checkUserPrivileges->getPrivileges();
+        $userPrivilegesFactory = new UserPrivilegesFactory(DatabaseInterface::getInstance());
+        $userPrivileges = $userPrivilegesFactory->getPrivileges();
 
         $numFields = 1;
 

--- a/src/Controllers/Normalization/AddNewPrimaryController.php
+++ b/src/Controllers/Normalization/AddNewPrimaryController.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Normalization;
 
+use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
+use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Identifiers\TableName;
@@ -23,6 +25,9 @@ final class AddNewPrimaryController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
+        $checkUserPrivileges = new CheckUserPrivileges(DatabaseInterface::getInstance());
+        $userPrivileges = $checkUserPrivileges->getPrivileges();
+
         $numFields = 1;
 
         $db = DatabaseName::tryFrom(Current::$database);
@@ -31,7 +36,13 @@ final class AddNewPrimaryController extends AbstractController
         $tableName = isset($table) ? $table->getName() : '';
 
         $columnMeta = ['Field' => $tableName . '_id', 'Extra' => 'auto_increment'];
-        $html = $this->normalization->getHtmlForCreateNewColumn($numFields, $dbName, $tableName, $columnMeta);
+        $html = $this->normalization->getHtmlForCreateNewColumn(
+            $userPrivileges,
+            $numFields,
+            $dbName,
+            $tableName,
+            $columnMeta,
+        );
         $html .= Url::getHiddenInputs($dbName, $tableName);
         $this->response->addHTML($html);
     }

--- a/src/Controllers/Normalization/AddNewPrimaryController.php
+++ b/src/Controllers/Normalization/AddNewPrimaryController.php
@@ -6,7 +6,6 @@ namespace PhpMyAdmin\Controllers\Normalization;
 
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
-use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Identifiers\TableName;
@@ -18,15 +17,18 @@ use PhpMyAdmin\UserPrivilegesFactory;
 
 final class AddNewPrimaryController extends AbstractController
 {
-    public function __construct(ResponseRenderer $response, Template $template, private Normalization $normalization)
-    {
+    public function __construct(
+        ResponseRenderer $response,
+        Template $template,
+        private Normalization $normalization,
+        private readonly UserPrivilegesFactory $userPrivilegesFactory,
+    ) {
         parent::__construct($response, $template);
     }
 
     public function __invoke(ServerRequest $request): void
     {
-        $userPrivilegesFactory = new UserPrivilegesFactory(DatabaseInterface::getInstance());
-        $userPrivileges = $userPrivilegesFactory->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         $numFields = 1;
 

--- a/src/Controllers/Normalization/CreateNewColumnController.php
+++ b/src/Controllers/Normalization/CreateNewColumnController.php
@@ -6,7 +6,6 @@ namespace PhpMyAdmin\Controllers\Normalization;
 
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
-use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Normalization;
 use PhpMyAdmin\ResponseRenderer;
@@ -19,15 +18,18 @@ use function min;
 
 final class CreateNewColumnController extends AbstractController
 {
-    public function __construct(ResponseRenderer $response, Template $template, private Normalization $normalization)
-    {
+    public function __construct(
+        ResponseRenderer $response,
+        Template $template,
+        private Normalization $normalization,
+        private readonly UserPrivilegesFactory $userPrivilegesFactory,
+    ) {
         parent::__construct($response, $template);
     }
 
     public function __invoke(ServerRequest $request): void
     {
-        $userPrivilegesFactory = new UserPrivilegesFactory(DatabaseInterface::getInstance());
-        $userPrivileges = $userPrivilegesFactory->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         $numFields = min(4096, intval($request->getParsedBodyParam('numFields')));
         $html = $this->normalization->getHtmlForCreateNewColumn(

--- a/src/Controllers/Normalization/CreateNewColumnController.php
+++ b/src/Controllers/Normalization/CreateNewColumnController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Normalization;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
@@ -13,6 +12,7 @@ use PhpMyAdmin\Normalization;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
+use PhpMyAdmin\UserPrivilegesFactory;
 
 use function intval;
 use function min;
@@ -26,8 +26,8 @@ final class CreateNewColumnController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $checkUserPrivileges = new CheckUserPrivileges(DatabaseInterface::getInstance());
-        $userPrivileges = $checkUserPrivileges->getPrivileges();
+        $userPrivilegesFactory = new UserPrivilegesFactory(DatabaseInterface::getInstance());
+        $userPrivileges = $userPrivilegesFactory->getPrivileges();
 
         $numFields = min(4096, intval($request->getParsedBodyParam('numFields')));
         $html = $this->normalization->getHtmlForCreateNewColumn(

--- a/src/Controllers/Normalization/CreateNewColumnController.php
+++ b/src/Controllers/Normalization/CreateNewColumnController.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Normalization;
 
+use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
+use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Normalization;
 use PhpMyAdmin\ResponseRenderer;
@@ -24,8 +26,16 @@ final class CreateNewColumnController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
+        $checkUserPrivileges = new CheckUserPrivileges(DatabaseInterface::getInstance());
+        $userPrivileges = $checkUserPrivileges->getPrivileges();
+
         $numFields = min(4096, intval($request->getParsedBodyParam('numFields')));
-        $html = $this->normalization->getHtmlForCreateNewColumn($numFields, Current::$database, Current::$table);
+        $html = $this->normalization->getHtmlForCreateNewColumn(
+            $userPrivileges,
+            $numFields,
+            Current::$database,
+            Current::$table,
+        );
         $html .= Url::getHiddenInputs(Current::$database, Current::$table);
         $this->response->addHTML($html);
     }

--- a/src/Controllers/Operations/DatabaseController.php
+++ b/src/Controllers/Operations/DatabaseController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers\Operations;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
@@ -24,6 +23,7 @@ use PhpMyAdmin\Query\Utilities;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PhpMyAdmin\Util;
 
 use function __;
@@ -38,7 +38,7 @@ class DatabaseController extends AbstractController
         ResponseRenderer $response,
         Template $template,
         private Operations $operations,
-        private CheckUserPrivileges $checkUserPrivileges,
+        private UserPrivilegesFactory $userPrivilegesFactory,
         private Relation $relation,
         private RelationCleanup $relationCleanup,
         private DatabaseInterface $dbi,
@@ -54,7 +54,7 @@ class DatabaseController extends AbstractController
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['single_table'] ??= null;
 
-        $userPrivileges = $this->checkUserPrivileges->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         $this->addScriptFiles(['database/operations.js']);
 

--- a/src/Controllers/Operations/DatabaseController.php
+++ b/src/Controllers/Operations/DatabaseController.php
@@ -24,7 +24,6 @@ use PhpMyAdmin\Query\Utilities;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
-use PhpMyAdmin\UserPrivileges;
 use PhpMyAdmin\Util;
 
 use function __;
@@ -55,7 +54,7 @@ class DatabaseController extends AbstractController
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['single_table'] ??= null;
 
-        $this->checkUserPrivileges->getPrivileges();
+        $userPrivileges = $this->checkUserPrivileges->getPrivileges();
 
         $this->addScriptFiles(['database/operations.js']);
 
@@ -86,7 +85,7 @@ class DatabaseController extends AbstractController
                     );
                 } else {
                     if ($move || $request->hasBodyParam('create_database_before_copying')) {
-                        $this->operations->createDbBeforeCopy($newDatabaseName);
+                        $this->operations->createDbBeforeCopy($userPrivileges, $newDatabaseName);
                     }
 
                     // here I don't use DELIMITER because it's not part of the
@@ -147,7 +146,11 @@ class DatabaseController extends AbstractController
 
                     if ($move) {
                         if ($request->hasBodyParam('adjust_privileges')) {
-                            $this->operations->adjustPrivilegesMoveDb(Current::$database, $newDatabaseName);
+                            $this->operations->adjustPrivilegesMoveDb(
+                                $userPrivileges,
+                                Current::$database,
+                                $newDatabaseName,
+                            );
                         }
 
                         /**
@@ -167,7 +170,11 @@ class DatabaseController extends AbstractController
                         $GLOBALS['message']->addParam($newDatabaseName->getName());
                     } else {
                         if ($request->hasBodyParam('adjust_privileges')) {
-                            $this->operations->adjustPrivilegesCopyDb(Current::$database, $newDatabaseName);
+                            $this->operations->adjustPrivilegesCopyDb(
+                                $userPrivileges,
+                                Current::$database,
+                                $newDatabaseName,
+                            );
                         }
 
                         $GLOBALS['message'] = Message::success(
@@ -260,8 +267,8 @@ class DatabaseController extends AbstractController
             $databaseComment = $this->relation->getDbComment(Current::$database);
         }
 
-        $hasAdjustPrivileges = UserPrivileges::$database && UserPrivileges::$table
-            && UserPrivileges::$column && UserPrivileges::$routines && UserPrivileges::$isReload;
+        $hasAdjustPrivileges = $userPrivileges->database && $userPrivileges->table
+            && $userPrivileges->column && $userPrivileges->routines && $userPrivileges->isReload;
 
         $isDropDatabaseAllowed = ($this->dbi->isSuperUser() || $config->settings['AllowUserDropDatabase'])
             && Current::$database !== 'mysql';

--- a/src/Controllers/Operations/TableController.php
+++ b/src/Controllers/Operations/TableController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers\Operations;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\AbstractController;
@@ -26,6 +25,7 @@ use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\StorageEngine;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PhpMyAdmin\Util;
 
 use function __;
@@ -46,7 +46,7 @@ class TableController extends AbstractController
         ResponseRenderer $response,
         Template $template,
         private Operations $operations,
-        private CheckUserPrivileges $checkUserPrivileges,
+        private UserPrivilegesFactory $userPrivilegesFactory,
         private Relation $relation,
         private DatabaseInterface $dbi,
         private readonly DbTableExists $dbTableExists,
@@ -61,7 +61,7 @@ class TableController extends AbstractController
         $GLOBALS['message_to_show'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
 
-        $userPrivileges = $this->checkUserPrivileges->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         if ($this->dbi->getLowerCaseNames() === 1) {
             Current::$table = mb_strtolower(Current::$table);

--- a/src/Controllers/Server/Databases/DestroyController.php
+++ b/src/Controllers/Server/Databases/DestroyController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Server\Databases;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\Controllers\AbstractController;
@@ -15,6 +14,7 @@ use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Transformations;
 use PhpMyAdmin\Url;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PhpMyAdmin\Util;
 
 use function __;
@@ -39,8 +39,8 @@ final class DestroyController extends AbstractController
         $GLOBALS['selected'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
 
-        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-        $userPrivileges = $checkUserPrivileges->getPrivileges();
+        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
+        $userPrivileges = $userPrivilegesFactory->getPrivileges();
 
         $selectedDbs = $request->getParsedBodyParam('selected_dbs');
 

--- a/src/Controllers/Server/Databases/DestroyController.php
+++ b/src/Controllers/Server/Databases/DestroyController.php
@@ -30,6 +30,7 @@ final class DestroyController extends AbstractController
         private DatabaseInterface $dbi,
         private Transformations $transformations,
         private RelationCleanup $relationCleanup,
+        private readonly UserPrivilegesFactory $userPrivilegesFactory,
     ) {
         parent::__construct($response, $template);
     }
@@ -39,8 +40,7 @@ final class DestroyController extends AbstractController
         $GLOBALS['selected'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
 
-        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
-        $userPrivileges = $userPrivilegesFactory->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         $selectedDbs = $request->getParsedBodyParam('selected_dbs');
 

--- a/src/Controllers/Server/Databases/DestroyController.php
+++ b/src/Controllers/Server/Databases/DestroyController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Server\Databases;
 
+use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\Controllers\AbstractController;
@@ -37,6 +38,9 @@ final class DestroyController extends AbstractController
     {
         $GLOBALS['selected'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
+
+        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
+        $userPrivileges = $checkUserPrivileges->getPrivileges();
 
         $selectedDbs = $request->getParsedBodyParam('selected_dbs');
 
@@ -77,7 +81,7 @@ final class DestroyController extends AbstractController
             $this->transformations->clear($database);
         }
 
-        $this->dbi->getDatabaseList()->build();
+        $this->dbi->getDatabaseList()->build($userPrivileges);
 
         $message = Message::success(
             _ngettext(

--- a/src/Controllers/Server/DatabasesController.php
+++ b/src/Controllers/Server/DatabasesController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers\Server;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
@@ -18,6 +17,7 @@ use PhpMyAdmin\Replication\ReplicationInfo;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PhpMyAdmin\Util;
 use Webmozart\Assert\Assert;
 
@@ -71,8 +71,8 @@ class DatabasesController extends AbstractController
     {
         $GLOBALS['errorUrl'] ??= null;
 
-        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-        $userPrivileges = $checkUserPrivileges->getPrivileges();
+        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
+        $userPrivileges = $userPrivilegesFactory->getPrivileges();
 
         $this->hasStatistics = ! empty($request->getParam('statistics'));
         $position = (int) $request->getParam('pos');

--- a/src/Controllers/Server/DatabasesController.php
+++ b/src/Controllers/Server/DatabasesController.php
@@ -63,6 +63,7 @@ class DatabasesController extends AbstractController
         ResponseRenderer $response,
         Template $template,
         private DatabaseInterface $dbi,
+        private readonly UserPrivilegesFactory $userPrivilegesFactory,
     ) {
         parent::__construct($response, $template);
     }
@@ -71,8 +72,7 @@ class DatabasesController extends AbstractController
     {
         $GLOBALS['errorUrl'] ??= null;
 
-        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
-        $userPrivileges = $userPrivilegesFactory->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         $this->hasStatistics = ! empty($request->getParam('statistics'));
         $position = (int) $request->getParam('pos');

--- a/src/Controllers/Server/PrivilegesController.php
+++ b/src/Controllers/Server/PrivilegesController.php
@@ -38,6 +38,7 @@ class PrivilegesController extends AbstractController
         Template $template,
         private Relation $relation,
         private DatabaseInterface $dbi,
+        private readonly UserPrivilegesFactory $userPrivilegesFactory,
     ) {
         parent::__construct($response, $template);
     }
@@ -50,8 +51,7 @@ class PrivilegesController extends AbstractController
         $GLOBALS['hostname'] ??= null;
         $GLOBALS['dbname'] ??= null;
 
-        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
-        $userPrivileges = $userPrivilegesFactory->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         $relationParameters = $this->relation->getRelationParameters();
 

--- a/src/Controllers/Server/PrivilegesController.php
+++ b/src/Controllers/Server/PrivilegesController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Server;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\Controllers\AbstractController;
@@ -19,6 +18,7 @@ use PhpMyAdmin\Server\Plugins;
 use PhpMyAdmin\Server\Privileges;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
+use PhpMyAdmin\UserPrivilegesFactory;
 
 use function __;
 use function htmlspecialchars;
@@ -50,8 +50,8 @@ class PrivilegesController extends AbstractController
         $GLOBALS['hostname'] ??= null;
         $GLOBALS['dbname'] ??= null;
 
-        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-        $userPrivileges = $checkUserPrivileges->getPrivileges();
+        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
+        $userPrivileges = $userPrivilegesFactory->getPrivileges();
 
         $relationParameters = $this->relation->getRelationParameters();
 

--- a/src/Controllers/Server/PrivilegesController.php
+++ b/src/Controllers/Server/PrivilegesController.php
@@ -51,7 +51,7 @@ class PrivilegesController extends AbstractController
         $GLOBALS['dbname'] ??= null;
 
         $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-        $checkUserPrivileges->getPrivileges();
+        $userPrivileges = $checkUserPrivileges->getPrivileges();
 
         $relationParameters = $this->relation->getRelationParameters();
 
@@ -364,6 +364,7 @@ class PrivilegesController extends AbstractController
                 // No username is given --> display the overview
                 $this->response->addHTML(
                     $serverPrivileges->getHtmlForUserOverview(
+                        $userPrivileges,
                         LanguageManager::$textDir,
                         $request->getQueryParam('initial'),
                     ),

--- a/src/Controllers/Server/UserGroupsFormController.php
+++ b/src/Controllers/Server/UserGroupsFormController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers\Server;
 
 use Fig\Http\Message\StatusCodeInterface;
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\ConfigStorage\Features\ConfigurableMenusFeature;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\AbstractController;
@@ -46,9 +45,6 @@ final class UserGroupsFormController extends AbstractController
 
             return;
         }
-
-        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-        $checkUserPrivileges->getPrivileges();
 
         $configurableMenusFeature = $this->relation->getRelationParameters()->configurableMenusFeature;
         if ($configurableMenusFeature === null) {

--- a/src/Controllers/Sql/ColumnPreferencesController.php
+++ b/src/Controllers/Sql/ColumnPreferencesController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Sql;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
@@ -24,7 +23,6 @@ final class ColumnPreferencesController extends AbstractController
     public function __construct(
         ResponseRenderer $response,
         Template $template,
-        private CheckUserPrivileges $checkUserPrivileges,
         private DatabaseInterface $dbi,
     ) {
         parent::__construct($response, $template);
@@ -32,8 +30,6 @@ final class ColumnPreferencesController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $this->checkUserPrivileges->getPrivileges();
-
         $tableObject = $this->dbi->getTable(Current::$database, Current::$table);
         $status = false;
 

--- a/src/Controllers/Sql/DefaultForeignKeyCheckValueController.php
+++ b/src/Controllers/Sql/DefaultForeignKeyCheckValueController.php
@@ -4,26 +4,14 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Sql;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Http\ServerRequest;
-use PhpMyAdmin\ResponseRenderer;
-use PhpMyAdmin\Template;
 use PhpMyAdmin\Utils\ForeignKey;
 
 final class DefaultForeignKeyCheckValueController extends AbstractController
 {
-    public function __construct(
-        ResponseRenderer $response,
-        Template $template,
-        private CheckUserPrivileges $checkUserPrivileges,
-    ) {
-        parent::__construct($response, $template);
-    }
-
     public function __invoke(ServerRequest $request): void
     {
-        $this->checkUserPrivileges->getPrivileges();
         $this->response->addJSON('default_fk_check_value', ForeignKey::isCheckEnabled());
     }
 }

--- a/src/Controllers/Sql/EnumValuesController.php
+++ b/src/Controllers/Sql/EnumValuesController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Sql;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\Http\ServerRequest;
@@ -21,7 +20,6 @@ final class EnumValuesController extends AbstractController
         ResponseRenderer $response,
         Template $template,
         private Sql $sql,
-        private CheckUserPrivileges $checkUserPrivileges,
     ) {
         parent::__construct($response, $template);
     }
@@ -31,8 +29,6 @@ final class EnumValuesController extends AbstractController
      */
     public function __invoke(ServerRequest $request): void
     {
-        $this->checkUserPrivileges->getPrivileges();
-
         $column = $request->getParsedBodyParam('column');
         $currValue = $request->getParsedBodyParam('curr_value');
         $values = $this->sql->getValuesForColumn(Current::$database, Current::$table, strval($column));

--- a/src/Controllers/Sql/RelationalValuesController.php
+++ b/src/Controllers/Sql/RelationalValuesController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Sql;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\Http\ServerRequest;
@@ -20,7 +19,6 @@ final class RelationalValuesController extends AbstractController
         ResponseRenderer $response,
         Template $template,
         private Sql $sql,
-        private CheckUserPrivileges $checkUserPrivileges,
     ) {
         parent::__construct($response, $template);
     }
@@ -32,8 +30,6 @@ final class RelationalValuesController extends AbstractController
      */
     public function __invoke(ServerRequest $request): void
     {
-        $this->checkUserPrivileges->getPrivileges();
-
         $column = $request->getParsedBodyParam('column');
         $relationKeyOrDisplayColumn = $request->getParsedBodyParam('relation_key_or_display_column');
 

--- a/src/Controllers/Sql/SetValuesController.php
+++ b/src/Controllers/Sql/SetValuesController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Sql;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\Http\ServerRequest;
@@ -21,7 +20,6 @@ final class SetValuesController extends AbstractController
         ResponseRenderer $response,
         Template $template,
         private Sql $sql,
-        private CheckUserPrivileges $checkUserPrivileges,
     ) {
         parent::__construct($response, $template);
     }
@@ -31,8 +29,6 @@ final class SetValuesController extends AbstractController
      */
     public function __invoke(ServerRequest $request): void
     {
-        $this->checkUserPrivileges->getPrivileges();
-
         $column = $request->getParsedBodyParam('column');
         $currentValue = $request->getParsedBodyParam('curr_value');
         $whereClause = $request->getParsedBodyParam('where_clause');

--- a/src/Controllers/Sql/SqlController.php
+++ b/src/Controllers/Sql/SqlController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers\Sql;
 
 use PhpMyAdmin\Bookmarks\BookmarkRepository;
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\Controllers\AbstractController;
@@ -33,7 +32,6 @@ class SqlController extends AbstractController
         ResponseRenderer $response,
         Template $template,
         private Sql $sql,
-        private CheckUserPrivileges $checkUserPrivileges,
         private DatabaseInterface $dbi,
         private PageSettings $pageSettings,
         private readonly BookmarkRepository $bookmarkRepository,
@@ -54,8 +52,6 @@ class SqlController extends AbstractController
         $GLOBALS['disp_message'] ??= null;
         $GLOBALS['complete_query'] ??= null;
         $GLOBALS['back'] ??= null;
-
-        $this->checkUserPrivileges->getPrivileges();
 
         $this->pageSettings->init('Browse');
         $this->response->addHTML($this->pageSettings->getErrorHTML());

--- a/src/Controllers/Table/AddFieldController.php
+++ b/src/Controllers/Table/AddFieldController.php
@@ -43,6 +43,7 @@ class AddFieldController extends AbstractController
         private DatabaseInterface $dbi,
         private ColumnsDefinition $columnsDefinition,
         private readonly DbTableExists $dbTableExists,
+        private readonly UserPrivilegesFactory $userPrivilegesFactory,
     ) {
         parent::__construct($response, $template);
     }
@@ -61,8 +62,7 @@ class AddFieldController extends AbstractController
             return;
         }
 
-        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
-        $userPrivileges = $userPrivilegesFactory->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         $cfg = $this->config->settings;
 

--- a/src/Controllers/Table/AddFieldController.php
+++ b/src/Controllers/Table/AddFieldController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Table;
 
+use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Core;
@@ -59,6 +60,9 @@ class AddFieldController extends AbstractController
         if (! $this->checkParameters(['db', 'table'])) {
             return;
         }
+
+        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
+        $userPrivileges = $checkUserPrivileges->getPrivileges();
 
         $cfg = $this->config->settings;
 
@@ -188,7 +192,7 @@ class AddFieldController extends AbstractController
             return;
         }
 
-        $templateData = $this->columnsDefinition->displayForm('/table/add-field', $numFields);
+        $templateData = $this->columnsDefinition->displayForm($userPrivileges, '/table/add-field', $numFields);
 
         $this->render('columns_definitions/column_definitions_form', $templateData);
     }

--- a/src/Controllers/Table/AddFieldController.php
+++ b/src/Controllers/Table/AddFieldController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Table;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Core;
@@ -22,6 +21,7 @@ use PhpMyAdmin\Table\ColumnsDefinition;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Transformations;
 use PhpMyAdmin\Url;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PhpMyAdmin\Util;
 
 use function __;
@@ -61,8 +61,8 @@ class AddFieldController extends AbstractController
             return;
         }
 
-        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-        $userPrivileges = $checkUserPrivileges->getPrivileges();
+        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
+        $userPrivileges = $userPrivilegesFactory->getPrivileges();
 
         $cfg = $this->config->settings;
 

--- a/src/Controllers/Table/CreateController.php
+++ b/src/Controllers/Table/CreateController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Table;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Core;
@@ -18,6 +17,7 @@ use PhpMyAdmin\Table\ColumnsDefinition;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Transformations;
 use PhpMyAdmin\Url;
+use PhpMyAdmin\UserPrivilegesFactory;
 
 use function __;
 use function htmlspecialchars;
@@ -50,8 +50,8 @@ class CreateController extends AbstractController
             return;
         }
 
-        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-        $userPrivileges = $checkUserPrivileges->getPrivileges();
+        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
+        $userPrivileges = $userPrivilegesFactory->getPrivileges();
 
         $cfg = $this->config->settings;
 

--- a/src/Controllers/Table/CreateController.php
+++ b/src/Controllers/Table/CreateController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Table;
 
+use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Core;
@@ -48,6 +49,9 @@ class CreateController extends AbstractController
         if (! $this->checkParameters(['db'])) {
             return;
         }
+
+        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
+        $userPrivileges = $checkUserPrivileges->getPrivileges();
 
         $cfg = $this->config->settings;
 
@@ -148,7 +152,7 @@ class CreateController extends AbstractController
             return;
         }
 
-        $templateData = $this->columnsDefinition->displayForm('/table/create', $numFields);
+        $templateData = $this->columnsDefinition->displayForm($userPrivileges, '/table/create', $numFields);
 
         $this->render('columns_definitions/column_definitions_form', $templateData);
     }

--- a/src/Controllers/Table/CreateController.php
+++ b/src/Controllers/Table/CreateController.php
@@ -40,6 +40,7 @@ class CreateController extends AbstractController
         private Config $config,
         private DatabaseInterface $dbi,
         private ColumnsDefinition $columnsDefinition,
+        private readonly UserPrivilegesFactory $userPrivilegesFactory,
     ) {
         parent::__construct($response, $template);
     }
@@ -50,8 +51,7 @@ class CreateController extends AbstractController
             return;
         }
 
-        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
-        $userPrivileges = $userPrivilegesFactory->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         $cfg = $this->config->settings;
 

--- a/src/Controllers/Table/PrivilegesController.php
+++ b/src/Controllers/Table/PrivilegesController.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Table;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\DatabaseInterface;
@@ -53,9 +52,6 @@ class PrivilegesController extends AbstractController
 
             return;
         }
-
-        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-        $checkUserPrivileges->getPrivileges();
 
         $this->addScriptFiles(['server/privileges.js', 'vendor/zxcvbn-ts.js']);
 

--- a/src/Controllers/Table/Structure/ChangeController.php
+++ b/src/Controllers/Table/Structure/ChangeController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Table\Structure;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\ColumnFull;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
@@ -13,6 +12,7 @@ use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Table\ColumnsDefinition;
 use PhpMyAdmin\Template;
+use PhpMyAdmin\UserPrivilegesFactory;
 
 use function __;
 use function array_filter;
@@ -85,8 +85,8 @@ final class ChangeController extends AbstractController
         /**
          * Form for changing properties.
          */
-        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-        $userPrivileges = $checkUserPrivileges->getPrivileges();
+        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
+        $userPrivileges = $userPrivilegesFactory->getPrivileges();
 
         $this->addScriptFiles(['vendor/jquery/jquery.uitablefilter.js']);
 

--- a/src/Controllers/Table/Structure/ChangeController.php
+++ b/src/Controllers/Table/Structure/ChangeController.php
@@ -86,11 +86,12 @@ final class ChangeController extends AbstractController
          * Form for changing properties.
          */
         $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-        $checkUserPrivileges->getPrivileges();
+        $userPrivileges = $checkUserPrivileges->getPrivileges();
 
         $this->addScriptFiles(['vendor/jquery/jquery.uitablefilter.js']);
 
         $templateData = $this->columnsDefinition->displayForm(
+            $userPrivileges,
             '/table/structure/save',
             count($fieldsMeta),
             $selected,

--- a/src/Controllers/Table/Structure/ChangeController.php
+++ b/src/Controllers/Table/Structure/ChangeController.php
@@ -29,6 +29,7 @@ final class ChangeController extends AbstractController
         Template $template,
         private DatabaseInterface $dbi,
         private ColumnsDefinition $columnsDefinition,
+        private readonly UserPrivilegesFactory $userPrivilegesFactory,
     ) {
         parent::__construct($response, $template);
     }
@@ -85,8 +86,7 @@ final class ChangeController extends AbstractController
         /**
          * Form for changing properties.
          */
-        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
-        $userPrivileges = $userPrivilegesFactory->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         $this->addScriptFiles(['vendor/jquery/jquery.uitablefilter.js']);
 

--- a/src/Controllers/Table/Structure/SaveController.php
+++ b/src/Controllers/Table/Structure/SaveController.php
@@ -44,6 +44,7 @@ final class SaveController extends AbstractController
         private Transformations $transformations,
         private DatabaseInterface $dbi,
         private StructureController $structureController,
+        private readonly UserPrivilegesFactory $userPrivilegesFactory,
     ) {
         parent::__construct($response, $template);
 
@@ -52,8 +53,7 @@ final class SaveController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
-        $userPrivileges = $userPrivilegesFactory->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         $regenerate = $this->updateColumns($userPrivileges);
         if (! $regenerate) {

--- a/src/Controllers/Table/Structure/SaveController.php
+++ b/src/Controllers/Table/Structure/SaveController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Table\Structure;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\AbstractController;
@@ -22,6 +21,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Transformations;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\UserPrivileges;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PhpMyAdmin\Util;
 
 use function __;
@@ -52,8 +52,8 @@ final class SaveController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-        $userPrivileges = $checkUserPrivileges->getPrivileges();
+        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
+        $userPrivileges = $userPrivilegesFactory->getPrivileges();
 
         $regenerate = $this->updateColumns($userPrivileges);
         if (! $regenerate) {

--- a/src/Controllers/Table/StructureController.php
+++ b/src/Controllers/Table/StructureController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers\Table;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\ColumnFull;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
@@ -73,9 +72,6 @@ class StructureController extends AbstractController
         $this->pageSettings->init('TableStructure');
         $this->response->addHTML($this->pageSettings->getErrorHTML());
         $this->response->addHTML($this->pageSettings->getHTML());
-
-        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-        $checkUserPrivileges->getPrivileges();
 
         $this->addScriptFiles(['table/structure.js']);
 

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -1972,7 +1972,7 @@ class DatabaseInterface implements DbalInterface
     public function getDatabaseList(): ListDatabase
     {
         if ($this->databaseList === null) {
-            $this->databaseList = new ListDatabase($this, Config::getInstance(), new CheckUserPrivileges($this));
+            $this->databaseList = new ListDatabase($this, Config::getInstance(), new UserPrivilegesFactory($this));
         }
 
         return $this->databaseList;

--- a/src/Import/Import.php
+++ b/src/Import/Import.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Import;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
@@ -86,9 +85,6 @@ class Import
     public function __construct()
     {
         Config::getInstance()->selectedServer['DisableIS'] = false;
-
-        $checkUserPrivileges = new CheckUserPrivileges(DatabaseInterface::getInstance());
-        $checkUserPrivileges->getPrivileges();
     }
 
     /**

--- a/src/ListDatabase.php
+++ b/src/ListDatabase.php
@@ -28,11 +28,11 @@ class ListDatabase extends ArrayObject
     public function __construct(
         private readonly DatabaseInterface $dbi,
         private readonly Config $config,
-        private readonly CheckUserPrivileges $checkUserPrivileges,
+        private readonly UserPrivilegesFactory $userPrivilegesFactory,
     ) {
         parent::__construct();
 
-        $userPrivileges = $this->checkUserPrivileges->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         $this->build($userPrivileges);
     }

--- a/src/Navigation/Navigation.php
+++ b/src/Navigation/Navigation.php
@@ -41,10 +41,12 @@ use const PHP_URL_HOST;
 class Navigation
 {
     private NavigationTree $tree;
+    private readonly UserPrivilegesFactory $userPrivilegesFactory;
 
     public function __construct(private Template $template, private Relation $relation, private DatabaseInterface $dbi)
     {
         $this->tree = new NavigationTree($this->template, $this->dbi, $this->relation);
+        $this->userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
     }
 
     /**
@@ -54,8 +56,7 @@ class Navigation
      */
     public function getDisplay(): string
     {
-        $userPrivilegesFactory = new UserPrivilegesFactory(DatabaseInterface::getInstance());
-        $userPrivileges = $userPrivilegesFactory->getPrivileges();
+        $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
         $config = Config::getInstance();
         $logo = [

--- a/src/Navigation/Navigation.php
+++ b/src/Navigation/Navigation.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Navigation;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\ConfigStorage\Relation;
@@ -23,6 +22,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Theme\ThemeManager;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\UserPreferences;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PhpMyAdmin\Util;
 
 use function __;
@@ -54,8 +54,8 @@ class Navigation
      */
     public function getDisplay(): string
     {
-        $checkUserPrivileges = new CheckUserPrivileges(DatabaseInterface::getInstance());
-        $userPrivileges = $checkUserPrivileges->getPrivileges();
+        $userPrivilegesFactory = new UserPrivilegesFactory(DatabaseInterface::getInstance());
+        $userPrivileges = $userPrivilegesFactory->getPrivileges();
 
         $config = Config::getInstance();
         $logo = [

--- a/src/Navigation/Navigation.php
+++ b/src/Navigation/Navigation.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Navigation;
 
+use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\ConfigStorage\Relation;
@@ -53,6 +54,9 @@ class Navigation
      */
     public function getDisplay(): string
     {
+        $checkUserPrivileges = new CheckUserPrivileges(DatabaseInterface::getInstance());
+        $userPrivileges = $checkUserPrivileges->getPrivileges();
+
         $config = Config::getInstance();
         $logo = [
             'is_displayed' => $config->settings['NavigationDisplayLogo'],
@@ -103,13 +107,13 @@ class Navigation
         if (! $response->isAjax() || ! empty($_POST['full']) || ! empty($_POST['reload'])) {
             if ($config->settings['ShowDatabasesNavigationAsTree']) {
                 // provide database tree in navigation
-                $navRender = $this->tree->renderState();
+                $navRender = $this->tree->renderState($userPrivileges);
             } else {
                 // provide legacy pre-4.0 navigation
-                $navRender = $this->tree->renderDbSelect();
+                $navRender = $this->tree->renderDbSelect($userPrivileges);
             }
         } else {
-            $navRender = $this->tree->renderPath();
+            $navRender = $this->tree->renderPath($userPrivileges);
         }
 
         return $this->template->render('navigation/main', [

--- a/src/Navigation/NavigationTree.php
+++ b/src/Navigation/NavigationTree.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Navigation;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
@@ -39,6 +38,7 @@ use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\UserPrivileges;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PhpMyAdmin\Util;
 
 use function __;
@@ -147,8 +147,8 @@ class NavigationTree
     public function __construct(private Template $template, private DatabaseInterface $dbi, Relation $relation)
     {
         $this->relationParameters = $relation->getRelationParameters();
-        $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
-        $userPrivileges = $checkUserPrivileges->getPrivileges();
+        $userPrivilegesFactory = new UserPrivilegesFactory($this->dbi);
+        $userPrivileges = $userPrivilegesFactory->getPrivileges();
 
         // Save the position at which we are in the database list
         if (isset($_POST['pos'])) {

--- a/src/Navigation/Nodes/NodeDatabase.php
+++ b/src/Navigation/Nodes/NodeDatabase.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Dbal\ConnectionType;
 use PhpMyAdmin\Dbal\ResultInterface;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Url;
+use PhpMyAdmin\UserPrivileges;
 use PhpMyAdmin\Util;
 
 use function __;
@@ -72,7 +73,7 @@ class NodeDatabase extends Node
      * @param string $searchClause A string used to filter the results of
      *                             the query
      */
-    public function getPresence(string $type = '', string $searchClause = ''): int
+    public function getPresence(UserPrivileges $userPrivileges, string $type = '', string $searchClause = ''): int
     {
         return $this->presenceCounts[$type][$searchClause] ??= match ($type) {
             'tables' => $this->getTableCount($searchClause),
@@ -260,6 +261,7 @@ class NodeDatabase extends Node
      * @return mixed[]
      */
     public function getData(
+        UserPrivileges $userPrivileges,
         RelationParameters $relationParameters,
         string $type,
         int $pos,

--- a/src/Navigation/Nodes/NodeDatabaseContainer.php
+++ b/src/Navigation/Nodes/NodeDatabaseContainer.php
@@ -7,10 +7,10 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Navigation\Nodes;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Navigation\NodeType;
+use PhpMyAdmin\UserPrivilegesFactory;
 
 use function _pgettext;
 
@@ -26,8 +26,8 @@ class NodeDatabaseContainer extends Node
      */
     public function __construct(string $name)
     {
-        $checkUserPrivileges = new CheckUserPrivileges(DatabaseInterface::getInstance());
-        $userPrivileges = $checkUserPrivileges->getPrivileges();
+        $userPrivilegesFactory = new UserPrivilegesFactory(DatabaseInterface::getInstance());
+        $userPrivileges = $userPrivilegesFactory->getPrivileges();
 
         parent::__construct($name, NodeType::Container);
 

--- a/src/Navigation/Nodes/NodeDatabaseContainer.php
+++ b/src/Navigation/Nodes/NodeDatabaseContainer.php
@@ -11,7 +11,6 @@ use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Navigation\NodeType;
-use PhpMyAdmin\UserPrivileges;
 
 use function _pgettext;
 
@@ -28,11 +27,11 @@ class NodeDatabaseContainer extends Node
     public function __construct(string $name)
     {
         $checkUserPrivileges = new CheckUserPrivileges(DatabaseInterface::getInstance());
-        $checkUserPrivileges->getPrivileges();
+        $userPrivileges = $checkUserPrivileges->getPrivileges();
 
         parent::__construct($name, NodeType::Container);
 
-        if (! UserPrivileges::$isCreateDatabase || Config::getInstance()->settings['ShowCreateDb'] === false) {
+        if (! $userPrivileges->isCreateDatabase || Config::getInstance()->settings['ShowCreateDb'] === false) {
             return;
         }
 

--- a/src/Navigation/Nodes/NodeTable.php
+++ b/src/Navigation/Nodes/NodeTable.php
@@ -11,6 +11,7 @@ use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Url;
+use PhpMyAdmin\UserPrivileges;
 use PhpMyAdmin\Util;
 
 use function __;
@@ -80,7 +81,7 @@ class NodeTable extends NodeDatabaseChild
      *                             ('columns' or 'indexes')
      * @param string $searchClause A string used to filter the results of the query
      */
-    public function getPresence(string $type = '', string $searchClause = ''): int
+    public function getPresence(UserPrivileges $userPrivileges, string $type = '', string $searchClause = ''): int
     {
         $retval = 0;
         $db = $this->realParent()->realName;
@@ -145,6 +146,7 @@ class NodeTable extends NodeDatabaseChild
      * @return mixed[]
      */
     public function getData(
+        UserPrivileges $userPrivileges,
         RelationParameters $relationParameters,
         string $type,
         int $pos,

--- a/src/Normalization.php
+++ b/src/Normalization.php
@@ -109,6 +109,7 @@ class Normalization
      * @return string HTML
      */
     public function getHtmlForCreateNewColumn(
+        UserPrivileges $userPrivileges,
         int $numFields,
         string $db,
         string $table,
@@ -175,7 +176,7 @@ class Normalization
             'max_rows' => intval($config->settings['MaxRows']),
             'char_editing' => $config->settings['CharEditing'],
             'attribute_types' => $this->dbi->types->getAttributes(),
-            'privs_available' => UserPrivileges::$column && UserPrivileges::$isReload,
+            'privs_available' => $userPrivileges->column && $userPrivileges->isReload,
             'max_length' => $this->dbi->getVersion() >= 50503 ? 1024 : 255,
             'charsets' => $charsetsList,
         ]);

--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -2577,8 +2577,11 @@ class Privileges
      *
      * @param string $textDir text directory
      */
-    public function getHtmlForUserOverview(string $textDir, string|null $initial): string
-    {
+    public function getHtmlForUserOverview(
+        UserPrivileges $userPrivileges,
+        string $textDir,
+        string|null $initial,
+    ): string {
         $serverVersion = $this->dbi->getVersion();
         $passwordColumn = Compatibility::isMySqlOrPerconaDb() && $serverVersion >= 50706
             ? 'authentication_string'
@@ -2604,7 +2607,7 @@ class Privileges
 
             $response = ResponseRenderer::getInstance();
             if (! $response->isAjax() || ! empty($_REQUEST['ajax_page_request'])) {
-                if (UserPrivileges::$isReload) {
+                if ($userPrivileges->isReload) {
                     $flushnote = new Message(
                         __(
                             'Note: phpMyAdmin gets the users’ privileges directly '

--- a/src/Table/ColumnsDefinition.php
+++ b/src/Table/ColumnsDefinition.php
@@ -65,6 +65,7 @@ final class ColumnsDefinition
      * @return array<string, mixed>
      */
     public function displayForm(
+        UserPrivileges $userPrivileges,
         string $action,
         int $numFields = 0,
         array|null $selected = null,
@@ -356,7 +357,7 @@ final class ColumnsDefinition
             'max_rows' => intval($config->settings['MaxRows']),
             'char_editing' => $config->settings['CharEditing'] ?? null,
             'attribute_types' => $this->dbi->types->getAttributes(),
-            'privs_available' => UserPrivileges::$column && UserPrivileges::$isReload,
+            'privs_available' => $userPrivileges->column && $userPrivileges->isReload,
             'max_length' => $this->dbi->getVersion() >= 50503 ? 1024 : 255,
             'have_partitioning' => Partition::havePartitioning(),
             'disable_is' => $config->selectedServer['DisableIS'],

--- a/src/UserPrivileges.php
+++ b/src/UserPrivileges.php
@@ -6,13 +6,16 @@ namespace PhpMyAdmin;
 
 final class UserPrivileges
 {
-    public static bool $database = false;
-    public static bool $table = false;
-    public static bool $column = false;
-    public static bool $routines = false;
-    public static bool $isReload = false;
-    public static bool $isCreateDatabase = false;
-    public static string $databaseToCreate = '';
-    /** @var string[]|false */
-    public static array|bool $databasesToTest = false;
+    /** @param string[]|false $databasesToTest */
+    public function __construct(
+        public bool $database = false,
+        public bool $table = false,
+        public bool $column = false,
+        public bool $routines = false,
+        public bool $isReload = false,
+        public bool $isCreateDatabase = false,
+        public string $databaseToCreate = '',
+        public array|false $databasesToTest = false,
+    ) {
+    }
 }

--- a/src/UserPrivilegesFactory.php
+++ b/src/UserPrivilegesFactory.php
@@ -15,7 +15,7 @@ use function str_contains;
 /**
  * Get user's global privileges and some db-specific privileges
  */
-class CheckUserPrivileges
+class UserPrivilegesFactory
 {
     public function __construct(private DatabaseInterface $dbi)
     {

--- a/tests/classes/AbstractTestCase.php
+++ b/tests/classes/AbstractTestCase.php
@@ -16,7 +16,6 @@ use PhpMyAdmin\SqlParser\Translator;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tracking\Tracker;
-use PhpMyAdmin\UserPrivileges;
 use PhpMyAdmin\Utils\HttpRequest;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -78,16 +77,6 @@ abstract class AbstractTestCase extends TestCase
         Current::$database = '';
         Current::$table = '';
         $GLOBALS['sql_query'] = '';
-
-        UserPrivileges::$column = false;
-        UserPrivileges::$database = false;
-        UserPrivileges::$table = false;
-        UserPrivileges::$column = false;
-        UserPrivileges::$routines = false;
-        UserPrivileges::$isReload = false;
-        UserPrivileges::$isCreateDatabase = false;
-        UserPrivileges::$databaseToCreate = '';
-        UserPrivileges::$databasesToTest = false;
 
         // Config before DBI
         $this->setGlobalConfig();

--- a/tests/classes/CheckUserPrivilegesTest.php
+++ b/tests/classes/CheckUserPrivilegesTest.php
@@ -25,11 +25,6 @@ class CheckUserPrivilegesTest extends AbstractTestCase
 
         DatabaseInterface::$instance = $this->createDatabaseInterface();
         Config::getInstance()->selectedServer['DisableIS'] = false;
-        UserPrivileges::$column = false;
-        UserPrivileges::$database = false;
-        UserPrivileges::$routines = false;
-        UserPrivileges::$table = false;
-        UserPrivileges::$isReload = false;
 
         $this->checkUserPrivileges = new CheckUserPrivileges(DatabaseInterface::getInstance());
     }
@@ -40,56 +35,51 @@ class CheckUserPrivilegesTest extends AbstractTestCase
     public function testCheckRequiredPrivilegesForAdjust(): void
     {
         // TEST CASE 1
+        $userPrivileges = new UserPrivileges();
         $showGrants = new ShowGrants('GRANT ALL PRIVILEGES ON *.* TO \'root\'@\'localhost\' WITH GRANT OPTION');
 
         // call the to-be-tested function
-        $this->checkUserPrivileges->checkRequiredPrivilegesForAdjust($showGrants);
+        $this->checkUserPrivileges->checkRequiredPrivilegesForAdjust($userPrivileges, $showGrants);
 
-        self::assertTrue(UserPrivileges::$column);
-        self::assertTrue(UserPrivileges::$database);
-        self::assertTrue(UserPrivileges::$routines);
-        self::assertTrue(UserPrivileges::$table);
-
-        // re-initialise the privileges
-        $this->setUp();
+        self::assertTrue($userPrivileges->column);
+        self::assertTrue($userPrivileges->database);
+        self::assertTrue($userPrivileges->routines);
+        self::assertTrue($userPrivileges->table);
 
         // TEST CASE 2
+        $userPrivileges = new UserPrivileges();
         $showGrants = new ShowGrants('GRANT ALL PRIVILEGES ON `mysql`.* TO \'root\'@\'localhost\' WITH GRANT OPTION');
 
         // call the to-be-tested function
-        $this->checkUserPrivileges->checkRequiredPrivilegesForAdjust($showGrants);
+        $this->checkUserPrivileges->checkRequiredPrivilegesForAdjust($userPrivileges, $showGrants);
 
-        self::assertTrue(UserPrivileges::$column);
-        self::assertTrue(UserPrivileges::$database);
-        self::assertTrue(UserPrivileges::$routines);
-        self::assertTrue(UserPrivileges::$table);
-
-        // re-initialise the privileges
-        $this->setUp();
+        self::assertTrue($userPrivileges->column);
+        self::assertTrue($userPrivileges->database);
+        self::assertTrue($userPrivileges->routines);
+        self::assertTrue($userPrivileges->table);
 
         // TEST CASE 3
+        $userPrivileges = new UserPrivileges();
         $showGrants = new ShowGrants('GRANT SELECT, INSERT, UPDATE, DELETE ON `mysql`.* TO \'root\'@\'localhost\'');
 
         // call the to-be-tested function
-        $this->checkUserPrivileges->checkRequiredPrivilegesForAdjust($showGrants);
+        $this->checkUserPrivileges->checkRequiredPrivilegesForAdjust($userPrivileges, $showGrants);
 
-        self::assertTrue(UserPrivileges::$column);
-        self::assertTrue(UserPrivileges::$database);
-        self::assertTrue(UserPrivileges::$routines);
-        self::assertTrue(UserPrivileges::$table);
-
-        // re-initialise the privileges
-        $this->setUp();
+        self::assertTrue($userPrivileges->column);
+        self::assertTrue($userPrivileges->database);
+        self::assertTrue($userPrivileges->routines);
+        self::assertTrue($userPrivileges->table);
 
         // TEST CASE 4
+        $userPrivileges = new UserPrivileges();
         $showGrants = new ShowGrants('GRANT SELECT, INSERT, UPDATE, DELETE ON `mysql`.`db` TO \'root\'@\'localhost\'');
 
         // call the to-be-tested function
-        $this->checkUserPrivileges->checkRequiredPrivilegesForAdjust($showGrants);
+        $this->checkUserPrivileges->checkRequiredPrivilegesForAdjust($userPrivileges, $showGrants);
 
-        self::assertFalse(UserPrivileges::$column);
-        self::assertTrue(UserPrivileges::$database);
-        self::assertFalse(UserPrivileges::$routines);
-        self::assertFalse(UserPrivileges::$table);
+        self::assertFalse($userPrivileges->column);
+        self::assertTrue($userPrivileges->database);
+        self::assertFalse($userPrivileges->routines);
+        self::assertFalse($userPrivileges->table);
     }
 }

--- a/tests/classes/Controllers/Database/RoutinesControllerTest.php
+++ b/tests/classes/Controllers/Database/RoutinesControllerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Database;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\Database\RoutinesController;
 use PhpMyAdmin\Current;
@@ -15,6 +14,7 @@ use PhpMyAdmin\Http\Factory\ServerRequestFactory;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(RoutinesController::class)]
@@ -107,7 +107,7 @@ final class RoutinesControllerTest extends AbstractTestCase
         (new RoutinesController(
             $response,
             $template,
-            new CheckUserPrivileges($dbi),
+            new UserPrivilegesFactory($dbi),
             $dbi,
             new Routines($dbi),
             new DbTableExists($dbi),
@@ -280,7 +280,7 @@ HTML;
         (new RoutinesController(
             $response,
             $template,
-            new CheckUserPrivileges($dbi),
+            new UserPrivilegesFactory($dbi),
             $dbi,
             new Routines($dbi),
             new DbTableExists($dbi),

--- a/tests/classes/Controllers/Normalization/AddNewPrimaryControllerTest.php
+++ b/tests/classes/Controllers/Normalization/AddNewPrimaryControllerTest.php
@@ -15,7 +15,6 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Transformations;
-use PhpMyAdmin\UserPrivileges;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(AddNewPrimaryController::class)]
@@ -24,7 +23,6 @@ class AddNewPrimaryControllerTest extends AbstractTestCase
     public function testDefault(): void
     {
         Config::getInstance()->selectedServer['DisableIS'] = false;
-        UserPrivileges::$column = false;
         Current::$database = 'test_db';
         Current::$table = 'test_table';
 

--- a/tests/classes/Controllers/Normalization/AddNewPrimaryControllerTest.php
+++ b/tests/classes/Controllers/Normalization/AddNewPrimaryControllerTest.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Transformations;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(AddNewPrimaryController::class)]
@@ -37,6 +38,7 @@ class AddNewPrimaryControllerTest extends AbstractTestCase
             $response,
             $template,
             new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new UserPrivilegesFactory($dbi),
         );
         $controller(self::createStub(ServerRequest::class));
 

--- a/tests/classes/Controllers/Normalization/CreateNewColumnControllerTest.php
+++ b/tests/classes/Controllers/Normalization/CreateNewColumnControllerTest.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Transformations;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(CreateNewColumnController::class)]
@@ -39,6 +40,7 @@ class CreateNewColumnControllerTest extends AbstractTestCase
             $response,
             $template,
             new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new UserPrivilegesFactory($dbi),
         );
         $controller($request);
 

--- a/tests/classes/Controllers/Normalization/CreateNewColumnControllerTest.php
+++ b/tests/classes/Controllers/Normalization/CreateNewColumnControllerTest.php
@@ -15,7 +15,6 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Transformations;
-use PhpMyAdmin\UserPrivileges;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(CreateNewColumnController::class)]
@@ -24,7 +23,6 @@ class CreateNewColumnControllerTest extends AbstractTestCase
     public function testDefault(): void
     {
         Config::getInstance()->selectedServer['DisableIS'] = false;
-        UserPrivileges::$column = false;
         Current::$database = 'test_db';
         Current::$table = 'test_table';
 

--- a/tests/classes/Controllers/Operations/TableControllerTest.php
+++ b/tests/classes/Controllers/Operations/TableControllerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Controllers\Operations;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\Operations\TableController;
@@ -19,6 +18,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(TableController::class)]
@@ -126,7 +126,7 @@ class TableControllerTest extends AbstractTestCase
             $responseRenderer,
             new Template($config),
             new Operations($this->dbi, $relation),
-            new CheckUserPrivileges($this->dbi),
+            new UserPrivilegesFactory($this->dbi),
             $relation,
             $this->dbi,
             new DbTableExists($this->dbi),

--- a/tests/classes/Controllers/Server/Databases/DestroyControllerTest.php
+++ b/tests/classes/Controllers/Server/Databases/DestroyControllerTest.php
@@ -14,6 +14,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Transformations;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 use function __;
@@ -44,6 +45,7 @@ class DestroyControllerTest extends AbstractTestCase
             $dbi,
             new Transformations(),
             new RelationCleanup($dbi, new Relation($dbi)),
+            new UserPrivilegesFactory($dbi),
         );
 
         $request = self::createStub(ServerRequest::class);

--- a/tests/classes/Controllers/Server/DatabasesControllerTest.php
+++ b/tests/classes/Controllers/Server/DatabasesControllerTest.php
@@ -13,7 +13,6 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
-use PhpMyAdmin\UserPrivileges;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 use function __;
@@ -88,7 +87,6 @@ class DatabasesControllerTest extends AbstractTestCase
         $controller = new DatabasesController($response, $template, DatabaseInterface::getInstance());
 
         $config->settings['ShowCreateDb'] = true;
-        UserPrivileges::$isCreateDatabase = true;
 
         $request = ServerRequestFactory::create()->createServerRequest('GET', 'http://example.com/')
             ->withQueryParams([
@@ -112,6 +110,5 @@ class DatabasesControllerTest extends AbstractTestCase
         self::assertStringContainsString('title="4358144"', $actual);
         self::assertStringContainsString('4.2', $actual);
         self::assertStringContainsString('MiB', $actual);
-        self::assertStringContainsString('name="db_collation"', $actual);
     }
 }

--- a/tests/classes/Controllers/Server/DatabasesControllerTest.php
+++ b/tests/classes/Controllers/Server/DatabasesControllerTest.php
@@ -13,6 +13,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 use function __;
@@ -47,7 +48,7 @@ class DatabasesControllerTest extends AbstractTestCase
 
         $response = new ResponseRenderer();
 
-        $controller = new DatabasesController($response, $template, $this->dbi);
+        $controller = new DatabasesController($response, $template, $this->dbi, new UserPrivilegesFactory($this->dbi));
 
         $this->dummyDbi->addResult(
             'SELECT `SCHEMA_NAME` FROM `INFORMATION_SCHEMA`.`SCHEMATA`',
@@ -84,7 +85,8 @@ class DatabasesControllerTest extends AbstractTestCase
 
         $response = new ResponseRenderer();
 
-        $controller = new DatabasesController($response, $template, DatabaseInterface::getInstance());
+        $dbi = DatabaseInterface::getInstance();
+        $controller = new DatabasesController($response, $template, $dbi, new UserPrivilegesFactory($dbi));
 
         $config->settings['ShowCreateDb'] = true;
 

--- a/tests/classes/Controllers/Server/PrivilegesControllerTest.php
+++ b/tests/classes/Controllers/Server/PrivilegesControllerTest.php
@@ -14,6 +14,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(PrivilegesController::class)]
@@ -68,7 +69,13 @@ class PrivilegesControllerTest extends AbstractTestCase
         $request->method('getQueryParam')->willReturnMap([['initial', null, null]]);
 
         $response = new ResponseRenderer();
-        (new PrivilegesController($response, new Template(), new Relation($this->dbi), $this->dbi))($request);
+        (new PrivilegesController(
+            $response,
+            new Template(),
+            new Relation($this->dbi),
+            $this->dbi,
+            new UserPrivilegesFactory($this->dbi),
+        ))($request);
 
         $actual = $response->getHTMLResult();
         self::assertStringContainsString('User accounts overview', $actual);

--- a/tests/classes/Controllers/Sql/EnumValuesControllerTest.php
+++ b/tests/classes/Controllers/Sql/EnumValuesControllerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Controllers\Sql;
 
 use PhpMyAdmin\Bookmarks\BookmarkRepository;
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\Controllers\Sql\EnumValuesController;
@@ -67,12 +66,7 @@ class EnumValuesControllerTest extends AbstractTestCase
             $bookmarkRepository,
         );
 
-        $sqlController = new EnumValuesController(
-            $responseRenderer,
-            $template,
-            $sql,
-            new CheckUserPrivileges($this->dbi),
-        );
+        $sqlController = new EnumValuesController($responseRenderer, $template, $sql);
         $sqlController($request);
 
         self::assertFalse($responseRenderer->hasSuccessState(), 'expected the request to fail');
@@ -123,12 +117,7 @@ class EnumValuesControllerTest extends AbstractTestCase
             $bookmarkRepository,
         );
 
-        $sqlController = new EnumValuesController(
-            $responseRenderer,
-            $template,
-            $sql,
-            new CheckUserPrivileges($this->dbi),
-        );
+        $sqlController = new EnumValuesController($responseRenderer, $template, $sql);
         $sqlController($request);
 
         self::assertTrue($responseRenderer->hasSuccessState(), 'expected the request not to fail');

--- a/tests/classes/Controllers/Sql/SetValuesControllerTest.php
+++ b/tests/classes/Controllers/Sql/SetValuesControllerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Controllers\Sql;
 
 use PhpMyAdmin\Bookmarks\BookmarkRepository;
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\Controllers\Sql\SetValuesController;
@@ -68,12 +67,7 @@ class SetValuesControllerTest extends AbstractTestCase
             $bookmarkRepository,
         );
 
-        $sqlController = new SetValuesController(
-            $responseRenderer,
-            $template,
-            $sql,
-            new CheckUserPrivileges($this->dbi),
-        );
+        $sqlController = new SetValuesController($responseRenderer, $template, $sql);
         $sqlController($request);
 
         self::assertFalse($responseRenderer->hasSuccessState(), 'expected the request to fail');
@@ -125,12 +119,7 @@ class SetValuesControllerTest extends AbstractTestCase
             $bookmarkRepository,
         );
 
-        $sqlController = new SetValuesController(
-            $responseRenderer,
-            $template,
-            $sql,
-            new CheckUserPrivileges($this->dbi),
-        );
+        $sqlController = new SetValuesController($responseRenderer, $template, $sql);
         $sqlController($request);
 
         self::assertTrue($responseRenderer->hasSuccessState(), 'expected the request not to fail');

--- a/tests/classes/Controllers/Table/AddFieldControllerTest.php
+++ b/tests/classes/Controllers/Table/AddFieldControllerTest.php
@@ -16,6 +16,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Transformations;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(AddFieldController::class)]
@@ -265,6 +266,7 @@ class AddFieldControllerTest extends AbstractTestCase
             $dbi,
             new ColumnsDefinition($dbi, $relation, $transformations),
             new DbTableExists($dbi),
+            new UserPrivilegesFactory($dbi),
         ))($request);
 
         self::assertSame($expected, $response->getHTMLResult());

--- a/tests/classes/Controllers/Table/CreateControllerTest.php
+++ b/tests/classes/Controllers/Table/CreateControllerTest.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Transformations;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 use function array_merge;
@@ -259,6 +260,7 @@ class CreateControllerTest extends AbstractTestCase
             $this->createConfig(),
             $dbi,
             new ColumnsDefinition($dbi, $relation, $transformations),
+            new UserPrivilegesFactory($dbi),
         ))($request);
 
         self::assertSame($expected, $response->getHTMLResult());

--- a/tests/classes/Controllers/Table/ReplaceControllerTest.php
+++ b/tests/classes/Controllers/Table/ReplaceControllerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Controllers\Table;
 
 use PhpMyAdmin\Bookmarks\BookmarkRepository;
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\ConfigStorage\Relation;
@@ -115,7 +114,6 @@ class ReplaceControllerTest extends AbstractTestCase
                 $template,
                 $bookmarkRepository,
             ),
-            new CheckUserPrivileges($dbi),
             $dbi,
             $pageSettings,
             $bookmarkRepository,

--- a/tests/classes/Controllers/Table/Structure/ChangeControllerTest.php
+++ b/tests/classes/Controllers/Table/Structure/ChangeControllerTest.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseStub;
 use PhpMyAdmin\Transformations;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClass;
 
@@ -51,6 +52,7 @@ class ChangeControllerTest extends AbstractTestCase
             new Template(),
             $this->dbi,
             new ColumnsDefinition($this->dbi, new Relation($this->dbi), new Transformations()),
+            new UserPrivilegesFactory($this->dbi),
         );
 
         $method->invokeArgs($ctrl, [[$_REQUEST['field']]]);

--- a/tests/classes/Controllers/Table/Structure/SaveControllerTest.php
+++ b/tests/classes/Controllers/Table/Structure/SaveControllerTest.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Transformations;
 use PhpMyAdmin\UserPrivileges;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClass;
 
@@ -98,6 +99,7 @@ class SaveControllerTest extends AbstractTestCase
             new Transformations(),
             $dbi,
             $mock,
+            new UserPrivilegesFactory($dbi),
         ))($request);
 
         self::assertArrayNotHasKey('selected', $_POST);
@@ -120,6 +122,7 @@ class SaveControllerTest extends AbstractTestCase
             new Transformations(),
             $dbi,
             self::createStub(StructureController::class),
+            new UserPrivilegesFactory($dbi),
         );
 
         self::assertFalse(

--- a/tests/classes/Controllers/Table/Structure/SaveControllerTest.php
+++ b/tests/classes/Controllers/Table/Structure/SaveControllerTest.php
@@ -14,6 +14,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Transformations;
+use PhpMyAdmin\UserPrivileges;
 use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClass;
 
@@ -122,7 +123,7 @@ class SaveControllerTest extends AbstractTestCase
         );
 
         self::assertFalse(
-            $method->invokeArgs($ctrl, [[]]),
+            $method->invokeArgs($ctrl, [new UserPrivileges(), []]),
         );
     }
 }

--- a/tests/classes/Database/RoutinesTest.php
+++ b/tests/classes/Database/RoutinesTest.php
@@ -11,7 +11,6 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Dbal\ConnectionType;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Types;
-use PhpMyAdmin\UserPrivileges;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -37,8 +36,6 @@ class RoutinesTest extends AbstractTestCase
         $config->settings['ActionLinksMode'] = 'icons';
         Current::$database = 'db';
         Current::$table = 'table';
-        UserPrivileges::$routines = false;
-        UserPrivileges::$isReload = false;
         $GLOBALS['errors'] = [];
 
         $this->routines = new Routines(DatabaseInterface::getInstance());

--- a/tests/classes/ListDatabaseTest.php
+++ b/tests/classes/ListDatabaseTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\ListDatabase;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(ListDatabase::class)]
@@ -29,7 +29,7 @@ class ListDatabaseTest extends AbstractTestCase
         $config = new Config();
         $config->selectedServer['DisableIS'] = false;
         $config->selectedServer['only_db'] = ['single\\_db'];
-        $this->object = new ListDatabase($dbi, $config, new CheckUserPrivileges($dbi));
+        $this->object = new ListDatabase($dbi, $config, new UserPrivilegesFactory($dbi));
     }
 
     /**
@@ -41,7 +41,7 @@ class ListDatabaseTest extends AbstractTestCase
         $config = new Config();
         $config->selectedServer['DisableIS'] = false;
         $config->selectedServer['only_db'] = ['single\\_db'];
-        $arr = new ListDatabase($dbi, $config, new CheckUserPrivileges($dbi));
+        $arr = new ListDatabase($dbi, $config, new UserPrivilegesFactory($dbi));
         self::assertTrue($arr->exists('single_db'));
     }
 
@@ -51,7 +51,7 @@ class ListDatabaseTest extends AbstractTestCase
         $config = new Config();
         $config->selectedServer['DisableIS'] = false;
         $config->selectedServer['only_db'] = ['single\\_db'];
-        $arr = new ListDatabase($dbi, $config, new CheckUserPrivileges($dbi));
+        $arr = new ListDatabase($dbi, $config, new UserPrivilegesFactory($dbi));
 
         Current::$database = 'db';
         self::assertEquals(

--- a/tests/classes/Navigation/NavigationTreeTest.php
+++ b/tests/classes/Navigation/NavigationTreeTest.php
@@ -11,6 +11,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Navigation\NavigationTree;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\UserPrivileges;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(NavigationTree::class)]
@@ -60,7 +61,7 @@ class NavigationTreeTest extends AbstractTestCase
      */
     public function testRenderState(): void
     {
-        $result = $this->object->renderState();
+        $result = $this->object->renderState(new UserPrivileges());
         self::assertStringContainsString('pma_quick_warp', $result);
     }
 
@@ -69,7 +70,7 @@ class NavigationTreeTest extends AbstractTestCase
      */
     public function testRenderPath(): void
     {
-        $result = $this->object->renderPath();
+        $result = $this->object->renderPath(new UserPrivileges());
         self::assertIsString($result);
         self::assertStringContainsString('list_container', $result);
     }
@@ -79,7 +80,7 @@ class NavigationTreeTest extends AbstractTestCase
      */
     public function testRenderDbSelect(): void
     {
-        $result = $this->object->renderDbSelect();
+        $result = $this->object->renderDbSelect(new UserPrivileges());
         self::assertStringContainsString('pma_navigation_select_database', $result);
     }
 
@@ -109,7 +110,7 @@ class NavigationTreeTest extends AbstractTestCase
         DatabaseInterface::$instance = $dbi;
 
         $object = new NavigationTree(new Template(), $dbi, new Relation($dbi));
-        $result = $object->renderState();
+        $result = $object->renderState(new UserPrivileges());
         self::assertStringContainsString('<li class="first navGroup">', $result);
         self::assertStringContainsString('functions' . "\n", $result);
         self::assertStringContainsString('<div class="list_container" style="display: none;">', $result);

--- a/tests/classes/Navigation/Nodes/NodeDatabaseTest.php
+++ b/tests/classes/Navigation/Nodes/NodeDatabaseTest.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Navigation\Nodes\NodeDatabase;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\UserPrivileges;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(NodeDatabase::class)]
@@ -38,27 +39,28 @@ class NodeDatabaseTest extends AbstractTestCase
     {
         Config::getInstance()->selectedServer['DisableIS'] = true;
         DatabaseInterface::$instance = $this->createDatabaseInterface();
+        $userPrivileges = new UserPrivileges();
 
         $parent = new NodeDatabase('default');
         self::assertEquals(
             2,
-            $parent->getPresence('tables'),
+            $parent->getPresence($userPrivileges, 'tables'),
         );
         self::assertEquals(
             0,
-            $parent->getPresence('views'),
+            $parent->getPresence($userPrivileges, 'views'),
         );
         self::assertEquals(
             1,
-            $parent->getPresence('functions'),
+            $parent->getPresence($userPrivileges, 'functions'),
         );
         self::assertEquals(
             0,
-            $parent->getPresence('procedures'),
+            $parent->getPresence($userPrivileges, 'procedures'),
         );
         self::assertEquals(
             0,
-            $parent->getPresence('events'),
+            $parent->getPresence($userPrivileges, 'events'),
         );
     }
 
@@ -69,6 +71,7 @@ class NodeDatabaseTest extends AbstractTestCase
     {
         Config::getInstance()->selectedServer['DisableIS'] = true;
         DatabaseInterface::$instance = $this->createDatabaseInterface();
+        $userPrivileges = new UserPrivileges();
 
         $relationParameters = RelationParameters::fromArray([
             'db' => 'pmadb',
@@ -78,19 +81,19 @@ class NodeDatabaseTest extends AbstractTestCase
 
         $parent = new NodeDatabase('default');
 
-        $tables = $parent->getData($relationParameters, 'tables', 0);
+        $tables = $parent->getData($userPrivileges, $relationParameters, 'tables', 0);
         self::assertContains('test1', $tables);
         self::assertContains('test2', $tables);
 
-        $views = $parent->getData($relationParameters, 'views', 0);
+        $views = $parent->getData($userPrivileges, $relationParameters, 'views', 0);
         self::assertEmpty($views);
 
-        $functions = $parent->getData($relationParameters, 'functions', 0);
+        $functions = $parent->getData($userPrivileges, $relationParameters, 'functions', 0);
         self::assertContains('testFunction', $functions);
         self::assertCount(1, $functions);
 
-        self::assertEmpty($parent->getData($relationParameters, 'procedures', 0));
-        self::assertEmpty($parent->getData($relationParameters, 'events', 0));
+        self::assertEmpty($parent->getData($userPrivileges, $relationParameters, 'procedures', 0));
+        self::assertEmpty($parent->getData($userPrivileges, $relationParameters, 'events', 0));
     }
 
     /**

--- a/tests/classes/Navigation/Nodes/NodeTest.php
+++ b/tests/classes/Navigation/Nodes/NodeTest.php
@@ -358,7 +358,7 @@ final class NodeTest extends AbstractTestCase
         $dbi->expects(self::any())->method('quoteString')
             ->willReturnCallback(static fn (string $string): string => "'" . $string . "'");
         DatabaseInterface::$instance = $dbi;
-        $node->getData($relationParameters, '', 10);
+        $node->getData(new UserPrivileges(), $relationParameters, '', 10);
     }
 
     /**
@@ -389,7 +389,7 @@ final class NodeTest extends AbstractTestCase
         $dbi->expects(self::once())->method('fetchResult')->with($expectedSql);
 
         DatabaseInterface::$instance = $dbi;
-        $node->getData($relationParameters, '', 10);
+        $node->getData(new UserPrivileges(), $relationParameters, '', 10);
     }
 
     /**
@@ -399,7 +399,6 @@ final class NodeTest extends AbstractTestCase
     {
         $config = Config::getInstance();
         $config->selectedServer['DisableIS'] = true;
-        UserPrivileges::$databasesToTest = false;
         $config->settings['NavigationTreeEnableGrouping'] = true;
         $config->settings['FirstLevelNavigationItems'] = 10;
         $config->settings['NavigationTreeDbSeparator'] = '_';
@@ -436,7 +435,7 @@ final class NodeTest extends AbstractTestCase
             ->willReturnCallback(static fn (string $string): string => "'" . $string . "'");
 
         DatabaseInterface::$instance = $dbi;
-        $node->getData($relationParameters, '', 0, 'db');
+        $node->getData(new UserPrivileges(), $relationParameters, '', 0, 'db');
     }
 
     /**
@@ -462,7 +461,7 @@ final class NodeTest extends AbstractTestCase
         $dbi = self::createMock(DatabaseInterface::class);
         $dbi->expects(self::once())->method('fetchValue')->with($query);
         DatabaseInterface::$instance = $dbi;
-        self::assertSame(0, $node->getPresence());
+        self::assertSame(0, $node->getPresence(new UserPrivileges()));
     }
 
     /**
@@ -482,7 +481,7 @@ final class NodeTest extends AbstractTestCase
         $dbi = self::createMock(DatabaseInterface::class);
         $dbi->expects(self::once())->method('fetchValue')->with($query);
         DatabaseInterface::$instance = $dbi;
-        self::assertSame(0, $node->getPresence());
+        self::assertSame(0, $node->getPresence(new UserPrivileges()));
     }
 
     /**
@@ -492,7 +491,6 @@ final class NodeTest extends AbstractTestCase
     {
         $config = Config::getInstance();
         $config->selectedServer['DisableIS'] = true;
-        UserPrivileges::$databasesToTest = false;
         $config->settings['NavigationTreeEnableGrouping'] = true;
 
         $node = new Node('node');
@@ -507,7 +505,7 @@ final class NodeTest extends AbstractTestCase
             ->willReturn($resultStub);
 
         DatabaseInterface::$instance = $dbi;
-        self::assertSame(0, $node->getPresence());
+        self::assertSame(0, $node->getPresence(new UserPrivileges()));
 
         // test with a search clause
         $dbi = self::createMock(DatabaseInterface::class);
@@ -521,7 +519,7 @@ final class NodeTest extends AbstractTestCase
             ->willReturnCallback(static fn (string $string): string => "'" . $string . "'");
 
         DatabaseInterface::$instance = $dbi;
-        self::assertSame(0, $node->getPresence('', 'dbname'));
+        self::assertSame(0, $node->getPresence(new UserPrivileges(), '', 'dbname'));
     }
 
     public function testGetInstanceForNewNode(): void

--- a/tests/classes/NormalizationTest.php
+++ b/tests/classes/NormalizationTest.php
@@ -125,7 +125,7 @@ class NormalizationTest extends AbstractTestCase
         $config = Config::getInstance();
         $config->settings['BrowseMIME'] = true;
         $config->settings['MaxRows'] = 25;
-        UserPrivileges::$column = false;
+        $userPrivileges = new UserPrivileges();
         $config->selectedServer['DisableIS'] = false;
         DatabaseInterface::$instance = $this->dbi;
         $db = 'testdb';
@@ -137,7 +137,7 @@ class NormalizationTest extends AbstractTestCase
             new Transformations(),
             new Template(),
         );
-        $result = $normalization->getHtmlForCreateNewColumn($numFields, $db, $table);
+        $result = $normalization->getHtmlForCreateNewColumn($userPrivileges, $numFields, $db, $table);
         self::assertStringContainsString('<table id="table_columns"', $result);
     }
 

--- a/tests/classes/Server/PrivilegesTest.php
+++ b/tests/classes/Server/PrivilegesTest.php
@@ -1465,7 +1465,7 @@ class PrivilegesTest extends AbstractTestCase
     {
         Config::getInstance()->selectedServer['DisableIS'] = false;
         $GLOBALS['lang'] = 'en';
-        UserPrivileges::$isReload = true;
+        $userPrivileges = new UserPrivileges(isReload: true);
 
         $dummyDbi = $this->createDbiDummy();
         // phpcs:disable Generic.Files.LineLength.TooLong
@@ -1493,7 +1493,7 @@ class PrivilegesTest extends AbstractTestCase
         $serverPrivileges = $this->getPrivileges($this->createDatabaseInterface($dummyDbi));
 
         $_REQUEST = ['ajax_page_request' => '1'];
-        $actual = $serverPrivileges->getHtmlForUserOverview('ltr', null);
+        $actual = $serverPrivileges->getHtmlForUserOverview($userPrivileges, 'ltr', null);
         self::assertStringContainsString('Note: MySQL privilege names are expressed in English.', $actual);
         self::assertStringContainsString(
             'Note: phpMyAdmin gets the users’ privileges directly from MySQL’s privilege tables.',
@@ -1513,7 +1513,7 @@ class PrivilegesTest extends AbstractTestCase
         );
         $dummyDbi->addResult('SELECT 1 FROM `mysql`.`user`', false);
         $serverPrivileges = $this->getPrivileges($this->createDatabaseInterface($dummyDbi));
-        $html = $serverPrivileges->getHtmlForUserOverview('ltr', null);
+        $html = $serverPrivileges->getHtmlForUserOverview($userPrivileges, 'ltr', null);
 
         self::assertStringContainsString(
             Url::getCommon(['adduser' => 1], ''),
@@ -1541,7 +1541,7 @@ class PrivilegesTest extends AbstractTestCase
         );
         $dummyDbi->addResult('SELECT 1 FROM `mysql`.`user`', [[1]]);
         $serverPrivileges = $this->getPrivileges($this->createDatabaseInterface($dummyDbi));
-        $actual = $serverPrivileges->getHtmlForUserOverview('ltr', null);
+        $actual = $serverPrivileges->getHtmlForUserOverview($userPrivileges, 'ltr', null);
 
         self::assertStringContainsString('Your privilege table structure seems to be older than'
             . ' this MySQL version!<br>'

--- a/tests/classes/Table/ColumnsDefinitionTest.php
+++ b/tests/classes/Table/ColumnsDefinitionTest.php
@@ -77,11 +77,16 @@ SQL;
 
         Current::$database = 'sakila';
         Current::$table = 'actor';
-        UserPrivileges::$column = true;
-        UserPrivileges::$isReload = true;
+        $userPrivileges = new UserPrivileges(column: true, isReload: true);
         $GLOBALS['mime_map'] = null;
 
-        $actual = $columnsDefinition->displayForm('/table/structure/save', 1, ['actor_id'], [$columnMeta]);
+        $actual = $columnsDefinition->displayForm(
+            $userPrivileges,
+            '/table/structure/save',
+            1,
+            ['actor_id'],
+            [$columnMeta],
+        );
 
         $contentCell = [
             'column_number' => 0,

--- a/tests/classes/UserPrivilegesFactoryTest.php
+++ b/tests/classes/UserPrivilegesFactoryTest.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests;
 
-use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\ShowGrants;
 use PhpMyAdmin\UserPrivileges;
+use PhpMyAdmin\UserPrivilegesFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 
-#[CoversClass(CheckUserPrivileges::class)]
-class CheckUserPrivilegesTest extends AbstractTestCase
+#[CoversClass(UserPrivilegesFactory::class)]
+final class UserPrivilegesFactoryTest extends AbstractTestCase
 {
-    private CheckUserPrivileges $checkUserPrivileges;
+    private UserPrivilegesFactory $userPrivilegesFactory;
 
     /**
      * prepares environment for tests
@@ -26,7 +26,7 @@ class CheckUserPrivilegesTest extends AbstractTestCase
         DatabaseInterface::$instance = $this->createDatabaseInterface();
         Config::getInstance()->selectedServer['DisableIS'] = false;
 
-        $this->checkUserPrivileges = new CheckUserPrivileges(DatabaseInterface::getInstance());
+        $this->userPrivilegesFactory = new UserPrivilegesFactory(DatabaseInterface::getInstance());
     }
 
     /**
@@ -39,7 +39,7 @@ class CheckUserPrivilegesTest extends AbstractTestCase
         $showGrants = new ShowGrants('GRANT ALL PRIVILEGES ON *.* TO \'root\'@\'localhost\' WITH GRANT OPTION');
 
         // call the to-be-tested function
-        $this->checkUserPrivileges->checkRequiredPrivilegesForAdjust($userPrivileges, $showGrants);
+        $this->userPrivilegesFactory->checkRequiredPrivilegesForAdjust($userPrivileges, $showGrants);
 
         self::assertTrue($userPrivileges->column);
         self::assertTrue($userPrivileges->database);
@@ -51,7 +51,7 @@ class CheckUserPrivilegesTest extends AbstractTestCase
         $showGrants = new ShowGrants('GRANT ALL PRIVILEGES ON `mysql`.* TO \'root\'@\'localhost\' WITH GRANT OPTION');
 
         // call the to-be-tested function
-        $this->checkUserPrivileges->checkRequiredPrivilegesForAdjust($userPrivileges, $showGrants);
+        $this->userPrivilegesFactory->checkRequiredPrivilegesForAdjust($userPrivileges, $showGrants);
 
         self::assertTrue($userPrivileges->column);
         self::assertTrue($userPrivileges->database);
@@ -63,7 +63,7 @@ class CheckUserPrivilegesTest extends AbstractTestCase
         $showGrants = new ShowGrants('GRANT SELECT, INSERT, UPDATE, DELETE ON `mysql`.* TO \'root\'@\'localhost\'');
 
         // call the to-be-tested function
-        $this->checkUserPrivileges->checkRequiredPrivilegesForAdjust($userPrivileges, $showGrants);
+        $this->userPrivilegesFactory->checkRequiredPrivilegesForAdjust($userPrivileges, $showGrants);
 
         self::assertTrue($userPrivileges->column);
         self::assertTrue($userPrivileges->database);
@@ -75,7 +75,7 @@ class CheckUserPrivilegesTest extends AbstractTestCase
         $showGrants = new ShowGrants('GRANT SELECT, INSERT, UPDATE, DELETE ON `mysql`.`db` TO \'root\'@\'localhost\'');
 
         // call the to-be-tested function
-        $this->checkUserPrivileges->checkRequiredPrivilegesForAdjust($userPrivileges, $showGrants);
+        $this->userPrivilegesFactory->checkRequiredPrivilegesForAdjust($userPrivileges, $showGrants);
 
         self::assertFalse($userPrivileges->column);
         self::assertTrue($userPrivileges->database);


### PR DESCRIPTION
Use `UserPrivileges` as a value object instead of static properties. This makes the intent of `CheckUserPrivileges::getPrivileges()` more clear.