### PR TITLE
Fix #18276 - changing column with `on update CURRENT_TIMESTAMP` active

### DIFF
--- a/templates/columns_definitions/column_attribute.twig
+++ b/templates/columns_definitions/column_attribute.twig
@@ -2,7 +2,7 @@
     {% set attribute = submit_attribute %}
     {# MariaDB has additional parentheses #}
 {% elseif column_meta['Extra'] is defined
-    and ('on update current_timestamp' in column_meta['Extra'] or 'on update current_timestamp()' in column_meta['Extra']|lower) %}
+    and ('on update current_timestamp' in column_meta['Extra']|lower or 'on update current_timestamp()' in column_meta['Extra']|lower) %}
     {% set attribute = 'on update CURRENT_TIMESTAMP' %}
 {% elseif extracted_columnspec['attribute'] is defined %}
     {% set attribute = extracted_columnspec['attribute'] %}


### PR DESCRIPTION
Fixes #18276

Select on update CURRENT_TIMESTAMP by default when changing a timestamp column where this is already set.