### PR TITLE
Stop using Util::getDbInfo

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3001,21 +3001,6 @@ parameters:
 			path: src/Controllers/Operations/Database/CollationController.php
 
 		-
-			message: "#^Parameter \\#1 \\$identifier of static method PhpMyAdmin\\\\Util\\:\\:backquote\\(\\) expects string\\|Stringable\\|null, mixed given\\.$#"
-			count: 1
-			path: src/Controllers/Operations/Database/CollationController.php
-
-		-
-			message: "#^Parameter \\#2 \\$table of method PhpMyAdmin\\\\Operations\\:\\:changeAllColumnsCollation\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Controllers/Operations/Database/CollationController.php
-
-		-
-			message: "#^Parameter \\#2 \\$tableName of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getTable\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Controllers/Operations/Database/CollationController.php
-
-		-
 			message: "#^Parameter \\#3 \\$tableCollation of method PhpMyAdmin\\\\Operations\\:\\:changeAllColumnsCollation\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/Operations/Database/CollationController.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2046,22 +2046,12 @@ parameters:
 			path: src/Controllers/Database/Structure/FavoriteTableController.php
 
 		-
-			message: "#^Cannot access offset 'TABLE_NAME' on mixed\\.$#"
-			count: 2
-			path: src/Controllers/Database/Structure/RealRowCountController.php
-
-		-
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 1
 			path: src/Controllers/Database/Structure/RealRowCountController.php
 
 		-
 			message: "#^Parameter \\#1 \\$value of static method PhpMyAdmin\\\\Util\\:\\:formatNumber\\(\\) expects float\\|int\\|string, int\\|null given\\.$#"
-			count: 1
-			path: src/Controllers/Database/Structure/RealRowCountController.php
-
-		-
-			message: "#^Parameter \\#2 \\$tableName of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getTable\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/Database/Structure/RealRowCountController.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2190,15 +2190,10 @@
     </InvalidArrayOffset>
     <MixedArgument>
       <code>$dbCollation</code>
-      <code>$tableName</code>
     </MixedArgument>
-    <MixedArrayAccess>
-      <code>$tableName</code>
-    </MixedArrayAccess>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
       <code>$dbCollation</code>
-      <code><![CDATA[['Name' => $tableName]]]></code>
     </MixedAssignment>
     <PossiblyUnusedMethod>
       <code>__construct</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1483,16 +1483,8 @@
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
     </InvalidArrayOffset>
-    <MixedArgument>
-      <code><![CDATA[$table['TABLE_NAME']]]></code>
-    </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$table['TABLE_NAME']]]></code>
-      <code><![CDATA[$table['TABLE_NAME']]]></code>
-    </MixedArrayAccess>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
-      <code>$table</code>
     </MixedAssignment>
     <PossiblyInvalidCast>
       <code><![CDATA[$parameters['table']]]></code>

--- a/src/Controllers/Database/Structure/RealRowCountController.php
+++ b/src/Controllers/Database/Structure/RealRowCountController.php
@@ -64,8 +64,6 @@ final class RealRowCountController extends AbstractController
             return;
         }
 
-        [$tables] = Util::getDbInfo($request, Current::$database);
-
         // If there is a request to update all table's row count.
         if (! isset($parameters['real_row_count_all'])) {
             // Get the real row count for the table.
@@ -83,11 +81,11 @@ final class RealRowCountController extends AbstractController
         // Array to store the results.
         $realRowCountAll = [];
         // Iterate over each table and fetch real row count.
-        foreach ($tables as $table) {
+        foreach ($this->dbi->getTables(Current::$database) as $table) {
             $rowCount = $this->dbi
-                ->getTable(Current::$database, $table['TABLE_NAME'])
+                ->getTable(Current::$database, $table)
                 ->getRealRowCountTable();
-            $realRowCountAll[] = ['table' => $table['TABLE_NAME'], 'row_count' => Util::formatNumber($rowCount, 0)];
+            $realRowCountAll[] = ['table' => $table, 'row_count' => Util::formatNumber($rowCount, 0)];
         }
 
         $this->response->addJSON(['real_row_count_all' => $realRowCountAll]);

--- a/src/Controllers/Database/TrackingController.php
+++ b/src/Controllers/Database/TrackingController.php
@@ -23,7 +23,6 @@ use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
 
 use function __;
-use function count;
 use function htmlspecialchars;
 use function sprintf;
 
@@ -74,7 +73,6 @@ class TrackingController extends AbstractController
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/table/tracking');
         $GLOBALS['urlParams']['back'] = Url::getFromRoute('/database/tracking');
 
-        $numTables = count(Util::getDbInfo($request, Current::$database)[0]);
         $isSystemSchema = Utilities::isSystemSchema(Current::$database);
 
         if ($request->hasBodyParam('delete_tracking') && $request->hasBodyParam('table')) {
@@ -132,7 +130,7 @@ class TrackingController extends AbstractController
         $trackedData = $this->tracking->getTrackedData(Current::$database, '', '1');
 
         // No tables present and no log exist
-        if ($numTables === 0 && $trackedData->ddlog === []) {
+        if ($trackedData->ddlog === [] && $this->dbi->getTables(Current::$database) === []) {
             $this->response->addHTML('<p>' . __('No tables found in database.') . '</p>' . "\n");
 
             if (! $isSystemSchema) {

--- a/src/Controllers/Operations/Database/CollationController.php
+++ b/src/Controllers/Operations/Database/CollationController.php
@@ -75,8 +75,7 @@ final class CollationController extends AbstractController
          * Changes tables charset if requested by the user
          */
         if ($request->getParsedBodyParam('change_all_tables_collations') === 'on') {
-            [$tables] = Util::getDbInfo($request, Current::$database);
-            foreach ($tables as ['Name' => $tableName]) {
+            foreach ($this->dbi->getTables(Current::$database) as $tableName) {
                 if ($this->dbi->getTable(Current::$database, $tableName)->isView()) {
                     // Skip views, we can not change the collation of a view.
                     // issue #15283


### PR DESCRIPTION
This removes all but one usage of `Util::getDbInfo`. IMHO the only valid use of this function was on /database/structure page. This function is really slow and bulky. This should optimize the few controllers that still used it. 