### PR TITLE
Make PHPUnit's assertions stricter

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15511,6 +15511,16 @@ parameters:
 			path: tests/classes/Config/DescriptionTest.php
 
 		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with ''\\|'; Compressed export…'\\|'Compressed export…'\\|'Compressed import…'\\|'Compressed import…'\\|'Compressed import…' and null will always evaluate to false\\.$#"
+			count: 1
+			path: tests/classes/Config/FormDisplayTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with 'string' and 'string' will always evaluate to true\\.$#"
+			count: 1
+			path: tests/classes/Config/FormDisplayTest.php
+
+		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\) with null will always evaluate to false\\.$#"
 			count: 1
 			path: tests/classes/Config/FormDisplayTest.php
@@ -16356,6 +16366,11 @@ parameters:
 			path: tests/classes/NormalizationTest.php
 
 		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with '' and PhpMyAdmin\\\\Message will always evaluate to false\\.$#"
+			count: 1
+			path: tests/classes/NormalizationTest.php
+
+		-
 			message: "#^Property PhpMyAdmin\\\\Config\\:\\:\\$settings \\(array\\{PmaAbsoluteUri\\: string, AuthLog\\: string, AuthLogSuccess\\: bool, PmaNoRelation_DisableWarning\\: bool, SuhosinDisableWarning\\: bool, LoginCookieValidityDisableWarning\\: bool, ReservedWordDisableWarning\\: bool, TranslationWarningThreshold\\: int, \\.\\.\\.\\}\\) does not accept array\\{PmaAbsoluteUri\\: string, AuthLog\\: string, AuthLogSuccess\\: bool, PmaNoRelation_DisableWarning\\: bool, SuhosinDisableWarning\\: bool, LoginCookieValidityDisableWarning\\: bool, ReservedWordDisableWarning\\: bool, TranslationWarningThreshold\\: int, \\.\\.\\.\\}\\.$#"
 			count: 2
 			path: tests/classes/NormalizationTest.php
@@ -16391,6 +16406,11 @@ parameters:
 			path: tests/classes/Plugins/Auth/AuthenticationCookieTest.php
 
 		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with array\\{host\\: 'b', port\\: '2', socket\\: true, ssl\\: true, user\\: 'pmaUser2', password\\: 'testPW'\\} and array\\{host\\: string, port\\: string, socket\\: string, ssl\\: bool, ssl_key\\: string\\|null, ssl_cert\\: string\\|null, ssl_ca\\: string\\|null, ssl_ca_path\\: string\\|null, \\.\\.\\.\\} will always evaluate to false\\.$#"
+			count: 1
+			path: tests/classes/Plugins/Auth/AuthenticationCookieTest.php
+
+		-
 			message: "#^Cannot access offset 'default' on mixed\\.$#"
 			count: 2
 			path: tests/classes/Plugins/Auth/AuthenticationCookieTest.php
@@ -16414,6 +16434,11 @@ parameters:
 			message: "#^Property PhpMyAdmin\\\\Config\\:\\:\\$settings \\(array\\{PmaAbsoluteUri\\: string, AuthLog\\: string, AuthLogSuccess\\: bool, PmaNoRelation_DisableWarning\\: bool, SuhosinDisableWarning\\: bool, LoginCookieValidityDisableWarning\\: bool, ReservedWordDisableWarning\\: bool, TranslationWarningThreshold\\: int, \\.\\.\\.\\}\\) does not accept array\\{PmaAbsoluteUri\\: string, AuthLog\\: string, AuthLogSuccess\\: bool, PmaNoRelation_DisableWarning\\: bool, SuhosinDisableWarning\\: bool, LoginCookieValidityDisableWarning\\: bool, ReservedWordDisableWarning\\: bool, TranslationWarningThreshold\\: int, \\.\\.\\.\\}\\.$#"
 			count: 10
 			path: tests/classes/Plugins/Auth/AuthenticationCookieTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with 'testUser' and 'testUser' will always evaluate to true\\.$#"
+			count: 1
+			path: tests/classes/Plugins/Auth/AuthenticationHttpTest.php
 
 		-
 			message: "#^Property PhpMyAdmin\\\\Config\\:\\:\\$selectedServer \\(array\\{host\\: string, port\\: string, socket\\: string, ssl\\: bool, ssl_key\\: string\\|null, ssl_cert\\: string\\|null, ssl_ca\\: string\\|null, ssl_ca_path\\: string\\|null, \\.\\.\\.\\}\\) does not accept array\\{host\\: 'a', user\\: 'user2'\\}\\.$#"
@@ -16751,12 +16776,27 @@ parameters:
 			path: tests/classes/Stubs/ResponseRenderer.php
 
 		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertFalse\\(\\) with true will always evaluate to false\\.$#"
+			count: 1
+			path: tests/classes/Table/TableTest.php
+
+		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpMyAdmin\\\\\\\\Table\\\\\\\\Table' and PhpMyAdmin\\\\Table\\\\Table will always evaluate to true\\.$#"
 			count: 1
 			path: tests/classes/Table/TableTest.php
 
 		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with array\\<PhpMyAdmin\\\\FieldMetadata\\> and array\\{'aNonValidExampleToR…'\\} will always evaluate to false\\.$#"
+			count: 1
+			path: tests/classes/Table/TableTest.php
+
+		-
 			message: "#^Cannot access offset 'SCHEMA_TABLES' on mixed\\.$#"
+			count: 1
+			path: tests/classes/Table/TableTest.php
+
+		-
+			message: "#^Offset 'col_order' on array in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: tests/classes/Table/TableTest.php
 
@@ -16782,6 +16822,11 @@ parameters:
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpMyAdmin\\\\\\\\Theme\\\\\\\\Theme' and PhpMyAdmin\\\\Theme\\\\Theme will always evaluate to true\\.$#"
+			count: 1
+			path: tests/classes/Theme/ThemeTest.php
+
+		-
+			message: "#^Casting to int something that's already int\\.$#"
 			count: 1
 			path: tests/classes/Theme/ThemeTest.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -12249,7 +12249,6 @@
     <MixedAssignment>
       <code>$context</code>
       <code>$context</code>
-      <code>$context</code>
       <code>$filesFound</code>
       <code>$filesFound</code>
       <code>$filesInfos</code>
@@ -12292,6 +12291,11 @@
     <PossiblyUnusedMethod>
       <code>getValues</code>
     </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/classes/Config/FormDisplayTemplateTest.php">
+    <TypeDoesNotContainType>
+      <code>assertSame</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="tests/classes/Config/FormDisplayTest.php">
     <DeprecatedMethod>
@@ -13320,9 +13324,6 @@
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
     </DeprecatedMethod>
-    <MixedAssignment>
-      <code>$output</code>
-    </MixedAssignment>
     <PossiblyUnusedMethod>
       <code>providerGetDataFromRequest</code>
     </PossiblyUnusedMethod>
@@ -13384,6 +13385,10 @@
       <code>providerTestGotoNowhere</code>
       <code>providerTestLinkURL</code>
     </PossiblyUnusedMethod>
+    <TypeDoesNotContainType>
+      <code>assertSame</code>
+      <code>assertSame</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="tests/classes/CreateAddFieldTest.php">
     <DeprecatedMethod>
@@ -13460,9 +13465,6 @@
       <code>DatabaseInterface::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
-    <MixedAssignment>
-      <code>$result</code>
-    </MixedAssignment>
   </file>
   <file src="tests/classes/Database/EventsTest.php">
     <DeprecatedMethod>
@@ -13846,13 +13848,6 @@
       <code>$dataSet</code>
       <code>$dataSet</code>
       <code>$queryString</code>
-      <code>$queryString</code>
-      <code>$queryString</code>
-      <code>$queryString</code>
-      <code>$queryString</code>
-      <code>$queryString</code>
-      <code>$queryString</code>
-      <code>$queryString</code>
     </MixedAssignment>
   </file>
   <file src="tests/classes/HeaderTest.php">
@@ -13942,6 +13937,11 @@
       <code>providerForTestCreateUri</code>
       <code>uriFactoryProviders</code>
     </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/classes/Http/Middleware/TokenRequestParamCheckingTest.php">
+    <RedundantCondition>
+      <code>assertSame</code>
+    </RedundantCondition>
   </file>
   <file src="tests/classes/Http/ResponseTest.php">
     <PossiblyUnusedMethod>
@@ -14093,12 +14093,6 @@
       <code>$result</code>
       <code>$result</code>
       <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
     </MixedAssignment>
     <PossiblyInvalidCast>
       <code>$value</code>
@@ -14110,6 +14104,11 @@
     <PropertyTypeCoercion>
       <code><![CDATA[Config::getInstance()->settings]]></code>
     </PropertyTypeCoercion>
+    <TypeDoesNotContainType>
+      <code>assertSame</code>
+      <code>assertSame</code>
+      <code>assertSame</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="tests/classes/IpAllowDenyTest.php">
     <DeprecatedMethod>
@@ -14227,15 +14226,15 @@
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
     </DeprecatedMethod>
+    <DocblockTypeContradiction>
+      <code>assertSame</code>
+    </DocblockTypeContradiction>
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$config->settings]]></code>
       <code><![CDATA[$config->settings]]></code>
       <code><![CDATA[$config->settings]]></code>
       <code><![CDATA[$config->settings]]></code>
     </InvalidPropertyAssignmentValue>
-    <MixedAssignment>
-      <code>$result</code>
-    </MixedAssignment>
   </file>
   <file src="tests/classes/OpenDocumentTest.php">
     <RedundantCondition>
@@ -14246,6 +14245,9 @@
     <PossiblyUnusedMethod>
       <code>providerGetPartitionMaintenanceChoices</code>
     </PossiblyUnusedMethod>
+    <TypeDoesNotContainType>
+      <code>assertSame</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="tests/classes/Partitioning/PartitionTest.php">
     <PossiblyUnusedMethod>
@@ -14358,6 +14360,9 @@
       <code><![CDATA[$config->settings]]></code>
       <code><![CDATA[$config->settings]]></code>
     </PropertyTypeCoercion>
+    <TypeDoesNotContainType>
+      <code>assertSame</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="tests/classes/Plugins/Auth/AuthenticationHttpTest.php">
     <DeprecatedMethod>
@@ -14378,6 +14383,14 @@
     <PossiblyUnusedMethod>
       <code>readCredentialsProvider</code>
     </PossiblyUnusedMethod>
+    <RedundantCondition>
+      <code>assertSame</code>
+      <code>assertSame</code>
+      <code>assertSame</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType>
+      <code>assertSame</code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="tests/classes/Plugins/Auth/AuthenticationSignonTest.php">
     <DeprecatedMethod>
@@ -14407,6 +14420,9 @@
       <code><![CDATA[$config->selectedServer]]></code>
       <code><![CDATA[$config->settings]]></code>
     </InvalidPropertyAssignmentValue>
+    <RedundantCondition>
+      <code>assertSame</code>
+    </RedundantCondition>
   </file>
   <file src="tests/classes/Plugins/AuthenticationPluginFactoryTest.php">
     <DeprecatedMethod>
@@ -14418,18 +14434,23 @@
       <code>providerForTestValidPlugins</code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="tests/classes/Plugins/Export/ExportCodegenTest.php">
-    <MixedAssignment>
-      <code>$result</code>
-      <code>$result</code>
-    </MixedAssignment>
-  </file>
   <file src="tests/classes/Plugins/Export/ExportCsvTest.php">
+    <DocblockTypeContradiction>
+      <code>assertSame</code>
+    </DocblockTypeContradiction>
     <RedundantCondition>
       <code>assertFalse</code>
+      <code>assertSame</code>
     </RedundantCondition>
     <RedundantConditionGivenDocblockType>
       <code>assertFalse</code>
+      <code>assertSame</code>
+      <code>assertSame</code>
+      <code>assertSame</code>
+      <code>assertSame</code>
+      <code>assertSame</code>
+      <code>assertSame</code>
+      <code>assertSame</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="tests/classes/Plugins/Export/ExportHtmlwordTest.php">
@@ -14463,6 +14484,11 @@
       <code><![CDATA[$GLOBALS['plugin_param']['single_table']]]></code>
     </PossiblyInvalidArrayOffset>
   </file>
+  <file src="tests/classes/Plugins/Export/ExportOdsTest.php">
+    <TypeDoesNotContainType>
+      <code>assertSame</code>
+    </TypeDoesNotContainType>
+  </file>
   <file src="tests/classes/Plugins/Export/ExportOdtTest.php">
     <DeprecatedMethod>
       <code>Config::getInstance()</code>
@@ -14482,6 +14508,9 @@
       <code><![CDATA[$GLOBALS['plugin_param']['single_table']]]></code>
       <code><![CDATA[$GLOBALS['plugin_param']['single_table']]]></code>
     </PossiblyInvalidArrayOffset>
+    <TypeDoesNotContainType>
+      <code>assertSame</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="tests/classes/Plugins/Export/ExportSqlTest.php">
     <DeprecatedMethod>
@@ -14506,8 +14535,6 @@
       <code>$result</code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$result</code>
-      <code>$result</code>
       <code>$result</code>
       <code>$result</code>
     </MixedAssignment>
@@ -14584,6 +14611,7 @@
     </DeprecatedMethod>
     <RedundantCondition>
       <code>assertFalse</code>
+      <code>assertSame</code>
     </RedundantCondition>
   </file>
   <file src="tests/classes/Plugins/Import/ImportSqlTest.php">
@@ -14811,7 +14839,6 @@
   <file src="tests/classes/Setup/ConfigGeneratorTest.php">
     <MixedAssignment>
       <code>$result</code>
-      <code>$result</code>
     </MixedAssignment>
   </file>
   <file src="tests/classes/Setup/FormProcessingTest.php">
@@ -14827,6 +14854,9 @@
       <code><![CDATA[$_SESSION['messages']['type']]]></code>
       <code><![CDATA[$_SESSION['messages']['type']['123']]]></code>
     </MixedArrayAccess>
+    <TypeDoesNotContainType>
+      <code>assertSame</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="tests/classes/SqlQueryFormTest.php">
     <DeprecatedMethod>
@@ -14853,9 +14883,6 @@
       <code>Config::getInstance()</code>
       <code>Config::getInstance()</code>
     </DeprecatedMethod>
-    <MixedAssignment>
-      <code>$result</code>
-    </MixedAssignment>
     <PossiblyUnusedMethod>
       <code>dataProviderCountQueryResults</code>
     </PossiblyUnusedMethod>
@@ -14933,7 +14960,6 @@
     </InvalidArrayOffset>
     <MixedAssignment>
       <code>$isDefineProperty</code>
-      <code>$sql</code>
       <code>$sql</code>
     </MixedAssignment>
     <PossiblyUnusedMethod>

--- a/tests/classes/Advisory/AdvisorTest.php
+++ b/tests/classes/Advisory/AdvisorTest.php
@@ -35,7 +35,7 @@ class AdvisorTest extends AbstractTestCase
     public function testAdvisorBytime(float $time, string $expected): void
     {
         $result = Advisor::byTime($time, 2);
-        self::assertEquals($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /** @return mixed[][] */
@@ -69,7 +69,7 @@ class AdvisorTest extends AbstractTestCase
         $advisor->addRule('fired', $rule);
         $runResult = $advisor->getRunResult();
         if ($error !== null) {
-            self::assertEquals([$error], $runResult['errors']);
+            self::assertSame([$error], $runResult['errors']);
         }
 
         if ($runResult['fired'] === [] && $expected === []) {

--- a/tests/classes/BrowseForeignersTest.php
+++ b/tests/classes/BrowseForeignersTest.php
@@ -34,14 +34,14 @@ class BrowseForeignersTest extends AbstractTestCase
             $this->browseForeigners->getForeignLimit('Show all'),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'LIMIT 0, 25 ',
             $this->browseForeigners->getForeignLimit(null),
         );
 
         $_POST['pos'] = 10;
 
-        self::assertEquals(
+        self::assertSame(
             'LIMIT 10, 25 ',
             $this->browseForeigners->getForeignLimit(null),
         );
@@ -50,12 +50,12 @@ class BrowseForeignersTest extends AbstractTestCase
         $config->set('MaxRows', 50);
         $browseForeigners = new BrowseForeigners(new Template(), $config, new ThemeManager());
 
-        self::assertEquals(
+        self::assertSame(
             'LIMIT 10, 50 ',
             $browseForeigners->getForeignLimit(null),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'LIMIT 10, 50 ',
             $browseForeigners->getForeignLimit('xyz'),
         );
@@ -66,7 +66,7 @@ class BrowseForeignersTest extends AbstractTestCase
      */
     public function testGetHtmlForGotoPage(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '',
             $this->callFunction(
                 $this->browseForeigners,
@@ -81,7 +81,7 @@ class BrowseForeignersTest extends AbstractTestCase
         $foreignData['disp_row'] = [];
         $foreignData['the_total'] = 5;
 
-        self::assertEquals(
+        self::assertSame(
             '',
             $this->callFunction(
                 $this->browseForeigners,
@@ -117,7 +117,7 @@ class BrowseForeignersTest extends AbstractTestCase
     {
         $desc = 'foobar<baz';
 
-        self::assertEquals(
+        self::assertSame(
             ['foobar<baz', ''],
             $this->callFunction(
                 $this->browseForeigners,
@@ -131,7 +131,7 @@ class BrowseForeignersTest extends AbstractTestCase
         $config->set('LimitChars', 5);
         $browseForeigners = new BrowseForeigners(new Template(), $config, new ThemeManager());
 
-        self::assertEquals(
+        self::assertSame(
             ['fooba...', 'foobar<baz'],
             $this->callFunction(
                 $browseForeigners,

--- a/tests/classes/Charsets/CollationTest.php
+++ b/tests/classes/Charsets/CollationTest.php
@@ -47,7 +47,7 @@ class CollationTest extends AbstractTestCase
     public function testBuildDescription(string $collation, string $description): void
     {
         $actual = Collation::fromServer(['Collation' => $collation]);
-        self::assertEquals($description, $actual->getDescription());
+        self::assertSame($description, $actual->getDescription());
     }
 
     /** @return array<array{string, string}> */

--- a/tests/classes/Command/TwigLintCommandTest.php
+++ b/tests/classes/Command/TwigLintCommandTest.php
@@ -55,7 +55,7 @@ class TwigLintCommandTest extends AbstractTestCase
         // Sort results to avoid file system test specific failures
         sort($filesFound, SORT_NATURAL);
 
-        self::assertEquals([
+        self::assertSame([
             $path . DIRECTORY_SEPARATOR . 'one.txt',
             $path . DIRECTORY_SEPARATOR . 'subfolder' . DIRECTORY_SEPARATOR . 'one.ini',
             $path . DIRECTORY_SEPARATOR . 'subfolder' . DIRECTORY_SEPARATOR . 'zero.txt',
@@ -71,7 +71,7 @@ class TwigLintCommandTest extends AbstractTestCase
         // Sort results to avoid file system test specific failures
         sort($filesInfos, SORT_REGULAR);
 
-        self::assertEquals([
+        self::assertSame([
             ['template' => '', 'file' => $path . DIRECTORY_SEPARATOR . 'one.txt', 'valid' => true],
             ['template' => '', 'file' => $path . DIRECTORY_SEPARATOR . 'two.md', 'valid' => true],
             [
@@ -127,14 +127,14 @@ class TwigLintCommandTest extends AbstractTestCase
     {
         $context = $this->callFunction($this->command, TwigLintCommand::class, 'getContext', ['{{ file }', 0]);
 
-        self::assertEquals([1 => '{{ file }'], $context);
+        self::assertSame([1 => '{{ file }'], $context);
 
         $context = $this->callFunction($this->command, TwigLintCommand::class, 'getContext', ['{{ file }', 3]);
 
-        self::assertEquals([1 => '{{ file }'], $context);
+        self::assertSame([1 => '{{ file }'], $context);
 
         $context = $this->callFunction($this->command, TwigLintCommand::class, 'getContext', ['{{ file }', 5]);
 
-        self::assertEquals([], $context);
+        self::assertSame([], $context);
     }
 }

--- a/tests/classes/Config/ConfigFileTest.php
+++ b/tests/classes/Config/ConfigFileTest.php
@@ -54,13 +54,13 @@ class ConfigFileTest extends AbstractTestCase
     public function testNewObjectState(): void
     {
         // Check default dynamic values
-        self::assertEquals(
+        self::assertSame(
             [],
             $this->object->getConfig(),
         );
 
         // Check environment state
-        self::assertEquals(
+        self::assertSame(
             [],
             $_SESSION['ConfigFile1'],
         );
@@ -98,7 +98,7 @@ class ConfigFileTest extends AbstractTestCase
         $this->object->setPersistKeys(array_keys($defaultConfig));
         $this->object->resetConfigData();
         self::assertEmpty($this->object->getConfig());
-        self::assertEquals(
+        self::assertSame(
             $defaultConfig,
             $this->object->getConfigArray(),
         );
@@ -108,7 +108,7 @@ class ConfigFileTest extends AbstractTestCase
          * even if set to default values
          */
         $this->object->set('Servers/2/host', $defaultHost);
-        self::assertEquals(
+        self::assertSame(
             ['Servers' => [2 => ['host' => $defaultHost]]],
             $this->object->getConfig(),
         );
@@ -127,7 +127,7 @@ class ConfigFileTest extends AbstractTestCase
         $this->object->set('b', 2);
         $this->object->set('c', 3);
 
-        self::assertEquals(
+        self::assertSame(
             ['a' => 1, 'c' => 3],
             $this->object->getConfig(),
         );
@@ -156,11 +156,11 @@ class ConfigFileTest extends AbstractTestCase
         $this->object->set('Servers/1/passthrough2', 2);
         $this->object->updateWithGlobalConfig(['Servers/value1' => 3]);
 
-        self::assertEquals(
+        self::assertSame(
             ['Servers' => [1 => ['passthrough1' => 1, 'passthrough2' => 2, 'value1' => 3]]],
             $this->object->getConfig(),
         );
-        self::assertEquals(
+        self::assertSame(
             3,
             $this->object->get('Servers/1/value1'),
         );
@@ -187,11 +187,11 @@ class ConfigFileTest extends AbstractTestCase
         $this->object->set('abc', 'should be deleted by setConfigData');
         $this->object->setConfigData(['a' => 'b']);
 
-        self::assertEquals(
+        self::assertSame(
             ['a' => 'b'],
             $this->object->getConfig(),
         );
-        self::assertEquals(
+        self::assertSame(
             ['a' => 'b'],
             $this->object->getConfigArray(),
         );
@@ -208,15 +208,12 @@ class ConfigFileTest extends AbstractTestCase
         $this->object->set('Servers/4/host', $nonDefaultHost);
         $this->object->set('Servers/5/host', $defaultHost);
         $this->object->set('Servers/6/host', $defaultHost, 'Servers/6/host');
-        self::assertEquals(
+        self::assertSame(
             $nonDefaultHost,
             $this->object->get('Servers/4/host'),
         );
-        self::assertEquals(
-            null,
-            $this->object->get('Servers/5/host'),
-        );
-        self::assertEquals(
+        self::assertNull($this->object->get('Servers/5/host'));
+        self::assertSame(
             $defaultHost,
             $this->object->get('Servers/6/host'),
         );
@@ -225,7 +222,7 @@ class ConfigFileTest extends AbstractTestCase
         self::assertNull(
             $this->object->get('key not excist'),
         );
-        self::assertEquals(
+        self::assertSame(
             [1],
             $this->object->get('key not excist', [1]),
         );
@@ -269,7 +266,7 @@ class ConfigFileTest extends AbstractTestCase
             [self::SIMPLE_KEY_WITH_DEFAULT_VALUE => $configIncPhpValue],
         );
         $this->object->set(self::SIMPLE_KEY_WITH_DEFAULT_VALUE, $defaultValue);
-        self::assertEquals(
+        self::assertSame(
             [self::SIMPLE_KEY_WITH_DEFAULT_VALUE => $defaultValue],
             $this->object->getConfig(),
         );
@@ -284,10 +281,10 @@ class ConfigFileTest extends AbstractTestCase
         $flatDefaultConfig = $this->object->getFlatDefaultConfig();
 
         $defaultValue = $this->object->getDefault(self::SIMPLE_KEY_WITH_DEFAULT_VALUE);
-        self::assertEquals($defaultValue, $flatDefaultConfig[self::SIMPLE_KEY_WITH_DEFAULT_VALUE]);
+        self::assertSame($defaultValue, $flatDefaultConfig[self::SIMPLE_KEY_WITH_DEFAULT_VALUE]);
 
         $localhostValue = $this->object->getDefault('Servers/1/host');
-        self::assertEquals($localhostValue, $flatDefaultConfig['Servers/1/host']);
+        self::assertSame($localhostValue, $flatDefaultConfig['Servers/1/host']);
 
         $settings = new Settings([]);
         $cfg = $settings->asArray();
@@ -305,7 +302,7 @@ class ConfigFileTest extends AbstractTestCase
         $this->object->set('key2', 'value');
         $this->object->updateWithGlobalConfig(['key' => 'ABC']);
 
-        self::assertEquals(
+        self::assertSame(
             ['key' => 'ABC', 'key2' => 'value'],
             $this->object->getConfig(),
         );
@@ -316,12 +313,12 @@ class ConfigFileTest extends AbstractTestCase
      */
     public function testGetCanonicalPath(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'Servers/1/abcd',
             $this->object->getCanonicalPath('Servers/2/abcd'),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Servers/foo/bar',
             $this->object->getCanonicalPath('Servers/foo/bar'),
         );
@@ -336,12 +333,12 @@ class ConfigFileTest extends AbstractTestCase
         // verify that $cfg_db read from config.values.php is valid
         self::assertGreaterThanOrEqual(20, count($cfgDb));
 
-        self::assertEquals(
+        self::assertSame(
             $cfgDb['Servers'][1]['port'],
             $this->object->getDbEntry('Servers/1/port'),
         );
         self::assertNull($this->object->getDbEntry('no such key'));
-        self::assertEquals(
+        self::assertSame(
             [1],
             $this->object->getDbEntry('no such key', [1]),
         );
@@ -358,7 +355,7 @@ class ConfigFileTest extends AbstractTestCase
         $this->object->set('Servers/4/x', 4);
         $this->object->set('ServerDefault', 3);
 
-        self::assertEquals(
+        self::assertSame(
             4,
             $this->object->getServerCount(),
         );
@@ -366,7 +363,7 @@ class ConfigFileTest extends AbstractTestCase
         $this->object->removeServer(2);
         $this->object->removeServer(2);
 
-        self::assertEquals(
+        self::assertSame(
             2,
             $this->object->getServerCount(),
         );
@@ -375,11 +372,11 @@ class ConfigFileTest extends AbstractTestCase
             2,
             $this->object->get('ServerDefault'),
         );
-        self::assertEquals(
+        self::assertSame(
             ['Servers' => [1 => ['x' => 1], 2 => ['x' => 4]]],
             $this->object->getConfig(),
         );
-        self::assertEquals(
+        self::assertSame(
             ['Servers/1/x' => 1, 'Servers/2/x' => 4],
             $this->object->getConfigArray(),
         );
@@ -393,7 +390,7 @@ class ConfigFileTest extends AbstractTestCase
         $this->object->set('Servers/1/x', 'a');
         $this->object->set('Servers/2/x', 'b');
 
-        self::assertEquals(
+        self::assertSame(
             [1 => ['x' => 'a'], 2 => ['x' => 'b']],
             $this->object->getServers(),
         );
@@ -404,7 +401,7 @@ class ConfigFileTest extends AbstractTestCase
      */
     public function testGetServerDSN(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '',
             $this->object->getServerDSN(1),
         );
@@ -421,7 +418,7 @@ class ConfigFileTest extends AbstractTestCase
                 ],
             ],
         );
-        self::assertEquals(
+        self::assertSame(
             'mysqli://testUser@example.com:21',
             $this->object->getServerDSN(1),
         );
@@ -440,7 +437,7 @@ class ConfigFileTest extends AbstractTestCase
                 ],
             ],
         );
-        self::assertEquals(
+        self::assertSame(
             'mysqli://testUser@123',
             $this->object->getServerDSN(1),
         );
@@ -458,7 +455,7 @@ class ConfigFileTest extends AbstractTestCase
                 ],
             ],
         );
-        self::assertEquals(
+        self::assertSame(
             'mysqli://testUser:***@example.com:21',
             $this->object->getServerDSN(1),
         );
@@ -469,19 +466,19 @@ class ConfigFileTest extends AbstractTestCase
      */
     public function testGetServerName(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '',
             $this->object->getServerName(1),
         );
 
         $this->object->set('Servers/1/host', 'example.com');
-        self::assertEquals(
+        self::assertSame(
             'example.com',
             $this->object->getServerName(1),
         );
 
         $this->object->set('Servers/1/verbose', 'testData');
-        self::assertEquals(
+        self::assertSame(
             'testData',
             $this->object->getServerName(1),
         );

--- a/tests/classes/Config/DescriptionTest.php
+++ b/tests/classes/Config/DescriptionTest.php
@@ -35,7 +35,7 @@ class DescriptionTest extends AbstractTestCase
     #[DataProvider('getValues')]
     public function testGet(string $item, string $type, string $expected): void
     {
-        self::assertEquals($expected, Descriptions::get($item, $type));
+        self::assertSame($expected, Descriptions::get($item, $type));
     }
 
     /**

--- a/tests/classes/Config/FormDisplayTemplateTest.php
+++ b/tests/classes/Config/FormDisplayTemplateTest.php
@@ -196,7 +196,7 @@ class FormDisplayTemplateTest extends AbstractTestCase
      */
     public function testDisplayGroupHeader(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '',
             $this->formDisplayTemplate->displayGroupHeader(''),
         );
@@ -226,7 +226,7 @@ class FormDisplayTemplateTest extends AbstractTestCase
     {
         $this->formDisplayTemplate->group = 3;
         $this->formDisplayTemplate->displayGroupFooter();
-        self::assertEquals(2, $this->formDisplayTemplate->group);
+        self::assertSame(2, $this->formDisplayTemplate->group);
     }
 
     /**
@@ -240,7 +240,7 @@ class FormDisplayTemplateTest extends AbstractTestCase
 
         $this->formDisplayTemplate->addJsValidate('testID', $validators, $js);
 
-        self::assertEquals(
+        self::assertSame(
             [
                 'window.Config.registerFieldValidator(\'testID\', \'\\\';\', true, '
                 . '["\\\\r\\\\n\\\\\''

--- a/tests/classes/Config/FormDisplayTest.php
+++ b/tests/classes/Config/FormDisplayTest.php
@@ -66,14 +66,14 @@ class FormDisplayTest extends AbstractTestCase
 
         $attrSystemPaths = $reflection->getProperty('systemPaths');
 
-        self::assertEquals(
+        self::assertSame(
             ['Servers/2/test' => 'Servers/1/test', 'Servers/2/:group:end:0' => 'Servers/1/:group:end:0'],
             $attrSystemPaths->getValue($this->object),
         );
 
         $attrTranslatedPaths = $reflection->getProperty('translatedPaths');
 
-        self::assertEquals(
+        self::assertSame(
             ['Servers/2/test' => 'Servers-2-test', 'Servers/2/:group:end:0' => 'Servers-2-:group:end:0'],
             $attrTranslatedPaths->getValue($this->object),
         );
@@ -174,7 +174,7 @@ class FormDisplayTest extends AbstractTestCase
 
         $this->object->fixErrors();
 
-        self::assertEquals(
+        self::assertSame(
             ['Servers' => ['1' => ['test' => 'localhost']]],
             $_SESSION['ConfigFile2'],
         );
@@ -204,7 +204,7 @@ class FormDisplayTest extends AbstractTestCase
                 [&$value, $arr],
             ),
         );
-        self::assertEquals(
+        self::assertSame(
             'string',
             gettype($value),
         );
@@ -248,18 +248,18 @@ class FormDisplayTest extends AbstractTestCase
      */
     public function testGetDocLink(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'index.php?route=/url&url='
             . 'https%3A%2F%2Fdocs.phpmyadmin.net%2Fen%2Flatest%2Fconfig.html%23cfg_Servers_3_test_2_',
             $this->object->getDocLink('Servers/3/test/2/'),
         );
 
-        self::assertEquals(
+        self::assertSame(
             '',
             $this->object->getDocLink('Import'),
         );
 
-        self::assertEquals(
+        self::assertSame(
             '',
             $this->object->getDocLink('Export'),
         );
@@ -272,12 +272,12 @@ class FormDisplayTest extends AbstractTestCase
     {
         $method = new ReflectionMethod(FormDisplay::class, 'getOptName');
 
-        self::assertEquals(
+        self::assertSame(
             'Servers_',
             $method->invoke($this->object, 'Servers/1/'),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Servers_23_',
             $method->invoke($this->object, 'Servers/1/23/'),
         );
@@ -293,7 +293,7 @@ class FormDisplayTest extends AbstractTestCase
         $attrUserprefs = new ReflectionProperty(FormDisplay::class, 'userprefsDisallow');
 
         $method->invoke($this->object, null);
-        self::assertEquals(
+        self::assertSame(
             [],
             $attrUserprefs->getValue($this->object),
         );
@@ -346,7 +346,7 @@ class FormDisplayTest extends AbstractTestCase
             'due to missing function gzcompress.';
         }
 
-        self::assertEquals($comment, $opts['comment']);
+        self::assertSame($comment, $opts['comment']);
 
         self::assertTrue($opts['comment_warning']);
 
@@ -365,7 +365,7 @@ class FormDisplayTest extends AbstractTestCase
             'due to missing function gzencode.';
         }
 
-        self::assertEquals($comment, $opts['comment']);
+        self::assertSame($comment, $opts['comment']);
 
         self::assertTrue($opts['comment_warning']);
 
@@ -384,7 +384,7 @@ class FormDisplayTest extends AbstractTestCase
             'due to missing function bzcompress.';
         }
 
-        self::assertEquals($comment, $opts['comment']);
+        self::assertSame($comment, $opts['comment']);
 
         self::assertTrue($opts['comment_warning']);
 
@@ -400,20 +400,20 @@ class FormDisplayTest extends AbstractTestCase
             ['MaxDbList', &$opts],
         );
 
-        self::assertEquals('maximum 10', $opts['comment']);
+        self::assertSame('maximum 10', $opts['comment']);
 
         $method->invokeArgs(
             $this->object,
             ['MaxTableList', &$opts],
         );
 
-        self::assertEquals('maximum 10', $opts['comment']);
+        self::assertSame('maximum 10', $opts['comment']);
 
         $method->invokeArgs(
             $this->object,
             ['QueryHistoryMax', &$opts],
         );
 
-        self::assertEquals('maximum 10', $opts['comment']);
+        self::assertSame('maximum 10', $opts['comment']);
     }
 }

--- a/tests/classes/Config/FormTest.php
+++ b/tests/classes/Config/FormTest.php
@@ -53,8 +53,8 @@ class FormTest extends AbstractTestCase
     #[Group('medium')]
     public function testContructor(): void
     {
-        self::assertEquals(1, $this->object->index);
-        self::assertEquals('pma_form_name', $this->object->name);
+        self::assertSame(1, $this->object->index);
+        self::assertSame('pma_form_name', $this->object->name);
         self::assertArrayHasKey('pma_form1', $this->object->fields);
     }
 
@@ -72,7 +72,7 @@ class FormTest extends AbstractTestCase
             $this->object->getOptionType('123/4/5/6'),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Seven',
             $this->object->getOptionType('123/4/5/7'),
         );
@@ -83,7 +83,7 @@ class FormTest extends AbstractTestCase
      */
     public function testGetOptionValueList(): void
     {
-        self::assertEquals(
+        self::assertSame(
             ['NHibernate C# DO', 'NHibernate XML'],
             $this->object->getOptionValueList('Export/codegen_format'),
         );
@@ -93,7 +93,7 @@ class FormTest extends AbstractTestCase
             $this->object->getOptionValueList('OBGzip'),
         );
 
-        self::assertEquals(
+        self::assertSame(
             ['none' => 'Nowhere', 'left' => 'Left', 'right' => 'Right', 'both' => 'Both'],
             $this->object->getOptionValueList('RowActionLinks'),
         );
@@ -115,11 +115,11 @@ class FormTest extends AbstractTestCase
 
         self::assertCount(4, $result);
 
-        self::assertEquals('pma_form1', $result['pma_form1']);
+        self::assertSame('pma_form1', $result['pma_form1']);
 
-        self::assertEquals('pma_form2', $result['pma_form2']);
+        self::assertSame('pma_form2', $result['pma_form2']);
 
-        self::assertEquals('preffoo/foo/bar/test', $result[0]);
+        self::assertSame('preffoo/foo/bar/test', $result[0]);
 
         // needs regexp because the counter is static
         self::assertMatchesRegularExpression('/^preffoo\/foo\/bar\/\:group\:end\:\d+$/', $result[1]);
@@ -141,7 +141,7 @@ class FormTest extends AbstractTestCase
 
         self::assertCount(2, $result);
 
-        self::assertEquals('foo/bar/test', $result['test']);
+        self::assertSame('foo/bar/test', $result['test']);
 
         unset($result['test']);
 
@@ -154,7 +154,7 @@ class FormTest extends AbstractTestCase
         preg_match('/^\:group\:end\:(\d+)$/', $key, $matches);
         $digit = $matches[1];
 
-        self::assertEquals('foo/bar/:group:end:' . $digit, $result[':group:end:' . $digit]);
+        self::assertSame('foo/bar/:group:end:' . $digit, $result[':group:end:' . $digit]);
     }
 
     /**
@@ -176,7 +176,7 @@ class FormTest extends AbstractTestCase
 
         $method->invoke($this->object, null);
 
-        self::assertEquals(
+        self::assertSame(
             ['pma_form1' => 'integer', 'pma_form2' => 'select', ':group:end:0' => 'group', '1' => 'NULL'],
             $attrFieldsTypes->getValue($this->object),
         );
@@ -201,7 +201,7 @@ class FormTest extends AbstractTestCase
 
         $this->object->loadForm('pmaform', ['testForm']);
 
-        self::assertEquals('pmaform', $this->object->name);
+        self::assertSame('pmaform', $this->object->name);
     }
 
     /**

--- a/tests/classes/Config/Forms/FormListTest.php
+++ b/tests/classes/Config/Forms/FormListTest.php
@@ -46,7 +46,7 @@ class FormListTest extends AbstractTestCase
 
         /* Static API */
         self::assertTrue($class::isValid('Export'));
-        self::assertEquals($prefix, $class::get('Export'));
+        self::assertSame($prefix, $class::get('Export'));
         foreach ($class::getAllFormNames() as $form) {
             $formClass = $class::get($form);
             self::assertNotNull($formClass);
@@ -61,7 +61,7 @@ class FormListTest extends AbstractTestCase
         self::assertFalse($forms->process());
         $forms->fixErrors();
         self::assertFalse($forms->hasErrors());
-        self::assertEquals('', $forms->displayErrors());
+        self::assertSame('', $forms->displayErrors());
     }
 
     /**

--- a/tests/classes/Config/PageSettingsTest.php
+++ b/tests/classes/Config/PageSettingsTest.php
@@ -47,7 +47,7 @@ class PageSettingsTest extends AbstractTestCase
         $object = new PageSettings(new UserPreferences($dbi, new Relation($dbi), new Template()));
         $object->init('NonExistent');
 
-        self::assertEquals('', $object->getHTML());
+        self::assertSame('', $object->getHTML());
     }
 
     /**

--- a/tests/classes/Config/ServerConfigChecksTest.php
+++ b/tests/classes/Config/ServerConfigChecksTest.php
@@ -77,7 +77,7 @@ class ServerConfigChecksTest extends AbstractTestCase
 
         $configChecker->performConfigChecks();
 
-        self::assertEquals(
+        self::assertSame(
             [
                 'Servers/1/ssl',
                 'Servers/1/auth_type',
@@ -90,7 +90,7 @@ class ServerConfigChecksTest extends AbstractTestCase
             array_keys($_SESSION['messages']['notice']),
         );
 
-        self::assertEquals(
+        self::assertSame(
             ['LoginCookieValidity', 'GZipDump', 'BZipDump', 'ZipDump_import', 'ZipDump_export'],
             array_keys($_SESSION['messages']['error']),
         );

--- a/tests/classes/ConfigStorage/RelationParametersTest.php
+++ b/tests/classes/ConfigStorage/RelationParametersTest.php
@@ -171,7 +171,7 @@ class RelationParametersTest extends TestCase
             'userconfigwork' => true,
         ]);
         self::assertInstanceOf(DatabaseName::class, $relationParameters->db);
-        self::assertEquals('db', $relationParameters->db->getName());
+        self::assertSame('db', $relationParameters->db->getName());
         self::assertNotNull($relationParameters->bookmarkFeature);
         self::assertSame($relationParameters->db, $relationParameters->bookmarkFeature->database);
         self::assertNotNull($relationParameters->browserTransformationFeature);

--- a/tests/classes/ConfigStorage/RelationTest.php
+++ b/tests/classes/ConfigStorage/RelationTest.php
@@ -42,7 +42,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addSelectDb('phpmyadmin');
         $db = 'information_schema';
         $table = 'CHARACTER_SETS';
-        self::assertEquals(
+        self::assertSame(
             'DESCRIPTION',
             $relation->getDisplayField($db, $table),
         );
@@ -50,7 +50,7 @@ class RelationTest extends AbstractTestCase
 
         $db = 'information_schema';
         $table = 'TABLES';
-        self::assertEquals(
+        self::assertSame(
             'TABLE_COMMENT',
             $relation->getDisplayField($db, $table),
         );
@@ -88,14 +88,14 @@ class RelationTest extends AbstractTestCase
         DatabaseInterface::$instance = $dbi;
 
         $db = 'information_schema';
-        self::assertEquals(
+        self::assertSame(
             [''],
             $relation->getComments($db),
         );
 
         $db = 'information_schema';
         $table = 'TABLES';
-        self::assertEquals(
+        self::assertSame(
             ['field1' => 'Comment1', 'field2' => 'Comment1'],
             $relation->getComments($db, $table),
         );

--- a/tests/classes/ConfigTest.php
+++ b/tests/classes/ConfigTest.php
@@ -173,8 +173,8 @@ PHP;
     ): void {
         $_SERVER['HTTP_USER_AGENT'] = $agent;
         $this->object->checkClient();
-        self::assertEquals($os, $this->object->get('PMA_USR_OS'));
-        self::assertEquals($browser, $this->object->get('PMA_USR_BROWSER_AGENT'));
+        self::assertSame($os, $this->object->get('PMA_USR_OS'));
+        self::assertSame($browser, $this->object->get('PMA_USR_BROWSER_AGENT'));
 
         if ($version === null) {
             return;
@@ -258,17 +258,17 @@ PHP;
     {
         $this->object->set('GD2Available', 'yes');
         $this->object->checkGd2();
-        self::assertEquals(1, $this->object->get('PMA_IS_GD2'));
+        self::assertSame(1, $this->object->get('PMA_IS_GD2'));
 
         $this->object->set('GD2Available', 'no');
         $this->object->checkGd2();
-        self::assertEquals(0, $this->object->get('PMA_IS_GD2'));
+        self::assertSame(0, $this->object->get('PMA_IS_GD2'));
 
         $this->object->set('GD2Available', 'auto');
 
         if (! function_exists('imagecreatetruecolor')) {
             $this->object->checkGd2();
-            self::assertEquals(
+            self::assertSame(
                 0,
                 $this->object->get('PMA_IS_GD2'),
                 'imagecreatetruecolor does not exist, PMA_IS_GD2 should be 0',
@@ -279,13 +279,13 @@ PHP;
             $this->object->checkGd2();
             $gdNfo = gd_info();
             if (str_contains($gdNfo['GD Version'], '2.')) {
-                self::assertEquals(
+                self::assertSame(
                     1,
                     $this->object->get('PMA_IS_GD2'),
                     'GD Version >= 2, PMA_IS_GD2 should be 1',
                 );
             } else {
-                self::assertEquals(
+                self::assertSame(
                     0,
                     $this->object->get('PMA_IS_GD2'),
                     'GD Version < 2, PMA_IS_GD2 should be 0',
@@ -305,13 +305,13 @@ PHP;
 
         // TODO: The variable $v clearly is incorrect. Was this meant to be $a?
         if (str_contains($v, '2.')) {
-            self::assertEquals(
+            self::assertSame(
                 1,
                 $this->object->get('PMA_IS_GD2'),
                 'PMA_IS_GD2 should be 1',
             );
         } else {
-            self::assertEquals(
+            self::assertSame(
                 0,
                 $this->object->get('PMA_IS_GD2'),
                 'PMA_IS_GD2 should be 0',
@@ -339,7 +339,7 @@ PHP;
                 self::markTestIncomplete('Not known PHP_OS: ' . PHP_OS);
             }
         } else {
-            self::assertEquals(0, $this->object->get('PMA_IS_WINDOWS'));
+            self::assertSame(0, $this->object->get('PMA_IS_WINDOWS'));
 
             define('PHP_OS', 'Windows');
             self::assertTrue($this->object->get('PMA_IS_WINDOWS'));
@@ -353,7 +353,7 @@ PHP;
         $config = $settings->asArray();
         self::assertIsArray($config['Servers']);
         self::assertEquals($settings, $object->getSettings());
-        self::assertEquals($config, $object->default);
+        self::assertSame($config, $object->default);
         self::assertSame($config, $object->settings);
         self::assertSame($config, $object->baseSettings);
     }
@@ -365,7 +365,7 @@ PHP;
     {
         $this->object->setSource('unexisted.config.php');
         self::assertFalse($this->object->checkConfigSource());
-        self::assertEquals(0, $this->object->sourceMtime);
+        self::assertSame(0, $this->object->sourceMtime);
 
         $this->object->setSource(TEST_PATH . 'tests/test_data/config.inc.php');
 
@@ -382,7 +382,7 @@ PHP;
 
         $this->object->set('test_setting', 'test_value');
 
-        self::assertEquals('test_value', $this->object->get('test_setting'));
+        self::assertSame('test_value', $this->object->get('test_setting'));
     }
 
     /**
@@ -396,7 +396,7 @@ PHP;
 
         $this->object->setSource(ROOT_PATH . 'config.sample.inc.php');
 
-        self::assertEquals(
+        self::assertSame(
             ROOT_PATH . 'config.sample.inc.php',
             $this->object->getSource(),
             'Cant set new source',
@@ -444,7 +444,7 @@ PHP;
 
         $this->object->set('is_https', null);
         $this->object->set('PmaAbsoluteUri', $pmaAbsoluteUri);
-        self::assertEquals($expected, $this->object->isHttps());
+        self::assertSame($expected, $this->object->isHttps());
     }
 
     /**
@@ -500,7 +500,7 @@ PHP;
         $_SERVER['REQUEST_URI'] = '';
         $_SERVER['PATH_INFO'] = '';
         $this->object->set('PmaAbsoluteUri', $absolute);
-        self::assertEquals($expected, $this->object->getRootPath());
+        self::assertSame($expected, $this->object->getRootPath());
     }
 
     /**
@@ -560,7 +560,7 @@ PHP;
     {
         $this->object->setUserValue(null, 'lang', 'cs', 'en');
         $this->object->setUserValue('TEST_COOKIE_USER_VAL', '', 'cfg_val_1');
-        self::assertEquals(
+        self::assertSame(
             $this->object->getUserValue('TEST_COOKIE_USER_VAL', 'fail'),
             'cfg_val_1',
         );
@@ -573,7 +573,7 @@ PHP;
      */
     public function testGetUserValue(): void
     {
-        self::assertEquals($this->object->getUserValue('test_val', 'val'), 'val');
+        self::assertSame($this->object->getUserValue('test_val', 'val'), 'val');
     }
 
     /**
@@ -651,7 +651,7 @@ PHP;
         (new ReflectionProperty(Config::class, 'tempDir'))->setValue(null, []);
         $this->object->set('TempDir', $dir . DIRECTORY_SEPARATOR);
         // Check no double slash is here
-        self::assertEquals(
+        self::assertSame(
             $dir . DIRECTORY_SEPARATOR . 'upload',
             $this->object->getTempDir('upload'),
         );
@@ -671,7 +671,7 @@ PHP;
 
         $this->object->set('TempDir', $dir . DIRECTORY_SEPARATOR);
 
-        self::assertEquals(
+        self::assertSame(
             $this->object->getTempDir('upload'),
             $this->object->getUploadTempDir(),
         );

--- a/tests/classes/ConsoleTest.php
+++ b/tests/classes/ConsoleTest.php
@@ -22,7 +22,7 @@ class ConsoleTest extends AbstractTestCase
         $relation = new Relation($dbi);
         $bookmarkRepository = new BookmarkRepository($dbi, $relation);
         $console = new Console($relation, new Template(), $bookmarkRepository);
-        self::assertEquals(['console.js'], $console->getScripts());
+        self::assertSame(['console.js'], $console->getScripts());
     }
 
     public function testSetAjax(): void

--- a/tests/classes/Controllers/Database/Structure/FavoriteTableControllerTest.php
+++ b/tests/classes/Controllers/Database/Structure/FavoriteTableControllerTest.php
@@ -51,7 +51,7 @@ final class FavoriteTableControllerTest extends AbstractTestCase
         $json = $method->invokeArgs($controller, [$favoriteInstance, $user, $favoriteTable]);
 
         self::assertIsArray($json);
-        self::assertEquals(json_encode($favoriteTable), $json['favoriteTables'] ?? '');
+        self::assertSame(json_encode($favoriteTable), $json['favoriteTables'] ?? '');
         self::assertArrayHasKey('list', $json);
         /**
          * @psalm-suppress TypeDoesNotContainType

--- a/tests/classes/Controllers/Database/Structure/RealRowCountControllerTest.php
+++ b/tests/classes/Controllers/Database/Structure/RealRowCountControllerTest.php
@@ -38,7 +38,7 @@ class RealRowCountControllerTest extends AbstractTestCase
         (new RealRowCountController($response, new Template(), $dbi, new DbTableExists($dbi)))($request);
 
         $json = $response->getJSONResult();
-        self::assertEquals('4,079', $json['real_row_count']);
+        self::assertSame('4,079', $json['real_row_count']);
 
         $_REQUEST['real_row_count_all'] = 'on';
 
@@ -50,7 +50,7 @@ class RealRowCountControllerTest extends AbstractTestCase
             ['table' => 'Country', 'row_count' => '239'],
             ['table' => 'CountryLanguage', 'row_count' => '984'],
         ];
-        self::assertEquals($expected, $json['real_row_count_all']);
+        self::assertSame($expected, $json['real_row_count_all']);
 
         $dbiDummy->assertAllSelectsConsumed();
     }

--- a/tests/classes/Controllers/Database/StructureControllerTest.php
+++ b/tests/classes/Controllers/Database/StructureControllerTest.php
@@ -103,8 +103,8 @@ class StructureControllerTest extends AbstractTestCase
         );
 
         self::assertTrue($currentTable['COUNTED']);
-        self::assertEquals(6, $currentTable['TABLE_ROWS']);
-        self::assertEquals(16394, $sumSize);
+        self::assertSame(6, $currentTable['TABLE_ROWS']);
+        self::assertSame(16394, $sumSize);
 
         $currentTable['ENGINE'] = 'MYISAM';
         [$currentTable, , , $sumSize] = $method->invokeArgs(
@@ -113,7 +113,7 @@ class StructureControllerTest extends AbstractTestCase
         );
 
         self::assertFalse($currentTable['COUNTED']);
-        self::assertEquals(16394, $sumSize);
+        self::assertSame(16394, $sumSize);
 
         $controller = new StructureController(
             $this->response,
@@ -129,12 +129,12 @@ class StructureControllerTest extends AbstractTestCase
         $currentTable['ENGINE'] = 'InnoDB';
         [$currentTable, , , $sumSize] = $method->invokeArgs($controller, [$currentTable, 10]);
         self::assertTrue($currentTable['COUNTED']);
-        self::assertEquals(10, $sumSize);
+        self::assertSame(10, $sumSize);
 
         $currentTable['ENGINE'] = 'MYISAM';
         [$currentTable, , , $sumSize] = $method->invokeArgs($controller, [$currentTable, 10]);
         self::assertFalse($currentTable['COUNTED']);
-        self::assertEquals(10, $sumSize);
+        self::assertSame(10, $sumSize);
     }
 
     /**
@@ -167,16 +167,16 @@ class StructureControllerTest extends AbstractTestCase
             $controller,
             [$currentTable, 0, 0, 0, 0, 0, 0],
         );
-        self::assertEquals(6, $currentTable['Rows']);
-        self::assertEquals(16384, $sumSize);
-        self::assertEquals(300, $overheadSize);
+        self::assertSame(6, $currentTable['Rows']);
+        self::assertSame(16384, $sumSize);
+        self::assertSame(300, $overheadSize);
 
         unset($currentTable['Data_free']);
         [$currentTable, , , , , $overheadSize] = $method->invokeArgs(
             $controller,
             [$currentTable, 0, 0, 0, 0, 0, 0],
         );
-        self::assertEquals(0, $overheadSize);
+        self::assertSame(0, $overheadSize);
 
         $controller = new StructureController(
             $this->response,
@@ -192,7 +192,7 @@ class StructureControllerTest extends AbstractTestCase
             $controller,
             [$currentTable, 0, 0, 0, 0, 0, 0],
         );
-        self::assertEquals(0, $sumSize);
+        self::assertSame(0, $sumSize);
 
         $controller = new StructureController(
             $this->response,

--- a/tests/classes/Controllers/Export/Template/CreateControllerTest.php
+++ b/tests/classes/Controllers/Export/Template/CreateControllerTest.php
@@ -86,6 +86,6 @@ class CreateControllerTest extends AbstractTestCase
         ]);
 
         self::assertTrue($response->hasSuccessState());
-        self::assertEquals(['data' => $options], $response->getJSONResult());
+        self::assertSame(['data' => $options], $response->getJSONResult());
     }
 }

--- a/tests/classes/Controllers/Export/Template/LoadControllerTest.php
+++ b/tests/classes/Controllers/Export/Template/LoadControllerTest.php
@@ -57,6 +57,6 @@ class LoadControllerTest extends AbstractTestCase
         ))($request);
 
         self::assertTrue($response->hasSuccessState());
-        self::assertEquals(['data' => 'data1'], $response->getJSONResult());
+        self::assertSame(['data' => 'data1'], $response->getJSONResult());
     }
 }

--- a/tests/classes/Controllers/GisDataEditorControllerTest.php
+++ b/tests/classes/Controllers/GisDataEditorControllerTest.php
@@ -47,7 +47,7 @@ class GisDataEditorControllerTest extends AbstractTestCase
                 $value,
             ],
         );
-        self::assertEquals($expected, $gisData);
+        self::assertSame($expected, $gisData);
     }
 
     /** @return iterable<array{0:mixed,1:string,2:string|null,3:string}> */

--- a/tests/classes/Controllers/JavaScriptMessagesControllerTest.php
+++ b/tests/classes/Controllers/JavaScriptMessagesControllerTest.php
@@ -33,6 +33,6 @@ class JavaScriptMessagesControllerTest extends TestCase
 
         self::assertIsArray($array);
         self::assertArrayHasKey('strDoYouReally', $array);
-        self::assertEquals('Do you really want to execute "%s"?', $array['strDoYouReally']);
+        self::assertSame('Do you really want to execute "%s"?', $array['strDoYouReally']);
     }
 }

--- a/tests/classes/Controllers/Operations/TableControllerTest.php
+++ b/tests/classes/Controllers/Operations/TableControllerTest.php
@@ -133,6 +133,6 @@ class TableControllerTest extends AbstractTestCase
         );
         $controller($request);
 
-        self::assertEquals($expectedOutput, $responseRenderer->getHTMLResult());
+        self::assertSame($expectedOutput, $responseRenderer->getHTMLResult());
     }
 }

--- a/tests/classes/Controllers/Server/Privileges/AccountLockControllerTest.php
+++ b/tests/classes/Controllers/Server/Privileges/AccountLockControllerTest.php
@@ -57,9 +57,9 @@ class AccountLockControllerTest extends AbstractTestCase
         ($this->controller)($this->requestStub);
 
         $message = Message::success('The account test.user@test.host has been successfully locked.');
-        self::assertEquals(200, $this->responseRendererStub->getResponse()->getStatusCode());
+        self::assertSame(200, $this->responseRendererStub->getResponse()->getStatusCode());
         self::assertTrue($this->responseRendererStub->hasSuccessState());
-        self::assertEquals(['message' => $message->getDisplay()], $this->responseRendererStub->getJSONResult());
+        self::assertSame(['message' => $message->getDisplay()], $this->responseRendererStub->getJSONResult());
     }
 
     public function testWithInvalidAccount(): void
@@ -71,9 +71,9 @@ class AccountLockControllerTest extends AbstractTestCase
         ($this->controller)($this->requestStub);
 
         $message = Message::error('Invalid account.');
-        self::assertEquals(400, $this->responseRendererStub->getResponse()->getStatusCode());
+        self::assertSame(400, $this->responseRendererStub->getResponse()->getStatusCode());
         self::assertFalse($this->responseRendererStub->hasSuccessState());
-        self::assertEquals(['message' => $message->getDisplay()], $this->responseRendererStub->getJSONResult());
+        self::assertSame(['message' => $message->getDisplay()], $this->responseRendererStub->getJSONResult());
     }
 
     public function testWithUnsupportedServer(): void
@@ -83,8 +83,8 @@ class AccountLockControllerTest extends AbstractTestCase
         ($this->controller)($this->requestStub);
 
         $message = Message::error('Account locking is not supported.');
-        self::assertEquals(400, $this->responseRendererStub->getResponse()->getStatusCode());
+        self::assertSame(400, $this->responseRendererStub->getResponse()->getStatusCode());
         self::assertFalse($this->responseRendererStub->hasSuccessState());
-        self::assertEquals(['message' => $message->getDisplay()], $this->responseRendererStub->getJSONResult());
+        self::assertSame(['message' => $message->getDisplay()], $this->responseRendererStub->getJSONResult());
     }
 }

--- a/tests/classes/Controllers/Server/Privileges/AccountUnlockControllerTest.php
+++ b/tests/classes/Controllers/Server/Privileges/AccountUnlockControllerTest.php
@@ -57,9 +57,9 @@ class AccountUnlockControllerTest extends AbstractTestCase
         ($this->controller)($this->requestStub);
 
         $message = Message::success('The account test.user@test.host has been successfully unlocked.');
-        self::assertEquals(200, $this->responseRendererStub->getResponse()->getStatusCode());
+        self::assertSame(200, $this->responseRendererStub->getResponse()->getStatusCode());
         self::assertTrue($this->responseRendererStub->hasSuccessState());
-        self::assertEquals(['message' => $message->getDisplay()], $this->responseRendererStub->getJSONResult());
+        self::assertSame(['message' => $message->getDisplay()], $this->responseRendererStub->getJSONResult());
     }
 
     public function testWithInvalidAccount(): void
@@ -71,9 +71,9 @@ class AccountUnlockControllerTest extends AbstractTestCase
         ($this->controller)($this->requestStub);
 
         $message = Message::error('Invalid account.');
-        self::assertEquals(400, $this->responseRendererStub->getResponse()->getStatusCode());
+        self::assertSame(400, $this->responseRendererStub->getResponse()->getStatusCode());
         self::assertFalse($this->responseRendererStub->hasSuccessState());
-        self::assertEquals(['message' => $message->getDisplay()], $this->responseRendererStub->getJSONResult());
+        self::assertSame(['message' => $message->getDisplay()], $this->responseRendererStub->getJSONResult());
     }
 
     public function testWithUnsupportedServer(): void
@@ -83,8 +83,8 @@ class AccountUnlockControllerTest extends AbstractTestCase
         ($this->controller)($this->requestStub);
 
         $message = Message::error('Account locking is not supported.');
-        self::assertEquals(400, $this->responseRendererStub->getResponse()->getStatusCode());
+        self::assertSame(400, $this->responseRendererStub->getResponse()->getStatusCode());
         self::assertFalse($this->responseRendererStub->hasSuccessState());
-        self::assertEquals(['message' => $message->getDisplay()], $this->responseRendererStub->getJSONResult());
+        self::assertSame(['message' => $message->getDisplay()], $this->responseRendererStub->getJSONResult());
     }
 }

--- a/tests/classes/Controllers/Server/Status/Monitor/GeneralLogControllerTest.php
+++ b/tests/classes/Controllers/Server/Status/Monitor/GeneralLogControllerTest.php
@@ -78,7 +78,7 @@ class GeneralLogControllerTest extends AbstractTestCase
         $resultRows = [$value, $value2];
         $resultSum = ['argument' => 10, 'TOTAL' => 21, 'argument3' => 11];
 
-        self::assertEquals(2, $ret['message']['numRows']);
+        self::assertSame(2, $ret['message']['numRows']);
         self::assertEquals($resultRows, $ret['message']['rows']);
         self::assertEquals($resultSum, $ret['message']['sum']);
     }

--- a/tests/classes/Controllers/Server/Status/Monitor/LogVarsControllerTest.php
+++ b/tests/classes/Controllers/Server/Status/Monitor/LogVarsControllerTest.php
@@ -74,6 +74,6 @@ class LogVarsControllerTest extends AbstractTestCase
         $this->dummyDbi->assertAllSelectsConsumed();
         $ret = $response->getJSONResult();
 
-        self::assertEquals($value, $ret['message']);
+        self::assertSame($value, $ret['message']);
     }
 }

--- a/tests/classes/Controllers/Server/Status/Monitor/QueryAnalyzerControllerTest.php
+++ b/tests/classes/Controllers/Server/Status/Monitor/QueryAnalyzerControllerTest.php
@@ -55,8 +55,8 @@ class QueryAnalyzerControllerTest extends AbstractTestCase
         $dummyDbi->assertAllSelectsConsumed();
         $ret = $response->getJSONResult();
 
-        self::assertEquals('cached_affected_rows', $ret['message']['affectedRows']);
-        self::assertEquals(
+        self::assertSame('cached_affected_rows', $ret['message']['affectedRows']);
+        self::assertSame(
             [],
             $ret['message']['profiling'],
         );

--- a/tests/classes/Controllers/Server/Status/Monitor/SlowLogControllerTest.php
+++ b/tests/classes/Controllers/Server/Status/Monitor/SlowLogControllerTest.php
@@ -69,7 +69,7 @@ class SlowLogControllerTest extends AbstractTestCase
 
         $resultRows = [['sql_text' => 'insert sql_text', '#' => 11], ['sql_text' => 'update sql_text', '#' => 10]];
         $resultSum = ['insert' => 11, 'TOTAL' => 21, 'update' => 10];
-        self::assertEquals(2, $ret['message']['numRows']);
+        self::assertSame(2, $ret['message']['numRows']);
         self::assertEquals($resultRows, $ret['message']['rows']);
         self::assertEquals($resultSum, $ret['message']['sum']);
     }

--- a/tests/classes/Controllers/Server/VariablesControllerTest.php
+++ b/tests/classes/Controllers/Server/VariablesControllerTest.php
@@ -146,7 +146,7 @@ class VariablesControllerTest extends AbstractTestCase
             $args,
         );
 
-        self::assertEquals('<abbr title="3">3 B</abbr>', $formattedValue);
+        self::assertSame('<abbr title="3">3 B</abbr>', $formattedValue);
         self::assertTrue($isHtmlFormatted);
 
         //name is_numeric and the value type is not byte
@@ -157,7 +157,7 @@ class VariablesControllerTest extends AbstractTestCase
             'formatVariable',
             $args,
         );
-        self::assertEquals('3', $formattedValue);
+        self::assertSame('3', $formattedValue);
         self::assertFalse($isHtmlFormatted);
 
         //value is not a number
@@ -168,7 +168,7 @@ class VariablesControllerTest extends AbstractTestCase
             'formatVariable',
             $args,
         );
-        self::assertEquals('value', $formattedValue);
+        self::assertSame('value', $formattedValue);
         self::assertFalse($isHtmlFormatted);
     }
 
@@ -203,7 +203,7 @@ class VariablesControllerTest extends AbstractTestCase
             $args,
         );
 
-        self::assertEquals('<abbr title="3">3 B</abbr>', $formattedValue);
+        self::assertSame('<abbr title="3">3 B</abbr>', $formattedValue);
         self::assertTrue($isHtmlFormatted);
 
         //name is_numeric and the value type is not byte
@@ -214,7 +214,7 @@ class VariablesControllerTest extends AbstractTestCase
             'formatVariable',
             $args,
         );
-        self::assertEquals('3', $formattedValue);
+        self::assertSame('3', $formattedValue);
         self::assertFalse($isHtmlFormatted);
 
         //value is not a number
@@ -225,7 +225,7 @@ class VariablesControllerTest extends AbstractTestCase
             'formatVariable',
             $args,
         );
-        self::assertEquals('value', $formattedValue);
+        self::assertSame('value', $formattedValue);
         self::assertFalse($isHtmlFormatted);
     }
 
@@ -255,7 +255,7 @@ class VariablesControllerTest extends AbstractTestCase
             $args,
         );
 
-        self::assertEquals('3', $formattedValue);
+        self::assertSame('3', $formattedValue);
         self::assertFalse($isHtmlFormatted);
     }
 }

--- a/tests/classes/Controllers/Table/ChangeControllerTest.php
+++ b/tests/classes/Controllers/Table/ChangeControllerTest.php
@@ -203,7 +203,7 @@ final class ChangeControllerTest extends AbstractTestCase
 
         $result = $changeController->urlParamsInEditMode([1], $whereClauseArray);
 
-        self::assertEquals(
+        self::assertSame(
             ['0' => 1, 'where_clause' => 'bar=2', 'sql_query' => 'SELECT 1'],
             $result,
         );

--- a/tests/classes/Controllers/Table/FindReplaceControllerTest.php
+++ b/tests/classes/Controllers/Table/FindReplaceControllerTest.php
@@ -82,7 +82,7 @@ class FindReplaceControllerTest extends AbstractTestCase
         $result = 'UPDATE `table` SET `Field1` = '
             . "REPLACE(`Field1`, 'Field', 'Column') "
             . "WHERE `Field1` LIKE '%Field%' COLLATE UTF-8_bin";
-        self::assertEquals($result, $sqlQuery);
+        self::assertSame($result, $sqlQuery);
     }
 
     public function testReplaceWithRegex(): void
@@ -108,6 +108,6 @@ class FindReplaceControllerTest extends AbstractTestCase
         $result = 'UPDATE `table` SET `Field1` = `Field1`'
             . " WHERE `Field1` RLIKE 'Field' COLLATE UTF-8_bin";
 
-        self::assertEquals($result, $sqlQuery);
+        self::assertSame($result, $sqlQuery);
     }
 }

--- a/tests/classes/Controllers/Table/RelationControllerTest.php
+++ b/tests/classes/Controllers/Table/RelationControllerTest.php
@@ -80,7 +80,7 @@ class RelationControllerTest extends AbstractTestCase
 
         $ctrl->getDropdownValueForTable();
         $json = $this->response->getJSONResult();
-        self::assertEquals($viewColumns, $json['columns']);
+        self::assertSame($viewColumns, $json['columns']);
     }
 
     /**
@@ -113,7 +113,7 @@ class RelationControllerTest extends AbstractTestCase
 
         $ctrl->getDropdownValueForTable();
         $json = $this->response->getJSONResult();
-        self::assertEquals($indexedColumns, $json['columns']);
+        self::assertSame($indexedColumns, $json['columns']);
     }
 
     /**
@@ -145,7 +145,7 @@ class RelationControllerTest extends AbstractTestCase
         $_POST['foreign'] = 'true';
         $ctrl->getDropdownValueForDatabase('INNODB');
         $json = $this->response->getJSONResult();
-        self::assertEquals(
+        self::assertSame(
             ['table'],
             $json['tables'],
         );
@@ -178,7 +178,7 @@ class RelationControllerTest extends AbstractTestCase
         $_POST['foreign'] = 'false';
         $ctrl->getDropdownValueForDatabase('INNODB');
         $json = $this->response->getJSONResult();
-        self::assertEquals(
+        self::assertSame(
             ['table'],
             $json['tables'],
         );

--- a/tests/classes/Controllers/Table/ReplaceControllerTest.php
+++ b/tests/classes/Controllers/Table/ReplaceControllerTest.php
@@ -178,7 +178,7 @@ class ReplaceControllerTest extends AbstractTestCase
             [$request1],
         );
 
-        self::assertEquals(
+        self::assertSame(
             [['LIMIT 1'], true, true],
             $result,
         );
@@ -197,7 +197,7 @@ class ReplaceControllerTest extends AbstractTestCase
             [$request2],
         );
 
-        self::assertEquals(
+        self::assertSame(
             [['a', 'c'], false, true],
             $result,
         );

--- a/tests/classes/Controllers/Table/SearchControllerTest.php
+++ b/tests/classes/Controllers/Table/SearchControllerTest.php
@@ -104,7 +104,7 @@ class SearchControllerTest extends AbstractTestCase
         );
 
         $result = $ctrl->getColumnMinMax('column');
-        self::assertEquals([$expected], $result);
+        self::assertSame([$expected], $result);
     }
 
     /**

--- a/tests/classes/Controllers/Triggers/IndexControllerTest.php
+++ b/tests/classes/Controllers/Triggers/IndexControllerTest.php
@@ -285,7 +285,7 @@ HTML;
             ->willReturn('foo');
 
         $output = $method->invoke($indexController, $request);
-        self::assertEquals($out, $output);
+        self::assertSame($out, $output);
     }
 
     /**

--- a/tests/classes/CoreTest.php
+++ b/tests/classes/CoreTest.php
@@ -56,72 +56,72 @@ class CoreTest extends AbstractTestCase
             'sarr' => ['arr1' => [1, 2, 3], [3, ['a', 'b', 'c'], 4]],
         ];
 
-        self::assertEquals(
+        self::assertSame(
             Core::arrayRead('int', $arr),
             $arr['int'],
         );
 
-        self::assertEquals(
+        self::assertSame(
             Core::arrayRead('str', $arr),
             $arr['str'],
         );
 
-        self::assertEquals(
+        self::assertSame(
             Core::arrayRead('arr/0', $arr),
             $arr['arr'][0],
         );
 
-        self::assertEquals(
+        self::assertSame(
             Core::arrayRead('arr/1', $arr),
             $arr['arr'][1],
         );
 
-        self::assertEquals(
+        self::assertSame(
             Core::arrayRead('arr/2', $arr),
             $arr['arr'][2],
         );
 
-        self::assertEquals(
+        self::assertSame(
             Core::arrayRead('sarr/arr1/0', $arr),
             $arr['sarr']['arr1'][0],
         );
 
-        self::assertEquals(
+        self::assertSame(
             Core::arrayRead('sarr/arr1/1', $arr),
             $arr['sarr']['arr1'][1],
         );
 
-        self::assertEquals(
+        self::assertSame(
             Core::arrayRead('sarr/arr1/2', $arr),
             $arr['sarr']['arr1'][2],
         );
 
-        self::assertEquals(
+        self::assertSame(
             Core::arrayRead('sarr/0/0', $arr),
             $arr['sarr'][0][0],
         );
 
-        self::assertEquals(
+        self::assertSame(
             Core::arrayRead('sarr/0/1', $arr),
             $arr['sarr'][0][1],
         );
 
-        self::assertEquals(
+        self::assertSame(
             Core::arrayRead('sarr/0/1/2', $arr),
             $arr['sarr'][0][1][2],
         );
 
-        self::assertEquals(
+        self::assertSame(
             Core::arrayRead('sarr/not_exiting/1', $arr),
             null,
         );
 
-        self::assertEquals(
+        self::assertSame(
             Core::arrayRead('sarr/not_exiting/1', $arr, 0),
             0,
         );
 
-        self::assertEquals(
+        self::assertSame(
             Core::arrayRead('sarr/not_exiting/1', $arr, 'default_val'),
             'default_val',
         );
@@ -140,37 +140,37 @@ class CoreTest extends AbstractTestCase
         ];
 
         Core::arrayWrite('int', $arr, 5);
-        self::assertEquals($arr['int'], 5);
+        self::assertSame($arr['int'], 5);
 
         Core::arrayWrite('str', $arr, '_str');
-        self::assertEquals($arr['str'], '_str');
+        self::assertSame($arr['str'], '_str');
 
         Core::arrayWrite('arr/0', $arr, 'val_arr_0');
-        self::assertEquals($arr['arr'][0], 'val_arr_0');
+        self::assertSame($arr['arr'][0], 'val_arr_0');
 
         Core::arrayWrite('arr/1', $arr, 'val_arr_1');
-        self::assertEquals($arr['arr'][1], 'val_arr_1');
+        self::assertSame($arr['arr'][1], 'val_arr_1');
 
         Core::arrayWrite('arr/2', $arr, 'val_arr_2');
-        self::assertEquals($arr['arr'][2], 'val_arr_2');
+        self::assertSame($arr['arr'][2], 'val_arr_2');
 
         Core::arrayWrite('sarr/arr1/0', $arr, 'val_sarr_arr_0');
-        self::assertEquals($arr['sarr']['arr1'][0], 'val_sarr_arr_0');
+        self::assertSame($arr['sarr']['arr1'][0], 'val_sarr_arr_0');
 
         Core::arrayWrite('sarr/arr1/1', $arr, 'val_sarr_arr_1');
-        self::assertEquals($arr['sarr']['arr1'][1], 'val_sarr_arr_1');
+        self::assertSame($arr['sarr']['arr1'][1], 'val_sarr_arr_1');
 
         Core::arrayWrite('sarr/arr1/2', $arr, 'val_sarr_arr_2');
-        self::assertEquals($arr['sarr']['arr1'][2], 'val_sarr_arr_2');
+        self::assertSame($arr['sarr']['arr1'][2], 'val_sarr_arr_2');
 
         Core::arrayWrite('sarr/0/0', $arr, 5);
-        self::assertEquals($arr['sarr'][0][0], 5);
+        self::assertSame($arr['sarr'][0][0], 5);
 
         Core::arrayWrite('sarr/0/1/0', $arr, 'e');
-        self::assertEquals($arr['sarr'][0][1][0], 'e');
+        self::assertSame($arr['sarr'][0][1][0], 'e');
 
         Core::arrayWrite('sarr/not_existing/1', $arr, 'some_val');
-        self::assertEquals($arr['sarr']['not_existing'][1], 'some_val');
+        self::assertSame($arr['sarr']['not_existing'][1], 'some_val');
 
         Core::arrayWrite('sarr/0/2', $arr, null);
         self::assertNull($arr['sarr'][0][2]);
@@ -205,7 +205,7 @@ class CoreTest extends AbstractTestCase
 
         $tmpArr = $arr;
         Core::arrayRemove('sarr/not_existing/1', $arr);
-        self::assertEquals($tmpArr, $arr);
+        self::assertSame($tmpArr, $arr);
 
         Core::arrayRemove('sarr/arr1/0', $arr);
         self::assertArrayNotHasKey(0, $arr['sarr']['arr1']);
@@ -272,7 +272,7 @@ class CoreTest extends AbstractTestCase
     #[Group('32bit-incompatible')]
     public function testGetRealSize(string $size, int $expected): void
     {
-        self::assertEquals($expected, Core::getRealSize($size));
+        self::assertSame($expected, Core::getRealSize($size));
     }
 
     /**
@@ -304,7 +304,7 @@ class CoreTest extends AbstractTestCase
     public function testGetPHPDocLink(): void
     {
         $lang = _pgettext('PHP documentation language', 'en');
-        self::assertEquals(
+        self::assertSame(
             Core::getPHPDocLink('function'),
             'index.php?route=/url&url=https%3A%2F%2Fwww.php.net%2Fmanual%2F'
             . $lang . '%2Ffunction',
@@ -320,7 +320,7 @@ class CoreTest extends AbstractTestCase
     #[DataProvider('providerTestLinkURL')]
     public function testLinkURL(string $link, string $url): void
     {
-        self::assertEquals(Core::linkURL($link), $url);
+        self::assertSame(Core::linkURL($link), $url);
     }
 
     /**
@@ -342,7 +342,7 @@ class CoreTest extends AbstractTestCase
     public function testIsAllowedDomain(string $url, bool $expected): void
     {
         $_SERVER['SERVER_NAME'] = 'server.local';
-        self::assertEquals(
+        self::assertSame(
             $expected,
             Core::isAllowedDomain($url),
         );
@@ -391,7 +391,7 @@ class CoreTest extends AbstractTestCase
     #[DataProvider('provideTestSafeUnserialize')]
     public function testSafeUnserialize(string $data, mixed $expected): void
     {
-        self::assertEquals(
+        self::assertSame(
             $expected,
             Core::safeUnserialize($data),
         );
@@ -431,7 +431,7 @@ class CoreTest extends AbstractTestCase
     #[DataProvider('provideTestSanitizeMySQLHost')]
     public function testSanitizeMySQLHost(string $host, string $expected): void
     {
-        self::assertEquals(
+        self::assertSame(
             $expected,
             Core::sanitizeMySQLHost($host),
         );
@@ -457,15 +457,15 @@ class CoreTest extends AbstractTestCase
      */
     public function testReplaceDots(): void
     {
-        self::assertEquals(
+        self::assertSame(
             Core::securePath('../../../etc/passwd'),
             './././etc/passwd',
         );
-        self::assertEquals(
+        self::assertSame(
             Core::securePath('/var/www/../phpmyadmin'),
             '/var/www/./phpmyadmin',
         );
-        self::assertEquals(
+        self::assertSame(
             Core::securePath('./path/with..dots/../../file..php'),
             './path/with.dots/././file.php',
         );
@@ -622,8 +622,8 @@ class CoreTest extends AbstractTestCase
 
         $expected = ['pos' => '0', 'db' => 'test_db', 'table' => 'test_table'];
 
-        self::assertEquals($expected, $_GET);
-        self::assertEquals($expected, $_REQUEST);
+        self::assertSame($expected, $_GET);
+        self::assertSame($expected, $_REQUEST);
     }
 
     /**
@@ -651,8 +651,8 @@ class CoreTest extends AbstractTestCase
 
         Core::populateRequestWithEncryptedQueryParams($request);
 
-        self::assertEquals($decrypted, $_GET);
-        self::assertEquals($decrypted, $_REQUEST);
+        self::assertSame($decrypted, $_GET);
+        self::assertSame($decrypted, $_REQUEST);
     }
 
     /** @return array<int, array<int, array<string, string|mixed[]>>> */

--- a/tests/classes/CreateAddFieldTest.php
+++ b/tests/classes/CreateAddFieldTest.php
@@ -38,7 +38,7 @@ class CreateAddFieldTest extends AbstractTestCase
     {
         $_POST = $request;
         $actual = $this->createAddField->getPartitionsDefinition();
-        self::assertEquals($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -231,7 +231,7 @@ class CreateAddFieldTest extends AbstractTestCase
     {
         $_POST = $request;
         $actual = $this->createAddField->getTableCreationQuery($db, $table);
-        self::assertEquals($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -463,6 +463,6 @@ class CreateAddFieldTest extends AbstractTestCase
     {
         $_POST = $request;
         $sqlQuery = $this->createAddField->getColumnCreationQuery('my_table');
-        self::assertEquals($expected, $sqlQuery);
+        self::assertSame($expected, $sqlQuery);
     }
 }

--- a/tests/classes/Crypto/CryptoTest.php
+++ b/tests/classes/Crypto/CryptoTest.php
@@ -49,7 +49,7 @@ class CryptoTest extends AbstractTestCase
         self::assertNotSame('test', $encrypted);
         self::assertSame('test', $crypto->decrypt($encrypted));
         self::assertArrayHasKey('URLQueryEncryptionSecretKey', $_SESSION);
-        self::assertEquals(32, mb_strlen($_SESSION['URLQueryEncryptionSecretKey'], '8bit'));
+        self::assertSame(32, mb_strlen($_SESSION['URLQueryEncryptionSecretKey'], '8bit'));
     }
 
     public function testDecryptWithInvalidKey(): void

--- a/tests/classes/Database/CentralColumnsTest.php
+++ b/tests/classes/Database/CentralColumnsTest.php
@@ -182,11 +182,11 @@ class CentralColumnsTest extends AbstractTestCase
                 array_slice($this->columnData, 1, 2),
             );
 
-        self::assertEquals(
+        self::assertSame(
             $this->modifiedColumnData,
             $this->centralColumns->getColumnsList('phpmyadmin'),
         );
-        self::assertEquals(
+        self::assertSame(
             array_slice($this->modifiedColumnData, 1, 2),
             $this->centralColumns->getColumnsList('phpmyadmin', 1, 2),
         );
@@ -207,7 +207,7 @@ class CentralColumnsTest extends AbstractTestCase
             )
             ->willReturn([3]);
 
-        self::assertEquals(
+        self::assertSame(
             3,
             $this->centralColumns->getCount('phpmyadmin'),
         );
@@ -265,7 +265,7 @@ class CentralColumnsTest extends AbstractTestCase
                 ConnectionType::ControlUser,
             )
             ->willReturn(['id', 'col1']);
-        self::assertEquals(
+        self::assertSame(
             ['id', 'col1'],
             $this->centralColumns->getFromTable(
                 $db,
@@ -292,7 +292,7 @@ class CentralColumnsTest extends AbstractTestCase
                 ConnectionType::ControlUser,
             )
             ->willReturn(array_slice($this->columnData, 0, 2));
-        self::assertEquals(
+        self::assertSame(
             array_slice($this->modifiedColumnData, 0, 2),
             $this->centralColumns->getFromTable(
                 $db,
@@ -407,7 +407,7 @@ class CentralColumnsTest extends AbstractTestCase
                 ConnectionType::ControlUser,
             )
             ->willReturn($this->columnData);
-        self::assertEquals(
+        self::assertSame(
             $this->modifiedColumnData,
             $this->centralColumns->getListRaw(
                 'phpmyadmin',
@@ -432,7 +432,7 @@ class CentralColumnsTest extends AbstractTestCase
                 ConnectionType::ControlUser,
             )
             ->willReturn($this->columnData);
-        self::assertEquals(
+        self::assertSame(
             $this->modifiedColumnData,
             $this->centralColumns->getListRaw(
                 'phpmyadmin',
@@ -455,7 +455,7 @@ class CentralColumnsTest extends AbstractTestCase
                 ConnectionType::ControlUser,
             )
             ->willReturn(array_slice($this->columnData, 1, 1));
-        self::assertEquals(
+        self::assertSame(
             array_slice($this->modifiedColumnData, 1, 1),
             $this->callFunction(
                 $this->centralColumns,
@@ -470,6 +470,6 @@ class CentralColumnsTest extends AbstractTestCase
     {
         $columns = $this->centralColumns->getColumnsNotInCentralList('PMA_db', 'PMA_table');
         self::assertIsArray($columns);
-        self::assertEquals(['id', 'col1', 'col2'], $columns);
+        self::assertSame(['id', 'col1', 'col2'], $columns);
     }
 }

--- a/tests/classes/Database/Designer/CommonTest.php
+++ b/tests/classes/Database/Designer/CommonTest.php
@@ -108,7 +108,7 @@ class CommonTest extends AbstractTestCase
 
         $result = $this->designerCommon->getPageName($pg);
 
-        self::assertEquals($pageName, $result);
+        self::assertSame($pageName, $result);
     }
 
     /**
@@ -196,7 +196,7 @@ class CommonTest extends AbstractTestCase
         $this->designerCommon = new Common(DatabaseInterface::getInstance(), new Relation($dbi));
 
         $result = $this->designerCommon->getDefaultPage($db);
-        self::assertEquals(-1, $result);
+        self::assertSame(-1, $result);
     }
 
     /**

--- a/tests/classes/Database/DesignerTest.php
+++ b/tests/classes/Database/DesignerTest.php
@@ -95,7 +95,7 @@ class DesignerTest extends AbstractTestCase
         $method = new ReflectionMethod(Designer::class, 'getPageIdsAndNames');
         $result = $method->invokeArgs($this->designer, [$db]);
 
-        self::assertEquals(
+        self::assertSame(
             ['1' => 'page1', '2' => 'page2'],
             $result,
         );

--- a/tests/classes/Database/EventsTest.php
+++ b/tests/classes/Database/EventsTest.php
@@ -154,7 +154,7 @@ class EventsTest extends AbstractTestCase
             ->getMock();
         DatabaseInterface::$instance = $dbi;
 
-        self::assertEquals($query, $this->events->getQueryFromRequest());
+        self::assertSame($query, $this->events->getQueryFromRequest());
         self::assertCount($numErr, $GLOBALS['errors']);
     }
 

--- a/tests/classes/Database/RoutinesTest.php
+++ b/tests/classes/Database/RoutinesTest.php
@@ -256,7 +256,7 @@ class RoutinesTest extends AbstractTestCase
 
         unset($_POST);
         $_POST = $request;
-        self::assertEquals($query, $routines->getQueryFromRequest());
+        self::assertSame($query, $routines->getQueryFromRequest());
         self::assertCount($numErr, $GLOBALS['errors']);
 
         // reset

--- a/tests/classes/Database/SearchTest.php
+++ b/tests/classes/Database/SearchTest.php
@@ -74,7 +74,7 @@ class SearchTest extends AbstractTestCase
         $_POST['criteriaSearchString'] = 'search string';
 
         $this->object = new Search(DatabaseInterface::getInstance(), 'pma_test', new Template());
-        self::assertEquals(
+        self::assertSame(
             $expected,
             $this->callFunction(
                 $this->object,
@@ -130,7 +130,7 @@ class SearchTest extends AbstractTestCase
      */
     public function testGetSearchSqls(): void
     {
-        self::assertEquals(
+        self::assertSame(
             [
                 'select_columns' => 'SELECT * FROM `pma`.`table1` WHERE FALSE',
                 'select_count' => 'SELECT COUNT(*) AS `count` FROM `pma`.`table1` WHERE FALSE',

--- a/tests/classes/DatabaseInterfaceTest.php
+++ b/tests/classes/DatabaseInterfaceTest.php
@@ -75,9 +75,9 @@ class DatabaseInterfaceTest extends AbstractTestCase
             $dummyDbi->addResult('SELECT CURRENT_USER();', $value);
         }
 
-        self::assertEquals($expected, $dbi->getCurrentUserAndHost());
+        self::assertSame($expected, $dbi->getCurrentUserAndHost());
 
-        self::assertEquals($string, $dbi->getCurrentUser());
+        self::assertSame($string, $dbi->getCurrentUser());
 
         $dummyDbi->assertAllQueriesConsumed();
     }
@@ -187,9 +187,9 @@ class DatabaseInterfaceTest extends AbstractTestCase
 
         $mock->postConnect(new Server(['SessionTimeZone' => '']));
 
-        self::assertEquals($mock->getVersion(), $versionInt);
-        self::assertEquals($mock->isMariaDB(), $isMariaDb);
-        self::assertEquals($mock->isPercona(), $isPercona);
+        self::assertSame($mock->getVersion(), $versionInt);
+        self::assertSame($mock->isMariaDB(), $isMariaDb);
+        self::assertSame($mock->isPercona(), $isPercona);
     }
 
     /**
@@ -204,7 +204,7 @@ class DatabaseInterfaceTest extends AbstractTestCase
         $config->selectedServer['DisableIS'] = false;
         $config->settings['DBG']['sql'] = false;
 
-        self::assertEquals(
+        self::assertSame(
             'utf8_general_ci',
             $dbi->getDbCollation('pma_test'),
         );
@@ -217,7 +217,7 @@ class DatabaseInterfaceTest extends AbstractTestCase
         $dbiDummy->removeDefaultResults();
         $dbiDummy->addResult('SELECT @@collation_database', [['utf8mb3_general_ci']], ['@@collation_database']);
 
-        self::assertEquals('utf8mb3_general_ci', $dbi->getDbCollation('information_schema'));
+        self::assertSame('utf8mb3_general_ci', $dbi->getDbCollation('information_schema'));
     }
 
     /**
@@ -227,7 +227,7 @@ class DatabaseInterfaceTest extends AbstractTestCase
     {
         $dbi = $this->createDatabaseInterface();
         Config::getInstance()->settings['DBG']['sql'] = true;
-        self::assertEquals('utf8_general_ci', $dbi->getServerCollation());
+        self::assertSame('utf8_general_ci', $dbi->getServerCollation());
     }
 
     /**
@@ -276,7 +276,7 @@ class DatabaseInterfaceTest extends AbstractTestCase
 
         $dummyDbi->addResult('SELECT @@basedir', $value);
 
-        self::assertEquals(
+        self::assertSame(
             $expected,
             $dbi->isAmazonRds(),
         );
@@ -311,10 +311,10 @@ class DatabaseInterfaceTest extends AbstractTestCase
     public function testVersion(string $version, int $expected, int $major, bool $upgrade): void
     {
         $verInt = Utilities::versionToInt($version);
-        self::assertEquals($expected, $verInt);
-        self::assertEquals($major, (int) ($verInt / 10000));
+        self::assertSame($expected, $verInt);
+        self::assertSame($major, (int) ($verInt / 10000));
         $mysqlMinVersion = 50500;
-        self::assertEquals($upgrade, $verInt < $mysqlMinVersion);
+        self::assertSame($upgrade, $verInt < $mysqlMinVersion);
     }
 
     /** @return mixed[][] */
@@ -404,7 +404,7 @@ class DatabaseInterfaceTest extends AbstractTestCase
         ];
 
         $actual = $dbi->getTablesFull('test_db');
-        self::assertEquals($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     public function testGetTablesFullWithInformationSchema(): void
@@ -462,7 +462,7 @@ class DatabaseInterfaceTest extends AbstractTestCase
         ];
 
         $actual = $dbi->getTablesFull('test_db');
-        self::assertEquals($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     public function testGetTablesFullBug18913(): void
@@ -731,10 +731,10 @@ class DatabaseInterfaceTest extends AbstractTestCase
 
         $dbi->setVersion($version);
 
-        self::assertEquals($versionInt, $dbi->getVersion());
-        self::assertEquals($isMariaDb, $dbi->isMariaDB());
-        self::assertEquals($isPercona, $dbi->isPercona());
-        self::assertEquals($version['@@version'], $dbi->getVersionString());
+        self::assertSame($versionInt, $dbi->getVersion());
+        self::assertSame($isMariaDb, $dbi->isMariaDB());
+        self::assertSame($isPercona, $dbi->isPercona());
+        self::assertSame($version['@@version'], $dbi->getVersionString());
     }
 
     /**

--- a/tests/classes/Dbal/DbiDummyTest.php
+++ b/tests/classes/Dbal/DbiDummyTest.php
@@ -73,7 +73,7 @@ class DbiDummyTest extends AbstractTestCase
     #[DataProvider('schemaData')]
     public function testSystemSchema(string $schema, bool $expected): void
     {
-        self::assertEquals($expected, Utilities::isSystemSchema($schema));
+        self::assertSame($expected, Utilities::isSystemSchema($schema));
     }
 
     /** @return array<array{string, bool}> */
@@ -92,7 +92,7 @@ class DbiDummyTest extends AbstractTestCase
     #[DataProvider('errorData')]
     public function testFormatError(int $number, string $message, string $expected): void
     {
-        self::assertEquals(
+        self::assertSame(
             $expected,
             Utilities::formatError($number, $message),
         );

--- a/tests/classes/Dbal/DbiMysqliTest.php
+++ b/tests/classes/Dbal/DbiMysqliTest.php
@@ -118,7 +118,7 @@ class DbiMysqliTest extends AbstractTestCase
             ->method('real_escape_string')
             ->willReturn($string);
 
-        self::assertEquals($string, $this->object->escapeString(new Connection($mysqli), $string));
+        self::assertSame($string, $this->object->escapeString(new Connection($mysqli), $string));
     }
 
     public function testGetWarningCount(): void

--- a/tests/classes/Display/ResultsTest.php
+++ b/tests/classes/Display/ResultsTest.php
@@ -112,7 +112,7 @@ class ResultsTest extends AbstractTestCase
 
     public function testGetClassForDateTimeRelatedFieldsCase1(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'datetimefield',
             $this->callFunction(
                 $this->object,
@@ -125,7 +125,7 @@ class ResultsTest extends AbstractTestCase
 
     public function testGetClassForDateTimeRelatedFieldsCase2(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'datefield',
             $this->callFunction(
                 $this->object,
@@ -138,7 +138,7 @@ class ResultsTest extends AbstractTestCase
 
     public function testGetClassForDateTimeRelatedFieldsCase3(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'text',
             $this->callFunction(
                 $this->object,
@@ -155,7 +155,7 @@ class ResultsTest extends AbstractTestCase
     public function testGetOffsetsCase1(): void
     {
         $_SESSION['tmpval']['max_rows'] = DisplayResults::ALL_ROWS;
-        self::assertEquals(
+        self::assertSame(
             [0, 0],
             $this->callFunction(
                 $this->object,
@@ -173,7 +173,7 @@ class ResultsTest extends AbstractTestCase
     {
         $_SESSION['tmpval']['max_rows'] = 5;
         $_SESSION['tmpval']['pos'] = 4;
-        self::assertEquals(
+        self::assertSame(
             [9, 0],
             $this->callFunction(
                 $this->object,
@@ -256,7 +256,7 @@ class ResultsTest extends AbstractTestCase
             ],
         ];
 
-        self::assertEquals(
+        self::assertSame(
             $output,
             $this->callFunction(
                 $this->object,
@@ -328,7 +328,7 @@ class ResultsTest extends AbstractTestCase
             [Query::getAll($query)],
         );
 
-        self::assertEquals([
+        self::assertSame([
             'db_name' => true,
             'tbl' => true,
             'id' => true,
@@ -363,7 +363,7 @@ class ResultsTest extends AbstractTestCase
     {
         $_SESSION['tmpval']['pftext'] = $pftext;
         Config::getInstance()->settings['LimitChars'] = $limitChars;
-        self::assertEquals(
+        self::assertSame(
             $output,
             $this->callFunction(
                 $this->object,
@@ -1431,7 +1431,7 @@ class ResultsTest extends AbstractTestCase
             'text_dir' => 'ltr',
         ]);
 
-        self::assertEquals($tableTemplate, $actual);
+        self::assertSame($tableTemplate, $actual);
     }
 
     public function testGetTable2(): void
@@ -1667,7 +1667,7 @@ class ResultsTest extends AbstractTestCase
             'text_dir' => 'ltr',
         ]);
 
-        self::assertEquals($tableTemplate, $actual);
+        self::assertSame($tableTemplate, $actual);
     }
 
     /** @return array<string, array{string, string, int}> */

--- a/tests/classes/EncodingTest.php
+++ b/tests/classes/EncodingTest.php
@@ -45,7 +45,7 @@ class EncodingTest extends AbstractTestCase
     #[Group('medium')]
     public function testNoConversion(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'test',
             Encoding::convertString('UTF-8', 'UTF-8', 'test'),
         );
@@ -55,7 +55,7 @@ class EncodingTest extends AbstractTestCase
     {
         // Invalid value to use default case
         Encoding::setEngine(-1);
-        self::assertEquals(
+        self::assertSame(
             'test',
             Encoding::convertString('UTF-8', 'anything', 'test'),
         );
@@ -83,7 +83,7 @@ class EncodingTest extends AbstractTestCase
         if (PHP_INT_SIZE === 8) {
             $config->settings['IconvExtraParams'] = '//TRANSLIT';
             Encoding::setEngine(Encoding::ENGINE_ICONV);
-            self::assertEquals(
+            self::assertSame(
                 "This is the Euro symbol 'EUR'.",
                 Encoding::convertString(
                     'UTF-8',
@@ -96,7 +96,7 @@ class EncodingTest extends AbstractTestCase
             // NOTE: or it will throw "iconv(): Detected an illegal character in input string"
             $config->settings['IconvExtraParams'] = '//TRANSLIT//IGNORE';
             Encoding::setEngine(Encoding::ENGINE_ICONV);
-            self::assertEquals(
+            self::assertSame(
                 "This is the Euro symbol ''.",
                 Encoding::convertString(
                     'UTF-8',
@@ -110,7 +110,7 @@ class EncodingTest extends AbstractTestCase
     public function testMbstring(): void
     {
         Encoding::setEngine(Encoding::ENGINE_MB);
-        self::assertEquals(
+        self::assertSame(
             "This is the Euro symbol '?'.",
             Encoding::convertString(
                 'UTF-8',
@@ -125,11 +125,11 @@ class EncodingTest extends AbstractTestCase
      */
     public function testChangeOrder(): void
     {
-        self::assertEquals('ASCII,SJIS,EUC-JP,JIS', Encoding::getKanjiEncodings());
+        self::assertSame('ASCII,SJIS,EUC-JP,JIS', Encoding::getKanjiEncodings());
         Encoding::kanjiChangeOrder();
-        self::assertEquals('ASCII,EUC-JP,SJIS,JIS', Encoding::getKanjiEncodings());
+        self::assertSame('ASCII,EUC-JP,SJIS,JIS', Encoding::getKanjiEncodings());
         Encoding::kanjiChangeOrder();
-        self::assertEquals('ASCII,SJIS,EUC-JP,JIS', Encoding::getKanjiEncodings());
+        self::assertSame('ASCII,SJIS,EUC-JP,JIS', Encoding::getKanjiEncodings());
     }
 
     /**
@@ -137,24 +137,24 @@ class EncodingTest extends AbstractTestCase
      */
     public function testKanjiStrConv(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'test',
             Encoding::kanjiStrConv('test', '', ''),
         );
 
         $GLOBALS['kanji_encoding_list'] = 'ASCII,SJIS,EUC-JP,JIS';
 
-        self::assertEquals(
+        self::assertSame(
             'test è',
             Encoding::kanjiStrConv('test è', '', ''),
         );
 
-        self::assertEquals(
+        self::assertSame(
             mb_convert_encoding('test è', 'ASCII', 'SJIS'),
             Encoding::kanjiStrConv('test è', 'ASCII', ''),
         );
 
-        self::assertEquals(
+        self::assertSame(
             mb_convert_kana('全角', 'KV', 'SJIS'),
             Encoding::kanjiStrConv('全角', '', 'kana'),
         );
@@ -176,7 +176,7 @@ class EncodingTest extends AbstractTestCase
         Encoding::kanjiChangeOrder();
         $expected = Encoding::kanjiStrConv($fileStr, 'JIS', 'kana');
         Encoding::kanjiChangeOrder();
-        self::assertEquals($string, $expected);
+        self::assertSame($string, $expected);
         unlink($result);
     }
 

--- a/tests/classes/Engines/BdbTest.php
+++ b/tests/classes/Engines/BdbTest.php
@@ -44,7 +44,7 @@ class BdbTest extends AbstractTestCase
      */
     public function testGetVariables(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getVariables(),
             [
                 'version_bdb' => ['title' => __('Version information')],
@@ -71,7 +71,7 @@ class BdbTest extends AbstractTestCase
      */
     public function testGetVariablesLikePattern(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getVariablesLikePattern(),
             '%bdb%',
         );
@@ -82,7 +82,7 @@ class BdbTest extends AbstractTestCase
      */
     public function testGetMysqlHelpPage(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getMysqlHelpPage(),
             'bdb',
         );

--- a/tests/classes/Engines/BinlogTest.php
+++ b/tests/classes/Engines/BinlogTest.php
@@ -42,7 +42,7 @@ class BinlogTest extends AbstractTestCase
      */
     public function testGetMysqlHelpPage(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getMysqlHelpPage(),
             'binary-log',
         );

--- a/tests/classes/Engines/InnodbTest.php
+++ b/tests/classes/Engines/InnodbTest.php
@@ -44,7 +44,7 @@ class InnodbTest extends AbstractTestCase
      */
     public function testGetVariables(): void
     {
-        self::assertEquals(
+        self::assertSame(
             [
                 'innodb_data_home_dir' => [
                     'title' => __('Data home directory'),
@@ -103,7 +103,7 @@ class InnodbTest extends AbstractTestCase
      */
     public function testGetVariablesLikePattern(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'innodb\\_%',
             $this->object->getVariablesLikePattern(),
         );
@@ -114,12 +114,12 @@ class InnodbTest extends AbstractTestCase
      */
     public function testGetInfoPages(): void
     {
-        self::assertEquals(
+        self::assertSame(
             [],
             $this->object->getInfoPages(),
         );
         $this->object->support = 2;
-        self::assertEquals(
+        self::assertSame(
             ['Bufferpool' => 'Buffer Pool', 'Status' => 'InnoDB Status'],
             $this->object->getInfoPages(),
         );
@@ -130,7 +130,7 @@ class InnodbTest extends AbstractTestCase
      */
     public function testGetPageBufferpool(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '<table class="table table-striped table-hover w-auto float-start caption-top">' . "\n" .
             '    <caption>' . "\n" .
             '        Buffer Pool Usage' . "\n" .
@@ -213,7 +213,7 @@ class InnodbTest extends AbstractTestCase
      */
     public function testGetPageStatus(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '<pre id="pre_innodb_status">' . "\n\n" . '</pre>' . "\n",
             $this->object->getPageStatus(),
         );
@@ -224,12 +224,12 @@ class InnodbTest extends AbstractTestCase
      */
     public function testGetPage(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '',
             $this->object->getPage('Status'),
         );
         $this->object->support = 2;
-        self::assertEquals(
+        self::assertSame(
             '<pre id="pre_innodb_status">' . "\n\n" . '</pre>' . "\n",
             $this->object->getPage('Status'),
         );
@@ -240,7 +240,7 @@ class InnodbTest extends AbstractTestCase
      */
     public function testGetMysqlHelpPage(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'innodb-storage-engine',
             $this->object->getMysqlHelpPage(),
         );
@@ -251,7 +251,7 @@ class InnodbTest extends AbstractTestCase
      */
     public function testGetInnodbPluginVersion(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '1.1.8',
             $this->object->getInnodbPluginVersion(),
         );
@@ -272,7 +272,7 @@ class InnodbTest extends AbstractTestCase
      */
     public function testGetInnodbFileFormat(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'Antelope',
             $this->object->getInnodbFileFormat(),
         );

--- a/tests/classes/Engines/MemoryTest.php
+++ b/tests/classes/Engines/MemoryTest.php
@@ -42,7 +42,7 @@ class MemoryTest extends AbstractTestCase
      */
     public function testGetVariables(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getVariables(),
             ['max_heap_table_size' => ['type' => 1]],
         );

--- a/tests/classes/Engines/MrgMyisamTest.php
+++ b/tests/classes/Engines/MrgMyisamTest.php
@@ -42,7 +42,7 @@ class MrgMyisamTest extends AbstractTestCase
      */
     public function testGetMysqlHelpPage(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getMysqlHelpPage(),
             'merge-storage-engine',
         );

--- a/tests/classes/Engines/MyisamTest.php
+++ b/tests/classes/Engines/MyisamTest.php
@@ -44,7 +44,7 @@ class MyisamTest extends AbstractTestCase
      */
     public function testGetVariables(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getVariables(),
             [
                 'myisam_data_pointer_size' => [

--- a/tests/classes/Engines/NdbclusterTest.php
+++ b/tests/classes/Engines/NdbclusterTest.php
@@ -42,7 +42,7 @@ class NdbclusterTest extends AbstractTestCase
      */
     public function testGetVariables(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getVariables(),
             ['ndb_connectstring' => []],
         );
@@ -53,7 +53,7 @@ class NdbclusterTest extends AbstractTestCase
      */
     public function testGetVariablesLikePattern(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getVariablesLikePattern(),
             'ndb\\_%',
         );
@@ -64,7 +64,7 @@ class NdbclusterTest extends AbstractTestCase
      */
     public function testGetMysqlHelpPage(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getMysqlHelpPage(),
             'ndbcluster',
         );

--- a/tests/classes/Engines/PbxtTest.php
+++ b/tests/classes/Engines/PbxtTest.php
@@ -47,7 +47,7 @@ class PbxtTest extends AbstractTestCase
      */
     public function testGetVariables(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getVariables(),
             [
                 'pbxt_index_cache_size' => [
@@ -168,7 +168,7 @@ class PbxtTest extends AbstractTestCase
     #[DataProvider('providerFortTestResolveTypeSize')]
     public function testResolveTypeSize(string $formattedSize, array $output): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->resolveTypeSize($formattedSize),
             $output,
         );
@@ -189,7 +189,7 @@ class PbxtTest extends AbstractTestCase
      */
     public function testGetInfoPages(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getInfoPages(),
             ['Documentation' => 'Documentation'],
         );
@@ -200,7 +200,7 @@ class PbxtTest extends AbstractTestCase
      */
     public function testGetPage(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getPage('Documentation'),
             '<p>'
             . sprintf(

--- a/tests/classes/Engines/PerformanceSchemaTest.php
+++ b/tests/classes/Engines/PerformanceSchemaTest.php
@@ -42,7 +42,7 @@ class PerformanceSchemaTest extends AbstractTestCase
      */
     public function testGetMysqlHelpPage(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getMysqlHelpPage(),
             'performance-schema',
         );

--- a/tests/classes/Error/ErrorHandlerTest.php
+++ b/tests/classes/Error/ErrorHandlerTest.php
@@ -18,7 +18,6 @@ use Throwable;
 
 use function array_keys;
 use function array_pop;
-use function count;
 
 use const E_ERROR;
 use const E_RECOVERABLE_ERROR;
@@ -126,7 +125,7 @@ class ErrorHandlerTest extends AbstractTestCase
     public function testCountErrors(): void
     {
         $this->object->addError('Compile Error', E_WARNING, 'error.txt', 15);
-        self::assertEquals(
+        self::assertSame(
             1,
             $this->object->countErrors(),
         );
@@ -140,15 +139,15 @@ class ErrorHandlerTest extends AbstractTestCase
     {
         $this->object->addError('Compile Error', E_WARNING, 'error.txt', 15);
         $this->object->addError('Compile Error', E_WARNING, 'error.txt', 16);
-        self::assertEquals(
+        self::assertSame(
             2,
             $this->object->countErrors(),
         );
-        self::assertEquals(
+        self::assertSame(
             [],
             $this->object->sliceErrors(2),
         );
-        self::assertEquals(
+        self::assertSame(
             2,
             $this->object->countErrors(),
         );
@@ -156,7 +155,7 @@ class ErrorHandlerTest extends AbstractTestCase
             1,
             $this->object->sliceErrors(1),
         );
-        self::assertEquals(
+        self::assertSame(
             1,
             $this->object->countErrors(),
         );
@@ -173,32 +172,32 @@ class ErrorHandlerTest extends AbstractTestCase
         }
 
         // 10 initial items
-        self::assertEquals(10, $this->object->countErrors());
-        self::assertEquals(10, count($this->object->getCurrentErrors()));
+        self::assertSame(10, $this->object->countErrors());
+        self::assertCount(10, $this->object->getCurrentErrors());
 
         // slice 9 elements, returns one 10 - 9
         $elements = $this->object->sliceErrors(9);
         $firstKey = array_keys($elements)[0];
 
         // Gives the last element
-        self::assertEquals(
+        self::assertSame(
             [$firstKey => $elements[$firstKey]],
             $elements,
         );
-        self::assertEquals(9, count($this->object->getCurrentErrors()));
-        self::assertEquals(9, $this->object->countErrors());
+        self::assertCount(9, $this->object->getCurrentErrors());
+        self::assertSame(9, $this->object->countErrors());
 
         // Slice as much as there is (9), does nothing
         $elements = $this->object->sliceErrors(9);
-        self::assertEquals([], $elements);
-        self::assertEquals(9, count($this->object->getCurrentErrors()));
-        self::assertEquals(9, $this->object->countErrors());
+        self::assertSame([], $elements);
+        self::assertCount(9, $this->object->getCurrentErrors());
+        self::assertSame(9, $this->object->countErrors());
 
         // Slice 0, removes everything
         $elements = $this->object->sliceErrors(0);
-        self::assertEquals(9, count($elements));
-        self::assertEquals(0, count($this->object->getCurrentErrors()));
-        self::assertEquals(0, $this->object->countErrors());
+        self::assertCount(9, $elements);
+        self::assertCount(0, $this->object->getCurrentErrors());
+        self::assertSame(0, $this->object->countErrors());
     }
 
     /**
@@ -207,12 +206,12 @@ class ErrorHandlerTest extends AbstractTestCase
     public function testCountUserErrors(): void
     {
         $this->object->addError('Compile Error', E_WARNING, 'error.txt', 15);
-        self::assertEquals(
+        self::assertSame(
             0,
             $this->object->countUserErrors(),
         );
         $this->object->addError('Compile Error', E_USER_WARNING, 'error.txt', 15);
-        self::assertEquals(
+        self::assertSame(
             1,
             $this->object->countUserErrors(),
         );
@@ -239,7 +238,7 @@ class ErrorHandlerTest extends AbstractTestCase
      */
     public function testCountDisplayErrorsForDisplayTrue(): void
     {
-        self::assertEquals(
+        self::assertSame(
             0,
             $this->object->countDisplayErrors(),
         );
@@ -250,7 +249,7 @@ class ErrorHandlerTest extends AbstractTestCase
      */
     public function testCountDisplayErrorsForDisplayFalse(): void
     {
-        self::assertEquals(
+        self::assertSame(
             0,
             $this->object->countDisplayErrors(),
         );

--- a/tests/classes/Error/ErrorReportTest.php
+++ b/tests/classes/Error/ErrorReportTest.php
@@ -63,15 +63,15 @@ class ErrorReportTest extends AbstractTestCase
     public function testGetData(): void
     {
         $actual = $this->errorReport->getData('unknown');
-        self::assertEquals([], $actual);
+        self::assertSame([], $actual);
 
         $actual = $this->errorReport->getData('php');
-        self::assertEquals([], $actual);
+        self::assertSame([], $actual);
 
         $_SESSION['prev_errors'] = [];
 
         $actual = $this->errorReport->getData('php');
-        self::assertEquals([], $actual);
+        self::assertSame([], $actual);
 
         $_SESSION['prev_errors'] = [new Error(0, 'error 0', 'file', 1), new Error(1, 'error 1', 'file', 2)];
 
@@ -108,7 +108,7 @@ class ErrorReportTest extends AbstractTestCase
         ];
 
         $actual = $this->errorReport->getData('php');
-        self::assertEquals($report, $actual);
+        self::assertSame($report, $actual);
     }
 
     public function testSend(): void
@@ -139,7 +139,7 @@ class ErrorReportTest extends AbstractTestCase
         );
         $this->errorReport->setSubmissionUrl($submissionUrl);
 
-        self::assertEquals($return, $this->errorReport->send($report));
+        self::assertSame($return, $this->errorReport->send($report));
     }
 
     public function testGetForm(): void
@@ -278,7 +278,7 @@ class ErrorReportTest extends AbstractTestCase
         $data['stack'][1]['context'][1] = '!function(e,t){"use strict";"object"='
                                         . '=typeof module&&"object"==typeof modul//...';
 
-        self::assertEquals($data, $actual['exception']);
+        self::assertSame($data, $actual['exception']);
     }
 
     /**

--- a/tests/classes/Error/ErrorTest.php
+++ b/tests/classes/Error/ErrorTest.php
@@ -48,7 +48,7 @@ class ErrorTest extends AbstractTestCase
         $bt = [['file' => 'bt1', 'line' => 2, 'function' => 'bar', 'args' => ['foo' => $this]]];
         $this->object->setBacktrace($bt);
         $bt[0]['args']['foo'] = '<Class:PhpMyAdmin\Tests\Error\ErrorTest>';
-        self::assertEquals($bt, $this->object->getBacktrace());
+        self::assertSame($bt, $this->object->getBacktrace());
     }
 
     /**
@@ -57,7 +57,7 @@ class ErrorTest extends AbstractTestCase
     public function testSetLine(): void
     {
         $this->object->setLine(15);
-        self::assertEquals(15, $this->object->getLine());
+        self::assertSame(15, $this->object->getLine());
     }
 
     /**
@@ -70,7 +70,7 @@ class ErrorTest extends AbstractTestCase
     public function testSetFile(string $file, string $expected): void
     {
         $this->object->setFile($file);
-        self::assertEquals($expected, $this->object->getFile());
+        self::assertSame($expected, $this->object->getFile());
     }
 
     /**
@@ -96,7 +96,7 @@ class ErrorTest extends AbstractTestCase
      */
     public function testGetHash(): void
     {
-        self::assertEquals(
+        self::assertSame(
             1,
             preg_match('/^([a-z0-9]*)$/', $this->object->getHash()),
         );
@@ -138,7 +138,7 @@ class ErrorTest extends AbstractTestCase
      */
     public function testGetHtmlTitle(): void
     {
-        self::assertEquals('Warning: Compile Error', $this->object->getHtmlTitle());
+        self::assertSame('Warning: Compile Error', $this->object->getHtmlTitle());
     }
 
     /**
@@ -146,7 +146,7 @@ class ErrorTest extends AbstractTestCase
      */
     public function testGetTitle(): void
     {
-        self::assertEquals('Warning: Compile Error', $this->object->getTitle());
+        self::assertSame('Warning: Compile Error', $this->object->getTitle());
     }
 
     /**

--- a/tests/classes/Export/ExportTest.php
+++ b/tests/classes/Export/ExportTest.php
@@ -57,7 +57,7 @@ class ExportTest extends AbstractTestCase
             ],
         ];
         $actual = $export->mergeAliases($aliases1, $aliases2);
-        self::assertEquals($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     public function testGetFinalFilenameAndMimetypeForFilename(): void

--- a/tests/classes/FileListingTest.php
+++ b/tests/classes/FileListingTest.php
@@ -100,7 +100,7 @@ class FileListingTest extends AbstractTestCase
         $config->settings['ZipDump'] = true;
         $config->settings['GZipDump'] = true;
         $config->settings['BZipDump'] = true;
-        self::assertEquals('gz|bz2|zip', $this->fileListing->supportedDecompressions());
+        self::assertSame('gz|bz2|zip', $this->fileListing->supportedDecompressions());
     }
 
     public function testSupportedDecompressionsPartial(): void
@@ -115,6 +115,6 @@ class FileListingTest extends AbstractTestCase
         }
 
         $extensionString .= '|zip';
-        self::assertEquals($extensionString, $this->fileListing->supportedDecompressions());
+        self::assertSame($extensionString, $this->fileListing->supportedDecompressions());
     }
 }

--- a/tests/classes/FileTest.php
+++ b/tests/classes/FileTest.php
@@ -36,7 +36,7 @@ class FileTest extends AbstractTestCase
     public function testMIME(string $file, string $mime): void
     {
         $arr = new File($file);
-        self::assertEquals($mime, $arr->getCompression());
+        self::assertSame($mime, $arr->getCompression());
     }
 
     /**
@@ -49,7 +49,7 @@ class FileTest extends AbstractTestCase
     {
         $data = '0x' . bin2hex((string) file_get_contents($file));
         $file = new File($file);
-        self::assertEquals($data, $file->getContent());
+        self::assertSame($data, $file->getContent());
     }
 
     /**
@@ -65,7 +65,7 @@ class FileTest extends AbstractTestCase
         $file = new File($file);
         $file->setDecompressContent(true);
         $file->open();
-        self::assertEquals("TEST FILE\n", $file->read(100));
+        self::assertSame("TEST FILE\n", $file->read(100));
         $file->close();
     }
 

--- a/tests/classes/FlashMessagesTest.php
+++ b/tests/classes/FlashMessagesTest.php
@@ -36,7 +36,7 @@ class FlashMessagesTest extends AbstractTestCase
         $flash->addMessage('error', 'Error');
         self::assertArrayHasKey('error', $_SESSION[self::STORAGE_KEY]);
         self::assertIsArray($_SESSION[self::STORAGE_KEY]['error']);
-        self::assertEquals(['Error'], $_SESSION[self::STORAGE_KEY]['error']);
+        self::assertSame(['Error'], $_SESSION[self::STORAGE_KEY]['error']);
     }
 
     public function testGetMessage(): void
@@ -46,7 +46,7 @@ class FlashMessagesTest extends AbstractTestCase
         $message = $flash->getMessage('error');
         self::assertNull($message);
         $message = $flash->getMessage('warning');
-        self::assertEquals(['Warning'], $message);
+        self::assertSame(['Warning'], $message);
     }
 
     public function testGetMessages(): void
@@ -55,7 +55,7 @@ class FlashMessagesTest extends AbstractTestCase
         $flash = new FlashMessages();
         $flash->addMessage('notice', 'Notice');
         $messages = $flash->getMessages();
-        self::assertEquals(
+        self::assertSame(
             ['error' => ['Error1', 'Error2'], 'warning' => ['Warning']],
             $messages,
         );

--- a/tests/classes/FontTest.php
+++ b/tests/classes/FontTest.php
@@ -28,115 +28,115 @@ class FontTest extends AbstractTestCase
     public function testGetStringWidth(): void
     {
         // empty string
-        self::assertEquals(
+        self::assertSame(
             0,
             $this->font->getStringWidth('', 'arial', 10),
         );
 
         // empty string
-        self::assertEquals(
+        self::assertSame(
             3,
             $this->font->getStringWidth(' ', 'arial', 10),
         );
 
         // string "a"
-        self::assertEquals(
+        self::assertSame(
             6,
             $this->font->getStringWidth('a', 'arial', 10),
         );
 
         // string "aa"
-        self::assertEquals(
+        self::assertSame(
             12,
             $this->font->getStringWidth('aa', 'arial', 10),
         );
 
         // string "i"
-        self::assertEquals(
+        self::assertSame(
             3,
             $this->font->getStringWidth('i', 'arial', 10),
         );
 
         // string "f"
-        self::assertEquals(
+        self::assertSame(
             3,
             $this->font->getStringWidth('f', 'arial', 10),
         );
 
         // string "t"
-        self::assertEquals(
+        self::assertSame(
             3,
             $this->font->getStringWidth('t', 'arial', 10),
         );
 
         // string "if"
-        self::assertEquals(
+        self::assertSame(
             5,
             $this->font->getStringWidth('if', 'arial', 10),
         );
 
         // string "it"
-        self::assertEquals(
+        self::assertSame(
             6,
             $this->font->getStringWidth('it', 'arial', 10),
         );
 
         // string "r"
-        self::assertEquals(
+        self::assertSame(
             4,
             $this->font->getStringWidth('r', 'arial', 10),
         );
 
         // string "1"
-        self::assertEquals(
+        self::assertSame(
             5,
             $this->font->getStringWidth('1', 'arial', 10),
         );
 
         // string "c"
-        self::assertEquals(
+        self::assertSame(
             5,
             $this->font->getStringWidth('c', 'arial', 10),
         );
 
         // string "F"
-        self::assertEquals(
+        self::assertSame(
             7,
             $this->font->getStringWidth('F', 'arial', 10),
         );
 
         // string "A"
-        self::assertEquals(
+        self::assertSame(
             7,
             $this->font->getStringWidth('A', 'arial', 10),
         );
 
         // string "w"
-        self::assertEquals(
+        self::assertSame(
             8,
             $this->font->getStringWidth('w', 'arial', 10),
         );
 
         // string "G"
-        self::assertEquals(
+        self::assertSame(
             8,
             $this->font->getStringWidth('G', 'arial', 10),
         );
 
         // string "m"
-        self::assertEquals(
+        self::assertSame(
             9,
             $this->font->getStringWidth('m', 'arial', 10),
         );
 
         // string "W"
-        self::assertEquals(
+        self::assertSame(
             10,
             $this->font->getStringWidth('W', 'arial', 10),
         );
 
         // string "$"
-        self::assertEquals(
+        self::assertSame(
             3,
             $this->font->getStringWidth('$', 'arial', 10),
         );
@@ -148,25 +148,25 @@ class FontTest extends AbstractTestCase
     public function testGetStringWidthFont(): void
     {
         // string "phpMyAdmin", with Arial 10
-        self::assertEquals(
+        self::assertSame(
             59,
             $this->font->getStringWidth('phpMyAdmin', 'arial', 10),
         );
 
         // string "phpMyAdmin", with No font
-        self::assertEquals(
+        self::assertSame(
             59,
             $this->font->getStringWidth('phpMyAdmin', '', 10),
         );
 
         // string "phpMyAdmin", with Times 10
-        self::assertEquals(
+        self::assertSame(
             55,
             $this->font->getStringWidth('phpMyAdmin', 'times', 10),
         );
 
         // string "phpMyAdmin", with Broadway 10
-        self::assertEquals(
+        self::assertSame(
             73,
             $this->font->getStringWidth('phpMyAdmin', 'broadway', 10),
         );
@@ -178,25 +178,25 @@ class FontTest extends AbstractTestCase
     public function testGetStringWidthSize(): void
     {
         // string "phpMyAdmin", with font size 0
-        self::assertEquals(
+        self::assertSame(
             0,
             $this->font->getStringWidth('phpMyAdmin', 'arial', 0),
         );
 
         // string "phpMyAdmin", with Arial 10
-        self::assertEquals(
+        self::assertSame(
             59,
             $this->font->getStringWidth('phpMyAdmin', 'arial', 10),
         );
 
         // string "phpMyAdmin", with Arial 11
-        self::assertEquals(
+        self::assertSame(
             65,
             $this->font->getStringWidth('phpMyAdmin', 'arial', 11),
         );
 
         // string "phpMyAdmin", with Arial 20
-        self::assertEquals(
+        self::assertSame(
             118,
             $this->font->getStringWidth('phpMyAdmin', 'arial', 20),
         );
@@ -208,14 +208,14 @@ class FontTest extends AbstractTestCase
     public function testGetStringWidthCharLists(): void
     {
         // string "a", with invalid charlist (= array without proper structure)
-        self::assertEquals(
+        self::assertSame(
             6,
             $this->font->getStringWidth('a', 'arial', 10, ['list']),
         );
 
         // string "a", with invalid charlist (= array without proper structure :
         // modifier is missing
-        self::assertEquals(
+        self::assertSame(
             6,
             $this->font->getStringWidth(
                 'a',
@@ -227,7 +227,7 @@ class FontTest extends AbstractTestCase
 
         // string "a", with invalid charlist (= array without proper structure :
         // chars is missing
-        self::assertEquals(
+        self::assertSame(
             6,
             $this->font->getStringWidth(
                 'a',
@@ -239,7 +239,7 @@ class FontTest extends AbstractTestCase
 
         // string "a", with invalid charlist (= array without proper structure :
         // chars is not an array
-        self::assertEquals(
+        self::assertSame(
             6,
             $this->font->getStringWidth(
                 'a',
@@ -250,7 +250,7 @@ class FontTest extends AbstractTestCase
         );
 
         // string "a", with valid charlist
-        self::assertEquals(
+        self::assertSame(
             7,
             $this->font->getStringWidth(
                 'a',

--- a/tests/classes/FooterTest.php
+++ b/tests/classes/FooterTest.php
@@ -74,7 +74,7 @@ class FooterTest extends AbstractTestCase
             ['count' => 1, 'time' => 2.5, 'query' => 'SELECT * FROM `db` WHERE 1'],
         ];
 
-        self::assertEquals(
+        self::assertSame(
             '{"queries":[{"count":1,"time":0.2,"query":"SELECT * FROM `pma_bookmark` WHERE 1"},'
             . '{"count":1,"time":2.5,"query":"SELECT * FROM `db` WHERE 1"}]}',
             $this->object->getDebugMessage(),
@@ -92,7 +92,7 @@ class FooterTest extends AbstractTestCase
         $object->child->parent = $object;
 
         $this->callFunction($this->object, Footer::class, 'removeRecursion', [&$object]);
-        self::assertEquals(
+        self::assertSame(
             '{"child":{"parent":"***RECURSION***"},"childIterator":"***ITERATOR***"}',
             json_encode($object),
         );
@@ -105,7 +105,7 @@ class FooterTest extends AbstractTestCase
     {
         $footer = new Footer(new Template(), Config::getInstance());
         $footer->disable();
-        self::assertEquals(
+        self::assertSame(
             '',
             $footer->getDisplay(),
         );
@@ -116,7 +116,7 @@ class FooterTest extends AbstractTestCase
         $template = new Template();
         $footer = new Footer($template, Config::getInstance());
         $footer->setAjax(true);
-        self::assertEquals(
+        self::assertSame(
             $template->render('modals/function_confirm') . "\n"
             . $template->render('modals/add_index') . "\n"
             . $template->render('modals/page_settings') . "\n",
@@ -157,7 +157,7 @@ class FooterTest extends AbstractTestCase
         $template = new Template();
         $footer = new Footer($template, Config::getInstance());
         $footer->setMinimal();
-        self::assertEquals(
+        self::assertSame(
             $template->render('modals/function_confirm') . "\n"
             . $template->render('modals/add_index') . "\n"
             . $template->render('modals/page_settings')

--- a/tests/classes/Gis/Ds/PolygonTest.php
+++ b/tests/classes/Gis/Ds/PolygonTest.php
@@ -48,7 +48,7 @@ class PolygonTest extends AbstractTestCase
     #[DataProvider('providerForTestArea')]
     public function testArea(Polygon $ring, float $area): void
     {
-        self::assertEquals($area, $ring->area());
+        self::assertSame($area, $ring->area());
     }
 
     /**
@@ -95,7 +95,7 @@ class PolygonTest extends AbstractTestCase
     #[DataProvider('providerForTestIsPointInsidePolygon')]
     public function testIsPointInsidePolygon(Point $point, Polygon $polygon, bool $isInside): void
     {
-        self::assertEquals($isInside, $point->isInsidePolygon($polygon));
+        self::assertSame($isInside, $point->isInsidePolygon($polygon));
     }
 
     /**

--- a/tests/classes/Gis/GisGeometryCollectionTest.php
+++ b/tests/classes/Gis/GisGeometryCollectionTest.php
@@ -60,7 +60,7 @@ class GisGeometryCollectionTest extends GisGeomTestCase
     public function testGenerateWkt(array $gisData, int $index, string $empty, string $output): void
     {
         $object = GisGeometryCollection::singleton();
-        self::assertEquals($output, $object->generateWkt($gisData, $index, $empty));
+        self::assertSame($output, $object->generateWkt($gisData, $index, $empty));
     }
 
     /**
@@ -158,7 +158,7 @@ class GisGeometryCollectionTest extends GisGeomTestCase
     public function testGenerateParams(string $wkt, array $params): void
     {
         $object = GisGeometryCollection::singleton();
-        self::assertEquals($params, $object->generateParams($wkt));
+        self::assertSame($params, $object->generateParams($wkt));
     }
 
     /**
@@ -291,8 +291,8 @@ class GisGeometryCollectionTest extends GisGeomTestCase
             new ScaleData(offsetX: -19, offsetY: -3, scale: 2.29, height: 124),
             $image,
         );
-        self::assertEquals(200, $image->width());
-        self::assertEquals(124, $image->height());
+        self::assertSame(200, $image->width());
+        self::assertSame(124, $image->height());
 
         $fileExpected = $this->testDir . '/geometrycollection-expected.png';
         $fileActual = $this->testDir . '/geometrycollection-actual.png';
@@ -363,7 +363,7 @@ class GisGeometryCollectionTest extends GisGeomTestCase
     ): void {
         $object = GisGeometryCollection::singleton();
         $svg = $object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
-        self::assertEquals($output, $svg);
+        self::assertSame($output, $svg);
     }
 
     /**
@@ -405,7 +405,7 @@ class GisGeometryCollectionTest extends GisGeomTestCase
         string $output,
     ): void {
         $object = GisGeometryCollection::singleton();
-        self::assertEquals(
+        self::assertSame(
             $output,
             $object->prepareRowAsOl(
                 $spatial,

--- a/tests/classes/Gis/GisGeometryTest.php
+++ b/tests/classes/Gis/GisGeometryTest.php
@@ -85,7 +85,7 @@ class GisGeometryTest extends AbstractTestCase
     #[DataProvider('providerForTestParseWktAndSrid')]
     public function testParseWktAndSrid(string $value, array $output): void
     {
-        self::assertEquals(
+        self::assertSame(
             $output,
             $this->callFunction(
                 $this->object,

--- a/tests/classes/Gis/GisLineStringTest.php
+++ b/tests/classes/Gis/GisLineStringTest.php
@@ -71,7 +71,7 @@ class GisLineStringTest extends GisGeomTestCase
     public function testGenerateWkt(array $gisData, int $index, string $empty, string $output): void
     {
         $object = GisLineString::singleton();
-        self::assertEquals($output, $object->generateWkt($gisData, $index, $empty));
+        self::assertSame($output, $object->generateWkt($gisData, $index, $empty));
     }
 
     /**
@@ -164,8 +164,8 @@ class GisLineStringTest extends GisGeomTestCase
             new ScaleData(offsetX: -18, offsetY: 14, scale: 1.71, height: 124),
             $image,
         );
-        self::assertEquals(200, $image->width());
-        self::assertEquals(124, $image->height());
+        self::assertSame(200, $image->width());
+        self::assertSame(124, $image->height());
 
         $fileExpected = $this->testDir . '/linestring-expected.png';
         $fileActual = $this->testDir . '/linestring-actual.png';
@@ -234,7 +234,7 @@ class GisLineStringTest extends GisGeomTestCase
     ): void {
         $object = GisLineString::singleton();
         $svg = $object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
-        self::assertEquals($output, $svg);
+        self::assertSame($output, $svg);
     }
 
     /**
@@ -276,7 +276,7 @@ class GisLineStringTest extends GisGeomTestCase
     ): void {
         $object = GisLineString::singleton();
         $ol = $object->prepareRowAsOl($spatial, $srid, $label, $color);
-        self::assertEquals($output, $ol);
+        self::assertSame($output, $ol);
     }
 
     /**

--- a/tests/classes/Gis/GisMultiLineStringTest.php
+++ b/tests/classes/Gis/GisMultiLineStringTest.php
@@ -71,7 +71,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
     public function testGenerateWkt(array $gisData, int $index, string $empty, string $output): void
     {
         $object = GisMultiLineString::singleton();
-        self::assertEquals($output, $object->generateWkt($gisData, $index, $empty));
+        self::assertSame($output, $object->generateWkt($gisData, $index, $empty));
     }
 
     /**
@@ -88,7 +88,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
         ];
 
         $object = GisMultiLineString::singleton();
-        self::assertEquals(
+        self::assertSame(
             'MULTILINESTRING((5.02 8.45,6.14 0.15),(1.23 4.25,9.15 0.47))',
             $object->getShape($rowData),
         );
@@ -104,7 +104,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
     public function testGenerateParams(string $wkt, array $params): void
     {
         $object = GisMultiLineString::singleton();
-        self::assertEquals($params, $object->generateParams($wkt));
+        self::assertSame($params, $object->generateParams($wkt));
     }
 
     /**
@@ -172,8 +172,8 @@ class GisMultiLineStringTest extends GisGeomTestCase
             new ScaleData(offsetX: 3, offsetY: -16, scale: 1.06, height: 124),
             $image,
         );
-        self::assertEquals(200, $image->width());
-        self::assertEquals(124, $image->height());
+        self::assertSame(200, $image->width());
+        self::assertSame(124, $image->height());
 
         $fileExpected = $this->testDir . '/multilinestring-expected.png';
         $fileActual = $this->testDir . '/multilinestring-actual.png';
@@ -242,7 +242,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
     ): void {
         $object = GisMultiLineString::singleton();
         $svg = $object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
-        self::assertEquals($output, $svg);
+        self::assertSame($output, $svg);
     }
 
     /**
@@ -286,7 +286,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
     ): void {
         $object = GisMultiLineString::singleton();
         $ol = $object->prepareRowAsOl($spatial, $srid, $label, $color);
-        self::assertEquals($output, $ol);
+        self::assertSame($output, $ol);
     }
 
     /**

--- a/tests/classes/Gis/GisMultiPointTest.php
+++ b/tests/classes/Gis/GisMultiPointTest.php
@@ -60,7 +60,7 @@ class GisMultiPointTest extends GisGeomTestCase
     public function testGenerateWkt(array $gisData, int $index, string $empty, string $output): void
     {
         $object = GisMultiPoint::singleton();
-        self::assertEquals($output, $object->generateWkt($gisData, $index, $empty));
+        self::assertSame($output, $object->generateWkt($gisData, $index, $empty));
     }
 
     /**
@@ -71,7 +71,7 @@ class GisMultiPointTest extends GisGeomTestCase
         $gisData = ['numpoints' => 2, 'points' => [0 => ['x' => 5.02, 'y' => 8.45], 1 => ['x' => 6.14, 'y' => 0.15]]];
 
         $object = GisMultiPoint::singleton();
-        self::assertEquals('MULTIPOINT(5.02 8.45,6.14 0.15)', $object->getShape($gisData));
+        self::assertSame('MULTIPOINT(5.02 8.45,6.14 0.15)', $object->getShape($gisData));
     }
 
     /**
@@ -84,7 +84,7 @@ class GisMultiPointTest extends GisGeomTestCase
     public function testGenerateParams(string $wkt, array $params): void
     {
         $object = GisMultiPoint::singleton();
-        self::assertEquals($params, $object->generateParams($wkt));
+        self::assertSame($params, $object->generateParams($wkt));
     }
 
     /**
@@ -149,8 +149,8 @@ class GisMultiPointTest extends GisGeomTestCase
             new ScaleData(offsetX: -18, offsetY: 14, scale: 1.71, height: 124),
             $image,
         );
-        self::assertEquals(200, $image->width());
-        self::assertEquals(124, $image->height());
+        self::assertSame(200, $image->width());
+        self::assertSame(124, $image->height());
 
         $fileExpected = $this->testDir . '/multipoint-expected.png';
         $fileActual = $this->testDir . '/multipoint-actual.png';
@@ -221,7 +221,7 @@ class GisMultiPointTest extends GisGeomTestCase
     ): void {
         $object = GisMultiPoint::singleton();
         $svg = $object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
-        self::assertEquals($output, $svg);
+        self::assertSame($output, $svg);
     }
 
     /**
@@ -271,7 +271,7 @@ class GisMultiPointTest extends GisGeomTestCase
     ): void {
         $object = GisMultiPoint::singleton();
         $ol = $object->prepareRowAsOl($spatial, $srid, $label, $color);
-        self::assertEquals($output, $ol);
+        self::assertSame($output, $ol);
     }
 
     /**

--- a/tests/classes/Gis/GisMultiPolygonTest.php
+++ b/tests/classes/Gis/GisMultiPolygonTest.php
@@ -74,7 +74,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
     public function testGenerateWkt(array $gisData, int $index, string $empty, string $output): void
     {
         $object = GisMultiPolygon::singleton();
-        self::assertEquals($output, $object->generateWkt($gisData, $index, $empty));
+        self::assertSame($output, $object->generateWkt($gisData, $index, $empty));
     }
 
     /**
@@ -163,7 +163,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
     public function testGetShape(array $rowData, string $shape): void
     {
         $object = GisMultiPolygon::singleton();
-        self::assertEquals($shape, $object->getShape($rowData));
+        self::assertSame($shape, $object->getShape($rowData));
     }
 
     /**
@@ -258,8 +258,8 @@ class GisMultiPolygonTest extends GisGeomTestCase
             new ScaleData(offsetX: -202, offsetY: -125, scale: 0.50, height: 124),
             $image,
         );
-        self::assertEquals(200, $image->width());
-        self::assertEquals(124, $image->height());
+        self::assertSame(200, $image->width());
+        self::assertSame(124, $image->height());
 
         $fileExpected = $this->testDir . '/multipolygon-expected.png';
         $fileActual = $this->testDir . '/multipolygon-actual.png';
@@ -330,7 +330,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
     ): void {
         $object = GisMultiPolygon::singleton();
         $svg = $object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
-        self::assertEquals($output, $svg);
+        self::assertSame($output, $svg);
     }
 
     /**
@@ -377,7 +377,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
     ): void {
         $object = GisMultiPolygon::singleton();
         $ol = $object->prepareRowAsOl($spatial, $srid, $label, $color);
-        self::assertEquals($output, $ol);
+        self::assertSame($output, $ol);
     }
 
     /**

--- a/tests/classes/Gis/GisPointTest.php
+++ b/tests/classes/Gis/GisPointTest.php
@@ -50,7 +50,7 @@ class GisPointTest extends GisGeomTestCase
     public function testGenerateWkt(array $gisData, int $index, string $empty, string $output): void
     {
         $object = GisPoint::singleton();
-        self::assertEquals($output, $object->generateWkt($gisData, $index, $empty));
+        self::assertSame($output, $object->generateWkt($gisData, $index, $empty));
     }
 
     /**
@@ -63,7 +63,7 @@ class GisPointTest extends GisGeomTestCase
     public function testGetShape(array $rowData, string $shape): void
     {
         $object = GisPoint::singleton();
-        self::assertEquals($shape, $object->getShape($rowData));
+        self::assertSame($shape, $object->getShape($rowData));
     }
 
     /**
@@ -86,7 +86,7 @@ class GisPointTest extends GisGeomTestCase
     public function testGenerateParams(string $wkt, array $params): void
     {
         $object = GisPoint::singleton();
-        self::assertEquals($params, $object->generateParams($wkt));
+        self::assertSame($params, $object->generateParams($wkt));
     }
 
     /**
@@ -160,8 +160,8 @@ class GisPointTest extends GisGeomTestCase
             new ScaleData(offsetX: -88, offsetY: -27, scale: 1, height: 124),
             $image,
         );
-        self::assertEquals(200, $image->width());
-        self::assertEquals(124, $image->height());
+        self::assertSame(200, $image->width());
+        self::assertSame(124, $image->height());
 
         $fileExpected = $this->testDir . '/point-expected.png';
         $fileActual = $this->testDir . '/point-actual.png';
@@ -232,7 +232,7 @@ class GisPointTest extends GisGeomTestCase
     ): void {
         $object = GisPoint::singleton();
         $svg = $object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
-        self::assertEquals($output, $svg);
+        self::assertSame($output, $svg);
     }
 
     /**
@@ -272,7 +272,7 @@ class GisPointTest extends GisGeomTestCase
     ): void {
         $object = GisPoint::singleton();
         $ol = $object->prepareRowAsOl($spatial, $srid, $label, $color);
-        self::assertEquals($output, $ol);
+        self::assertSame($output, $ol);
     }
 
     /**

--- a/tests/classes/Gis/GisPolygonTest.php
+++ b/tests/classes/Gis/GisPolygonTest.php
@@ -61,7 +61,7 @@ class GisPolygonTest extends GisGeomTestCase
     public function testGenerateWkt(array $gisData, int $index, string $empty, string $output): void
     {
         $object = GisPolygon::singleton();
-        self::assertEquals($output, $object->generateWkt($gisData, $index, $empty));
+        self::assertSame($output, $object->generateWkt($gisData, $index, $empty));
     }
 
     /**
@@ -167,8 +167,8 @@ class GisPolygonTest extends GisGeomTestCase
             new ScaleData(offsetX: -56, offsetY: -16, scale: 0.94, height: 124),
             $image,
         );
-        self::assertEquals(200, $image->width());
-        self::assertEquals(124, $image->height());
+        self::assertSame(200, $image->width());
+        self::assertSame(124, $image->height());
 
         $fileExpected = $this->testDir . '/polygon-expected.png';
         $fileActual = $this->testDir . '/polygon-actual.png';
@@ -238,7 +238,7 @@ class GisPolygonTest extends GisGeomTestCase
     ): void {
         $object = GisPolygon::singleton();
         $svg = $object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
-        self::assertEquals($output, $svg);
+        self::assertSame($output, $svg);
     }
 
     /**
@@ -280,7 +280,7 @@ class GisPolygonTest extends GisGeomTestCase
     ): void {
         $object = GisPolygon::singleton();
         $ol = $object->prepareRowAsOl($spatial, $srid, $label, $color);
-        self::assertEquals($output, $ol);
+        self::assertSame($output, $ol);
     }
 
     /**

--- a/tests/classes/Gis/GisVisualizationTest.php
+++ b/tests/classes/Gis/GisVisualizationTest.php
@@ -105,7 +105,7 @@ class GisVisualizationTest extends AbstractTestCase
             [''],
         );
 
-        self::assertEquals('SELECT ASTEXT(`abc`) AS `abc`, SRID(`abc`) AS `srid` FROM () AS `temp_gis`', $queryString);
+        self::assertSame('SELECT ASTEXT(`abc`) AS `abc`, SRID(`abc`) AS `srid` FROM () AS `temp_gis`', $queryString);
     }
 
     /**
@@ -121,7 +121,7 @@ class GisVisualizationTest extends AbstractTestCase
             [''],
         );
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT ST_ASTEXT(`abc`) AS `abc`, ST_SRID(`abc`) AS `srid` FROM () AS `temp_gis`',
             $queryString,
         );
@@ -140,7 +140,7 @@ class GisVisualizationTest extends AbstractTestCase
             ['SELECT 1 FROM foo;'],
         );
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT ST_ASTEXT(`abc`) AS `abc`, ST_SRID(`abc`) AS `srid` FROM (SELECT 1 FROM foo) AS `temp_gis`',
             $queryString,
         );
@@ -164,7 +164,7 @@ class GisVisualizationTest extends AbstractTestCase
             [''],
         );
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT `country name`, ST_ASTEXT(`country_geom`) AS `country_geom`,'
             . ' ST_SRID(`country_geom`) AS `srid` FROM () AS `temp_gis`',
             $queryString,
@@ -186,7 +186,7 @@ class GisVisualizationTest extends AbstractTestCase
             [''],
         );
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT ST_ASTEXT(`abc`) AS `abc`, ST_SRID(`abc`) AS `srid` FROM () AS `temp_gis` LIMIT 10',
             $queryString,
         );
@@ -201,7 +201,7 @@ class GisVisualizationTest extends AbstractTestCase
             [''],
         );
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT ST_ASTEXT(`abc`) AS `abc`, ST_SRID(`abc`) AS `srid` FROM () AS `temp_gis` LIMIT 10, 15',
             $queryString,
         );
@@ -220,7 +220,7 @@ class GisVisualizationTest extends AbstractTestCase
             [''],
         );
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT ST_ASTEXT(`abc`, \'axis-order=long-lat\') AS `abc`, ST_SRID(`abc`) AS `srid` FROM () AS `temp_gis`',
             $queryString,
         );
@@ -239,7 +239,7 @@ class GisVisualizationTest extends AbstractTestCase
             [''],
         );
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT ST_ASTEXT(`abc`) AS `abc`, ST_SRID(`abc`) AS `srid` FROM () AS `temp_gis`',
             $queryString,
         );

--- a/tests/classes/GitTest.php
+++ b/tests/classes/GitTest.php
@@ -74,7 +74,7 @@ class GitTest extends AbstractTestCase
 
         self::assertFalse($this->object->hasGitInformation());
 
-        self::assertEquals('.cachedgitlocation', $gitLocation);
+        self::assertSame('.cachedgitlocation', $gitLocation);
     }
 
     /**
@@ -354,7 +354,7 @@ class GitTest extends AbstractTestCase
         $gitFolder = '';
         self::assertTrue($this->object->isGitRevision($gitFolder));
 
-        self::assertEquals($gitFolder, 'customdir/.git');
+        self::assertSame($gitFolder, 'customdir/.git');
     }
 
     /**
@@ -368,7 +368,7 @@ class GitTest extends AbstractTestCase
         self::assertFalse($this->object->isGitRevision($gitFolder));
 
         // Assert that the value is replaced by cached one
-        self::assertEquals($gitFolder, null);
+        self::assertSame($gitFolder, null);
     }
 
     /**
@@ -382,7 +382,7 @@ class GitTest extends AbstractTestCase
         self::assertFalse($this->object->isGitRevision($gitFolder));
 
         // Assert that the value is replaced by cached one
-        self::assertEquals($gitFolder, 'randomdir/.git');
+        self::assertSame($gitFolder, 'randomdir/.git');
     }
 
     /**

--- a/tests/classes/HeaderTest.php
+++ b/tests/classes/HeaderTest.php
@@ -71,7 +71,7 @@ class HeaderTest extends AbstractTestCase
     {
         $header = $this->getNewHeaderInstance();
         $header->disable();
-        self::assertEquals(
+        self::assertSame(
             '',
             $header->getDisplay(),
         );

--- a/tests/classes/Html/GeneratorTest.php
+++ b/tests/classes/Html/GeneratorTest.php
@@ -44,7 +44,7 @@ class GeneratorTest extends AbstractTestCase
         Current::$database = 'test_db';
         Current::$server = 99;
         $database = Current::$database;
-        self::assertEquals(
+        self::assertSame(
             '<a href="'
             . Util::getScriptNameForOption(
                 Config::getInstance()->settings['DefaultTabDatabase'],
@@ -66,7 +66,7 @@ class GeneratorTest extends AbstractTestCase
     {
         Current::$server = 99;
         $database = 'test_database';
-        self::assertEquals(
+        self::assertSame(
             '<a href="' . Util::getScriptNameForOption(
                 Config::getInstance()->settings['DefaultTabDatabase'],
                 'database',
@@ -86,7 +86,7 @@ class GeneratorTest extends AbstractTestCase
     {
         Current::$server = 99;
         $database = 'test&data\'base';
-        self::assertEquals(
+        self::assertSame(
             '<a href="'
             . Util::getScriptNameForOption(
                 Config::getInstance()->settings['DefaultTabDatabase'],
@@ -108,7 +108,7 @@ class GeneratorTest extends AbstractTestCase
     {
         Config::getInstance()->settings['ActionLinksMode'] = 'text';
 
-        self::assertEquals(
+        self::assertSame(
             '<span class="text-nowrap"></span>',
             Generator::getIcon('b_comment'),
         );
@@ -121,7 +121,7 @@ class GeneratorTest extends AbstractTestCase
     {
         Config::getInstance()->settings['ActionLinksMode'] = 'icons';
 
-        self::assertEquals(
+        self::assertSame(
             '<span class="text-nowrap"><img src="themes/dot.gif" title="" alt="" class="icon ic_b_comment"></span>',
             Generator::getIcon('b_comment'),
         );
@@ -135,7 +135,7 @@ class GeneratorTest extends AbstractTestCase
         Config::getInstance()->settings['ActionLinksMode'] = 'icons';
         $alternateText = 'alt_str';
 
-        self::assertEquals(
+        self::assertSame(
             '<span class="text-nowrap"><img src="themes/dot.gif" title="'
             . $alternateText . '" alt="' . $alternateText
             . '" class="icon ic_b_comment"></span>',
@@ -153,7 +153,7 @@ class GeneratorTest extends AbstractTestCase
 
         // Here we are checking for an icon embedded inside a span (i.e not a menu
         // bar icon
-        self::assertEquals(
+        self::assertSame(
             '<span class="text-nowrap"><img src="themes/dot.gif" title="'
             . $alternateText . '" alt="' . $alternateText
             . '" class="icon ic_b_comment">&nbsp;' . $alternateText . '</span>',
@@ -175,7 +175,7 @@ class GeneratorTest extends AbstractTestCase
             . '<img src="themes/dot.gif" title="' . __('Documentation') . '" alt="'
             . __('Documentation') . '" class="icon ic_b_help"></a>';
 
-        self::assertEquals(
+        self::assertSame(
             $expected,
             Generator::showPHPDocumentation($target),
         );
@@ -196,7 +196,7 @@ class GeneratorTest extends AbstractTestCase
         $config->settings['LinkLengthLimit'] = $limit;
         try {
             $result = Generator::linkOrButton(...$params);
-            self::assertEquals($match, $result);
+            self::assertSame($match, $result);
         } finally {
             $config->settings['LinkLengthLimit'] = $restore;
         }
@@ -284,7 +284,7 @@ class GeneratorTest extends AbstractTestCase
 
     public function testFormatSql(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '<code class="sql" dir="ltr"><pre>' . "\n"
             . 'SELECT 1 &lt; 2' . "\n"
             . '</pre></code>',
@@ -293,7 +293,7 @@ class GeneratorTest extends AbstractTestCase
 
         Config::getInstance()->settings['MaxCharactersInDisplayedSQL'] = 6;
 
-        self::assertEquals(
+        self::assertSame(
             '<code class="sql" dir="ltr"><pre>' . "\n"
             . 'SELECT[...]' . "\n"
             . '</pre></code>',
@@ -318,7 +318,7 @@ class GeneratorTest extends AbstractTestCase
 
         $config = Config::getInstance();
         $config->selectedServer = ['ssl' => false, 'host' => '127.0.0.1'];
-        self::assertEquals(
+        self::assertSame(
             $sslNotUsed,
             Generator::getServerSSL(),
         );
@@ -326,7 +326,7 @@ class GeneratorTest extends AbstractTestCase
         $config->selectedServer = ['ssl' => false, 'host' => 'custom.host'];
         $config->settings['MysqlSslWarningSafeHosts'] = ['localhost', '127.0.0.1'];
 
-        self::assertEquals(
+        self::assertSame(
             $sslNotUsedCaution,
             Generator::getServerSSL(),
         );
@@ -334,21 +334,21 @@ class GeneratorTest extends AbstractTestCase
         $config->selectedServer = ['ssl' => false, 'host' => 'custom.host'];
         $config->settings['MysqlSslWarningSafeHosts'] = ['localhost', '127.0.0.1', 'custom.host'];
 
-        self::assertEquals(
+        self::assertSame(
             $sslNotUsed,
             Generator::getServerSSL(),
         );
 
         $config->selectedServer = ['ssl' => false, 'ssl_verify' => true, 'host' => 'custom.host'];
 
-        self::assertEquals(
+        self::assertSame(
             $sslNotUsed,
             Generator::getServerSSL(),
         );
 
         $config->selectedServer = ['ssl' => true, 'ssl_verify' => false, 'host' => 'custom.host'];
 
-        self::assertEquals(
+        self::assertSame(
             '<span class="text-danger">SSL is used with disabled verification</span>'
             . ' <a href="index.php?route=/url&url=https%3A%2F%2Fdocs.phpmyadmin.net%2Fen%2Flatest%2Fsetup.html%23ssl"'
             . ' target="documentation"><img src="themes/dot.gif" title="Documentation" alt="Documentation"'
@@ -358,7 +358,7 @@ class GeneratorTest extends AbstractTestCase
 
         $config->selectedServer = ['ssl' => true, 'ssl_verify' => true, 'host' => 'custom.host'];
 
-        self::assertEquals(
+        self::assertSame(
             '<span class="text-danger">SSL is used without certification authority</span>'
             . ' <a href="index.php?route=/url&url=https%3A%2F%2Fdocs.phpmyadmin.net%2Fen%2Flatest%2Fsetup.html%23ssl"'
             . ' target="documentation"><img src="themes/dot.gif" title="Documentation" alt="Documentation"'
@@ -373,7 +373,7 @@ class GeneratorTest extends AbstractTestCase
             'host' => 'custom.host',
         ];
 
-        self::assertEquals(
+        self::assertSame(
             '<span class="">SSL is used</span>'
             . ' <a href="index.php?route=/url&url=https%3A%2F%2Fdocs.phpmyadmin.net%2Fen%2Flatest%2Fsetup.html%23ssl"'
             . ' target="documentation"><img src="themes/dot.gif" title="Documentation" alt="Documentation"'
@@ -414,7 +414,7 @@ class GeneratorTest extends AbstractTestCase
             $insertMode,
         );
 
-        self::assertEquals($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**

--- a/tests/classes/Html/MySQLDocumentationTest.php
+++ b/tests/classes/Html/MySQLDocumentationTest.php
@@ -16,7 +16,7 @@ class MySQLDocumentationTest extends AbstractTestCase
     {
         Config::getInstance()->settings['ServerDefault'] = 1;
 
-        self::assertEquals(
+        self::assertSame(
             '<a href="index.php?route=/url&url=https%3A%2F%2Fdocs.phpmyadmin.net%2Fen'
             . '%2Flatest%2Fpage.html%23anchor" target="documentation"><img src="themes/dot.gif"'
             . ' title="Documentation" alt="Documentation" class="icon ic_b_help"></a>',

--- a/tests/classes/Http/Middleware/TokenRequestParamCheckingTest.php
+++ b/tests/classes/Http/Middleware/TokenRequestParamCheckingTest.php
@@ -28,7 +28,7 @@ final class TokenRequestParamCheckingTest extends TestCase
         self::assertFalse($GLOBALS['token_mismatch']);
         self::assertTrue($GLOBALS['token_provided']);
         self::assertArrayHasKey('test', $_POST);
-        self::assertEquals('test', $_POST['test']);
+        self::assertSame('test', $_POST['test']);
     }
 
     public function testCheckTokenRequestParamWithGetMethod(): void

--- a/tests/classes/Identifiers/DatabaseNameTest.php
+++ b/tests/classes/Identifiers/DatabaseNameTest.php
@@ -20,8 +20,8 @@ class DatabaseNameTest extends TestCase
     public function testValidName(string $validName): void
     {
         $name = DatabaseName::from($validName);
-        self::assertEquals($validName, $name->getName());
-        self::assertEquals($validName, (string) $name);
+        self::assertSame($validName, $name->getName());
+        self::assertSame($validName, (string) $name);
     }
 
     #[DataProvider('providerForTestValidNames')]
@@ -29,8 +29,8 @@ class DatabaseNameTest extends TestCase
     {
         $name = DatabaseName::tryFrom($validName);
         self::assertNotNull($name);
-        self::assertEquals($validName, $name->getName());
-        self::assertEquals($validName, (string) $name);
+        self::assertSame($validName, $name->getName());
+        self::assertSame($validName, (string) $name);
     }
 
     /** @return iterable<int, string[]> */

--- a/tests/classes/Identifiers/TableNameTest.php
+++ b/tests/classes/Identifiers/TableNameTest.php
@@ -20,8 +20,8 @@ class TableNameTest extends TestCase
     public function testValidName(string $validName): void
     {
         $name = TableName::from($validName);
-        self::assertEquals($validName, $name->getName());
-        self::assertEquals($validName, (string) $name);
+        self::assertSame($validName, $name->getName());
+        self::assertSame($validName, (string) $name);
     }
 
     #[DataProvider('providerForTestValidNames')]
@@ -29,8 +29,8 @@ class TableNameTest extends TestCase
     {
         $name = TableName::tryFrom($validName);
         self::assertNotNull($name);
-        self::assertEquals($validName, $name->getName());
-        self::assertEquals($validName, (string) $name);
+        self::assertSame($validName, $name->getName());
+        self::assertSame($validName, (string) $name);
     }
 
     /** @return iterable<int, string[]> */

--- a/tests/classes/Identifiers/TriggerNameTest.php
+++ b/tests/classes/Identifiers/TriggerNameTest.php
@@ -20,8 +20,8 @@ final class TriggerNameTest extends TestCase
     public function testValidName(string $validName): void
     {
         $name = TriggerName::from($validName);
-        self::assertEquals($validName, $name->getName());
-        self::assertEquals($validName, (string) $name);
+        self::assertSame($validName, $name->getName());
+        self::assertSame($validName, (string) $name);
     }
 
     #[DataProvider('providerForTestValidNames')]
@@ -29,8 +29,8 @@ final class TriggerNameTest extends TestCase
     {
         $name = TriggerName::tryFrom($validName);
         self::assertNotNull($name);
-        self::assertEquals($validName, $name->getName());
-        self::assertEquals($validName, (string) $name);
+        self::assertSame($validName, $name->getName());
+        self::assertSame($validName, (string) $name);
     }
 
     /** @return iterable<int, string[]> */

--- a/tests/classes/Import/ImportTest.php
+++ b/tests/classes/Import/ImportTest.php
@@ -86,17 +86,17 @@ class ImportTest extends AbstractTestCase
      */
     public function testLookForUse(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '',
             $this->import->lookForUse('select 1 from myTable'),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'anotherDb',
             $this->import->lookForUse('use anotherDb'),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'anotherDb',
             $this->import->lookForUse('use `anotherDb`;'),
         );
@@ -111,7 +111,7 @@ class ImportTest extends AbstractTestCase
     #[DataProvider('provGetColumnAlphaName')]
     public function testGetColumnAlphaName(string $expected, int $num): void
     {
-        self::assertEquals($expected, $this->import->getColumnAlphaName($num));
+        self::assertSame($expected, $this->import->getColumnAlphaName($num));
     }
 
     /**
@@ -133,7 +133,7 @@ class ImportTest extends AbstractTestCase
     #[DataProvider('provGetColumnNumberFromName')]
     public function testGetColumnNumberFromName(int $expected, string $name): void
     {
-        self::assertEquals($expected, $this->import->getColumnNumberFromName($name));
+        self::assertSame($expected, $this->import->getColumnNumberFromName($name));
     }
 
     /**
@@ -155,7 +155,7 @@ class ImportTest extends AbstractTestCase
     #[DataProvider('provGetDecimalPrecision')]
     public function testGetDecimalPrecision(int $expected, string $size): void
     {
-        self::assertEquals($expected, $this->import->getDecimalPrecision($size));
+        self::assertSame($expected, $this->import->getDecimalPrecision($size));
     }
 
     /**
@@ -177,7 +177,7 @@ class ImportTest extends AbstractTestCase
     #[DataProvider('provGetDecimalScale')]
     public function testGetDecimalScale(int $expected, string $size): void
     {
-        self::assertEquals($expected, $this->import->getDecimalScale($size));
+        self::assertSame($expected, $this->import->getDecimalScale($size));
     }
 
     /**
@@ -199,7 +199,7 @@ class ImportTest extends AbstractTestCase
     #[DataProvider('provGetDecimalSize')]
     public function testGetDecimalSize(array $expected, string $cell): void
     {
-        self::assertEquals($expected, $this->import->getDecimalSize($cell));
+        self::assertSame($expected, $this->import->getDecimalSize($cell));
     }
 
     /**
@@ -224,7 +224,7 @@ class ImportTest extends AbstractTestCase
     #[DataProvider('provDetectType')]
     public function testDetectType(int $expected, int|null $type, string|null $cell): void
     {
-        self::assertEquals($expected, $this->import->detectType($type, $cell));
+        self::assertSame($expected, $this->import->detectType($type, $cell));
     }
 
     /**
@@ -304,7 +304,7 @@ class ImportTest extends AbstractTestCase
     #[DataProvider('providerContentWithByteOrderMarks')]
     public function testSkipByteOrderMarksFromContents(string $input, string $cleanContents): void
     {
-        self::assertEquals($cleanContents, $this->import->skipByteOrderMarksFromContents($input));
+        self::assertSame($cleanContents, $this->import->skipByteOrderMarksFromContents($input));
     }
 
     /**

--- a/tests/classes/Import/SimulateDmlTest.php
+++ b/tests/classes/Import/SimulateDmlTest.php
@@ -49,7 +49,7 @@ class SimulateDmlTest extends AbstractTestCase
 
         $dummyDbi->assertAllSelectsConsumed();
         $dummyDbi->assertAllQueriesConsumed();
-        self::assertEquals([
+        self::assertSame([
             'sql_query' => Generator::formatSql($sqlQuery),
             'matched_rows' => count($result),
             'matched_rows_url' => $matchedRowsUrl,

--- a/tests/classes/IndexColumnTest.php
+++ b/tests/classes/IndexColumnTest.php
@@ -21,31 +21,31 @@ class IndexColumnTest extends TestCase
     public function testGetNull(): void
     {
         $this->object->set(['Null' => '']);
-        self::assertEquals('No', $this->object->getNull());
+        self::assertSame('No', $this->object->getNull());
         $this->object->set(['Null' => 'YES']);
-        self::assertEquals('Yes', $this->object->getNull());
+        self::assertSame('Yes', $this->object->getNull());
     }
 
     public function testIsNullable(): void
     {
         $this->object->set(['Null' => '']);
-        self::assertEquals(false, $this->object->isNullable());
+        self::assertFalse($this->object->isNullable());
         $this->object->set(['Null' => 'YES']);
-        self::assertEquals(true, $this->object->isNullable());
+        self::assertTrue($this->object->isNullable());
     }
 
     public function testGetSeqInIndex(): void
     {
-        self::assertEquals(1, $this->object->getSeqInIndex());
+        self::assertSame(1, $this->object->getSeqInIndex());
         $this->object->set(['Seq_in_index' => 2]);
-        self::assertEquals(2, $this->object->getSeqInIndex());
+        self::assertSame(2, $this->object->getSeqInIndex());
     }
 
     public function testGetSubPart(): void
     {
         self::assertNull($this->object->getSubPart());
         $this->object->set(['Sub_part' => 2]);
-        self::assertEquals(2, $this->object->getSubPart());
+        self::assertSame(2, $this->object->getSubPart());
     }
 
     public function testGetCompareData(): void
@@ -75,22 +75,22 @@ class IndexColumnTest extends TestCase
 
     public function testGetName(): void
     {
-        self::assertEquals('', $this->object->getName());
+        self::assertSame('', $this->object->getName());
         $this->object->set(['Column_name' => 'name']);
-        self::assertEquals('name', $this->object->getName());
+        self::assertSame('name', $this->object->getName());
     }
 
     public function testGetCardinality(): void
     {
         self::assertNull($this->object->getCardinality());
         $this->object->set(['Cardinality' => 2]);
-        self::assertEquals(2, $this->object->getCardinality());
+        self::assertSame(2, $this->object->getCardinality());
     }
 
     public function testGetCollation(): void
     {
         self::assertNull($this->object->getCollation());
         $this->object->set(['Collation' => 'collation']);
-        self::assertEquals('collation', $this->object->getCollation());
+        self::assertSame('collation', $this->object->getCollation());
     }
 }

--- a/tests/classes/IndexTest.php
+++ b/tests/classes/IndexTest.php
@@ -62,19 +62,19 @@ class IndexTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $index = new Index($this->params);
-        self::assertEquals(
+        self::assertSame(
             'PMA_Index_comment',
             $index->getComment(),
         );
-        self::assertEquals(
+        self::assertSame(
             'PMA_Comment',
             $index->getRemarks(),
         );
-        self::assertEquals(
+        self::assertSame(
             'PMA_Index_choice',
             $index->getChoice(),
         );
-        self::assertEquals(
+        self::assertSame(
             'PMA_Packed',
             $index->getPacked(),
         );
@@ -90,7 +90,7 @@ class IndexTest extends AbstractTestCase
             'PMA_Index_comment',
             $index->getComments(),
         );
-        self::assertEquals(
+        self::assertSame(
             'PMA_Index_choice',
             $index->getChoice(),
         );
@@ -106,7 +106,7 @@ class IndexTest extends AbstractTestCase
         self::assertTrue(
             $index->isUnique(),
         );
-        self::assertEquals(
+        self::assertSame(
             'Yes',
             $index->isUnique(true),
         );
@@ -122,7 +122,7 @@ class IndexTest extends AbstractTestCase
         self::assertTrue($index->hasColumn('column1'));
         self::assertTrue($index->hasColumn('column2'));
         self::assertTrue($index->hasColumn('column3'));
-        self::assertEquals(
+        self::assertSame(
             3,
             $index->getColumnCount(),
         );
@@ -135,7 +135,7 @@ class IndexTest extends AbstractTestCase
     {
         $index = new Index();
         $index->setName('PMA_name');
-        self::assertEquals(
+        self::assertSame(
             'PMA_name',
             $index->getName(),
         );
@@ -148,7 +148,7 @@ class IndexTest extends AbstractTestCase
 
         $indexColumns = $index->getColumns();
         $indexColumn = $indexColumns['column1'];
-        self::assertEquals(
+        self::assertSame(
             'column1',
             $indexColumn->getName(),
         );
@@ -156,7 +156,7 @@ class IndexTest extends AbstractTestCase
             '1',
             $indexColumn->getSeqInIndex(),
         );
-        self::assertEquals(
+        self::assertSame(
             'Collation1',
             $indexColumn->getCollation(),
         );

--- a/tests/classes/InsertEditTest.php
+++ b/tests/classes/InsertEditTest.php
@@ -135,7 +135,7 @@ class InsertEditTest extends AbstractTestCase
             'localhost',
         );
 
-        self::assertEquals(
+        self::assertSame(
             [
                 'db' => 'dbname',
                 'table' => 'tablename',
@@ -169,7 +169,7 @@ class InsertEditTest extends AbstractTestCase
             'localhost',
         );
 
-        self::assertEquals(
+        self::assertSame(
             [
                 'db' => 'dbname',
                 'table' => 'tablename',
@@ -332,7 +332,7 @@ class InsertEditTest extends AbstractTestCase
             ['table', 'db'],
         );
 
-        self::assertEquals($resultStub, $result);
+        self::assertSame($resultStub, $result);
     }
 
     /** @return list<array{int, array<false>}> */
@@ -358,7 +358,7 @@ class InsertEditTest extends AbstractTestCase
             [],
         );
 
-        self::assertEquals($rowsValue, $result);
+        self::assertSame($rowsValue, $result);
     }
 
     /**
@@ -418,7 +418,7 @@ class InsertEditTest extends AbstractTestCase
     {
         $fieldName = 'f1<';
 
-        self::assertEquals(
+        self::assertSame(
             $this->callFunction(
                 $this->insertEdit,
                 InsertEdit::class,
@@ -516,7 +516,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             false,
         );
-        self::assertEquals(
+        self::assertSame(
             '1',
             $this->callFunction(
                 $this->insertEdit,
@@ -539,7 +539,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             false,
         );
-        self::assertEquals(
+        self::assertSame(
             '2',
             $this->callFunction(
                 $this->insertEdit,
@@ -550,7 +550,7 @@ class InsertEditTest extends AbstractTestCase
         );
 
         $column = new InsertEditColumn('f', 'set', false, '', null, '', -1, false, false, false, false);
-        self::assertEquals(
+        self::assertSame(
             '3',
             $this->callFunction(
                 $this->insertEdit,
@@ -563,7 +563,7 @@ class InsertEditTest extends AbstractTestCase
         $column = new InsertEditColumn('f', '', false, '', null, '', -1, false, false, false, false);
         $foreigners['f'] = ['something'/* What should the mocked value actually be? */];
         $foreignData['foreign_link'] = '';
-        self::assertEquals(
+        self::assertSame(
             '4',
             $this->callFunction(
                 $this->insertEdit,
@@ -632,7 +632,7 @@ class InsertEditTest extends AbstractTestCase
             [$column, 'a', 'b', 30, 'c', 'DATE'],
         );
 
-        self::assertEquals(
+        self::assertSame(
             '<input type="text" name="fieldsa" value="b" size="30" data-type="DATE"'
             . ' class="textfield datefield" onchange="c" tabindex="23" id="field_23_3">',
             $result,
@@ -646,7 +646,7 @@ class InsertEditTest extends AbstractTestCase
             'getHtmlInput',
             [$column, 'a', 'b', 30, 'c', 'DATE'],
         );
-        self::assertEquals(
+        self::assertSame(
             '<input type="text" name="fieldsa" value="b" size="30" data-type="DATE"'
             . ' class="textfield datetimefield" onchange="c" tabindex="23" id="field_23_3">',
             $result,
@@ -660,7 +660,7 @@ class InsertEditTest extends AbstractTestCase
             'getHtmlInput',
             [$column, 'a', 'b', 30, 'c', 'DATE'],
         );
-        self::assertEquals(
+        self::assertSame(
             '<input type="text" name="fieldsa" value="b" size="30" data-type="DATE"'
             . ' class="textfield datetimefield" onchange="c" tabindex="23" id="field_23_3">',
             $result,
@@ -674,7 +674,7 @@ class InsertEditTest extends AbstractTestCase
             'getHtmlInput',
             [$column, 'a', 'b', 11, 'c', 'INT'],
         );
-        self::assertEquals(
+        self::assertSame(
             '<input type="text" name="fieldsa" value="b" size="11" min="-2147483648" max="2147483647" data-type="INT"'
             . ' class="textfield" onchange="c" tabindex="23" inputmode="numeric" id="field_23_3">',
             $result,
@@ -696,7 +696,7 @@ class InsertEditTest extends AbstractTestCase
             [$pmaType],
         );
 
-        self::assertEquals("(Max: 256B)\n", $result);
+        self::assertSame("(Max: 256B)\n", $result);
 
         // case 2
         $config->set('max_upload_size', 250);
@@ -708,7 +708,7 @@ class InsertEditTest extends AbstractTestCase
             [$pmaType],
         );
 
-        self::assertEquals("(Max: 250B)\n", $result);
+        self::assertSame("(Max: 250B)\n", $result);
     }
 
     /**
@@ -749,7 +749,7 @@ class InsertEditTest extends AbstractTestCase
             ],
         );
 
-        self::assertEquals(
+        self::assertSame(
             "a\na\n"
             . '<textarea name="fieldsb" class="char charField" '
             . 'data-maxlength="25" rows="7" cols="1" dir="/" '
@@ -790,7 +790,7 @@ class InsertEditTest extends AbstractTestCase
             ],
         );
 
-        self::assertEquals(
+        self::assertSame(
             "a\n"
             . '<input type="text" name="fieldsb" value="&lt;" size="20" data-type="'
             . 'DATE" class="textfield datetimefield" onchange="c" tabindex="22" id="field_22_3"'
@@ -931,7 +931,7 @@ class InsertEditTest extends AbstractTestCase
         $config->settings['MinSizeForInputField'] = 30;
         $config->settings['MaxSizeForInputField'] = 40;
 
-        self::assertEquals(
+        self::assertSame(
             40,
             $this->callFunction(
                 $this->insertEdit,
@@ -941,7 +941,7 @@ class InsertEditTest extends AbstractTestCase
             ),
         );
 
-        self::assertEquals('textarea', $config->settings['CharEditing']);
+        self::assertSame('textarea', $config->settings['CharEditing']);
 
         // case 2
         $column = new InsertEditColumn(
@@ -957,7 +957,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             false,
         );
-        self::assertEquals(
+        self::assertSame(
             30,
             $this->callFunction(
                 $this->insertEdit,
@@ -1188,7 +1188,7 @@ class InsertEditTest extends AbstractTestCase
             [$currentRow, $column, $extractedColumnSpec, 'a', false],
         );
 
-        self::assertEquals(
+        self::assertSame(
             [
                 false,
                 '3131303031',
@@ -1209,7 +1209,7 @@ class InsertEditTest extends AbstractTestCase
             [$currentRow, $column, $extractedColumnSpec, 'a', false],
         );
 
-        self::assertEquals(
+        self::assertSame(
             [
                 false,
                 '313130303100',
@@ -1242,7 +1242,7 @@ class InsertEditTest extends AbstractTestCase
             [$defaultValue, $trueType],
         );
 
-        self::assertEquals($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -1344,7 +1344,7 @@ class InsertEditTest extends AbstractTestCase
         );
         $this->insertEdit->setSessionForEditNext('`a` = 2');
 
-        self::assertEquals('CONCAT(`table`.`orgname`) IS NULL', $_SESSION['edit_next']);
+        self::assertSame('CONCAT(`table`.`orgname`) IS NULL', $_SESSION['edit_next']);
     }
 
     /**
@@ -1355,35 +1355,35 @@ class InsertEditTest extends AbstractTestCase
         $GLOBALS['goto'] = '123.php';
         Current::$table = '';
 
-        self::assertEquals(
+        self::assertSame(
             '/database/sql',
             $this->insertEdit->getGotoInclude('index'),
         );
 
         Current::$table = 'tbl';
-        self::assertEquals(
+        self::assertSame(
             '/table/sql',
             $this->insertEdit->getGotoInclude('index'),
         );
 
         $GLOBALS['goto'] = 'index.php?route=/database/sql';
 
-        self::assertEquals(
+        self::assertSame(
             '/database/sql',
             $this->insertEdit->getGotoInclude('index'),
         );
 
-        self::assertEquals('', Current::$table);
+        self::assertSame('', Current::$table);
 
         $GLOBALS['goto'] = 'index.php?route=/sql&server=2';
 
-        self::assertEquals(
+        self::assertSame(
             '/sql',
             $this->insertEdit->getGotoInclude('index'),
         );
 
         $_POST['after_insert'] = 'new_insert';
-        self::assertEquals(
+        self::assertSame(
             '/table/change',
             $this->insertEdit->getGotoInclude('index'),
         );
@@ -1395,13 +1395,13 @@ class InsertEditTest extends AbstractTestCase
     public function testGetErrorUrl(): void
     {
         Config::getInstance()->settings['ServerDefault'] = 1;
-        self::assertEquals(
+        self::assertSame(
             'index.php?route=/table/change&lang=en',
             $this->insertEdit->getErrorUrl([]),
         );
 
         $_POST['err_url'] = 'localhost';
-        self::assertEquals(
+        self::assertSame(
             'localhost',
             $this->insertEdit->getErrorUrl([]),
         );
@@ -1427,7 +1427,7 @@ class InsertEditTest extends AbstractTestCase
         );
         $result = $this->insertEdit->executeSqlQuery($query);
 
-        self::assertEquals([], $result[3]);
+        self::assertSame([], $result[3]);
     }
 
     /**
@@ -1450,7 +1450,7 @@ class InsertEditTest extends AbstractTestCase
         );
         $result = $this->insertEdit->executeSqlQuery($query);
 
-        self::assertEquals([], $result[3]);
+        self::assertSame([], $result[3]);
     }
 
     /**
@@ -1488,7 +1488,7 @@ class InsertEditTest extends AbstractTestCase
             [],
         );
 
-        self::assertEquals(['Error: #1001 Message 1', 'Warning: #1002 Message 2'], $result);
+        self::assertSame(['Error: #1001 Message 1', 'Warning: #1002 Message 2'], $result);
     }
 
     /**
@@ -1552,7 +1552,7 @@ class InsertEditTest extends AbstractTestCase
 
         $sqlSignature = Core::signSqlQuery('SELECT * FROM `information_schema`.`TABLES` WHERE `f`=1');
 
-        self::assertEquals(
+        self::assertSame(
             '<a href="index.php?route=/sql&db=information_schema&table=TABLES&pos=0&'
             . 'sql_signature=' . $sqlSignature . '&'
             . 'sql_query=SELECT+%2A+FROM+%60information_schema%60.%60TABLES%60+WHERE'
@@ -1563,7 +1563,7 @@ class InsertEditTest extends AbstractTestCase
         $_SESSION['tmpval']['relational_display'] = 'D';
         $result = $this->insertEdit->getLinkForRelationalDisplayField($map, 'f', '=1', 'a>', 'b<');
 
-        self::assertEquals(
+        self::assertSame(
             '<a href="index.php?route=/sql&db=information_schema&table=TABLES&pos=0&'
             . 'sql_signature=' . $sqlSignature . '&'
             . 'sql_query=SELECT+%2A+FROM+%60information_schema%60.%60TABLES%60+WHERE'
@@ -1596,7 +1596,7 @@ class InsertEditTest extends AbstractTestCase
             'transformation',
         );
 
-        self::assertEquals(
+        self::assertSame(
             ['a' => 'b', 'transformations' => ['cnameoption ,, quoted']],
             $result,
         );
@@ -1624,7 +1624,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals("'foo'", $result);
+        self::assertSame("'foo'", $result);
 
         // Test for file upload
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1644,7 +1644,7 @@ class InsertEditTest extends AbstractTestCase
             '',
         );
 
-        self::assertEquals('0x123', $result);
+        self::assertSame('0x123', $result);
 
         // Test functions
         $this->dummyDbi->addResult(
@@ -1672,7 +1672,7 @@ class InsertEditTest extends AbstractTestCase
             '',
         );
 
-        self::assertEquals("'uuid1234'", $result);
+        self::assertSame("'uuid1234'", $result);
 
         // case 2
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1691,7 +1691,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals("AES_ENCRYPT('\\'','')", $result);
+        self::assertSame("AES_ENCRYPT('\\'','')", $result);
 
         // case 3
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1710,7 +1710,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals("ABS('\\'')", $result);
+        self::assertSame("ABS('\\'')", $result);
 
         // case 4
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1729,7 +1729,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals('RAND()', $result);
+        self::assertSame('RAND()', $result);
 
         // case 5
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1756,7 +1756,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals('ST_GeomFromText(\'POINT(3 4)\',4326)', $result);
+        self::assertSame('ST_GeomFromText(\'POINT(3 4)\',4326)', $result);
 
         // case 8
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1764,7 +1764,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals('ST_GeomFromText(\'POINT(3 4)\',4326)', $result);
+        self::assertSame('ST_GeomFromText(\'POINT(3 4)\',4326)', $result);
 
         // case 9
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1772,7 +1772,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals('ST_GeomFromText(\'POINT(3 4)\')', $result);
+        self::assertSame('ST_GeomFromText(\'POINT(3 4)\')', $result);
 
         // case 10
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1780,7 +1780,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals('ST_GeomFromText(\'POINT(3 4)\')', $result);
+        self::assertSame('ST_GeomFromText(\'POINT(3 4)\')', $result);
 
         // Test different data types
 
@@ -1802,7 +1802,7 @@ class InsertEditTest extends AbstractTestCase
             true,
             '`id` = 4',
         );
-        self::assertEquals('0x313031', $result);
+        self::assertSame('0x313031', $result);
 
         // An empty value for auto increment column should be converted to NULL
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1821,7 +1821,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals('NULL', $result);
+        self::assertSame('NULL', $result);
 
         // Simple empty value
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1840,7 +1840,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals("''", $result);
+        self::assertSame("''", $result);
 
         // Datatype: set
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1859,7 +1859,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals("''", $result);
+        self::assertSame("''", $result);
 
         // Datatype: protected with no value should produce an empty string
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1878,7 +1878,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals('', $result);
+        self::assertSame('', $result);
 
         // Datatype: protected with null flag set
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1897,7 +1897,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals('NULL', $result);
+        self::assertSame('NULL', $result);
 
         // Datatype: bit
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1916,7 +1916,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals("b'00010'", $result);
+        self::assertSame("b'00010'", $result);
 
         // Datatype: date
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1935,7 +1935,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals("'20\\'12'", $result);
+        self::assertSame("'20\\'12'", $result);
 
         // A NULL checkbox
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1954,7 +1954,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals('NULL', $result);
+        self::assertSame('NULL', $result);
 
         // Datatype: protected but NULL checkbox was unchecked without uploading a file
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1973,7 +1973,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals("''", $result);
+        self::assertSame("''", $result);
 
         // Datatype: date with default value
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -1992,7 +1992,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals('current_timestamp()', $result);
+        self::assertSame('current_timestamp()', $result);
 
         // Datatype: hex without 0x
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -2011,7 +2011,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals('0x222aaafff', $result);
+        self::assertSame('0x222aaafff', $result);
 
         // Datatype: hex with 0x
         $result = $this->insertEdit->getQueryValueForInsert(
@@ -2030,7 +2030,7 @@ class InsertEditTest extends AbstractTestCase
             false,
             '',
         );
-        self::assertEquals('0x222aaafff', $result);
+        self::assertSame('0x222aaafff', $result);
     }
 
     /**
@@ -2053,7 +2053,7 @@ class InsertEditTest extends AbstractTestCase
                 false,
             ),
         );
-        self::assertEquals("`fld` = 'foo'", $result);
+        self::assertSame("`fld` = 'foo'", $result);
 
         // Update of null when it was null previously
         $result = $this->insertEdit->getQueryValueForUpdate(
@@ -2070,7 +2070,7 @@ class InsertEditTest extends AbstractTestCase
                 false,
             ),
         );
-        self::assertEquals('', $result);
+        self::assertSame('', $result);
 
         // Update of null when it was NOT null previously
         $result = $this->insertEdit->getQueryValueForUpdate(
@@ -2087,7 +2087,7 @@ class InsertEditTest extends AbstractTestCase
                 false,
             ),
         );
-        self::assertEquals('`fld` = NULL', $result);
+        self::assertSame('`fld` = NULL', $result);
 
         // Update to NOT null when it was null previously
         $result = $this->insertEdit->getQueryValueForUpdate(
@@ -2104,7 +2104,7 @@ class InsertEditTest extends AbstractTestCase
                 false,
             ),
         );
-        self::assertEquals("`fld` = 'ab\'c'", $result);
+        self::assertSame("`fld` = 'ab\'c'", $result);
 
         // Test to see if a zero-string is not ignored
         $result = $this->insertEdit->getQueryValueForUpdate(
@@ -2121,7 +2121,7 @@ class InsertEditTest extends AbstractTestCase
                 false,
             ),
         );
-        self::assertEquals("`fld` = '0'", $result);
+        self::assertSame("`fld` = '0'", $result);
 
         // Test to check if blob field that was left unchanged during edit will be ignored
         $result = $this->insertEdit->getQueryValueForUpdate(
@@ -2138,7 +2138,7 @@ class InsertEditTest extends AbstractTestCase
                 false,
             ),
         );
-        self::assertEquals('', $result);
+        self::assertSame('', $result);
 
         // Test to see if a field will be ignored if it the value is unchanged
         $result = $this->insertEdit->getQueryValueForUpdate(
@@ -2156,7 +2156,7 @@ class InsertEditTest extends AbstractTestCase
             ),
         );
 
-        self::assertEquals('', $result);
+        self::assertSame('', $result);
 
         // Test that an empty value uses the uuid function to generate a value
         $result = $this->insertEdit->getQueryValueForUpdate(
@@ -2174,7 +2174,7 @@ class InsertEditTest extends AbstractTestCase
             ),
         );
 
-        self::assertEquals('`fld` = uuid()', $result);
+        self::assertSame('`fld` = uuid()', $result);
 
         // Test that the uuid function as a value uses the uuid function to generate a value
         $result = $this->insertEdit->getQueryValueForUpdate(
@@ -2192,7 +2192,7 @@ class InsertEditTest extends AbstractTestCase
             ),
         );
 
-        self::assertEquals('`fld` = uuid()', $result);
+        self::assertSame('`fld` = uuid()', $result);
 
         // Test that the uuid function as a value uses the uuid function to generate a value
         $result = $this->insertEdit->getQueryValueForUpdate(
@@ -2210,7 +2210,7 @@ class InsertEditTest extends AbstractTestCase
             ),
         );
 
-        self::assertEquals('`fld` = uuid()', $result);
+        self::assertSame('`fld` = uuid()', $result);
 
         // Test that the uuid type does not have a default value other than null when it is nullable
         $result = $this->insertEdit->getQueryValueForUpdate(
@@ -2228,7 +2228,7 @@ class InsertEditTest extends AbstractTestCase
             ),
         );
 
-        self::assertEquals('`fld` = NULL', $result);
+        self::assertSame('`fld` = NULL', $result);
     }
 
     /**
@@ -2279,12 +2279,12 @@ class InsertEditTest extends AbstractTestCase
 
         $this->insertEdit->verifyWhetherValueCanBeTruncatedAndAppendExtraData('db', 'table', 'a', $extraData);
 
-        self::assertEquals('123', $extraData['truncatableFieldValue']);
+        self::assertSame('123', $extraData['truncatableFieldValue']);
         self::assertTrue($extraData['isNeedToRecheck']);
 
         $this->insertEdit->verifyWhetherValueCanBeTruncatedAndAppendExtraData('db', 'table', 'a', $extraData);
 
-        self::assertEquals('2013-08-28 06:34:14.000000', $extraData['truncatableFieldValue']);
+        self::assertSame('2013-08-28 06:34:14.000000', $extraData['truncatableFieldValue']);
         self::assertTrue($extraData['isNeedToRecheck']);
     }
 
@@ -2392,7 +2392,7 @@ class InsertEditTest extends AbstractTestCase
 
         $response->setValue(null, $restoreInstance);
 
-        self::assertEquals(
+        self::assertSame(
             [true, null, [], null, $resultStub, [false, false], false, 'edit_next'],
             $result,
         );
@@ -2429,14 +2429,14 @@ class InsertEditTest extends AbstractTestCase
             Config::getInstance(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             [],
             $this->insertEdit->getCommentsMap('db', 'table'),
         );
 
         $config->settings['ShowPropertyComments'] = true;
 
-        self::assertEquals(
+        self::assertSame(
             ['d' => 'b'],
             $this->insertEdit->getCommentsMap('db', 'table'),
         );
@@ -2451,12 +2451,12 @@ class InsertEditTest extends AbstractTestCase
             . ' id="insert_ignore_1"><label for="insert_ignore_1">'
             . 'Ignore</label><br>' . "\n";
         $checked = 'checked="checked" ';
-        self::assertEquals(
+        self::assertSame(
             sprintf($expected, $checked),
             $this->insertEdit->getHtmlForIgnoreOption(1),
         );
 
-        self::assertEquals(
+        self::assertSame(
             sprintf($expected, ''),
             $this->insertEdit->getHtmlForIgnoreOption(1, false),
         );

--- a/tests/classes/IpAllowDenyTest.php
+++ b/tests/classes/IpAllowDenyTest.php
@@ -68,7 +68,7 @@ class IpAllowDenyTest extends AbstractTestCase
             $_SERVER['TEST_FORWARDED_HEADER'] = $header;
         }
 
-        self::assertEquals(
+        self::assertSame(
             $expected,
             Core::getIp(),
         );

--- a/tests/classes/LanguageTest.php
+++ b/tests/classes/LanguageTest.php
@@ -116,11 +116,11 @@ class LanguageTest extends AbstractTestCase
         Config::getInstance()->set('FilterLanguages', '');
         $czech = $this->manager->getLanguage('cs');
         self::assertNotFalse($czech);
-        self::assertEquals('cs_CZ', $czech->getMySQLLocale());
+        self::assertSame('cs_CZ', $czech->getMySQLLocale());
 
         $azerbaijani = $this->manager->getLanguage('az');
         self::assertNotFalse($azerbaijani);
-        self::assertEquals('', $azerbaijani->getMySQLLocale());
+        self::assertSame('', $azerbaijani->getMySQLLocale());
     }
 
     /**
@@ -140,8 +140,8 @@ class LanguageTest extends AbstractTestCase
         Config::getInstance()->set('FilterLanguages', '');
         $lang = $this->manager->getLanguage('cs');
         self::assertNotFalse($lang);
-        self::assertEquals('Czech', $lang->getEnglishName());
-        self::assertEquals('Čeština', $lang->getNativeName());
+        self::assertSame('Czech', $lang->getEnglishName());
+        self::assertSame('Čeština', $lang->getNativeName());
         $lang = $this->manager->getLanguage('nonexisting');
         self::assertFalse($lang);
     }
@@ -187,7 +187,7 @@ class LanguageTest extends AbstractTestCase
 
         $lang = $this->manager->selectLanguage();
 
-        self::assertEquals($expect, $lang->getCode());
+        self::assertSame($expect, $lang->getCode());
 
         $config->set('Lang', '');
         $_POST['lang'] = '';
@@ -250,7 +250,7 @@ class LanguageTest extends AbstractTestCase
         self::assertStringContainsString('%s', _ngettext('%s table', '%s tables', 10));
         self::assertStringContainsString('%s', _ngettext('%s table', '%s tables', 1));
 
-        self::assertEquals(
+        self::assertSame(
             $locale,
             $this->manager->getCurrentLanguage()->getCode(),
         );

--- a/tests/classes/LinterTest.php
+++ b/tests/classes/LinterTest.php
@@ -29,9 +29,9 @@ class LinterTest extends AbstractTestCase
      */
     public function testGetLines(): void
     {
-        self::assertEquals([0], Linter::getLines(''));
-        self::assertEquals([0, 2], Linter::getLines("a\nb"));
-        self::assertEquals([0, 4, 7], Linter::getLines("abc\nde\n"));
+        self::assertSame([0], Linter::getLines(''));
+        self::assertSame([0, 2], Linter::getLines("a\nb"));
+        self::assertSame([0, 4, 7], Linter::getLines("abc\nde\n"));
     }
 
     /**
@@ -50,19 +50,19 @@ class LinterTest extends AbstractTestCase
         //      ( a, 0), ( b, 1), ( c, 2), (\n, 3),
         //      ( d, 4), ( e, 5), (\n, 6),
         //      (\n, 7).
-        self::assertEquals(
+        self::assertSame(
             [1, 0],
             Linter::findLineNumberAndColumn([0, 4, 7], 4),
         );
-        self::assertEquals(
+        self::assertSame(
             [1, 1],
             Linter::findLineNumberAndColumn([0, 4, 7], 5),
         );
-        self::assertEquals(
+        self::assertSame(
             [1, 2],
             Linter::findLineNumberAndColumn([0, 4, 7], 6),
         );
-        self::assertEquals(
+        self::assertSame(
             [2, 0],
             Linter::findLineNumberAndColumn([0, 4, 7], 7),
         );
@@ -77,7 +77,7 @@ class LinterTest extends AbstractTestCase
     #[DataProvider('lintProvider')]
     public function testLint(array $expected, string $query): void
     {
-        self::assertEquals($expected, Linter::lint($query));
+        self::assertSame($expected, Linter::lint($query));
     }
 
     /**

--- a/tests/classes/ListDatabaseTest.php
+++ b/tests/classes/ListDatabaseTest.php
@@ -54,13 +54,13 @@ class ListDatabaseTest extends AbstractTestCase
         $arr = new ListDatabase($dbi, $config, new UserPrivilegesFactory($dbi));
 
         Current::$database = 'db';
-        self::assertEquals(
+        self::assertSame(
             [['name' => 'single_db', 'is_selected' => false]],
             $arr->getList(),
         );
 
         Current::$database = 'single_db';
-        self::assertEquals(
+        self::assertSame(
             [['name' => 'single_db', 'is_selected' => true]],
             $arr->getList(),
         );

--- a/tests/classes/LoggingTest.php
+++ b/tests/classes/LoggingTest.php
@@ -14,8 +14,8 @@ class LoggingTest extends AbstractTestCase
     {
         $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
         $log = Logging::getLogMessage('user', 'ok');
-        self::assertEquals('user authenticated: user from 0.0.0.0', $log);
+        self::assertSame('user authenticated: user from 0.0.0.0', $log);
         $log = Logging::getLogMessage('user', 'error');
-        self::assertEquals('user denied: user (error) from 0.0.0.0', $log);
+        self::assertSame('user denied: user (error) from 0.0.0.0', $log);
     }
 }

--- a/tests/classes/MessageTest.php
+++ b/tests/classes/MessageTest.php
@@ -32,7 +32,7 @@ class MessageTest extends AbstractTestCase
     public function testToString(): void
     {
         $this->object->setMessage('test<&>');
-        self::assertEquals('test<&>', (string) $this->object);
+        self::assertSame('test<&>', (string) $this->object);
     }
 
     /**
@@ -42,7 +42,7 @@ class MessageTest extends AbstractTestCase
     {
         $this->object = new Message('test<&>', Message::SUCCESS);
         self::assertEquals($this->object, Message::success('test<&>'));
-        self::assertEquals(
+        self::assertSame(
             'Your SQL query has been executed successfully.',
             Message::success()->getString(),
         );
@@ -55,7 +55,7 @@ class MessageTest extends AbstractTestCase
     {
         $this->object = new Message('test<&>', Message::ERROR);
         self::assertEquals($this->object, Message::error('test<&>'));
-        self::assertEquals('Error', Message::error()->getString());
+        self::assertSame('Error', Message::error()->getString());
     }
 
     /**
@@ -141,7 +141,7 @@ class MessageTest extends AbstractTestCase
     public function testSetMessage(): void
     {
         $this->object->setMessage('test&<>');
-        self::assertEquals('test&<>', $this->object->getMessage());
+        self::assertSame('test&<>', $this->object->getMessage());
     }
 
     /**
@@ -150,7 +150,7 @@ class MessageTest extends AbstractTestCase
     public function testSetString(): void
     {
         $this->object->setString('test&<>');
-        self::assertEquals('test&<>', $this->object->getString());
+        self::assertSame('test&<>', $this->object->getString());
     }
 
     /**
@@ -184,7 +184,7 @@ class MessageTest extends AbstractTestCase
         $this->object->addParamHtml('<a href="">');
         $this->object->addParam('user<>');
         $this->object->addParamHtml('</a>');
-        self::assertEquals(
+        self::assertSame(
             'Hello <a href="">user&lt;&gt;</a>',
             $this->object->getMessage(),
         );
@@ -223,7 +223,7 @@ class MessageTest extends AbstractTestCase
             $this->object->getAddedMessages(),
         );
         $this->object->addMessage(Message::notice('test<>'));
-        self::assertEquals(
+        self::assertSame(
             'test&lt;&gt; <b>test</b> test<>',
             $this->object->getMessage(),
         );
@@ -259,7 +259,7 @@ class MessageTest extends AbstractTestCase
             $this->object->getAddedMessages(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'test1test&lt;b&gt;test2',
             $this->object->getMessage(),
         );
@@ -271,7 +271,7 @@ class MessageTest extends AbstractTestCase
     public function testSetParams(): void
     {
         $this->object->setParams(['test&<>']);
-        self::assertEquals(['test&<>'], $this->object->getParams());
+        self::assertSame(['test&<>'], $this->object->getParams());
     }
 
     /**
@@ -281,7 +281,7 @@ class MessageTest extends AbstractTestCase
     {
         $this->object->setString('<&>test');
         $this->object->setMessage('<&>test');
-        self::assertEquals(
+        self::assertSame(
             md5(Message::NOTICE . '<&>test<&>test'),
             $this->object->getHash(),
         );
@@ -297,7 +297,7 @@ class MessageTest extends AbstractTestCase
         $this->object->setString('test string %s %s');
         $this->object->addParam('test param 1');
         $this->object->addParam('test param 2');
-        self::assertEquals(
+        self::assertSame(
             'test string test param 1 test param 2',
             $this->object->getMessage(),
         );
@@ -310,7 +310,7 @@ class MessageTest extends AbstractTestCase
     {
         $this->object->setMessage('');
         $this->object->setString('');
-        self::assertEquals('', $this->object->getMessage());
+        self::assertSame('', $this->object->getMessage());
     }
 
     /**
@@ -320,7 +320,7 @@ class MessageTest extends AbstractTestCase
     public function testGetMessageWithMessageWithBBCode(): void
     {
         $this->object->setMessage('[kbd]test[/kbd] [doc@cfg_Example]test[/doc]');
-        self::assertEquals(
+        self::assertSame(
             '<kbd>test</kbd> <a href="index.php?route=/url&url=https%3A%2F%2Fdocs.phpmyadmin.'
             . 'net%2Fen%2Flatest%2Fconfig.html%23cfg_Example"'
             . ' target="documentation">test</a>',
@@ -333,11 +333,11 @@ class MessageTest extends AbstractTestCase
      */
     public function testGetLevel(): void
     {
-        self::assertEquals('notice', $this->object->getLevel());
+        self::assertSame('notice', $this->object->getLevel());
         $this->object->setType(Message::SUCCESS);
-        self::assertEquals('success', $this->object->getLevel());
+        self::assertSame('success', $this->object->getLevel());
         $this->object->setType(Message::ERROR);
-        self::assertEquals('error', $this->object->getLevel());
+        self::assertSame('error', $this->object->getLevel());
     }
 
     /**
@@ -347,7 +347,7 @@ class MessageTest extends AbstractTestCase
     {
         self::assertFalse($this->object->isDisplayed());
         $this->object->setMessage('Test Message');
-        self::assertEquals(
+        self::assertSame(
             '<div class="alert alert-primary" role="alert">' . "\n"
             . '  <img src="themes/dot.gif" title="" alt="" class="icon ic_s_notice"> Test Message' . "\n"
             . '</div>' . "\n",
@@ -407,7 +407,7 @@ class MessageTest extends AbstractTestCase
         $this->object = new Message();
         $msg = $this->object->getMessageForAffectedRows($rows);
         $this->object->addMessage($msg);
-        self::assertEquals($output, $this->object->getDisplay());
+        self::assertSame($output, $this->object->getDisplay());
     }
 
     /**
@@ -451,7 +451,7 @@ class MessageTest extends AbstractTestCase
         $this->object = new Message();
         $msg = $this->object->getMessageForInsertedRows($rows);
         $this->object->addMessage($msg);
-        self::assertEquals($output, $this->object->getDisplay());
+        self::assertSame($output, $this->object->getDisplay());
     }
 
     /**
@@ -495,6 +495,6 @@ class MessageTest extends AbstractTestCase
         $this->object = new Message();
         $msg = $this->object->getMessageForDeletedRows($rows);
         $this->object->addMessage($msg);
-        self::assertEquals($output, $this->object->getDisplay());
+        self::assertSame($output, $this->object->getDisplay());
     }
 }

--- a/tests/classes/MimeTest.php
+++ b/tests/classes/MimeTest.php
@@ -22,7 +22,7 @@ class MimeTest extends AbstractTestCase
     #[DataProvider('providerForTestDetect')]
     public function testDetect(string $test, string $output): void
     {
-        self::assertEquals(
+        self::assertSame(
             Mime::detect($test),
             $output,
         );

--- a/tests/classes/Navigation/Nodes/NodeDatabaseTest.php
+++ b/tests/classes/Navigation/Nodes/NodeDatabaseTest.php
@@ -21,7 +21,7 @@ class NodeDatabaseTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $parent = new NodeDatabase(new Config(), 'default');
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => ['route' => '/database/structure', 'params' => ['db' => null]],
                 'icon' => ['route' => '/database/operations', 'params' => ['db' => null]],
@@ -43,23 +43,23 @@ class NodeDatabaseTest extends AbstractTestCase
         $userPrivileges = new UserPrivileges();
 
         $parent = new NodeDatabase($config, 'default');
-        self::assertEquals(
+        self::assertSame(
             2,
             $parent->getPresence($userPrivileges, 'tables'),
         );
-        self::assertEquals(
+        self::assertSame(
             0,
             $parent->getPresence($userPrivileges, 'views'),
         );
-        self::assertEquals(
+        self::assertSame(
             1,
             $parent->getPresence($userPrivileges, 'functions'),
         );
-        self::assertEquals(
+        self::assertSame(
             0,
             $parent->getPresence($userPrivileges, 'procedures'),
         );
-        self::assertEquals(
+        self::assertSame(
             0,
             $parent->getPresence($userPrivileges, 'events'),
         );

--- a/tests/classes/Navigation/Nodes/NodeEventContainerTest.php
+++ b/tests/classes/Navigation/Nodes/NodeEventContainerTest.php
@@ -18,13 +18,13 @@ class NodeEventContainerTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $parent = new NodeEventContainer(new Config());
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => ['route' => '/database/events', 'params' => ['db' => null]],
                 'icon' => ['route' => '/database/events', 'params' => ['db' => null]],
             ],
             $parent->links,
         );
-        self::assertEquals('events', $parent->realName);
+        self::assertSame('events', $parent->realName);
     }
 }

--- a/tests/classes/Navigation/Nodes/NodeEventTest.php
+++ b/tests/classes/Navigation/Nodes/NodeEventTest.php
@@ -18,7 +18,7 @@ class NodeEventTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $parent = new NodeEvent(new Config(), 'default');
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => [
                     'route' => '/database/events',

--- a/tests/classes/Navigation/Nodes/NodeFunctionContainerTest.php
+++ b/tests/classes/Navigation/Nodes/NodeFunctionContainerTest.php
@@ -18,13 +18,13 @@ class NodeFunctionContainerTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $parent = new NodeFunctionContainer(new Config());
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => ['route' => '/database/routines', 'params' => ['type' => 'FUNCTION', 'db' => null]],
                 'icon' => ['route' => '/database/routines', 'params' => ['type' => 'FUNCTION', 'db' => null]],
             ],
             $parent->links,
         );
-        self::assertEquals('functions', $parent->realName);
+        self::assertSame('functions', $parent->realName);
     }
 }

--- a/tests/classes/Navigation/Nodes/NodeFunctionTest.php
+++ b/tests/classes/Navigation/Nodes/NodeFunctionTest.php
@@ -18,7 +18,7 @@ class NodeFunctionTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $parent = new NodeFunction(new Config(), 'default');
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => [
                     'route' => '/database/routines',

--- a/tests/classes/Navigation/Nodes/NodeIndexContainerTest.php
+++ b/tests/classes/Navigation/Nodes/NodeIndexContainerTest.php
@@ -18,13 +18,13 @@ class NodeIndexContainerTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $parent = new NodeIndexContainer(new Config());
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => ['route' => '/table/structure', 'params' => ['db' => null, 'table' => null]],
                 'icon' => ['route' => '/table/structure', 'params' => ['db' => null, 'table' => null]],
             ],
             $parent->links,
         );
-        self::assertEquals('indexes', $parent->realName);
+        self::assertSame('indexes', $parent->realName);
     }
 }

--- a/tests/classes/Navigation/Nodes/NodeIndexTest.php
+++ b/tests/classes/Navigation/Nodes/NodeIndexTest.php
@@ -18,7 +18,7 @@ class NodeIndexTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $parent = new NodeIndex(new Config(), 'default');
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => ['route' => '/table/indexes', 'params' => ['db' => null, 'table' => null, 'index' => null]],
                 'icon' => ['route' => '/table/indexes', 'params' => ['db' => null, 'table' => null, 'index' => null]],

--- a/tests/classes/Navigation/Nodes/NodeProcedureContainerTest.php
+++ b/tests/classes/Navigation/Nodes/NodeProcedureContainerTest.php
@@ -18,13 +18,13 @@ class NodeProcedureContainerTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $parent = new NodeProcedureContainer(new Config());
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => ['route' => '/database/routines', 'params' => ['type' => 'PROCEDURE', 'db' => null]],
                 'icon' => ['route' => '/database/routines', 'params' => ['type' => 'PROCEDURE', 'db' => null]],
             ],
             $parent->links,
         );
-        self::assertEquals('procedures', $parent->realName);
+        self::assertSame('procedures', $parent->realName);
     }
 }

--- a/tests/classes/Navigation/Nodes/NodeProcedureTest.php
+++ b/tests/classes/Navigation/Nodes/NodeProcedureTest.php
@@ -18,7 +18,7 @@ class NodeProcedureTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $parent = new NodeProcedure(new Config(), 'default');
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => [
                     'route' => '/database/routines',

--- a/tests/classes/Navigation/Nodes/NodeTableContainerTest.php
+++ b/tests/classes/Navigation/Nodes/NodeTableContainerTest.php
@@ -18,14 +18,14 @@ class NodeTableContainerTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $parent = new NodeTableContainer(new Config());
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => ['route' => '/database/structure', 'params' => ['tbl_type' => 'table', 'db' => null]],
                 'icon' => ['route' => '/database/structure', 'params' => ['tbl_type' => 'table', 'db' => null]],
             ],
             $parent->links,
         );
-        self::assertEquals('tables', $parent->realName);
+        self::assertSame('tables', $parent->realName);
         self::assertStringContainsString('tableContainer', $parent->classes);
     }
 }

--- a/tests/classes/Navigation/Nodes/NodeTableTest.php
+++ b/tests/classes/Navigation/Nodes/NodeTableTest.php
@@ -23,7 +23,7 @@ class NodeTableTest extends AbstractTestCase
         $config->settings['NavigationTreeDefaultTabTable2'] = 'insert';
 
         $parent = new NodeTable($config, 'default');
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => ['route' => '/sql', 'params' => ['pos' => 0, 'db' => null, 'table' => null]],
                 'icon' => ['route' => '/table/search', 'params' => ['db' => null, 'table' => null]],
@@ -47,8 +47,8 @@ class NodeTableTest extends AbstractTestCase
         $config = Config::getInstance();
         $config->settings['NavigationTreeDefaultTabTable'] = $target;
         $node = new NodeTable($config, 'default');
-        self::assertEquals($imageName, $node->icon['image']);
-        self::assertEquals($imageTitle, $node->icon['title']);
+        self::assertSame($imageName, $node->icon['image']);
+        self::assertSame($imageTitle, $node->icon['title']);
     }
 
     /**

--- a/tests/classes/Navigation/Nodes/NodeTest.php
+++ b/tests/classes/Navigation/Nodes/NodeTest.php
@@ -537,11 +537,11 @@ final class NodeTest extends AbstractTestCase
     public function testGetInstanceForNewNode(): void
     {
         $node = (new Node(new Config()))->getInstanceForNewNode('New', 'new_database italics');
-        self::assertEquals('New', $node->name);
-        self::assertEquals(NodeType::Object, $node->type);
+        self::assertSame('New', $node->name);
+        self::assertSame(NodeType::Object, $node->type);
         self::assertFalse($node->isGroup);
-        self::assertEquals('New', $node->title);
+        self::assertSame('New', $node->title);
         self::assertTrue($node->isNew);
-        self::assertEquals('new_database italics', $node->classes);
+        self::assertSame('new_database italics', $node->classes);
     }
 }

--- a/tests/classes/Navigation/Nodes/NodeTriggerContainerTest.php
+++ b/tests/classes/Navigation/Nodes/NodeTriggerContainerTest.php
@@ -18,13 +18,13 @@ class NodeTriggerContainerTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $parent = new NodeTriggerContainer(new Config());
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => ['route' => '/triggers', 'params' => ['db' => null, 'table' => null]],
                 'icon' => ['route' => '/triggers', 'params' => ['db' => null, 'table' => null]],
             ],
             $parent->links,
         );
-        self::assertEquals('triggers', $parent->realName);
+        self::assertSame('triggers', $parent->realName);
     }
 }

--- a/tests/classes/Navigation/Nodes/NodeTriggerTest.php
+++ b/tests/classes/Navigation/Nodes/NodeTriggerTest.php
@@ -18,7 +18,7 @@ class NodeTriggerTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $parent = new NodeTrigger(new Config(), 'default');
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => [
                     'route' => '/triggers',

--- a/tests/classes/Navigation/Nodes/NodeViewContainerTest.php
+++ b/tests/classes/Navigation/Nodes/NodeViewContainerTest.php
@@ -18,14 +18,14 @@ class NodeViewContainerTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $parent = new NodeViewContainer(new Config());
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => ['route' => '/database/structure', 'params' => ['tbl_type' => 'view', 'db' => null]],
                 'icon' => ['route' => '/database/structure', 'params' => ['tbl_type' => 'view', 'db' => null]],
             ],
             $parent->links,
         );
-        self::assertEquals('views', $parent->realName);
+        self::assertSame('views', $parent->realName);
         self::assertStringContainsString('viewContainer', $parent->classes);
     }
 }

--- a/tests/classes/Navigation/Nodes/NodeViewTest.php
+++ b/tests/classes/Navigation/Nodes/NodeViewTest.php
@@ -18,15 +18,15 @@ class NodeViewTest extends AbstractTestCase
     public function testConstructor(): void
     {
         $parent = new NodeView(new Config(), 'default');
-        self::assertEquals(
+        self::assertSame(
             [
                 'text' => ['route' => '/sql', 'params' => ['pos' => 0, 'db' => null, 'table' => null]],
                 'icon' => ['route' => '/table/structure', 'params' => ['db' => null, 'table' => null]],
             ],
             $parent->links,
         );
-        self::assertEquals('b_props', $parent->icon['image']);
-        self::assertEquals('View', $parent->icon['title']);
+        self::assertSame('b_props', $parent->icon['image']);
+        self::assertSame('View', $parent->icon['title']);
         self::assertStringContainsString('view', $parent->classes);
     }
 }

--- a/tests/classes/NormalizationTest.php
+++ b/tests/classes/NormalizationTest.php
@@ -111,7 +111,7 @@ class NormalizationTest extends AbstractTestCase
             '<option value="id">id [ integer ]</option>',
             $this->normalization->getHtmlForColumnsList($table, $db),
         );
-        self::assertEquals(
+        self::assertSame(
             '<input type="checkbox" value="col1">col1 [ varchar(100) ]<br>',
             $this->normalization->getHtmlForColumnsList($table, $db, 'String', 'checkbox'),
         );
@@ -185,10 +185,10 @@ class NormalizationTest extends AbstractTestCase
         self::assertArrayHasKey('extra', $result);
         self::assertStringContainsString('<a href="#" id="createPrimaryKey">', $result['subText']);
         self::assertStringContainsString('<a href="#" id="addNewPrimary">', $result['extra']);
-        self::assertEquals('0', $result['hasPrimaryKey']);
+        self::assertSame('0', $result['hasPrimaryKey']);
         self::assertStringContainsString(__('Step 1.') . 2, $result['legendText']);
         $result1 = $this->normalization->getHtmlContentsFor1NFStep2($db, 'PMA_table');
-        self::assertEquals('1', $result1['hasPrimaryKey']);
+        self::assertSame('1', $result1['hasPrimaryKey']);
     }
 
     /**
@@ -236,7 +236,7 @@ class NormalizationTest extends AbstractTestCase
             '<input class="btn btn-secondary" type="submit" id="moveRepeatingGroup"',
             $result['extra'],
         );
-        self::assertEquals(json_encode(['id']), $result['primary_key']);
+        self::assertSame(json_encode(['id']), $result['primary_key']);
     }
 
     /**
@@ -253,9 +253,9 @@ class NormalizationTest extends AbstractTestCase
         self::assertArrayHasKey('extra', $result);
         self::assertArrayHasKey('primary_key', $result);
         self::assertStringContainsString(__('Step 2.') . 1, $result['legendText']);
-        self::assertEquals('id', $result['primary_key']);
+        self::assertSame('id', $result['primary_key']);
         $result1 = $this->normalization->getHtmlFor2NFstep1($db, 'PMA_table2');
-        self::assertEquals('id, col1', $result1['primary_key']);
+        self::assertSame('id, col1', $result1['primary_key']);
         self::assertStringContainsString('<a href="#" id="showPossiblePd"', $result1['headText']);
         self::assertStringContainsString('<input type="checkbox" name="pd" value="id"', $result1['extra']);
     }
@@ -289,8 +289,8 @@ class NormalizationTest extends AbstractTestCase
         $partialDependencies = ['id' => ['col2'], 'col1' => ['col2']];
         $result1 = $this->normalization->createNewTablesFor2NF($partialDependencies, $tablesName, $table, $db);
         self::assertArrayHasKey('extra', $result1);
-        self::assertEquals(__('End of step'), $result1['legendText']);
-        self::assertEquals('', $result1['extra']);
+        self::assertSame(__('End of step'), $result1['legendText']);
+        self::assertSame('', $result1['extra']);
     }
 
     /**
@@ -312,7 +312,7 @@ class NormalizationTest extends AbstractTestCase
         $dependencies->PMA_table = ['col4', 'col5'];
         $result1 = $this->normalization->getHtmlForNewTables3NF($dependencies, $tables, $db);
         self::assertStringContainsString('<input type="text" name="PMA_table"', $result1['html']);
-        self::assertEquals(
+        self::assertSame(
             [
                 'PMA_table' => [
                     'PMA_table' => ['pk' => 'col1', 'nonpk' => 'col2'],
@@ -342,7 +342,7 @@ class NormalizationTest extends AbstractTestCase
         $newTables1 = [];
         $result1 = $this->normalization->createNewTablesFor3NF($newTables1, $db);
         self::assertArrayHasKey('queryError', $result1);
-        self::assertEquals(__('End of step'), $result1['legendText']);
+        self::assertSame(__('End of step'), $result1['legendText']);
         self::assertFalse($result1['queryError']);
     }
 
@@ -386,7 +386,7 @@ class NormalizationTest extends AbstractTestCase
         self::assertStringContainsString('<form', $result['extra']);
         self::assertStringContainsString('<input type="checkbox" name="pd" value="col1"', $result['extra']);
         $result1 = $this->normalization->getHtmlFor3NFstep1($db, ['PMA_table2']);
-        self::assertEquals('', $result1['subText']);
+        self::assertSame('', $result1['subText']);
     }
 
     /**
@@ -414,7 +414,7 @@ class NormalizationTest extends AbstractTestCase
             [$primaryKey],
         );
 
-        self::assertEquals(
+        self::assertSame(
             ['', 'id', 'col1', 'col1,id', 'col2', 'col2,id', 'col2,col1'],
             $result,
         );

--- a/tests/classes/OperationsTest.php
+++ b/tests/classes/OperationsTest.php
@@ -52,7 +52,7 @@ class OperationsTest extends AbstractTestCase
         $expected = array_merge($choices, $extraChoice);
 
         $actual = $this->object->getPartitionMaintenanceChoices();
-        self::assertEquals($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /** @psalm-return array<string, array{0: string, 1: array<string, string>}> */

--- a/tests/classes/Partitioning/PartitionTest.php
+++ b/tests/classes/Partitioning/PartitionTest.php
@@ -31,7 +31,7 @@ class PartitionTest extends AbstractTestCase
     public function testGetPartitionMethodWithRangeMethod(): void
     {
         $actual = Partition::getPartitionMethod('database', 'range_partition_method');
-        self::assertEquals('RANGE', $actual);
+        self::assertSame('RANGE', $actual);
     }
 
     /** @param array<int, array<string, string>> $pluginValue */

--- a/tests/classes/Partitioning/SubPartitionTest.php
+++ b/tests/classes/Partitioning/SubPartitionTest.php
@@ -26,13 +26,13 @@ class SubPartitionTest extends TestCase
             'PARTITION_COMMENT' => 'partition_comment',
         ];
         $object = new SubPartition($row);
-        self::assertEquals('subpartition_name', $object->getName());
-        self::assertEquals(1, $object->getOrdinal());
-        self::assertEquals('subpartition_method', $object->getMethod());
-        self::assertEquals('subpartition_expression', $object->getExpression());
-        self::assertEquals(2, $object->getRows());
-        self::assertEquals(3, $object->getDataLength());
-        self::assertEquals(4, $object->getIndexLength());
-        self::assertEquals('partition_comment', $object->getComment());
+        self::assertSame('subpartition_name', $object->getName());
+        self::assertSame(1, $object->getOrdinal());
+        self::assertSame('subpartition_method', $object->getMethod());
+        self::assertSame('subpartition_expression', $object->getExpression());
+        self::assertSame(2, $object->getRows());
+        self::assertSame(3, $object->getDataLength());
+        self::assertSame(4, $object->getIndexLength());
+        self::assertSame('partition_comment', $object->getComment());
     }
 }

--- a/tests/classes/Partitioning/TablePartitionDefinitionTest.php
+++ b/tests/classes/Partitioning/TablePartitionDefinitionTest.php
@@ -9,8 +9,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-use function count;
-
 #[CoversClass(TablePartitionDefinition::class)]
 class TablePartitionDefinitionTest extends TestCase
 {
@@ -233,7 +231,7 @@ class TablePartitionDefinitionTest extends TestCase
         ];
 
         $actual = TablePartitionDefinition::getDetails();
-        self::assertEquals($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     #[DataProvider('providerGetDetailsWithMaxPartitions')]
@@ -245,7 +243,7 @@ class TablePartitionDefinitionTest extends TestCase
         self::assertArrayHasKey('partitions', $actual);
         self::assertSame($partitionCount, $actual['partition_count']);
         self::assertIsArray($actual['partitions']);
-        self::assertEquals($partitionCount, count($actual['partitions']));
+        self::assertCount($partitionCount, $actual['partitions']);
     }
 
     /** @psalm-return array{0: int, 1: string}[] */

--- a/tests/classes/Plugins/Auth/AuthenticationCookieTest.php
+++ b/tests/classes/Plugins/Auth/AuthenticationCookieTest.php
@@ -379,10 +379,7 @@ class AuthenticationCookieTest extends AbstractTestCase
             $this->object->readCredentials(),
         );
 
-        self::assertEquals(
-            'Missing Captcha verification, maybe it has been blocked by adblock?',
-            $GLOBALS['conn_error'],
-        );
+        self::assertSame('Missing Captcha verification, maybe it has been blocked by adblock?', $GLOBALS['conn_error']);
     }
 
     #[RunInSeparateProcess]
@@ -462,11 +459,11 @@ class AuthenticationCookieTest extends AbstractTestCase
             $this->object->readCredentials(),
         );
 
-        self::assertEquals('testPMAUser', $this->object->user);
+        self::assertSame('testPMAUser', $this->object->user);
 
-        self::assertEquals('testPMAPSWD', $this->object->password);
+        self::assertSame('testPMAPSWD', $this->object->password);
 
-        self::assertEquals('testPMAServer', $GLOBALS['pma_auth_server']);
+        self::assertSame('testPMAServer', $GLOBALS['pma_auth_server']);
 
         self::assertArrayNotHasKey('pmaAuth-1', $_COOKIE);
     }
@@ -532,7 +529,7 @@ class AuthenticationCookieTest extends AbstractTestCase
             $this->object->readCredentials(),
         );
 
-        self::assertEquals('testBF', $this->object->user);
+        self::assertSame('testBF', $this->object->user);
     }
 
     public function testAuthCheckDecryptPassword(): void
@@ -570,7 +567,7 @@ class AuthenticationCookieTest extends AbstractTestCase
 
         self::assertTrue($GLOBALS['from_cookie']);
 
-        self::assertEquals('', $this->object->password);
+        self::assertSame('', $this->object->password);
     }
 
     public function testAuthCheckAuthFails(): void
@@ -638,7 +635,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         $arr['password'] = 'testPW';
         $arr['host'] = 'b';
         $arr['port'] = '2';
-        self::assertEquals($arr, $config->selectedServer);
+        self::assertSame($arr, $config->selectedServer);
     }
 
     public function testAuthSetUserWithHeaders(): void
@@ -694,7 +691,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         self::assertSame(['no-cache'], $response->getHeader('Pragma'));
         self::assertSame(200, $response->getStatusCode());
 
-        self::assertEquals(
+        self::assertSame(
             $GLOBALS['conn_error'],
             'Login without a password is forbidden by configuration (see AllowNoPassword)',
         );
@@ -737,7 +734,7 @@ class AuthenticationCookieTest extends AbstractTestCase
             );
         }
 
-        self::assertEquals($GLOBALS['conn_error'], $connError);
+        self::assertSame($GLOBALS['conn_error'], $connError);
     }
 
     #[RunInSeparateProcess]
@@ -769,7 +766,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         self::assertSame(['no-cache'], $response->getHeader('Pragma'));
         self::assertSame(200, $response->getStatusCode());
 
-        self::assertEquals($GLOBALS['conn_error'], 'Access denied!');
+        self::assertSame($GLOBALS['conn_error'], 'Access denied!');
     }
 
     #[RunInSeparateProcess]
@@ -804,7 +801,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         self::assertSame(['no-cache'], $response->getHeader('Pragma'));
         self::assertSame(200, $response->getStatusCode());
 
-        self::assertEquals(
+        self::assertSame(
             $GLOBALS['conn_error'],
             'You have been automatically logged out due to inactivity of 10 seconds.'
             . ' Once you log in again, you should be able to resume the work where you left off.',
@@ -851,7 +848,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         self::assertSame(['no-cache'], $response->getHeader('Pragma'));
         self::assertSame(200, $response->getStatusCode());
 
-        self::assertEquals($GLOBALS['conn_error'], '#42 Cannot log in to the MySQL server');
+        self::assertSame($GLOBALS['conn_error'], '#42 Cannot log in to the MySQL server');
     }
 
     #[RunInSeparateProcess]
@@ -894,7 +891,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         self::assertSame(['no-cache'], $response->getHeader('Pragma'));
         self::assertSame(200, $response->getStatusCode());
 
-        self::assertEquals($GLOBALS['conn_error'], 'Cannot log in to the MySQL server');
+        self::assertSame($GLOBALS['conn_error'], 'Cannot log in to the MySQL server');
     }
 
     public function testGetEncryptionSecretEmpty(): void
@@ -1000,15 +997,15 @@ class AuthenticationCookieTest extends AbstractTestCase
         $result = ob_get_clean();
 
         /* Nothing should be printed */
-        self::assertEquals('', $result);
+        self::assertSame('', $result);
 
         /* Verify readCredentials worked */
-        self::assertEquals('testUser', $this->object->user);
-        self::assertEquals('testPassword', $this->object->password);
+        self::assertSame('testUser', $this->object->user);
+        self::assertSame('testPassword', $this->object->password);
 
         /* Verify storeCredentials worked */
-        self::assertEquals('testUser', $config->selectedServer['user']);
-        self::assertEquals('testPassword', $config->selectedServer['password']);
+        self::assertSame('testUser', $config->selectedServer['user']);
+        self::assertSame('testPassword', $config->selectedServer['password']);
     }
 
     /**
@@ -1062,7 +1059,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         }
 
         if ($expected === '') {
-            self::assertEquals($expected, $result);
+            self::assertSame($expected, $result);
         } else {
             self::assertStringContainsString($expected, $result);
         }

--- a/tests/classes/Plugins/Auth/AuthenticationHttpTest.php
+++ b/tests/classes/Plugins/Auth/AuthenticationHttpTest.php
@@ -172,12 +172,12 @@ class AuthenticationHttpTest extends AbstractTestCase
 
         $_REQUEST['old_usr'] = $oldUsr;
 
-        self::assertEquals(
+        self::assertSame(
             $expectedReturn,
             $this->object->readCredentials(),
         );
 
-        self::assertEquals($expectedUser, $this->object->user);
+        self::assertSame($expectedUser, $this->object->user);
 
         self::assertEquals($expectedPass, $this->object->password);
 
@@ -231,13 +231,13 @@ class AuthenticationHttpTest extends AbstractTestCase
             $this->object->storeCredentials(),
         );
 
-        self::assertEquals('testUser', $config->selectedServer['user']);
+        self::assertSame('testUser', $config->selectedServer['user']);
 
-        self::assertEquals('testPass', $config->selectedServer['password']);
+        self::assertSame('testPass', $config->selectedServer['password']);
 
         self::assertArrayNotHasKey('PHP_AUTH_PW', $_SERVER);
 
-        self::assertEquals(2, Current::$server);
+        self::assertSame(2, Current::$server);
 
         // case 2
         $this->object->user = 'testUser';
@@ -255,7 +255,7 @@ class AuthenticationHttpTest extends AbstractTestCase
             $config->selectedServer,
         );
 
-        self::assertEquals(2, Current::$server);
+        self::assertSame(2, Current::$server);
 
         // case 3
         Current::$server = 3;
@@ -274,7 +274,7 @@ class AuthenticationHttpTest extends AbstractTestCase
             $config->selectedServer,
         );
 
-        self::assertEquals(3, Current::$server);
+        self::assertSame(3, Current::$server);
     }
 
     #[Group('medium')]

--- a/tests/classes/Plugins/Auth/AuthenticationSignonTest.php
+++ b/tests/classes/Plugins/Auth/AuthenticationSignonTest.php
@@ -144,11 +144,11 @@ class AuthenticationSignonTest extends AbstractTestCase
             $this->object->readCredentials(),
         );
 
-        self::assertEquals('user', $this->object->user);
+        self::assertSame('user', $this->object->user);
 
-        self::assertEquals('password', $this->object->password);
+        self::assertSame('password', $this->object->password);
 
-        self::assertEquals('https://example.com/SignonURL', $_SESSION['LAST_SIGNON_URL']);
+        self::assertSame('https://example.com/SignonURL', $_SESSION['LAST_SIGNON_URL']);
     }
 
     #[RunInSeparateProcess]
@@ -186,7 +186,7 @@ class AuthenticationSignonTest extends AbstractTestCase
         self::assertSame(['https://example.com/SignonURL'], $response->getHeader('Location'));
         self::assertSame(302, $response->getStatusCode());
 
-        self::assertEquals(
+        self::assertSame(
             (new Server([
                 'SignonURL' => 'https://example.com/SignonURL',
                 'SignonScript' => '',
@@ -199,12 +199,12 @@ class AuthenticationSignonTest extends AbstractTestCase
             $config->selectedServer,
         );
 
-        self::assertEquals(
+        self::assertSame(
             $sessionName,
             session_name(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             $sessionID,
             session_id(),
         );
@@ -235,9 +235,9 @@ class AuthenticationSignonTest extends AbstractTestCase
             $this->object->readCredentials(),
         );
 
-        self::assertEquals('user123', $this->object->user);
+        self::assertSame('user123', $this->object->user);
 
-        self::assertEquals('pass123', $this->object->password);
+        self::assertSame('pass123', $this->object->password);
     }
 
     public function testAuthSetUser(): void
@@ -250,9 +250,9 @@ class AuthenticationSignonTest extends AbstractTestCase
         );
 
         $config = Config::getInstance();
-        self::assertEquals('testUser123', $config->selectedServer['user']);
+        self::assertSame('testUser123', $config->selectedServer['user']);
 
-        self::assertEquals('testPass123', $config->selectedServer['password']);
+        self::assertSame('testPass123', $config->selectedServer['password']);
     }
 
     public function testAuthFailsForbidden(): void
@@ -274,7 +274,7 @@ class AuthenticationSignonTest extends AbstractTestCase
         } catch (ExitException) {
         }
 
-        self::assertEquals(
+        self::assertSame(
             'Login without a password is forbidden by configuration (see AllowNoPassword)',
             $_SESSION['PMA_single_signon_error_message'],
         );
@@ -299,7 +299,7 @@ class AuthenticationSignonTest extends AbstractTestCase
         } catch (ExitException) {
         }
 
-        self::assertEquals('Access denied!', $_SESSION['PMA_single_signon_error_message']);
+        self::assertSame('Access denied!', $_SESSION['PMA_single_signon_error_message']);
     }
 
     public function testAuthFailsTimeout(): void
@@ -324,7 +324,7 @@ class AuthenticationSignonTest extends AbstractTestCase
         } catch (ExitException) {
         }
 
-        self::assertEquals(
+        self::assertSame(
             'You have been automatically logged out due to inactivity of'
             . ' 1440 seconds. Once you log in again, you should be able to'
             . ' resume the work where you left off.',
@@ -361,7 +361,7 @@ class AuthenticationSignonTest extends AbstractTestCase
         } catch (ExitException) {
         }
 
-        self::assertEquals('error&lt;123&gt;', $_SESSION['PMA_single_signon_error_message']);
+        self::assertSame('error&lt;123&gt;', $_SESSION['PMA_single_signon_error_message']);
     }
 
     public function testAuthFailsConnect(): void
@@ -394,7 +394,7 @@ class AuthenticationSignonTest extends AbstractTestCase
         } catch (ExitException) {
         }
 
-        self::assertEquals('Cannot log in to the MySQL server', $_SESSION['PMA_single_signon_error_message']);
+        self::assertSame('Cannot log in to the MySQL server', $_SESSION['PMA_single_signon_error_message']);
     }
 
     public function testSetCookieParamsDefaults(): void

--- a/tests/classes/Plugins/Export/ExportCodegenTest.php
+++ b/tests/classes/Plugins/Export/ExportCodegenTest.php
@@ -65,22 +65,22 @@ class ExportCodegenTest extends AbstractTestCase
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
 
-        self::assertEquals(
+        self::assertSame(
             'CodeGen',
             $properties->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'cs',
             $properties->getExtension(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'text/cs',
             $properties->getMimeType(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Options',
             $properties->getOptionsText(),
         );
@@ -89,7 +89,7 @@ class ExportCodegenTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyRootGroup::class, $options);
 
-        self::assertEquals(
+        self::assertSame(
             'Format Specific Options',
             $options->getName(),
         );
@@ -99,7 +99,7 @@ class ExportCodegenTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'general_opts',
             $generalOptions->getName(),
         );
@@ -111,7 +111,7 @@ class ExportCodegenTest extends AbstractTestCase
 
         self::assertInstanceOf(HiddenPropertyItem::class, $hidden);
 
-        self::assertEquals(
+        self::assertSame(
             'structure_or_data',
             $hidden->getName(),
         );
@@ -120,17 +120,17 @@ class ExportCodegenTest extends AbstractTestCase
 
         self::assertInstanceOf(SelectPropertyItem::class, $select);
 
-        self::assertEquals(
+        self::assertSame(
             'format',
             $select->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Format:',
             $select->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             ['NHibernate C# DO', 'NHibernate XML'],
             $select->getValues(),
         );
@@ -178,7 +178,7 @@ class ExportCodegenTest extends AbstractTestCase
         $result = ob_get_clean();
 
         self::assertIsString($result);
-        self::assertEquals(
+        self::assertSame(
             '<?xml version="1.0" encoding="utf-8" ?>' . "\n"
             . '<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" namespace="Test_db" assembly="Test_db">' . "\n"
             . '    <class name="Test_table" table="Test_table">' . "\n"
@@ -206,17 +206,17 @@ class ExportCodegenTest extends AbstractTestCase
 
     public function testCgMakeIdentifier(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '_Ⅲfoo',
             ExportCodegen::cgMakeIdentifier('Ⅲ{}96`{}foo', true),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'TestⅢ',
             ExportCodegen::cgMakeIdentifier('`98testⅢ{}96`{}', true),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'testⅢ',
             ExportCodegen::cgMakeIdentifier('`98testⅢ{}96`{}', false),
         );
@@ -227,7 +227,7 @@ class ExportCodegenTest extends AbstractTestCase
         $method = new ReflectionMethod(ExportCodegen::class, 'handleNHibernateCSBody');
         $result = $method->invoke($this->object, 'test_db', 'test_table');
 
-        self::assertEquals(
+        self::assertSame(
             'using System;' . "\n" .
             'using System.Collections;' . "\n" .
             'using System.Collections.Generic;' . "\n" .
@@ -279,7 +279,7 @@ class ExportCodegenTest extends AbstractTestCase
         $method = new ReflectionMethod(ExportCodegen::class, 'handleNHibernateXMLBody');
         $result = $method->invoke($this->object, 'test_db', 'test_table');
 
-        self::assertEquals(
+        self::assertSame(
             '<?xml version="1.0" encoding="utf-8" ?>' . "\n" .
             '<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2" namespace="Test_db" assembly="Test_db">' . "\n" .
             '    <class name="Test_table" table="Test_table">' . "\n" .

--- a/tests/classes/Plugins/Export/ExportCsvTest.php
+++ b/tests/classes/Plugins/Export/ExportCsvTest.php
@@ -74,22 +74,22 @@ class ExportCsvTest extends AbstractTestCase
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
 
-        self::assertEquals(
+        self::assertSame(
             'CSV',
             $properties->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'csv',
             $properties->getExtension(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'text/comma-separated-values',
             $properties->getMimeType(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Options',
             $properties->getOptionsText(),
         );
@@ -98,7 +98,7 @@ class ExportCsvTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyRootGroup::class, $options);
 
-        self::assertEquals(
+        self::assertSame(
             'Format Specific Options',
             $options->getName(),
         );
@@ -108,7 +108,7 @@ class ExportCsvTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'general_opts',
             $generalOptions->getName(),
         );
@@ -120,12 +120,12 @@ class ExportCsvTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'separator',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Columns separated with:',
             $property->getText(),
         );
@@ -135,12 +135,12 @@ class ExportCsvTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'enclosed',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Columns enclosed with:',
             $property->getText(),
         );
@@ -150,12 +150,12 @@ class ExportCsvTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'escaped',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Columns escaped with:',
             $property->getText(),
         );
@@ -165,12 +165,12 @@ class ExportCsvTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'terminated',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Lines terminated with:',
             $property->getText(),
         );
@@ -180,12 +180,12 @@ class ExportCsvTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'null',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Replace NULL with:',
             $property->getText(),
         );
@@ -195,12 +195,12 @@ class ExportCsvTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'removeCRLF',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Remove carriage return/line feed characters within columns',
             $property->getText(),
         );
@@ -210,12 +210,12 @@ class ExportCsvTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'columns',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Put columns names in the first row',
             $property->getText(),
         );
@@ -224,7 +224,7 @@ class ExportCsvTest extends AbstractTestCase
 
         self::assertInstanceOf(HiddenPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'structure_or_data',
             $property->getName(),
         );
@@ -242,13 +242,13 @@ class ExportCsvTest extends AbstractTestCase
             $this->object->exportHeader(),
         );
 
-        self::assertEquals("\015\012", $GLOBALS['csv_terminated']);
+        self::assertSame("\015\012", $GLOBALS['csv_terminated']);
 
-        self::assertEquals(';', $GLOBALS['csv_separator']);
+        self::assertSame(';', $GLOBALS['csv_separator']);
 
-        self::assertEquals('"', $GLOBALS['csv_enclosed']);
+        self::assertSame('"', $GLOBALS['csv_enclosed']);
 
-        self::assertEquals('"', $GLOBALS['csv_escaped']);
+        self::assertSame('"', $GLOBALS['csv_escaped']);
 
         self::assertTrue($GLOBALS['csv_columns']);
 
@@ -262,13 +262,13 @@ class ExportCsvTest extends AbstractTestCase
             $this->object->exportHeader(),
         );
 
-        self::assertEquals("\015\012", $GLOBALS['csv_terminated']);
+        self::assertSame("\015\012", $GLOBALS['csv_terminated']);
 
-        self::assertEquals(';', $GLOBALS['csv_separator']);
+        self::assertSame(';', $GLOBALS['csv_separator']);
 
-        self::assertEquals('"', $GLOBALS['csv_enclosed']);
+        self::assertSame('"', $GLOBALS['csv_enclosed']);
 
-        self::assertEquals('"', $GLOBALS['csv_escaped']);
+        self::assertSame('"', $GLOBALS['csv_escaped']);
 
         self::assertFalse($GLOBALS['csv_columns']);
 
@@ -280,13 +280,13 @@ class ExportCsvTest extends AbstractTestCase
             $this->object->exportHeader(),
         );
 
-        self::assertEquals("\015\012", $GLOBALS['csv_terminated']);
+        self::assertSame("\015\012", $GLOBALS['csv_terminated']);
 
-        self::assertEquals(',', $GLOBALS['csv_separator']);
+        self::assertSame(',', $GLOBALS['csv_separator']);
 
-        self::assertEquals('"', $GLOBALS['csv_enclosed']);
+        self::assertSame('"', $GLOBALS['csv_enclosed']);
 
-        self::assertEquals('"', $GLOBALS['csv_escaped']);
+        self::assertSame('"', $GLOBALS['csv_escaped']);
 
         self::assertFalse($GLOBALS['csv_columns']);
 
@@ -299,7 +299,7 @@ class ExportCsvTest extends AbstractTestCase
             $this->object->exportHeader(),
         );
 
-        self::assertEquals('#', $GLOBALS['csv_separator']);
+        self::assertSame('#', $GLOBALS['csv_separator']);
 
         // case 5
 
@@ -311,9 +311,9 @@ class ExportCsvTest extends AbstractTestCase
             $this->object->exportHeader(),
         );
 
-        self::assertEquals($GLOBALS['csv_terminated'], "\n");
+        self::assertSame($GLOBALS['csv_terminated'], "\n");
 
-        self::assertEquals($GLOBALS['csv_separator'], "a\011");
+        self::assertSame($GLOBALS['csv_separator'], "a\011");
         // case 6
 
         $GLOBALS['csv_terminated'] = 'AUTO';
@@ -322,7 +322,7 @@ class ExportCsvTest extends AbstractTestCase
             $this->object->exportHeader(),
         );
 
-        self::assertEquals($GLOBALS['csv_terminated'], "\n");
+        self::assertSame($GLOBALS['csv_terminated'], "\n");
 
         // case 7
 
@@ -333,9 +333,9 @@ class ExportCsvTest extends AbstractTestCase
             $this->object->exportHeader(),
         );
 
-        self::assertEquals($GLOBALS['csv_terminated'], "a\015b\012c\011");
+        self::assertSame($GLOBALS['csv_terminated'], "a\015b\012c\011");
 
-        self::assertEquals($GLOBALS['csv_separator'], "a\011");
+        self::assertSame($GLOBALS['csv_separator'], "a\011");
     }
 
     public function testExportFooter(): void
@@ -408,7 +408,7 @@ class ExportCsvTest extends AbstractTestCase
         ));
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             'idnamedatetimefield;1abcd2011-01-20 02:00:02;2foo2010-01-20 02:00:02;3Abcd2012-01-20 02:00:02;',
             $result,
         );
@@ -426,7 +426,7 @@ class ExportCsvTest extends AbstractTestCase
         ));
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             '"id""name""datetimefield";"1""abcd""2011-01-20 02:00:02";'
             . '"2""foo""2010-01-20 02:00:02";"3""Abcd""2012-01-20 02:00:02";',
             $result,
@@ -447,7 +447,7 @@ class ExportCsvTest extends AbstractTestCase
         ));
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             '"id""name""datetimefield";"1""abcd""2011-01-20 02:00:02";'
             . '"2""foo""2010-01-20 02:00:02";"3""Abcd""2012-01-20 02:00:02";',
             $result,
@@ -467,7 +467,7 @@ class ExportCsvTest extends AbstractTestCase
         ));
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             '"id""name""datetimefield";"1""abcd""2011-01-20 02:00:02";'
             . '"2""foo""2010-01-20 02:00:02";"3""Abcd""2012-01-20 02:00:02";',
             $result,
@@ -487,7 +487,7 @@ class ExportCsvTest extends AbstractTestCase
         ));
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             '"id""name""datetimefield";"1""abcd""2011-01-20 02:00:02";'
             . '"2""foo""2010-01-20 02:00:02";"3""Abcd""2012-01-20 02:00:02";',
             $result,

--- a/tests/classes/Plugins/Export/ExportExcelTest.php
+++ b/tests/classes/Plugins/Export/ExportExcelTest.php
@@ -64,22 +64,22 @@ class ExportExcelTest extends AbstractTestCase
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
 
-        self::assertEquals(
+        self::assertSame(
             'CSV for MS Excel',
             $properties->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'csv',
             $properties->getExtension(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'text/comma-separated-values',
             $properties->getMimeType(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Options',
             $properties->getOptionsText(),
         );
@@ -88,7 +88,7 @@ class ExportExcelTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyRootGroup::class, $options);
 
-        self::assertEquals(
+        self::assertSame(
             'Format Specific Options',
             $options->getName(),
         );
@@ -98,7 +98,7 @@ class ExportExcelTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'general_opts',
             $generalOptions->getName(),
         );
@@ -110,12 +110,12 @@ class ExportExcelTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'null',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Replace NULL with:',
             $property->getText(),
         );
@@ -125,12 +125,12 @@ class ExportExcelTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'removeCRLF',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Remove carriage return/line feed characters within columns',
             $property->getText(),
         );
@@ -140,12 +140,12 @@ class ExportExcelTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'columns',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Put columns names in the first row',
             $property->getText(),
         );
@@ -155,12 +155,12 @@ class ExportExcelTest extends AbstractTestCase
 
         self::assertInstanceOf(SelectPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'edition',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             [
                 'win' => 'Windows',
                 'mac_excel2003' => 'Excel 2003 / Macintosh',
@@ -169,7 +169,7 @@ class ExportExcelTest extends AbstractTestCase
             $property->getValues(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Excel edition:',
             $property->getText(),
         );
@@ -178,7 +178,7 @@ class ExportExcelTest extends AbstractTestCase
 
         self::assertInstanceOf(HiddenPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'structure_or_data',
             $property->getName(),
         );

--- a/tests/classes/Plugins/Export/ExportHtmlwordTest.php
+++ b/tests/classes/Plugins/Export/ExportHtmlwordTest.php
@@ -92,22 +92,22 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
 
-        self::assertEquals(
+        self::assertSame(
             'Microsoft Word 2000',
             $properties->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'doc',
             $properties->getExtension(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'application/vnd.ms-word',
             $properties->getMimeType(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Options',
             $properties->getOptionsText(),
         );
@@ -120,7 +120,7 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyRootGroup::class, $options);
 
-        self::assertEquals(
+        self::assertSame(
             'Format Specific Options',
             $options->getName(),
         );
@@ -131,12 +131,12 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'dump_what',
             $generalOptions->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Dump table',
             $generalOptions->getText(),
         );
@@ -147,12 +147,12 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         self::assertInstanceOf(RadioPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'structure_or_data',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             ['structure' => __('structure'), 'data' => __('data'), 'structure_and_data' => __('structure and data')],
             $property->getValues(),
         );
@@ -161,17 +161,17 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'dump_what',
             $generalOptions->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Data dump options',
             $generalOptions->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'structure',
             $generalOptions->getForce(),
         );
@@ -183,12 +183,12 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'null',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Replace NULL with:',
             $property->getText(),
         );
@@ -197,12 +197,12 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'columns',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Put columns names in the first row',
             $property->getText(),
         );
@@ -227,7 +227,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             </head>
             <body>';
 
-        self::assertEquals($expected, $result);
+        self::assertSame($expected, $result);
 
         // case 2
 
@@ -249,7 +249,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             </head>
             <body>';
 
-        self::assertEquals($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function testExportFooter(): void
@@ -260,7 +260,7 @@ class ExportHtmlwordTest extends AbstractTestCase
         );
         $result = ob_get_clean();
 
-        self::assertEquals('</body></html>', $result);
+        self::assertSame('</body></html>', $result);
     }
 
     public function testExportDBHeader(): void
@@ -271,7 +271,7 @@ class ExportHtmlwordTest extends AbstractTestCase
         );
         $result = ob_get_clean();
 
-        self::assertEquals('<h1>Database d&quot;b</h1>', $result);
+        self::assertSame('<h1>Database d&quot;b</h1>', $result);
     }
 
     public function testExportDBFooter(): void
@@ -309,7 +309,7 @@ class ExportHtmlwordTest extends AbstractTestCase
         ));
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             '<h2>Dumping data for table test_table</h2>'
             . '<table width="100%" cellspacing="1"><tr class="print-category">'
             . '<td class="print"><strong>id</strong></td>'
@@ -360,7 +360,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             ->with($column, ['name1'], 'column')
             ->willReturn('1');
 
-        self::assertEquals(
+        self::assertSame(
             '<table width="100%" cellspacing="1">' .
             '<tr class="print-category"><th class="print">Column</th>' .
             '<td class="print"><strong>Type</strong></td>' .
@@ -438,7 +438,7 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         $result = $this->object->getTableDef('database', '', true, true, true);
 
-        self::assertEquals(
+        self::assertSame(
             '<table width="100%" cellspacing="1">' .
             '<tr class="print-category"><th class="print">Column</th>' .
             '<td class="print"><strong>Type</strong></td>' .
@@ -540,7 +540,7 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         $result = $this->object->getTableDef('database', '', false, false, false);
 
-        self::assertEquals(
+        self::assertSame(
             '<table width="100%" cellspacing="1">' .
             '<tr class="print-category"><th class="print">Column</th>' .
             '<td class="print"><strong>Type</strong></td>' .
@@ -590,7 +590,7 @@ class ExportHtmlwordTest extends AbstractTestCase
         $this->dummyDbi->assertAllSelectsConsumed();
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             '<h2>Table structure for table test_table</h2>'
             . '<table width="100%" cellspacing="1"><tr class="print-category">'
             . '<th class="print">Column</th><td class="print"><strong>Type</strong></td>'
@@ -615,7 +615,7 @@ class ExportHtmlwordTest extends AbstractTestCase
         );
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             '<h2>Triggers test_table</h2><table width="100%" cellspacing="1">'
             . '<tr class="print-category"><th class="print">Name</th>'
             . '<td class="print"><strong>Time</strong></td><td class="print"><strong>Event</strong></td>'
@@ -638,7 +638,7 @@ class ExportHtmlwordTest extends AbstractTestCase
         $this->dummyDbi->assertAllSelectsConsumed();
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             '<h2>Structure for view test_table</h2>'
             . '<table width="100%" cellspacing="1"><tr class="print-category">'
             . '<th class="print">Column</th><td class="print"><strong>Type</strong></td>'
@@ -663,7 +663,7 @@ class ExportHtmlwordTest extends AbstractTestCase
         );
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             '<h2>Stand-in structure for view test_table</h2>'
             . '<table width="100%" cellspacing="1"><tr class="print-category">'
             . '<th class="print">Column</th><td class="print"><strong>Type</strong></td>'
@@ -687,7 +687,7 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         $uniqueKeys = ['field'];
 
-        self::assertEquals(
+        self::assertSame(
             '<tr class="print-category"><td class="print"><em>' .
             '<strong>field</strong></em></td><td class="print">set(abc)</td>' .
             '<td class="print">Yes</td><td class="print">NULL</td>',
@@ -698,7 +698,7 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         $uniqueKeys = ['field'];
 
-        self::assertEquals(
+        self::assertSame(
             '<tr class="print-category"><td class="print">fields</td>' .
             '<td class="print">&amp;nbsp;</td><td class="print">No</td>' .
             '<td class="print">def</td>',

--- a/tests/classes/Plugins/Export/ExportJsonTest.php
+++ b/tests/classes/Plugins/Export/ExportJsonTest.php
@@ -67,22 +67,22 @@ class ExportJsonTest extends AbstractTestCase
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
 
-        self::assertEquals(
+        self::assertSame(
             'JSON',
             $properties->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'json',
             $properties->getExtension(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'text/plain',
             $properties->getMimeType(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Options',
             $properties->getOptionsText(),
         );
@@ -91,7 +91,7 @@ class ExportJsonTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyRootGroup::class, $options);
 
-        self::assertEquals(
+        self::assertSame(
             'Format Specific Options',
             $options->getName(),
         );
@@ -101,7 +101,7 @@ class ExportJsonTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'general_opts',
             $generalOptions->getName(),
         );
@@ -112,7 +112,7 @@ class ExportJsonTest extends AbstractTestCase
 
         self::assertInstanceOf(HiddenPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'structure_or_data',
             $property->getName(),
         );

--- a/tests/classes/Plugins/Export/ExportLatexTest.php
+++ b/tests/classes/Plugins/Export/ExportLatexTest.php
@@ -92,22 +92,22 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
 
-        self::assertEquals(
+        self::assertSame(
             'LaTeX',
             $properties->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'tex',
             $properties->getExtension(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'application/x-tex',
             $properties->getMimeType(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Options',
             $properties->getOptionsText(),
         );
@@ -116,7 +116,7 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyRootGroup::class, $options);
 
-        self::assertEquals(
+        self::assertSame(
             'Format Specific Options',
             $options->getName(),
         );
@@ -128,7 +128,7 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'general_opts',
             $generalOptions->getName(),
         );
@@ -139,12 +139,12 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'caption',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Include table caption',
             $property->getText(),
         );
@@ -154,12 +154,12 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'dump_what',
             $generalOptions->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Dump table',
             $generalOptions->getText(),
         );
@@ -170,12 +170,12 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(RadioPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'structure_or_data',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             ['structure' => __('structure'), 'data' => __('data'), 'structure_and_data' => __('structure and data')],
             $property->getValues(),
         );
@@ -186,17 +186,17 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'structure',
             $generalOptions->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Object creation options',
             $generalOptions->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'data',
             $generalOptions->getForce(),
         );
@@ -208,17 +208,17 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'structure_caption',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Table caption:',
             $property->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'faq6-27',
             $property->getDoc(),
         );
@@ -228,17 +228,17 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'structure_continued_caption',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Table caption (continued):',
             $property->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'faq6-27',
             $property->getDoc(),
         );
@@ -248,17 +248,17 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'structure_label',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Label key:',
             $property->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'faq6-27',
             $property->getDoc(),
         );
@@ -268,12 +268,12 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'relation',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Display foreign key relationships',
             $property->getText(),
         );
@@ -283,12 +283,12 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'comments',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Display comments',
             $property->getText(),
         );
@@ -297,12 +297,12 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'mime',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Display media types',
             $property->getText(),
         );
@@ -312,17 +312,17 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'data',
             $generalOptions->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Data dump options',
             $generalOptions->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'structure',
             $generalOptions->getForce(),
         );
@@ -334,12 +334,12 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'columns',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Put columns names in the first row:',
             $property->getText(),
         );
@@ -349,17 +349,17 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'data_caption',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Table caption:',
             $property->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'faq6-27',
             $property->getDoc(),
         );
@@ -369,17 +369,17 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'data_continued_caption',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Table caption (continued):',
             $property->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'faq6-27',
             $property->getDoc(),
         );
@@ -389,17 +389,17 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'data_label',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Label key:',
             $property->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'faq6-27',
             $property->getDoc(),
         );
@@ -408,12 +408,12 @@ class ExportLatexTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'null',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Replace NULL with:',
             $property->getText(),
         );
@@ -497,7 +497,7 @@ class ExportLatexTest extends AbstractTestCase
         ));
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             "\n" . '%' . "\n" .
             '% Data: test_table' . "\n" .
             '%' . "\n" .
@@ -529,7 +529,7 @@ class ExportLatexTest extends AbstractTestCase
         $result = ob_get_clean();
 
         self::assertIsString($result);
-        self::assertEquals(
+        self::assertSame(
             "\n" . '%' . "\n" .
             '% Data: test_table' . "\n" .
             '%' . "\n" .
@@ -620,7 +620,7 @@ class ExportLatexTest extends AbstractTestCase
         $result = ob_get_clean();
 
         //echo $result; die;
-        self::assertEquals(
+        self::assertSame(
             "\n" . '%' . "\n" .
             '% Structure: ' . "\n" .
             '%' . "\n" .
@@ -781,7 +781,7 @@ class ExportLatexTest extends AbstractTestCase
 
     public function testTexEscape(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '\\$\\%\\{foo\\&bar\\}\\#\\_\\^',
             ExportLatex::texEscape('$%{foo&bar}#_^'),
         );

--- a/tests/classes/Plugins/Export/ExportMediawikiTest.php
+++ b/tests/classes/Plugins/Export/ExportMediawikiTest.php
@@ -78,22 +78,22 @@ class ExportMediawikiTest extends AbstractTestCase
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
 
-        self::assertEquals(
+        self::assertSame(
             'MediaWiki Table',
             $properties->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'mediawiki',
             $properties->getExtension(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'text/plain',
             $properties->getMimeType(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Options',
             $properties->getOptionsText(),
         );
@@ -102,7 +102,7 @@ class ExportMediawikiTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyRootGroup::class, $options);
 
-        self::assertEquals(
+        self::assertSame(
             'Format Specific Options',
             $options->getName(),
         );
@@ -112,12 +112,12 @@ class ExportMediawikiTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'general_opts',
             $generalOptions->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Dump table',
             $generalOptions->getText(),
         );
@@ -129,12 +129,12 @@ class ExportMediawikiTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertySubgroup::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'dump_table',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Dump table',
             $property->getText(),
         );
@@ -143,12 +143,12 @@ class ExportMediawikiTest extends AbstractTestCase
 
         self::assertInstanceOf(RadioPropertyItem::class, $sgHeader);
 
-        self::assertEquals(
+        self::assertSame(
             'structure_or_data',
             $sgHeader->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             ['structure' => __('structure'), 'data' => __('data'), 'structure_and_data' => __('structure and data')],
             $sgHeader->getValues(),
         );
@@ -158,12 +158,12 @@ class ExportMediawikiTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'caption',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Export table names',
             $property->getText(),
         );
@@ -172,12 +172,12 @@ class ExportMediawikiTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'headers',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Export table headers',
             $property->getText(),
         );
@@ -252,7 +252,7 @@ class ExportMediawikiTest extends AbstractTestCase
         );
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             "\n<!--\n" .
             "Table structure for `table`\n" .
             "-->\n" .
@@ -300,7 +300,7 @@ class ExportMediawikiTest extends AbstractTestCase
         );
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             "\n<!--\n" .
             "Table data for `test_table`\n" .
             "-->\n" .

--- a/tests/classes/Plugins/Export/ExportOdsTest.php
+++ b/tests/classes/Plugins/Export/ExportOdsTest.php
@@ -84,22 +84,22 @@ class ExportOdsTest extends AbstractTestCase
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
 
-        self::assertEquals(
+        self::assertSame(
             'OpenDocument Spreadsheet',
             $properties->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'ods',
             $properties->getExtension(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'application/vnd.oasis.opendocument.spreadsheet',
             $properties->getMimeType(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Options',
             $properties->getOptionsText(),
         );
@@ -112,7 +112,7 @@ class ExportOdsTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyRootGroup::class, $options);
 
-        self::assertEquals(
+        self::assertSame(
             'Format Specific Options',
             $options->getName(),
         );
@@ -122,7 +122,7 @@ class ExportOdsTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'general_opts',
             $generalOptions->getName(),
         );
@@ -134,12 +134,12 @@ class ExportOdsTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'null',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Replace NULL with:',
             $property->getText(),
         );
@@ -149,12 +149,12 @@ class ExportOdsTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'columns',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Put columns names in the first row',
             $property->getText(),
         );
@@ -163,7 +163,7 @@ class ExportOdsTest extends AbstractTestCase
 
         self::assertInstanceOf(HiddenPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'structure_or_data',
             $property->getName(),
         );
@@ -269,7 +269,7 @@ class ExportOdsTest extends AbstractTestCase
             ),
         );
 
-        self::assertEquals(
+        self::assertSame(
             '<table:table table:name="table"><table:table-row><table:table-cell ' .
             'office:value-type="string"><text:p>&amp;</text:p></table:table-cell>' .
             '<table:table-cell office:value-type="string"><text:p></text:p>' .
@@ -345,7 +345,7 @@ class ExportOdsTest extends AbstractTestCase
             ),
         );
 
-        self::assertEquals(
+        self::assertSame(
             '<table:table table:name="table"><table:table-row><table:table-cell ' .
             'office:value-type="string"><text:p>fna\&quot;me</text:p></table:table' .
             '-cell><table:table-cell office:value-type="string"><text:p>' .
@@ -397,7 +397,7 @@ class ExportOdsTest extends AbstractTestCase
             ),
         );
 
-        self::assertEquals(
+        self::assertSame(
             '<table:table table:name="table"><table:table-row></table:table-row></table:table>',
             $GLOBALS['ods_buffer'],
         );

--- a/tests/classes/Plugins/Export/ExportOdtTest.php
+++ b/tests/classes/Plugins/Export/ExportOdtTest.php
@@ -110,22 +110,22 @@ class ExportOdtTest extends AbstractTestCase
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
 
-        self::assertEquals(
+        self::assertSame(
             'OpenDocument Text',
             $properties->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'odt',
             $properties->getExtension(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'application/vnd.oasis.opendocument.text',
             $properties->getMimeType(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Options',
             $properties->getOptionsText(),
         );
@@ -138,7 +138,7 @@ class ExportOdtTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyRootGroup::class, $options);
 
-        self::assertEquals(
+        self::assertSame(
             'Format Specific Options',
             $options->getName(),
         );
@@ -150,12 +150,12 @@ class ExportOdtTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'general_opts',
             $generalOptions->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Dump table',
             $generalOptions->getText(),
         );
@@ -166,12 +166,12 @@ class ExportOdtTest extends AbstractTestCase
 
         self::assertInstanceOf(RadioPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'structure_or_data',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             ['structure' => __('structure'), 'data' => __('data'), 'structure_and_data' => __('structure and data')],
             $property->getValues(),
         );
@@ -181,17 +181,17 @@ class ExportOdtTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'structure',
             $generalOptions->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Object creation options',
             $generalOptions->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'data',
             $generalOptions->getForce(),
         );
@@ -203,12 +203,12 @@ class ExportOdtTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'relation',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Display foreign key relationships',
             $property->getText(),
         );
@@ -218,12 +218,12 @@ class ExportOdtTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'comments',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Display comments',
             $property->getText(),
         );
@@ -232,12 +232,12 @@ class ExportOdtTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'mime',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Display media types',
             $property->getText(),
         );
@@ -247,17 +247,17 @@ class ExportOdtTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'data',
             $generalOptions->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Data dump options',
             $generalOptions->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'structure',
             $generalOptions->getForce(),
         );
@@ -269,12 +269,12 @@ class ExportOdtTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'columns',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Put columns names in the first row',
             $property->getText(),
         );
@@ -283,12 +283,12 @@ class ExportOdtTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'null',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Replace NULL with:',
             $property->getText(),
         );
@@ -404,7 +404,7 @@ class ExportOdtTest extends AbstractTestCase
             ),
         );
 
-        self::assertEquals(
+        self::assertSame(
             '<text:h text:outline-level="2" text:style-name="Heading_2" ' .
             'text:is-list-header="true">Dumping data for table ta&lt;ble</text:h>' .
             '<table:table table:name="ta&lt;ble_structure"><table:table-column ' .
@@ -473,7 +473,7 @@ class ExportOdtTest extends AbstractTestCase
             ),
         );
 
-        self::assertEquals(
+        self::assertSame(
             '<text:h text:outline-level="2" text:style-name="Heading_2" text:' .
             'is-list-header="true">Dumping data for table table</text:h><table:' .
             'table table:name="table_structure"><table:table-column table:number-' .
@@ -527,7 +527,7 @@ class ExportOdtTest extends AbstractTestCase
             ),
         );
 
-        self::assertEquals(
+        self::assertSame(
             '<text:h text:outline-level="2" text:style-name="Heading_2" ' .
             'text:is-list-header="true">Dumping data for table table</text:h>' .
             '<table:table table:name="table_structure"><table:table-column ' .
@@ -546,7 +546,7 @@ class ExportOdtTest extends AbstractTestCase
         );
         $this->dummyDbi->assertAllSelectsConsumed();
 
-        self::assertEquals(
+        self::assertSame(
             '<table:table table:name="test_table_data">'
             . '<table:table-column table:number-columns-repeated="4"/><table:table-row>'
             . '<table:table-cell office:value-type="string"><text:p>Column</text:p>'
@@ -766,7 +766,7 @@ class ExportOdtTest extends AbstractTestCase
         );
         $this->dummyDbi->assertAllSelectsConsumed();
 
-        self::assertEquals(
+        self::assertSame(
             '<text:h text:outline-level="2" text:style-name="Heading_2" text:is-list-header="true">'
             . 'Table structure for table test_table</text:h><table:table table:name="test_table_structure">'
             . '<table:table-column table:number-columns-repeated="4"/><table:table-row>'
@@ -805,7 +805,7 @@ class ExportOdtTest extends AbstractTestCase
             ),
         );
 
-        self::assertEquals(
+        self::assertSame(
             '<text:h text:outline-level="2" text:style-name="Heading_2" text:is-list-header="true">'
             . 'Triggers test_table</text:h><table:table table:name="test_table_triggers">'
             . '<table:table-column table:number-columns-repeated="4"/><table:table-row>'
@@ -836,7 +836,7 @@ class ExportOdtTest extends AbstractTestCase
         );
         $this->dummyDbi->assertAllSelectsConsumed();
 
-        self::assertEquals(
+        self::assertSame(
             '<text:h text:outline-level="2" text:style-name="Heading_2" text:is-list-header="true">'
             . 'Structure for view test_table</text:h><table:table table:name="test_table_structure">'
             . '<table:table-column table:number-columns-repeated="4"/><table:table-row>'
@@ -876,7 +876,7 @@ class ExportOdtTest extends AbstractTestCase
         );
         $this->dummyDbi->assertAllSelectsConsumed();
 
-        self::assertEquals(
+        self::assertSame(
             '<text:h text:outline-level="2" text:style-name="Heading_2" text:is-list-header="true">'
             . 'Stand-in structure for view test_table</text:h><table:table table:name="test_table_data">'
             . '<table:table-column table:number-columns-repeated="4"/><table:table-row>'
@@ -912,7 +912,7 @@ class ExportOdtTest extends AbstractTestCase
 
         $colAlias = 'alias';
 
-        self::assertEquals(
+        self::assertSame(
             '<table:table-row><table:table-cell office:value-type="string">' .
             '<text:p>alias</text:p></table:table-cell><table:table-cell off' .
             'ice:value-type="string"><text:p>set(abc)</text:p></table:table' .
@@ -924,7 +924,7 @@ class ExportOdtTest extends AbstractTestCase
 
         $column = new Column('fields', '', false, 'COMP', 'def', '');
 
-        self::assertEquals(
+        self::assertSame(
             '<table:table-row><table:table-cell office:value-type="string">' .
             '<text:p>fields</text:p></table:table-cell><table:table-cell off' .
             'ice:value-type="string"><text:p>&amp;nbsp;</text:p></table:table' .

--- a/tests/classes/Plugins/Export/ExportPdfTest.php
+++ b/tests/classes/Plugins/Export/ExportPdfTest.php
@@ -70,22 +70,22 @@ class ExportPdfTest extends AbstractTestCase
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
 
-        self::assertEquals(
+        self::assertSame(
             'PDF',
             $properties->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'pdf',
             $properties->getExtension(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'application/pdf',
             $properties->getMimeType(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Options',
             $properties->getOptionsText(),
         );
@@ -98,7 +98,7 @@ class ExportPdfTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyRootGroup::class, $options);
 
-        self::assertEquals(
+        self::assertSame(
             'Format Specific Options',
             $options->getName(),
         );
@@ -110,7 +110,7 @@ class ExportPdfTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'general_opts',
             $generalOptions->getName(),
         );
@@ -121,7 +121,7 @@ class ExportPdfTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'report_title',
             $property->getName(),
         );
@@ -130,12 +130,12 @@ class ExportPdfTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'dump_what',
             $generalOptions->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Dump table',
             $generalOptions->getText(),
         );
@@ -146,12 +146,12 @@ class ExportPdfTest extends AbstractTestCase
 
         self::assertInstanceOf(RadioPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'structure_or_data',
             $property->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             ['structure' => __('structure'), 'data' => __('data'), 'structure_and_data' => __('structure and data')],
             $property->getValues(),
         );

--- a/tests/classes/Plugins/Export/ExportPhparrayTest.php
+++ b/tests/classes/Plugins/Export/ExportPhparrayTest.php
@@ -73,22 +73,22 @@ class ExportPhparrayTest extends AbstractTestCase
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
 
-        self::assertEquals(
+        self::assertSame(
             'PHP array',
             $properties->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'php',
             $properties->getExtension(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'text/plain',
             $properties->getMimeType(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Options',
             $properties->getOptionsText(),
         );
@@ -97,7 +97,7 @@ class ExportPhparrayTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyRootGroup::class, $options);
 
-        self::assertEquals(
+        self::assertSame(
             'Format Specific Options',
             $options->getName(),
         );
@@ -107,7 +107,7 @@ class ExportPhparrayTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'general_opts',
             $generalOptions->getName(),
         );
@@ -179,7 +179,7 @@ class ExportPhparrayTest extends AbstractTestCase
         );
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             "\n" . '/* `test_db`.`test_table` */' . "\n" .
             '$test_table = array(' . "\n" .
             '  array(\'id\' => \'1\',\'name\' => \'abcd\',\'datetimefield\' => \'2011-01-20 02:00:02\'),' . "\n" .
@@ -202,7 +202,7 @@ class ExportPhparrayTest extends AbstractTestCase
         $result = ob_get_clean();
 
         self::assertIsString($result);
-        self::assertEquals(
+        self::assertSame(
             "\n" . '/* `test_db`.`0``932table` */' . "\n" .
             '$_0_932table = array(' . "\n" .
             '  array(\'id\' => \'1\',\'name\' => \'abcd\',\'datetimefield\' => \'2011-01-20 02:00:02\'),' . "\n" .

--- a/tests/classes/Plugins/Export/ExportSqlTest.php
+++ b/tests/classes/Plugins/Export/ExportSqlTest.php
@@ -104,7 +104,7 @@ class ExportSqlTest extends AbstractTestCase
         $properties = $method->invoke($this->object, null);
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
-        self::assertEquals('SQL', $properties->getText());
+        self::assertSame('SQL', $properties->getText());
         self::assertNull($properties->getOptions());
     }
 
@@ -137,7 +137,7 @@ class ExportSqlTest extends AbstractTestCase
         $properties = $method->invoke($this->object, null);
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
-        self::assertEquals('SQL', $properties->getText());
+        self::assertSame('SQL', $properties->getText());
 
         $options = $properties->getOptions();
 
@@ -200,7 +200,7 @@ class ExportSqlTest extends AbstractTestCase
         $properties->next();
         self::assertInstanceOf(SelectPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             ['v1' => 'v1', 'v2' => 'v2'],
             $property->getValues(),
         );
@@ -240,7 +240,7 @@ class ExportSqlTest extends AbstractTestCase
         $leaves->next();
         self::assertInstanceOf(BoolPropertyItem::class, $leaf);
 
-        self::assertEquals(
+        self::assertSame(
             'Add <code>DROP TABLE / VIEW / PROCEDURE / FUNCTION / EVENT</code><code> / TRIGGER</code> statement',
             $leaf->getText(),
         );
@@ -323,26 +323,26 @@ class ExportSqlTest extends AbstractTestCase
 
         $GLOBALS['sql_include_comments'] = true;
 
-        self::assertEquals(
+        self::assertSame(
             '--' . "\n",
             $method->invoke($this->object, ''),
         );
 
-        self::assertEquals(
+        self::assertSame(
             '-- Comment' . "\n",
             $method->invoke($this->object, 'Comment'),
         );
 
         $GLOBALS['sql_include_comments'] = false;
 
-        self::assertEquals(
+        self::assertSame(
             '',
             $method->invoke($this->object, 'Comment'),
         );
 
         unset($GLOBALS['sql_include_comments']);
 
-        self::assertEquals(
+        self::assertSame(
             '',
             $method->invoke($this->object, 'Comment'),
         );
@@ -354,26 +354,26 @@ class ExportSqlTest extends AbstractTestCase
 
         $GLOBALS['sql_include_comments'] = true;
 
-        self::assertEquals(
+        self::assertSame(
             "\n",
             $method->invoke($this->object, ''),
         );
 
-        self::assertEquals(
+        self::assertSame(
             "\n",
             $method->invoke($this->object, 'Comment'),
         );
 
         $GLOBALS['sql_include_comments'] = false;
 
-        self::assertEquals(
+        self::assertSame(
             '',
             $method->invoke($this->object, 'Comment'),
         );
 
         unset($GLOBALS['sql_include_comments']);
 
-        self::assertEquals(
+        self::assertSame(
             '',
             $method->invoke($this->object, 'Comment'),
         );
@@ -633,7 +633,7 @@ class ExportSqlTest extends AbstractTestCase
         );
         $result = ob_get_clean();
 
-        self::assertEquals('SqlConstraints', $result);
+        self::assertSame('SqlConstraints', $result);
     }
 
     public function testGetTableDefStandIn(): void
@@ -696,7 +696,7 @@ class ExportSqlTest extends AbstractTestCase
         $method = new ReflectionMethod(ExportSql::class, 'getTableDefForView');
         $result = $method->invoke($this->object, 'db', 'view');
 
-        self::assertEquals(
+        self::assertSame(
             "CREATE TABLE `view`(\n" .
             "    `fname` char COLLATE utf-8 NOT NULL DEFAULT 'a' COMMENT 'cmt'\n" .
             ");\n",
@@ -732,7 +732,7 @@ class ExportSqlTest extends AbstractTestCase
 
         $result = $method->invoke($this->object, 'db', 'view');
 
-        self::assertEquals(
+        self::assertSame(
             "CREATE TABLE IF NOT EXISTS `view`(\n" .
             "    `fname` char COLLATE utf-8 DEFAULT NULL COMMENT 'cmt'\n" .
             ");\n",
@@ -1319,7 +1319,7 @@ SQL;
         $method = new ReflectionMethod(ExportSql::class, 'makeCreateTableMSSQLCompatible');
         $result = $method->invoke($this->object, $query);
 
-        self::assertEquals(
+        self::assertSame(
             "CREATE TABLE (\" datetime DEFAULT NULL,\n" .
             "\" datetime DEFAULT NULL\n" .
             "\" datetime NOT NULL,\n" .
@@ -1355,22 +1355,22 @@ SQL;
         $table = null;
 
         $this->object->initAlias($aliases, $db, $table);
-        self::assertEquals('aliastest', $db);
+        self::assertSame('aliastest', $db);
         self::assertNull($table);
 
         $db = 'foo';
         $table = 'qwerty';
 
         $this->object->initAlias($aliases, $db, $table);
-        self::assertEquals('foo', $db);
-        self::assertEquals('qwerty', $table);
+        self::assertSame('foo', $db);
+        self::assertSame('qwerty', $table);
 
         $db = 'a';
         $table = 'foo';
 
         $this->object->initAlias($aliases, $db, $table);
-        self::assertEquals('aliastest', $db);
-        self::assertEquals('qwerty', $table);
+        self::assertSame('aliastest', $db);
+        self::assertSame('qwerty', $table);
     }
 
     public function testGetAlias(): void
@@ -1385,22 +1385,22 @@ SQL;
             ],
         ];
 
-        self::assertEquals(
+        self::assertSame(
             'f',
             $this->object->getAlias($aliases, 'bar'),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'aliastest',
             $this->object->getAlias($aliases, 'a'),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'pphymdain',
             $this->object->getAlias($aliases, 'pqr'),
         );
 
-        self::assertEquals(
+        self::assertSame(
             '',
             $this->object->getAlias($aliases, 'abc'),
         );
@@ -1431,7 +1431,7 @@ SQL;
             . "latin1_general_ci COMMENT='List' AUTO_INCREMENT=5";
         $result = $this->object->replaceWithAliases(null, $sqlQuery, $aliases, $db);
 
-        self::assertEquals(
+        self::assertSame(
             "CREATE TABLE IF NOT EXISTS `bartest` (\n" .
             "  `p` tinyint(3) UNSIGNED NOT NULL COMMENT 'Primary Key',\n" .
             "  `xyz` varchar(255) COLLATE latin1_general_ci NOT NULL COMMENT 'xyz',\n" .
@@ -1443,7 +1443,7 @@ SQL;
 
         $result = $this->object->replaceWithAliases(null, $sqlQuery, [], '');
 
-        self::assertEquals(
+        self::assertSame(
             "CREATE TABLE IF NOT EXISTS foo (\n" .
             "  `baz` tinyint(3) UNSIGNED NOT NULL COMMENT 'Primary Key',\n" .
             "  `xyz` varchar(255) COLLATE latin1_general_ci NOT NULL COMMENT 'xyz',\n" .
@@ -1464,7 +1464,7 @@ SQL;
             . 'END IF; END';
         $result = $this->object->replaceWithAliases('$$', $sqlQuery, $aliases, $db);
 
-        self::assertEquals(
+        self::assertSame(
             'CREATE TRIGGER `BEFORE_bar_INSERT` BEFORE INSERT ON `f` FOR EACH ROW BEGIN ' .
             'SET @cnt=(SELECT count(*) FROM `f` WHERE `n`=NEW.`n` AND id=NEW.id AND abc=NEW.`n` LIMIT 1); ' .
             'IF @cnt<>0 THEN ' .
@@ -1519,6 +1519,6 @@ RETURN TextString ;
 END
 SQL;
 
-        self::assertEquals($expectedQuery, $result);
+        self::assertSame($expectedQuery, $result);
     }
 }

--- a/tests/classes/Plugins/Export/ExportTexytextTest.php
+++ b/tests/classes/Plugins/Export/ExportTexytextTest.php
@@ -95,17 +95,17 @@ class ExportTexytextTest extends AbstractTestCase
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
 
-        self::assertEquals(
+        self::assertSame(
             'Texy! text',
             $properties->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'txt',
             $properties->getExtension(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'text/plain',
             $properties->getMimeType(),
         );
@@ -114,7 +114,7 @@ class ExportTexytextTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyRootGroup::class, $options);
 
-        self::assertEquals(
+        self::assertSame(
             'Format Specific Options',
             $options->getName(),
         );
@@ -126,12 +126,12 @@ class ExportTexytextTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'general_opts',
             $generalOptions->getName(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'Dump table',
             $generalOptions->getText(),
         );
@@ -146,7 +146,7 @@ class ExportTexytextTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'data',
             $generalOptions->getName(),
         );
@@ -158,7 +158,7 @@ class ExportTexytextTest extends AbstractTestCase
 
         self::assertInstanceOf(BoolPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'columns',
             $property->getName(),
         );
@@ -167,7 +167,7 @@ class ExportTexytextTest extends AbstractTestCase
 
         self::assertInstanceOf(TextPropertyItem::class, $property);
 
-        self::assertEquals(
+        self::assertSame(
             'null',
             $property->getName(),
         );
@@ -227,7 +227,7 @@ class ExportTexytextTest extends AbstractTestCase
         $result = ob_get_clean();
 
         self::assertIsString($result);
-        self::assertEquals(
+        self::assertSame(
             '== Dumping data for table test_table' . "\n\n"
                 . '|------' . "\n"
                 . '|id|name|datetimefield' . "\n"
@@ -245,7 +245,7 @@ class ExportTexytextTest extends AbstractTestCase
         $result = $this->object->getTableDefStandIn('test_db', 'test_table');
         $this->dummyDbi->assertAllSelectsConsumed();
 
-        self::assertEquals(
+        self::assertSame(
             '|------' . "\n"
             . '|Column|Type|Null|Default' . "\n"
             . '|------' . "\n"
@@ -357,7 +357,7 @@ class ExportTexytextTest extends AbstractTestCase
         $result = ob_get_clean();
 
         self::assertIsString($result);
-        self::assertEquals(
+        self::assertSame(
             '== Table structure for table test_table' . "\n\n"
             . '|------' . "\n"
             . '|Column|Type|Null|Default' . "\n"
@@ -380,7 +380,7 @@ class ExportTexytextTest extends AbstractTestCase
         );
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             '== Triggers test_table' . "\n\n"
             . '|------' . "\n"
             . '|Name|Time|Event|Definition' . "\n"
@@ -403,7 +403,7 @@ class ExportTexytextTest extends AbstractTestCase
         $this->dummyDbi->assertAllSelectsConsumed();
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             '== Structure for view test_table' . "\n\n"
             . '|------' . "\n"
             . '|Column|Type|Null|Default' . "\n"
@@ -428,7 +428,7 @@ class ExportTexytextTest extends AbstractTestCase
         $this->dummyDbi->assertAllSelectsConsumed();
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             '== Stand-in structure for view test_table' . "\n\n"
             . '|------' . "\n"
             . '|Column|Type|Null|Default' . "\n"
@@ -446,7 +446,7 @@ class ExportTexytextTest extends AbstractTestCase
 
         $uniqueKeys = ['field'];
 
-        self::assertEquals(
+        self::assertSame(
             '|//**field**//|set(abc)|Yes|NULL',
             $this->object->formatOneColumnDefinition($cols, $uniqueKeys),
         );
@@ -455,7 +455,7 @@ class ExportTexytextTest extends AbstractTestCase
 
         $uniqueKeys = ['field'];
 
-        self::assertEquals(
+        self::assertSame(
             '|fields|&amp;nbsp;|No|def',
             $this->object->formatOneColumnDefinition($cols, $uniqueKeys),
         );

--- a/tests/classes/Plugins/Export/ExportXmlTest.php
+++ b/tests/classes/Plugins/Export/ExportXmlTest.php
@@ -79,17 +79,17 @@ class ExportXmlTest extends AbstractTestCase
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
 
-        self::assertEquals(
+        self::assertSame(
             'XML',
             $properties->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'xml',
             $properties->getExtension(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'text/xml',
             $properties->getMimeType(),
         );
@@ -98,7 +98,7 @@ class ExportXmlTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyRootGroup::class, $options);
 
-        self::assertEquals(
+        self::assertSame(
             'Format Specific Options',
             $options->getName(),
         );
@@ -110,7 +110,7 @@ class ExportXmlTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'general_opts',
             $generalOptions->getName(),
         );
@@ -126,7 +126,7 @@ class ExportXmlTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'structure',
             $generalOptions->getName(),
         );
@@ -157,7 +157,7 @@ class ExportXmlTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'data',
             $generalOptions->getName(),
         );
@@ -389,7 +389,7 @@ class ExportXmlTest extends AbstractTestCase
         $result = ob_get_clean();
 
         self::assertIsString($result);
-        self::assertEquals(
+        self::assertSame(
             '        <!-- Table test_table -->' . "\n"
             . '        <table name="test_table">' . "\n"
             . '            <column name="id">1</column>' . "\n"

--- a/tests/classes/Plugins/Export/ExportYamlTest.php
+++ b/tests/classes/Plugins/Export/ExportYamlTest.php
@@ -72,17 +72,17 @@ class ExportYamlTest extends AbstractTestCase
 
         self::assertInstanceOf(ExportPluginProperties::class, $properties);
 
-        self::assertEquals(
+        self::assertSame(
             'YAML',
             $properties->getText(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'yml',
             $properties->getExtension(),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'text/yaml',
             $properties->getMimeType(),
         );
@@ -91,7 +91,7 @@ class ExportYamlTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyRootGroup::class, $options);
 
-        self::assertEquals(
+        self::assertSame(
             'Format Specific Options',
             $options->getName(),
         );
@@ -102,7 +102,7 @@ class ExportYamlTest extends AbstractTestCase
 
         self::assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
-        self::assertEquals(
+        self::assertSame(
             'general_opts',
             $generalOptions->getName(),
         );
@@ -169,7 +169,7 @@ class ExportYamlTest extends AbstractTestCase
         );
         $result = ob_get_clean();
 
-        self::assertEquals(
+        self::assertSame(
             '# test_db.test_table' . "\n" .
             '-' . "\n" .
             '  id: 1' . "\n" .

--- a/tests/classes/Plugins/Export/Helpers/TablePropertyTest.php
+++ b/tests/classes/Plugins/Export/Helpers/TablePropertyTest.php
@@ -37,31 +37,31 @@ class TablePropertyTest extends AbstractTestCase
 
     public function testConstructor(): void
     {
-        self::assertEquals('name', $this->object->name);
+        self::assertSame('name', $this->object->name);
 
-        self::assertEquals('int', $this->object->type);
+        self::assertSame('int', $this->object->type);
 
         self::assertEquals(1, $this->object->nullable);
 
-        self::assertEquals('PRI', $this->object->key);
+        self::assertSame('PRI', $this->object->key);
 
-        self::assertEquals('0', $this->object->defaultValue);
+        self::assertSame('0', $this->object->defaultValue);
 
-        self::assertEquals('mysql', $this->object->ext);
+        self::assertSame('mysql', $this->object->ext);
     }
 
     public function testGetPureType(): void
     {
         $this->object->type = 'int(10)';
 
-        self::assertEquals(
+        self::assertSame(
             'int',
             $this->object->getPureType(),
         );
 
         $this->object->type = 'char';
 
-        self::assertEquals(
+        self::assertSame(
             'char',
             $this->object->getPureType(),
         );
@@ -76,7 +76,7 @@ class TablePropertyTest extends AbstractTestCase
     {
         $this->object->nullable = $nullable;
 
-        self::assertEquals(
+        self::assertSame(
             $expected,
             $this->object->isNotNull(),
         );
@@ -101,7 +101,7 @@ class TablePropertyTest extends AbstractTestCase
     {
         $this->object->key = $key;
 
-        self::assertEquals(
+        self::assertSame(
             $expected,
             $this->object->isUnique(),
         );
@@ -126,7 +126,7 @@ class TablePropertyTest extends AbstractTestCase
     {
         $this->object->type = $type;
 
-        self::assertEquals(
+        self::assertSame(
             $expected,
             $this->object->getDotNetPrimitiveType(),
         );
@@ -163,7 +163,7 @@ class TablePropertyTest extends AbstractTestCase
     {
         $this->object->type = $type;
 
-        self::assertEquals(
+        self::assertSame(
             $expected,
             $this->object->getDotNetObjectType(),
         );
@@ -196,14 +196,14 @@ class TablePropertyTest extends AbstractTestCase
         $this->object->name = "ä'7<ab>";
         $this->object->key = 'PRI';
 
-        self::assertEquals(
+        self::assertSame(
             "index=\"ä'7&lt;ab&gt;\"",
             $this->object->getIndexName(),
         );
 
         $this->object->key = '';
 
-        self::assertEquals(
+        self::assertSame(
             '',
             $this->object->getIndexName(),
         );
@@ -228,7 +228,7 @@ class TablePropertyTest extends AbstractTestCase
     {
         $this->object->name = 'Name#name#123';
 
-        self::assertEquals(
+        self::assertSame(
             'text123Namename',
             $this->object->formatCs('text123#name#'),
         );
@@ -238,7 +238,7 @@ class TablePropertyTest extends AbstractTestCase
     {
         $this->object->name = '"a\'';
 
-        self::assertEquals(
+        self::assertSame(
             '&quot;a\'index="&quot;a\'"',
             $this->object->formatXml('#name##indexName#'),
         );
@@ -246,7 +246,7 @@ class TablePropertyTest extends AbstractTestCase
 
     public function testFormat(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'NameintInt32intfalsetrue',
             $this->object->format(
                 '#ucfirstName##dotNetPrimitiveType##dotNetObjectType##type##notNull##unique#',

--- a/tests/classes/Plugins/Import/ImportCsvTest.php
+++ b/tests/classes/Plugins/Import/ImportCsvTest.php
@@ -103,11 +103,11 @@ class ImportCsvTest extends AbstractTestCase
     public function testGetProperties(): void
     {
         $properties = $this->object->getProperties();
-        self::assertEquals(
+        self::assertSame(
             __('CSV'),
             $properties->getText(),
         );
-        self::assertEquals(
+        self::assertSame(
             'csv',
             $properties->getExtension(),
         );
@@ -189,11 +189,11 @@ class ImportCsvTest extends AbstractTestCase
         $GLOBALS['plugin_param'] = 'table';
         $this->object = new ImportCsv();
         $properties = $this->object->getProperties();
-        self::assertEquals(
+        self::assertSame(
             __('CSV'),
             $properties->getText(),
         );
-        self::assertEquals(
+        self::assertSame(
             'csv',
             $properties->getExtension(),
         );

--- a/tests/classes/Plugins/Import/ImportLdiTest.php
+++ b/tests/classes/Plugins/Import/ImportLdiTest.php
@@ -73,11 +73,11 @@ class ImportLdiTest extends AbstractTestCase
     public function testGetProperties(): void
     {
         $properties = (new ImportLdi())->getProperties();
-        self::assertEquals(
+        self::assertSame(
             __('CSV using LOAD DATA'),
             $properties->getText(),
         );
-        self::assertEquals(
+        self::assertSame(
             'ldi',
             $properties->getExtension(),
         );
@@ -107,11 +107,11 @@ class ImportLdiTest extends AbstractTestCase
         $config->settings['Import']['ldi_local_option'] = 'auto';
         $properties = (new ImportLdi())->getProperties();
         self::assertTrue($config->settings['Import']['ldi_local_option']);
-        self::assertEquals(
+        self::assertSame(
             __('CSV using LOAD DATA'),
             $properties->getText(),
         );
-        self::assertEquals(
+        self::assertSame(
             'ldi',
             $properties->getExtension(),
         );

--- a/tests/classes/Plugins/Import/ImportMediawikiTest.php
+++ b/tests/classes/Plugins/Import/ImportMediawikiTest.php
@@ -75,20 +75,20 @@ class ImportMediawikiTest extends AbstractTestCase
     public function testGetProperties(): void
     {
         $properties = $this->object->getProperties();
-        self::assertEquals(
+        self::assertSame(
             __('MediaWiki Table'),
             $properties->getText(),
         );
-        self::assertEquals(
+        self::assertSame(
             'txt',
             $properties->getExtension(),
         );
-        self::assertEquals(
+        self::assertSame(
             'text/plain',
             $properties->getMimeType(),
         );
         self::assertNull($properties->getOptions());
-        self::assertEquals(
+        self::assertSame(
             __('Options'),
             $properties->getOptionsText(),
         );

--- a/tests/classes/Plugins/Import/ImportOdsTest.php
+++ b/tests/classes/Plugins/Import/ImportOdsTest.php
@@ -88,15 +88,15 @@ class ImportOdsTest extends AbstractTestCase
     public function testGetProperties(): void
     {
         $properties = $this->object->getProperties();
-        self::assertEquals(
+        self::assertSame(
             __('OpenDocument Spreadsheet'),
             $properties->getText(),
         );
-        self::assertEquals(
+        self::assertSame(
             'ods',
             $properties->getExtension(),
         );
-        self::assertEquals(
+        self::assertSame(
             __('Options'),
             $properties->getOptionsText(),
         );

--- a/tests/classes/Plugins/Import/ImportShpTest.php
+++ b/tests/classes/Plugins/Import/ImportShpTest.php
@@ -83,7 +83,7 @@ class ImportShpTest extends AbstractTestCase
         $GLOBALS['message'] = '';
         $GLOBALS['error'] = false;
         $this->object->doImport($importHandle);
-        self::assertEquals('', $GLOBALS['message']);
+        self::assertSame('', $GLOBALS['message']);
         self::assertFalse($GLOBALS['error']);
     }
 
@@ -105,16 +105,16 @@ class ImportShpTest extends AbstractTestCase
     public function testGetProperties(): void
     {
         $properties = $this->object->getProperties();
-        self::assertEquals(
+        self::assertSame(
             __('ESRI Shape File'),
             $properties->getText(),
         );
-        self::assertEquals(
+        self::assertSame(
             'shp',
             $properties->getExtension(),
         );
         self::assertNull($properties->getOptions());
-        self::assertEquals(
+        self::assertSame(
             __('Options'),
             $properties->getOptionsText(),
         );

--- a/tests/classes/Plugins/Import/ImportXmlTest.php
+++ b/tests/classes/Plugins/Import/ImportXmlTest.php
@@ -79,20 +79,20 @@ class ImportXmlTest extends AbstractTestCase
     public function testGetProperties(): void
     {
         $properties = $this->object->getProperties();
-        self::assertEquals(
+        self::assertSame(
             __('XML'),
             $properties->getText(),
         );
-        self::assertEquals(
+        self::assertSame(
             'xml',
             $properties->getExtension(),
         );
-        self::assertEquals(
+        self::assertSame(
             'text/xml',
             $properties->getMimeType(),
         );
         self::assertNull($properties->getOptions());
-        self::assertEquals(
+        self::assertSame(
             __('Options'),
             $properties->getOptionsText(),
         );

--- a/tests/classes/Plugins/Schema/DiaRelationSchemaTest.php
+++ b/tests/classes/Plugins/Schema/DiaRelationSchemaTest.php
@@ -66,10 +66,10 @@ class DiaRelationSchemaTest extends AbstractTestCase
     #[Group('medium')]
     public function testSetProperty(): void
     {
-        self::assertEquals(33, $this->object->getPageNumber());
+        self::assertSame(33, $this->object->getPageNumber());
         self::assertTrue($this->object->isShowColor());
         self::assertTrue($this->object->isShowKeys());
-        self::assertEquals('L', $this->object->getOrientation());
-        self::assertEquals('paper', $this->object->getPaper());
+        self::assertSame('L', $this->object->getOrientation());
+        self::assertSame('paper', $this->object->getPaper());
     }
 }

--- a/tests/classes/Plugins/Schema/EpsRelationSchemaTest.php
+++ b/tests/classes/Plugins/Schema/EpsRelationSchemaTest.php
@@ -65,12 +65,12 @@ class EpsRelationSchemaTest extends AbstractTestCase
     #[Group('medium')]
     public function testConstructor(): void
     {
-        self::assertEquals(33, $this->object->getPageNumber());
+        self::assertSame(33, $this->object->getPageNumber());
         self::assertTrue($this->object->isShowColor());
         self::assertTrue($this->object->isShowKeys());
         self::assertTrue($this->object->isTableDimension());
         self::assertTrue($this->object->isAllTableSameWidth());
-        self::assertEquals('L', $this->object->getOrientation());
+        self::assertSame('L', $this->object->getOrientation());
     }
 
     /**
@@ -80,6 +80,6 @@ class EpsRelationSchemaTest extends AbstractTestCase
     public function testSetPageNumber(): void
     {
         $this->object->setPageNumber(33);
-        self::assertEquals(33, $this->object->getPageNumber());
+        self::assertSame(33, $this->object->getPageNumber());
     }
 }

--- a/tests/classes/Plugins/Schema/ExportRelationSchemaTest.php
+++ b/tests/classes/Plugins/Schema/ExportRelationSchemaTest.php
@@ -49,7 +49,7 @@ class ExportRelationSchemaTest extends AbstractTestCase
     public function testSetPageNumber(): void
     {
         $this->object->setPageNumber(33);
-        self::assertEquals(
+        self::assertSame(
             33,
             $this->object->getPageNumber(),
         );
@@ -78,12 +78,12 @@ class ExportRelationSchemaTest extends AbstractTestCase
     public function testSetOrientation(): void
     {
         $this->object->setOrientation('P');
-        self::assertEquals(
+        self::assertSame(
             'P',
             $this->object->getOrientation(),
         );
         $this->object->setOrientation('A');
-        self::assertEquals(
+        self::assertSame(
             'L',
             $this->object->getOrientation(),
         );
@@ -112,12 +112,12 @@ class ExportRelationSchemaTest extends AbstractTestCase
     public function testSetPaper(): void
     {
         $this->object->setPaper('A5');
-        self::assertEquals(
+        self::assertSame(
             'A5',
             $this->object->getPaper(),
         );
         $this->object->setPaper('A4');
-        self::assertEquals(
+        self::assertSame(
             'A4',
             $this->object->getPaper(),
         );

--- a/tests/classes/Plugins/Schema/PdfRelationSchemaTest.php
+++ b/tests/classes/Plugins/Schema/PdfRelationSchemaTest.php
@@ -68,13 +68,13 @@ class PdfRelationSchemaTest extends AbstractTestCase
     #[Group('large')]
     public function testConstructor(): void
     {
-        self::assertEquals(33, $this->object->getPageNumber());
+        self::assertSame(33, $this->object->getPageNumber());
         self::assertTrue($this->object->isShowGrid());
         self::assertTrue($this->object->isShowColor());
         self::assertTrue($this->object->isShowKeys());
         self::assertTrue($this->object->isTableDimension());
         self::assertTrue($this->object->isAllTableSameWidth());
-        self::assertEquals('L', $this->object->getOrientation());
-        self::assertEquals('paper', $this->object->getPaper());
+        self::assertSame('L', $this->object->getOrientation());
+        self::assertSame('paper', $this->object->getPaper());
     }
 }

--- a/tests/classes/Plugins/Schema/SvgRelationSchemaTest.php
+++ b/tests/classes/Plugins/Schema/SvgRelationSchemaTest.php
@@ -68,7 +68,7 @@ class SvgRelationSchemaTest extends AbstractTestCase
     #[Group('medium')]
     public function testConstructor(): void
     {
-        self::assertEquals(33, $this->object->getPageNumber());
+        self::assertSame(33, $this->object->getPageNumber());
         self::assertTrue($this->object->isShowColor());
         self::assertTrue($this->object->isShowKeys());
         self::assertTrue($this->object->isTableDimension());

--- a/tests/classes/Plugins/Transformations/TransformationPluginsTest.php
+++ b/tests/classes/Plugins/Transformations/TransformationPluginsTest.php
@@ -671,7 +671,7 @@ class TransformationPluginsTest extends AbstractTestCase
 
         // For output transformation plugins, this method may not exist
         if (method_exists($object, 'isSuccess')) {
-            self::assertEquals(
+            self::assertSame(
                 $success,
                 $object->isSuccess(),
             );
@@ -682,7 +682,7 @@ class TransformationPluginsTest extends AbstractTestCase
             return;
         }
 
-        self::assertEquals(
+        self::assertSame(
             $error,
             $object->getError(),
         );

--- a/tests/classes/Plugins/TwoFactor/WebAuthnTest.php
+++ b/tests/classes/Plugins/TwoFactor/WebAuthnTest.php
@@ -88,7 +88,7 @@ class WebAuthnTest extends AbstractTestCase
         $optionsFromSession = $_SESSION['WebAuthnCredentialRequestOptions'] ?? null;
         self::assertIsString($optionsFromSession);
         self::assertJson($optionsFromSession);
-        self::assertEquals($expectedRequestOptions, json_decode($optionsFromSession, true));
+        self::assertSame($expectedRequestOptions, json_decode($optionsFromSession, true));
 
         self::assertStringContainsString('id="webauthn_request_response"', $actual);
         self::assertStringContainsString('name="webauthn_request_response"', $actual);
@@ -139,7 +139,7 @@ class WebAuthnTest extends AbstractTestCase
         $optionsFromSession = $_SESSION['WebAuthnCredentialCreationOptions'] ?? null;
         self::assertIsString($optionsFromSession);
         self::assertJson($optionsFromSession);
-        self::assertEquals($expectedCreationOptions, json_decode($optionsFromSession, true));
+        self::assertSame($expectedCreationOptions, json_decode($optionsFromSession, true));
 
         self::assertStringContainsString('id="webauthn_creation_response"', $actual);
         self::assertStringContainsString('name="webauthn_creation_response"', $actual);

--- a/tests/classes/PluginsTest.php
+++ b/tests/classes/PluginsTest.php
@@ -27,7 +27,7 @@ class PluginsTest extends AbstractTestCase
     public function testGetExport(): void
     {
         $plugins = Plugins::getExport('database', false);
-        self::assertEquals(['export_type' => 'database', 'single_table' => false], $GLOBALS['plugin_param']);
+        self::assertSame(['export_type' => 'database', 'single_table' => false], $GLOBALS['plugin_param']);
         self::assertIsArray($plugins);
         self::assertCount(14, $plugins);
         self::assertContainsOnlyInstancesOf(Plugins\ExportPlugin::class, $plugins);
@@ -36,7 +36,7 @@ class PluginsTest extends AbstractTestCase
     public function testGetImport(): void
     {
         $plugins = Plugins::getImport('database');
-        self::assertEquals('database', $GLOBALS['plugin_param']);
+        self::assertSame('database', $GLOBALS['plugin_param']);
         self::assertIsArray($plugins);
         self::assertCount(6, $plugins);
         self::assertContainsOnlyInstancesOf(Plugins\ImportPlugin::class, $plugins);
@@ -135,6 +135,6 @@ class PluginsTest extends AbstractTestCase
             ['name' => 'sql', 'text' => 'SQL', 'is_selected' => false, 'is_binary' => false],
             ['name' => 'xml', 'text' => 'XML', 'is_selected' => true, 'is_binary' => false],
         ];
-        self::assertEquals($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 }

--- a/tests/classes/Properties/Options/Groups/OptionsPropertyMainGroupTest.php
+++ b/tests/classes/Properties/Options/Groups/OptionsPropertyMainGroupTest.php
@@ -35,7 +35,7 @@ class OptionsPropertyMainGroupTest extends AbstractTestCase
 
     public function testGetItemType(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'main',
             $this->object->getItemType(),
         );

--- a/tests/classes/Properties/Options/Groups/OptionsPropertyRootGroupTest.php
+++ b/tests/classes/Properties/Options/Groups/OptionsPropertyRootGroupTest.php
@@ -35,7 +35,7 @@ class OptionsPropertyRootGroupTest extends AbstractTestCase
 
     public function testGetItemType(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'root',
             $this->object->getItemType(),
         );

--- a/tests/classes/Properties/Options/Groups/OptionsPropertySubgroupTest.php
+++ b/tests/classes/Properties/Options/Groups/OptionsPropertySubgroupTest.php
@@ -35,7 +35,7 @@ class OptionsPropertySubgroupTest extends AbstractTestCase
 
     public function testGetItemType(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'subgroup',
             $this->object->getItemType(),
         );
@@ -51,7 +51,7 @@ class OptionsPropertySubgroupTest extends AbstractTestCase
         $propertyItem = new OptionsPropertySubgroup();
         $this->object->setSubgroupHeader($propertyItem);
 
-        self::assertEquals(
+        self::assertSame(
             $propertyItem,
             $this->object->getSubgroupHeader(),
         );

--- a/tests/classes/Properties/Options/Items/PropertyItemsTest.php
+++ b/tests/classes/Properties/Options/Items/PropertyItemsTest.php
@@ -21,14 +21,14 @@ class PropertyItemsTest extends AbstractTestCase
     {
         $object = new BoolPropertyItem(null, 'Text');
 
-        self::assertEquals(
+        self::assertSame(
             'Text',
             $object->getText(),
         );
 
         $object->setText('xtext2');
 
-        self::assertEquals(
+        self::assertSame(
             'xtext2',
             $object->getText(),
         );
@@ -38,14 +38,14 @@ class PropertyItemsTest extends AbstractTestCase
     {
         $object = new BoolPropertyItem('xname');
 
-        self::assertEquals(
+        self::assertSame(
             'xname',
             $object->getName(),
         );
 
         $object->setName('xname2');
 
-        self::assertEquals(
+        self::assertSame(
             'xname2',
             $object->getName(),
         );
@@ -55,7 +55,7 @@ class PropertyItemsTest extends AbstractTestCase
     {
         $object = new BoolPropertyItem();
 
-        self::assertEquals(
+        self::assertSame(
             'bool',
             $object->getItemType(),
         );
@@ -65,7 +65,7 @@ class PropertyItemsTest extends AbstractTestCase
     {
         $object = new DocPropertyItem();
 
-        self::assertEquals(
+        self::assertSame(
             'doc',
             $object->getItemType(),
         );
@@ -75,7 +75,7 @@ class PropertyItemsTest extends AbstractTestCase
     {
         $object = new HiddenPropertyItem();
 
-        self::assertEquals(
+        self::assertSame(
             'hidden',
             $object->getItemType(),
         );
@@ -85,7 +85,7 @@ class PropertyItemsTest extends AbstractTestCase
     {
         $object = new MessageOnlyPropertyItem();
 
-        self::assertEquals(
+        self::assertSame(
             'messageOnly',
             $object->getItemType(),
         );
@@ -95,7 +95,7 @@ class PropertyItemsTest extends AbstractTestCase
     {
         $object = new RadioPropertyItem();
 
-        self::assertEquals(
+        self::assertSame(
             'radio',
             $object->getItemType(),
         );
@@ -105,7 +105,7 @@ class PropertyItemsTest extends AbstractTestCase
     {
         $object = new SelectPropertyItem();
 
-        self::assertEquals(
+        self::assertSame(
             'select',
             $object->getItemType(),
         );
@@ -115,7 +115,7 @@ class PropertyItemsTest extends AbstractTestCase
     {
         $object = new TextPropertyItem();
 
-        self::assertEquals(
+        self::assertSame(
             'text',
             $object->getItemType(),
         );

--- a/tests/classes/Properties/Options/OptionsPropertyGroupTest.php
+++ b/tests/classes/Properties/Options/OptionsPropertyGroupTest.php
@@ -44,7 +44,7 @@ class OptionsPropertyGroupTest extends AbstractTestCase
         self::assertTrue(
             $this->stub->getProperties()->contains($propertyItem),
         );
-        self::assertEquals(
+        self::assertSame(
             1,
             $this->stub->getNrOfProperties(),
         );
@@ -90,7 +90,7 @@ class OptionsPropertyGroupTest extends AbstractTestCase
         $this->stub->addProperty($propertyItem);
         $propertyItem2 = new BoolPropertyItem();
         $this->stub->addProperty($propertyItem2);
-        self::assertEquals(
+        self::assertSame(
             2,
             $this->stub->getNrOfProperties(),
         );

--- a/tests/classes/Properties/Options/OptionsPropertyItemTest.php
+++ b/tests/classes/Properties/Options/OptionsPropertyItemTest.php
@@ -43,7 +43,7 @@ class OptionsPropertyItemTest extends AbstractTestCase
     {
         $this->stub->setName('name123');
 
-        self::assertEquals(
+        self::assertSame(
             'name123',
             $this->stub->getName(),
         );
@@ -58,7 +58,7 @@ class OptionsPropertyItemTest extends AbstractTestCase
     {
         $this->stub->setText('text123');
 
-        self::assertEquals(
+        self::assertSame(
             'text123',
             $this->stub->getText(),
         );
@@ -73,7 +73,7 @@ class OptionsPropertyItemTest extends AbstractTestCase
     {
         $this->stub->setForce('force123');
 
-        self::assertEquals(
+        self::assertSame(
             'force123',
             $this->stub->getForce(),
         );
@@ -81,7 +81,7 @@ class OptionsPropertyItemTest extends AbstractTestCase
 
     public function testGetPropertyType(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'options',
             $this->stub->getPropertyType(),
         );

--- a/tests/classes/Properties/Options/OptionsPropertyOneItemTest.php
+++ b/tests/classes/Properties/Options/OptionsPropertyOneItemTest.php
@@ -43,7 +43,7 @@ class OptionsPropertyOneItemTest extends AbstractTestCase
     {
         $this->stub->setValues([1, 2]);
 
-        self::assertEquals(
+        self::assertSame(
             [1, 2],
             $this->stub->getValues(),
         );
@@ -58,7 +58,7 @@ class OptionsPropertyOneItemTest extends AbstractTestCase
     {
         $this->stub->setLen(12);
 
-        self::assertEquals(
+        self::assertSame(
             12,
             $this->stub->getLen(),
         );
@@ -73,7 +73,7 @@ class OptionsPropertyOneItemTest extends AbstractTestCase
     {
         $this->stub->setForce('force123');
 
-        self::assertEquals(
+        self::assertSame(
             'force123',
             $this->stub->getForce(),
         );
@@ -88,7 +88,7 @@ class OptionsPropertyOneItemTest extends AbstractTestCase
     {
         $this->stub->setDoc('doc123');
 
-        self::assertEquals(
+        self::assertSame(
             'doc123',
             $this->stub->getDoc(),
         );
@@ -103,7 +103,7 @@ class OptionsPropertyOneItemTest extends AbstractTestCase
     {
         $this->stub->setSize(22);
 
-        self::assertEquals(
+        self::assertSame(
             22,
             $this->stub->getSize(),
         );

--- a/tests/classes/Properties/Plugins/ExportPluginPropertiesTest.php
+++ b/tests/classes/Properties/Plugins/ExportPluginPropertiesTest.php
@@ -35,7 +35,7 @@ class ExportPluginPropertiesTest extends AbstractTestCase
 
     public function testGetItemType(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'export',
             $this->object->getItemType(),
         );

--- a/tests/classes/Properties/Plugins/ImportPluginPropertiesTest.php
+++ b/tests/classes/Properties/Plugins/ImportPluginPropertiesTest.php
@@ -35,7 +35,7 @@ class ImportPluginPropertiesTest extends AbstractTestCase
 
     public function testGetItemType(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'import',
             $this->object->getItemType(),
         );
@@ -50,7 +50,7 @@ class ImportPluginPropertiesTest extends AbstractTestCase
     {
         $this->object->setOptionsText('options123');
 
-        self::assertEquals(
+        self::assertSame(
             'options123',
             $this->object->getOptionsText(),
         );
@@ -65,7 +65,7 @@ class ImportPluginPropertiesTest extends AbstractTestCase
     {
         $this->object->setMimeType('mime123');
 
-        self::assertEquals(
+        self::assertSame(
             'mime123',
             $this->object->getMimeType(),
         );

--- a/tests/classes/Properties/Plugins/PluginPropertyItemTest.php
+++ b/tests/classes/Properties/Plugins/PluginPropertyItemTest.php
@@ -35,7 +35,7 @@ class PluginPropertyItemTest extends AbstractTestCase
 
     public function testGetPropertyType(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'plugin',
             $this->stub->getPropertyType(),
         );

--- a/tests/classes/Properties/PropertyItemTest.php
+++ b/tests/classes/Properties/PropertyItemTest.php
@@ -36,9 +36,6 @@ class PropertyItemTest extends AbstractTestCase
 
     public function testGetGroup(): void
     {
-        self::assertEquals(
-            null,
-            $this->stub->getGroup(),
-        );
+        self::assertNull($this->stub->getGroup());
     }
 }

--- a/tests/classes/Query/GeneratorTest.php
+++ b/tests/classes/Query/GeneratorTest.php
@@ -13,14 +13,14 @@ class GeneratorTest extends AbstractTestCase
 {
     public function testGetColumnsSql(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'SHOW  COLUMNS FROM `mydb`.`mytable`',
             Generator::getColumnsSql(
                 'mydb',
                 'mytable',
             ),
         );
-        self::assertEquals(
+        self::assertSame(
             'SHOW  COLUMNS FROM `mydb`.`mytable` LIKE \'_idcolumn\'',
             Generator::getColumnsSql(
                 'mydb',
@@ -28,7 +28,7 @@ class GeneratorTest extends AbstractTestCase
                 "'_idcolumn'",
             ),
         );
-        self::assertEquals(
+        self::assertSame(
             'SHOW FULL COLUMNS FROM `mydb`.`mytable`',
             Generator::getColumnsSql(
                 'mydb',
@@ -37,7 +37,7 @@ class GeneratorTest extends AbstractTestCase
                 true,
             ),
         );
-        self::assertEquals(
+        self::assertSame(
             'SHOW FULL COLUMNS FROM `mydb`.`mytable` LIKE \'_idcolumn\'',
             Generator::getColumnsSql(
                 'mydb',
@@ -50,14 +50,14 @@ class GeneratorTest extends AbstractTestCase
 
     public function testGetTableIndexesSql(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'SHOW INDEXES FROM `mydb`.`mytable`',
             Generator::getTableIndexesSql(
                 'mydb',
                 'mytable',
             ),
         );
-        self::assertEquals(
+        self::assertSame(
             'SHOW INDEXES FROM `mydb`.`mytable` WHERE (1)',
             Generator::getTableIndexesSql(
                 'mydb',
@@ -69,7 +69,7 @@ class GeneratorTest extends AbstractTestCase
 
     public function testGetSqlQueryForIndexRename(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'ALTER TABLE `mydb`.`mytable` RENAME INDEX `oldIndexName` TO `newIndexName`;',
             Generator::getSqlQueryForIndexRename(
                 'mydb',
@@ -82,7 +82,7 @@ class GeneratorTest extends AbstractTestCase
 
     public function testGetQueryForReorderingTable(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'ALTER TABLE `mytable` ORDER BY `myOrderField` ASC;',
             Generator::getQueryForReorderingTable(
                 'mytable',
@@ -90,7 +90,7 @@ class GeneratorTest extends AbstractTestCase
                 '',
             ),
         );
-        self::assertEquals(
+        self::assertSame(
             'ALTER TABLE `mytable` ORDER BY `myOrderField` ASC;',
             Generator::getQueryForReorderingTable(
                 'mytable',
@@ -98,7 +98,7 @@ class GeneratorTest extends AbstractTestCase
                 'S',
             ),
         );
-        self::assertEquals(
+        self::assertSame(
             'ALTER TABLE `mytable` ORDER BY `myOrderField` ASC;',
             Generator::getQueryForReorderingTable(
                 'mytable',
@@ -106,7 +106,7 @@ class GeneratorTest extends AbstractTestCase
                 'DESC',
             ),
         );
-        self::assertEquals(
+        self::assertSame(
             'ALTER TABLE `mytable` ORDER BY `myOrderField` DESC;',
             Generator::getQueryForReorderingTable(
                 'mytable',
@@ -114,7 +114,7 @@ class GeneratorTest extends AbstractTestCase
                 'desc',
             ),
         );
-        self::assertEquals(
+        self::assertSame(
             'ALTER TABLE `mytable` ORDER BY `myOrderField` ASC;',
             Generator::getQueryForReorderingTable(
                 'mytable',
@@ -126,7 +126,7 @@ class GeneratorTest extends AbstractTestCase
 
     public function testGetQueryForPartitioningTable(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'ALTER TABLE `mytable`  PARTITION ;',
             Generator::getQueryForPartitioningTable(
                 'mytable',
@@ -134,7 +134,7 @@ class GeneratorTest extends AbstractTestCase
                 [],
             ),
         );
-        self::assertEquals(
+        self::assertSame(
             'ALTER TABLE `mytable`  PARTITION p1;',
             Generator::getQueryForPartitioningTable(
                 'mytable',
@@ -142,7 +142,7 @@ class GeneratorTest extends AbstractTestCase
                 ['p1'],
             ),
         );
-        self::assertEquals(
+        self::assertSame(
             'ALTER TABLE `mytable`  PARTITION p1, p2;',
             Generator::getQueryForPartitioningTable(
                 'mytable',
@@ -150,7 +150,7 @@ class GeneratorTest extends AbstractTestCase
                 ['p1', 'p2'],
             ),
         );
-        self::assertEquals(
+        self::assertSame(
             'ALTER TABLE `mytable` COALESCE PARTITION 2',
             Generator::getQueryForPartitioningTable(
                 'mytable',
@@ -168,12 +168,12 @@ class GeneratorTest extends AbstractTestCase
         $queryFields = ['a', 'b'];
         $valueSets = ['1', '2'];
 
-        self::assertEquals(
+        self::assertSame(
             'INSERT IGNORE INTO `table` (a, b) VALUES (1), (2)',
             Generator::buildInsertSqlQuery('table', true, $queryFields, $valueSets),
         );
 
-        self::assertEquals(
+        self::assertSame(
             'INSERT INTO `table` (a, b) VALUES (1), (2)',
             Generator::buildInsertSqlQuery('table', false, $queryFields, $valueSets),
         );

--- a/tests/classes/Routing/RoutingTest.php
+++ b/tests/classes/Routing/RoutingTest.php
@@ -75,7 +75,7 @@ class RoutingTest extends AbstractTestCase
         $_SERVER['REQUEST_URI'] = $request;
         $_SERVER['PATH_INFO'] = $pathInfo;
         $actual = Routing::getCleanPathInfo();
-        self::assertEquals($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /** @return array<array{string, string, string, string}> */

--- a/tests/classes/SanitizeTest.php
+++ b/tests/classes/SanitizeTest.php
@@ -27,7 +27,7 @@ class SanitizeTest extends AbstractTestCase
      */
     public function testXssInHref(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '[a@javascript:alert(&#039;XSS&#039;);@target]link</a>',
             Sanitize::convertBBCode('[a@javascript:alert(\'XSS\');@target]link[/a]'),
         );
@@ -41,7 +41,7 @@ class SanitizeTest extends AbstractTestCase
         $lang = $GLOBALS['lang'];
 
         unset($GLOBALS['lang']);
-        self::assertEquals(
+        self::assertSame(
             '<a href="index.php?route=/url&url=https%3A%2F%2Fwww.phpmyadmin.net%2F" target="target">link</a>',
             Sanitize::convertBBCode('[a@https://www.phpmyadmin.net/@target]link[/a]'),
         );
@@ -58,7 +58,7 @@ class SanitizeTest extends AbstractTestCase
     #[DataProvider('docLinks')]
     public function testDoc(string $link, string $expected): void
     {
-        self::assertEquals(
+        self::assertSame(
             '<a href="index.php?route=/url&url=https%3A%2F%2Fdocs.phpmyadmin.net%2Fen%2Flatest%2F'
                 . $expected . '" target="documentation">doclink</a>',
             Sanitize::convertBBCode('[doc@' . $link . ']doclink[/doc]'),
@@ -85,7 +85,7 @@ class SanitizeTest extends AbstractTestCase
      */
     public function testInvalidTarget(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '[a@./Documentation.html@INVALID9]doc</a>',
             Sanitize::convertBBCode('[a@./Documentation.html@INVALID9]doc[/a]'),
         );
@@ -96,7 +96,7 @@ class SanitizeTest extends AbstractTestCase
      */
     public function testLinkDocXss(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '[a@./Documentation.html&quot; onmouseover=&quot;alert(foo)&quot;]doc</a>',
             Sanitize::convertBBCode('[a@./Documentation.html" onmouseover="alert(foo)"]doc[/a]'),
         );
@@ -107,7 +107,7 @@ class SanitizeTest extends AbstractTestCase
      */
     public function testLinkAndXssInHref(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '<a href="index.php?route=/url&url=https%3A%2F%2Fdocs.phpmyadmin.net%2F">doc</a>'
                 . '[a@javascript:alert(&#039;XSS&#039;);@target]link</a>',
             Sanitize::convertBBCode(
@@ -121,7 +121,7 @@ class SanitizeTest extends AbstractTestCase
      */
     public function testHtmlTags(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '&lt;div onclick=&quot;&quot;&gt;',
             Sanitize::convertBBCode('<div onclick="">'),
         );
@@ -132,7 +132,7 @@ class SanitizeTest extends AbstractTestCase
      */
     public function testBBCode(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '<strong>strong</strong>',
             Sanitize::convertBBCode('[strong]strong[/strong]'),
         );
@@ -143,7 +143,7 @@ class SanitizeTest extends AbstractTestCase
      */
     public function testSanitizeFilename(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'File_name_123',
             Sanitize::sanitizeFilename('File_name 123'),
         );
@@ -159,7 +159,7 @@ class SanitizeTest extends AbstractTestCase
     #[DataProvider('variables')]
     public function testGetJsValue(string $key, string|bool|int|array $value, string $expected): void
     {
-        self::assertEquals($expected, Sanitize::getJsValue($key, $value));
+        self::assertSame($expected, Sanitize::getJsValue($key, $value));
     }
 
     /**

--- a/tests/classes/ScriptsTest.php
+++ b/tests/classes/ScriptsTest.php
@@ -86,7 +86,7 @@ class ScriptsTest extends AbstractTestCase
         $this->object->addFile('vendor/codemirror/lib/codemirror.js');
 
         $this->object->addFile('common.js');
-        self::assertEquals(
+        self::assertSame(
             [['name' => 'vendor/codemirror/lib/codemirror.js', 'fire' => 0], ['name' => 'common.js', 'fire' => 1]],
             $this->object->getFiles(),
         );
@@ -101,14 +101,14 @@ class ScriptsTest extends AbstractTestCase
 
         // Assert empty _files property of
         // Scripts
-        self::assertEquals([], $reflection->getValue($this->object));
+        self::assertSame([], $reflection->getValue($this->object));
 
         // Add one script file
         $file = 'common.js';
         $hash = 'd7716810d825f4b55d18727c3ccb24e6';
         $files = [$hash => ['has_onload' => 1, 'filename' => 'common.js', 'params' => []]];
         $this->object->addFile($file);
-        self::assertEquals($files, $reflection->getValue($this->object));
+        self::assertSame($files, $reflection->getValue($this->object));
     }
 
     /**
@@ -124,6 +124,6 @@ class ScriptsTest extends AbstractTestCase
             '347a57484fcd6ea6d8a125e6e1d31f78' => ['has_onload' => 1, 'filename' => 'sql.js', 'params' => []],
         ];
         $this->object->addFiles($filenames);
-        self::assertEquals($files, $reflection->getValue($this->object));
+        self::assertSame($files, $reflection->getValue($this->object));
     }
 }

--- a/tests/classes/Server/PluginsTest.php
+++ b/tests/classes/Server/PluginsTest.php
@@ -97,7 +97,7 @@ class PluginsTest extends AbstractTestCase
         $plugins = $this->plugins->getAuthentication();
         self::assertIsArray($plugins);
         self::assertNotEmpty($plugins);
-        self::assertEquals(
+        self::assertSame(
             [
                 'mysql_old_password' => __('Old MySQL-4.0 authentication'),
                 'mysql_native_password' => __('Native MySQL authentication'),

--- a/tests/classes/Server/PrivilegesTest.php
+++ b/tests/classes/Server/PrivilegesTest.php
@@ -68,42 +68,42 @@ class PrivilegesTest extends AbstractTestCase
             $routinename,
             $dbnameIsWildcard,
         ] = $serverPrivileges->getDataForDBInfo();
-        self::assertEquals('PMA_username', $username);
-        self::assertEquals('PMA_hostname', $hostname);
-        self::assertEquals('PMA_dbname', $dbname);
-        self::assertEquals('PMA_tablename', $tablename);
+        self::assertSame('PMA_username', $username);
+        self::assertSame('PMA_hostname', $hostname);
+        self::assertSame('PMA_dbname', $dbname);
+        self::assertSame('PMA_tablename', $tablename);
         self::assertTrue($dbnameIsWildcard);
 
         //pre variable have been defined
         $_POST['pred_tablename'] = 'PMA_pred__tablename';
         $_POST['pred_dbname'] = ['PMA_pred_dbname'];
         [, , $dbname, $tablename, $routinename, $dbnameIsWildcard] = $serverPrivileges->getDataForDBInfo();
-        self::assertEquals('PMA_pred_dbname', $dbname);
-        self::assertEquals('PMA_pred__tablename', $tablename);
+        self::assertSame('PMA_pred_dbname', $dbname);
+        self::assertSame('PMA_pred__tablename', $tablename);
         self::assertTrue($dbnameIsWildcard);
 
         // Escaped database
         $_POST['pred_tablename'] = 'PMA_pred__tablename';
         $_POST['pred_dbname'] = ['PMA\_pred\_dbname'];
         [, , $dbname, $tablename, $routinename, $dbnameIsWildcard] = $serverPrivileges->getDataForDBInfo();
-        self::assertEquals('PMA\_pred\_dbname', $dbname);
-        self::assertEquals('PMA_pred__tablename', $tablename);
+        self::assertSame('PMA\_pred\_dbname', $dbname);
+        self::assertSame('PMA_pred__tablename', $tablename);
         self::assertFalse($dbnameIsWildcard);
 
         // Multiselect database - pred
         unset($_POST['pred_tablename'], $_REQUEST['tablename'], $_REQUEST['dbname']);
         $_POST['pred_dbname'] = ['PMA\_pred\_dbname', 'PMADbname2'];
         [, , $dbname, $tablename, , $dbnameIsWildcard] = $serverPrivileges->getDataForDBInfo();
-        self::assertEquals(['PMA\_pred\_dbname', 'PMADbname2'], $dbname);
-        self::assertEquals(null, $tablename);
+        self::assertSame(['PMA\_pred\_dbname', 'PMADbname2'], $dbname);
+        self::assertNull($tablename);
         self::assertFalse($dbnameIsWildcard);
 
         // Multiselect database
         unset($_POST['pred_tablename'], $_REQUEST['tablename'], $_POST['pred_dbname']);
         $_REQUEST['dbname'] = ['PMA\_dbname', 'PMADbname2'];
         [, , $dbname, $tablename, , $dbnameIsWildcard] = $serverPrivileges->getDataForDBInfo();
-        self::assertEquals(['PMA\_dbname', 'PMADbname2'], $dbname);
-        self::assertEquals(null, $tablename);
+        self::assertSame(['PMA\_dbname', 'PMADbname2'], $dbname);
+        self::assertNull($tablename);
         self::assertFalse($dbnameIsWildcard);
     }
 
@@ -114,17 +114,17 @@ class PrivilegesTest extends AbstractTestCase
         $dbname = '';
         $tablename = '';
         $dbAndTable = $serverPrivileges->wildcardEscapeForGrant($dbname, $tablename);
-        self::assertEquals('*.*', $dbAndTable);
+        self::assertSame('*.*', $dbAndTable);
 
         $dbname = 'dbname';
         $tablename = '';
         $dbAndTable = $serverPrivileges->wildcardEscapeForGrant($dbname, $tablename);
-        self::assertEquals('`dbname`.*', $dbAndTable);
+        self::assertSame('`dbname`.*', $dbAndTable);
 
         $dbname = 'dbname';
         $tablename = 'tablename';
         $dbAndTable = $serverPrivileges->wildcardEscapeForGrant($dbname, $tablename);
-        self::assertEquals('`dbname`.`tablename`', $dbAndTable);
+        self::assertSame('`dbname`.`tablename`', $dbAndTable);
     }
 
     public function testRangeOfUsers(): void
@@ -132,16 +132,16 @@ class PrivilegesTest extends AbstractTestCase
         $serverPrivileges = $this->getPrivileges($this->createDatabaseInterface());
 
         $ret = $serverPrivileges->rangeOfUsers('INIT');
-        self::assertEquals('WHERE `User` LIKE \'INIT%\' OR `User` LIKE \'init%\'', $ret);
+        self::assertSame('WHERE `User` LIKE \'INIT%\' OR `User` LIKE \'init%\'', $ret);
 
         $ret = $serverPrivileges->rangeOfUsers('%');
-        self::assertEquals('WHERE `User` LIKE \'\\\\%%\' OR `User` LIKE \'\\\\%%\'', $ret);
+        self::assertSame('WHERE `User` LIKE \'\\\\%%\' OR `User` LIKE \'\\\\%%\'', $ret);
 
         $ret = $serverPrivileges->rangeOfUsers('');
-        self::assertEquals("WHERE `User` = ''", $ret);
+        self::assertSame("WHERE `User` = ''", $ret);
 
         $ret = $serverPrivileges->rangeOfUsers();
-        self::assertEquals('', $ret);
+        self::assertSame('', $ret);
     }
 
     public function testGetTableGrantsArray(): void
@@ -149,11 +149,11 @@ class PrivilegesTest extends AbstractTestCase
         $serverPrivileges = $this->getPrivileges($this->createDatabaseInterface());
 
         $ret = $serverPrivileges->getTableGrantsArray();
-        self::assertEquals(
+        self::assertSame(
             ['Delete', 'DELETE', __('Allows deleting data.')],
             $ret[0],
         );
-        self::assertEquals(
+        self::assertSame(
             ['Create', 'CREATE', __('Allows creating new tables.')],
             $ret[1],
         );
@@ -164,11 +164,11 @@ class PrivilegesTest extends AbstractTestCase
         $serverPrivileges = $this->getPrivileges($this->createDatabaseInterface());
 
         $ret = $serverPrivileges->getGrantsArray();
-        self::assertEquals(
+        self::assertSame(
             ['Select_priv', 'SELECT', __('Allows reading data.')],
             $ret[0],
         );
-        self::assertEquals(
+        self::assertSame(
             ['Insert_priv', 'INSERT', __('Allows inserting and replacing data.')],
             $ret[1],
         );
@@ -189,7 +189,7 @@ class PrivilegesTest extends AbstractTestCase
         $sql = 'SELECT * FROM `mysql`.`user`'
             . ' WHERE `User` = ' . $dbi->quoteString($username)
             . ' AND `Host` = ' . $dbi->quoteString($hostname) . ';';
-        self::assertEquals($sql, $ret);
+        self::assertSame($sql, $ret);
 
         //$table == '*'
         $db = 'pma_db';
@@ -200,7 +200,7 @@ class PrivilegesTest extends AbstractTestCase
             . ' AND `Host` = ' . $dbi->quoteString($hostname)
             . ' AND `Db` = \'' . $db . '\'';
 
-        self::assertEquals($sql, $ret);
+        self::assertSame($sql, $ret);
 
         //$table == 'pma_table'
         $db = 'pma_db';
@@ -212,13 +212,13 @@ class PrivilegesTest extends AbstractTestCase
             . ' AND `Host` = ' . $dbi->quoteString($hostname)
             . " AND `Db` = '" . $serverPrivileges->unescapeGrantWildcards($db) . "'"
             . ' AND `Table_name` = ' . $dbi->quoteString($table) . ';';
-        self::assertEquals($sql, $ret);
+        self::assertSame($sql, $ret);
 
         // SQL escaping
         $db = "db' AND";
         $table = 'pma_table';
         $ret = $serverPrivileges->getSqlQueryForDisplayPrivTable($db, $table, $username, $hostname);
-        self::assertEquals(
+        self::assertSame(
             'SELECT `Table_priv` FROM `mysql`.`tables_priv` '
             . "WHERE `User` = 'pma_username' AND "
             . "`Host` = 'pma_hostname' AND `Db` = 'db\' AND' AND "
@@ -250,7 +250,7 @@ class PrivilegesTest extends AbstractTestCase
         //$_POST['change_copy'] is set
         $_POST['change_copy'] = true;
         $password = $serverPrivileges->getDataForChangeOrCopyUser('PMA_old_username', 'PMA_old_hostname');
-        self::assertEquals('pma_password', $password);
+        self::assertSame('pma_password', $password);
         unset($_POST['change_copy']);
     }
 
@@ -311,11 +311,11 @@ class PrivilegesTest extends AbstractTestCase
             $sqlQuery,
             $addUserError,
         ] = $serverPrivileges->addUser($dbname, $username, $hostname, $dbname, true);
-        self::assertEquals(
+        self::assertSame(
             'You have added a new user.',
             $retMessage->getMessage(),
         );
-        self::assertEquals(
+        self::assertSame(
             "CREATE USER ''@'localhost' IDENTIFIED WITH mysql_native_password AS '***';"
             . "GRANT USAGE ON *.* TO ''@'localhost' REQUIRE NONE;"
             . "GRANT ALL PRIVILEGES ON `pma_dbname`.* TO ''@'localhost';",
@@ -361,11 +361,11 @@ class PrivilegesTest extends AbstractTestCase
             $addUserError,
         ] = $serverPrivileges->addUser($dbname, $username, $hostname, $dbname, true);
 
-        self::assertEquals(
+        self::assertSame(
             'You have added a new user.',
             $retMessage->getMessage(),
         );
-        self::assertEquals(
+        self::assertSame(
             "CREATE USER ''@'localhost';"
             . "GRANT USAGE ON *.* TO ''@'localhost' REQUIRE NONE;"
             . "SET PASSWORD FOR ''@'localhost' = '***';"
@@ -393,7 +393,7 @@ class PrivilegesTest extends AbstractTestCase
 
         $message = $serverPrivileges->updatePassword($errUrl, $username, $hostname);
 
-        self::assertEquals(
+        self::assertSame(
             'The password for \'pma_username\'@\'pma_hostname\' was changed successfully.',
             $message->getMessage(),
         );
@@ -431,11 +431,11 @@ class PrivilegesTest extends AbstractTestCase
             '',
         );
 
-        self::assertEquals(
+        self::assertSame(
             "You have revoked the privileges for 'pma_username'@'pma_hostname'.",
             $message->getMessage(),
         );
-        self::assertEquals(
+        self::assertSame(
             'REVOKE ALL PRIVILEGES ON  `pma_dbname`.`pma_tablename` '
             . "FROM 'pma_username'@'pma_hostname'; "
             . 'REVOKE GRANT OPTION ON  `pma_dbname`.`pma_tablename` '
@@ -465,11 +465,11 @@ class PrivilegesTest extends AbstractTestCase
         $_POST['max_questions'] = 1000;
         [$sqlQuery, $message] = $serverPrivileges->updatePrivileges($username, $hostname, $tablename, $dbname, '');
 
-        self::assertEquals(
+        self::assertSame(
             "You have updated the privileges for 'pma_username'@'pma_hostname'.",
             $message->getMessage(),
         );
-        self::assertEquals(
+        self::assertSame(
             'REVOKE ALL PRIVILEGES ON  `pma_dbname`.`pma_tablename` FROM \'pma_username\'@\'pma_hostname\';   ',
             $sqlQuery,
         );
@@ -508,11 +508,11 @@ class PrivilegesTest extends AbstractTestCase
 
         [$sqlQuery, $message] = $serverPrivileges->updatePrivileges($username, $hostname, $tablename, $dbname, '');
 
-        self::assertEquals(
+        self::assertSame(
             "You have updated the privileges for 'pma_username'@'pma_hostname'.",
             $message->getMessage(),
         );
-        self::assertEquals(
+        self::assertSame(
             '  GRANT USAGE ON  *.* TO \'pma_username\'@\'pma_hostname\' REQUIRE NONE'
             . ' WITH GRANT OPTION MAX_QUERIES_PER_HOUR 1000 MAX_CONNECTIONS_PER_HOUR 20'
             . ' MAX_UPDATES_PER_HOUR 30 MAX_USER_CONNECTIONS 40; ',
@@ -552,11 +552,11 @@ class PrivilegesTest extends AbstractTestCase
 
         [$sqlQuery, $message] = $serverPrivileges->updatePrivileges($username, $hostname, $tablename, $dbname, '');
 
-        self::assertEquals(
+        self::assertSame(
             "You have updated the privileges for 'pma_username'@'pma_hostname'.",
             $message->getMessage(),
         );
-        self::assertEquals(
+        self::assertSame(
             '  GRANT USAGE ON  *.* TO \'pma_username\'@\'pma_hostname\';'
             . ' ALTER USER \'pma_username\'@\'pma_hostname\'  REQUIRE NONE'
             . ' WITH MAX_QUERIES_PER_HOUR 1000 MAX_CONNECTIONS_PER_HOUR'
@@ -665,13 +665,13 @@ class PrivilegesTest extends AbstractTestCase
         ] = $serverPrivileges->getSqlQueriesForDisplayAndAddUser($username, $hostname, $password);
 
         //validate 1: $create_user_real
-        self::assertEquals(
+        self::assertSame(
             'CREATE USER \'PMA_username\'@\'PMA_hostname\' IDENTIFIED WITH mysql_native_password BY \'pma_password\';',
             $createUserReal,
         );
 
         //validate 2: $create_user_show
-        self::assertEquals(
+        self::assertSame(
             'CREATE USER \'PMA_username\'@\'PMA_hostname\' IDENTIFIED WITH mysql_native_password BY \'***\';',
             $createUserShow,
         );
@@ -698,13 +698,13 @@ class PrivilegesTest extends AbstractTestCase
         ] = $serverPrivileges->getSqlQueriesForDisplayAndAddUser($username, $hostname, $password);
 
         //validate 1: $createUserReal
-        self::assertEquals(
+        self::assertSame(
             'CREATE USER \'PMA_username\'@\'PMA_hostname\' IDENTIFIED BY \'pma_password\';',
             $createUserReal,
         );
 
         //validate 2: $createUserShow
-        self::assertEquals('CREATE USER \'PMA_username\'@\'PMA_hostname\' IDENTIFIED BY \'***\';', $createUserShow);
+        self::assertSame('CREATE USER \'PMA_username\'@\'PMA_hostname\' IDENTIFIED BY \'***\';', $createUserShow);
     }
 
     public function testGetSqlQueriesForDisplayAndAddUser(): void
@@ -738,22 +738,22 @@ class PrivilegesTest extends AbstractTestCase
         ] = $serverPrivileges->getSqlQueriesForDisplayAndAddUser($username, $hostname, $password);
 
         //validate 1: $createUserReal
-        self::assertEquals(
+        self::assertSame(
             'CREATE USER \'PMA_username\'@\'PMA_hostname\' IDENTIFIED WITH mysql_native_password AS \'pma_password\';',
             $createUserReal,
         );
 
         //validate 2: $createUserShow
-        self::assertEquals(
+        self::assertSame(
             'CREATE USER \'PMA_username\'@\'PMA_hostname\' IDENTIFIED WITH mysql_native_password AS \'***\';',
             $createUserShow,
         );
 
         //validate 3:$realSqlQuery
-        self::assertEquals('GRANT USAGE ON *.* TO \'PMA_username\'@\'PMA_hostname\' REQUIRE NONE;', $realSqlQuery);
+        self::assertSame('GRANT USAGE ON *.* TO \'PMA_username\'@\'PMA_hostname\' REQUIRE NONE;', $realSqlQuery);
 
         //validate 4:$sqlQuery
-        self::assertEquals('GRANT USAGE ON *.* TO \'PMA_username\'@\'PMA_hostname\' REQUIRE NONE;', $sqlQuery);
+        self::assertSame('GRANT USAGE ON *.* TO \'PMA_username\'@\'PMA_hostname\' REQUIRE NONE;', $sqlQuery);
 
         self::assertSame('', $alterRealSqlQuery);
 
@@ -775,12 +775,12 @@ class PrivilegesTest extends AbstractTestCase
         );
 
         //validate 5: $sqlQuery
-        self::assertEquals('GRANT USAGE ON *.* TO \'PMA_username\'@\'PMA_hostname\' REQUIRE NONE;', $sqlQuery);
+        self::assertSame('GRANT USAGE ON *.* TO \'PMA_username\'@\'PMA_hostname\' REQUIRE NONE;', $sqlQuery);
 
         self::assertInstanceOf(Message::class, $message);
 
         //validate 6: $message
-        self::assertEquals(
+        self::assertSame(
             'You have added a new user.',
             $message->getMessage(),
         );
@@ -1112,10 +1112,10 @@ class PrivilegesTest extends AbstractTestCase
         self::assertFalse($extraData['db_specific_privs']);
 
         //new_user_initial
-        self::assertEquals('P', $extraData['new_user_initial']);
+        self::assertSame('P', $extraData['new_user_initial']);
 
         //sql_query
-        self::assertEquals(
+        self::assertSame(
             Generator::getMessage('', $sqlQuery),
             $extraData['sql_query'],
         );
@@ -1157,7 +1157,7 @@ class PrivilegesTest extends AbstractTestCase
 
         $serverPrivileges = $this->getPrivileges($this->createDatabaseInterface($dummyDbi));
 
-        self::assertEquals('pma_usergroup', $serverPrivileges->getUserGroupForUser('pma_username'));
+        self::assertSame('pma_usergroup', $serverPrivileges->getUserGroupForUser('pma_username'));
     }
 
     public function testGetUsersOverview(): void
@@ -1274,7 +1274,7 @@ class PrivilegesTest extends AbstractTestCase
         $ret = $serverPrivileges->getDataForDeleteUsers($queries);
 
         $item = ["# Deleting 'old_username'@'old_hostname' ...", "DROP USER 'old_username'@'old_hostname';"];
-        self::assertEquals($item, $ret);
+        self::assertSame($item, $ret);
     }
 
     public function testGetHtmlHeaderForUserProperties(): void
@@ -1707,7 +1707,7 @@ class PrivilegesTest extends AbstractTestCase
             ],
         ];
         $actual = $serverPrivileges->getDbRightsForUserOverview('A');
-        self::assertEquals($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     public function testDeleteUser(): void
@@ -1738,8 +1738,8 @@ class PrivilegesTest extends AbstractTestCase
         $actual = $serverPrivileges->deleteUser($queries);
         self::assertArrayHasKey(0, $actual);
         self::assertArrayHasKey(1, $actual);
-        self::assertEquals('', $actual[0]);
-        self::assertEquals(
+        self::assertSame('', $actual[0]);
+        self::assertSame(
             'No users selected for deleting!',
             $actual[1]->getMessage(),
         );
@@ -1750,8 +1750,8 @@ class PrivilegesTest extends AbstractTestCase
         $actual = $serverPrivileges->deleteUser($queries);
         self::assertArrayHasKey(0, $actual);
         self::assertArrayHasKey(1, $actual);
-        self::assertEquals("foo\n# Reloading the privileges …\nFLUSH PRIVILEGES;", $actual[0]);
-        self::assertEquals(
+        self::assertSame("foo\n# Reloading the privileges …\nFLUSH PRIVILEGES;", $actual[0]);
+        self::assertSame(
             'The selected users have been deleted successfully.',
             $actual[1]->getMessage(),
         );
@@ -1762,8 +1762,8 @@ class PrivilegesTest extends AbstractTestCase
         $actual = $serverPrivileges->deleteUser($queries);
         self::assertArrayHasKey(0, $actual);
         self::assertArrayHasKey(1, $actual);
-        self::assertEquals('bar', $actual[0]);
-        self::assertEquals(
+        self::assertSame('bar', $actual[0]);
+        self::assertSame(
             'Some error occurred!' . "\n",
             $actual[1]->getMessage(),
         );
@@ -1852,7 +1852,7 @@ class PrivilegesTest extends AbstractTestCase
         /** @var array|null $actual */
         $actual = $method->invokeArgs($serverPrivileges, ['test.user', 'test.host', true]);
 
-        self::assertEquals(['Host' => 'test.host', 'User' => 'test.user', 'account_locked' => 'Y'], $actual);
+        self::assertSame(['Host' => 'test.host', 'User' => 'test.user', 'account_locked' => 'Y'], $actual);
     }
 
     private function getPrivileges(DatabaseInterface $dbi): Privileges
@@ -1890,7 +1890,7 @@ class PrivilegesTest extends AbstractTestCase
     {
         $dbi = $this->createDatabaseInterface();
         $serverPrivileges = $this->getPrivileges($dbi);
-        self::assertEquals(
+        self::assertSame(
             $a,
             $serverPrivileges->escapeGrantWildcards($b),
         );
@@ -1905,7 +1905,7 @@ class PrivilegesTest extends AbstractTestCase
     {
         $dbi = $this->createDatabaseInterface();
         $serverPrivileges = $this->getPrivileges($dbi);
-        self::assertEquals(
+        self::assertSame(
             $b,
             $serverPrivileges->unescapeGrantWildcards($a),
         );

--- a/tests/classes/Server/SysInfo/SysInfoTest.php
+++ b/tests/classes/Server/SysInfo/SysInfoTest.php
@@ -22,7 +22,7 @@ class SysInfoTest extends AbstractTestCase
     #[DataProvider('sysInfoOsProvider')]
     public function testGetSysInfoOs(string $os, string $expected): void
     {
-        self::assertEquals(
+        self::assertSame(
             $expected,
             SysInfo::getOs($os),
         );

--- a/tests/classes/Setup/ConfigGeneratorTest.php
+++ b/tests/classes/Setup/ConfigGeneratorTest.php
@@ -71,18 +71,18 @@ class ConfigGeneratorTest extends AbstractTestCase
         $reflection = new ReflectionClass(ConfigGenerator::class);
         $method = $reflection->getMethod('getVarExport');
 
-        self::assertEquals(
+        self::assertSame(
             '$cfg[\'var_name\'] = 1;' . "\n",
             $method->invoke(null, 'var_name', 1, "\n"),
         );
 
-        self::assertEquals(
+        self::assertSame(
             '$cfg[\'var_name\'] = array (' .
             "\n);\n",
             $method->invoke(null, 'var_name', [], "\n"),
         );
 
-        self::assertEquals(
+        self::assertSame(
             '$cfg[\'var_name\'] = [1, 2, 3];' . "\n",
             $method->invoke(
                 null,
@@ -92,7 +92,7 @@ class ConfigGeneratorTest extends AbstractTestCase
             ),
         );
 
-        self::assertEquals(
+        self::assertSame(
             '$cfg[\'var_name\'][\'1a\'] = \'foo\';' . "\n" .
             '$cfg[\'var_name\'][\'b\'] = \'bar\';' . "\n",
             $method->invoke(
@@ -109,7 +109,7 @@ class ConfigGeneratorTest extends AbstractTestCase
         $reflection = new ReflectionClass(ConfigGenerator::class);
         $method = $reflection->getMethod('getVarExport');
 
-        self::assertEquals(
+        self::assertSame(
             '$cfg[\'blowfish_secret\'] = \sodium_hex2bin(\''
             . '6161616161616161616161616161616161616161616161616161616161616161\');' . "\n",
             $method->invoke(null, 'blowfish_secret', str_repeat('a', SODIUM_CRYPTO_SECRETBOX_KEYBYTES), "\n"),
@@ -175,13 +175,13 @@ class ConfigGeneratorTest extends AbstractTestCase
 
         $result = $method->invoke(null, $arr, "\n");
 
-        self::assertEquals('[1, 2, 3, 4]', $result);
+        self::assertSame('[1, 2, 3, 4]', $result);
 
         $arr = [1, 2, 3, 4, 7, 'foo'];
 
         $result = $method->invoke(null, $arr, "\n");
 
-        self::assertEquals(
+        self::assertSame(
             '[' . "\n" .
             '    1,' . "\n" .
             '    2,' . "\n" .

--- a/tests/classes/Setup/IndexTest.php
+++ b/tests/classes/Setup/IndexTest.php
@@ -31,7 +31,7 @@ class IndexTest extends AbstractTestCase
 
         SetupIndex::messagesBegin();
 
-        self::assertEquals(
+        self::assertSame(
             [[[0 => 'foo', 'fresh' => false, 'active' => false], [0 => 'bar', 'fresh' => false, 'active' => false]]],
             $_SESSION['messages'],
         );
@@ -40,7 +40,7 @@ class IndexTest extends AbstractTestCase
 
         unset($_SESSION['messages']);
         SetupIndex::messagesBegin();
-        self::assertEquals(
+        self::assertSame(
             ['error' => [], 'notice' => []],
             $_SESSION['messages'],
         );
@@ -53,7 +53,7 @@ class IndexTest extends AbstractTestCase
     {
         SetupIndex::messagesSet('type', '123', 'testTitle', 'msg');
 
-        self::assertEquals(
+        self::assertSame(
             ['fresh' => true, 'active' => true, 'title' => 'testTitle', 'message' => 'msg'],
             $_SESSION['messages']['type']['123'],
         );
@@ -91,6 +91,6 @@ class IndexTest extends AbstractTestCase
             ['id' => 1, 'title' => 'bar', 'type' => 'type', 'message' => '321', 'is_hidden' => false],
         ];
 
-        self::assertEquals($expected, SetupIndex::messagesShowHtml());
+        self::assertSame($expected, SetupIndex::messagesShowHtml());
     }
 }

--- a/tests/classes/ShowGrantsTest.php
+++ b/tests/classes/ShowGrantsTest.php
@@ -13,17 +13,17 @@ class ShowGrantsTest extends AbstractTestCase
     public function test1(): void
     {
         $showGrants = new ShowGrants('GRANT ALL PRIVILEGES ON *.* TO \'root\'@\'localhost\' WITH GRANT OPTION');
-        self::assertEquals('ALL PRIVILEGES', $showGrants->grants);
-        self::assertEquals('*', $showGrants->dbName);
-        self::assertEquals('*', $showGrants->tableName);
+        self::assertSame('ALL PRIVILEGES', $showGrants->grants);
+        self::assertSame('*', $showGrants->dbName);
+        self::assertSame('*', $showGrants->tableName);
     }
 
     public function test2(): void
     {
         $showGrants = new ShowGrants('GRANT ALL PRIVILEGES ON `mysql`.* TO \'root\'@\'localhost\' WITH GRANT OPTION');
-        self::assertEquals('ALL PRIVILEGES', $showGrants->grants);
-        self::assertEquals('mysql', $showGrants->dbName);
-        self::assertEquals('*', $showGrants->tableName);
+        self::assertSame('ALL PRIVILEGES', $showGrants->grants);
+        self::assertSame('mysql', $showGrants->dbName);
+        self::assertSame('*', $showGrants->tableName);
     }
 
     public function test3(): void
@@ -31,20 +31,20 @@ class ShowGrantsTest extends AbstractTestCase
         $showGrants = new ShowGrants(
             'GRANT SELECT, INSERT, UPDATE, DELETE ON `mysql`.`columns_priv` TO \'root\'@\'localhost\'',
         );
-        self::assertEquals('SELECT, INSERT, UPDATE, DELETE', $showGrants->grants);
-        self::assertEquals('mysql', $showGrants->dbName);
-        self::assertEquals('columns_priv', $showGrants->tableName);
+        self::assertSame('SELECT, INSERT, UPDATE, DELETE', $showGrants->grants);
+        self::assertSame('mysql', $showGrants->dbName);
+        self::assertSame('columns_priv', $showGrants->tableName);
     }
 
     public function test4(): void
     {
         $showGrants = new ShowGrants('GRANT ALL PRIVILEGES ON `cptest\_.`.* TO \'cptest\'@\'localhost\'');
-        self::assertEquals('cptest\_.', $showGrants->dbName);
+        self::assertSame('cptest\_.', $showGrants->dbName);
 
         $showGrants = new ShowGrants(
             'GRANT ALL PRIVILEGES ON `cptest\_.a.b.c.d.e.f.g.h.i.j.k.'
                 . 'l.m.n.o.p.q.r.s.t.u.v.w.x.y.z`.* TO \'cptest\'@\'localhost\'',
         );
-        self::assertEquals('cptest\_.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z', $showGrants->dbName);
+        self::assertSame('cptest\_.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z', $showGrants->dbName);
     }
 }

--- a/tests/classes/SqlTest.php
+++ b/tests/classes/SqlTest.php
@@ -84,7 +84,7 @@ class SqlTest extends AbstractTestCase
         $GLOBALS['_SESSION']['tmpval']['pos'] = 1;
         $GLOBALS['_SESSION']['tmpval']['max_rows'] = 2;
 
-        self::assertEquals('SELECT * FROM test LIMIT 1, 2 ', $this->callFunction(
+        self::assertSame('SELECT * FROM test LIMIT 1, 2 ', $this->callFunction(
             $this->sql,
             Sql::class,
             'getSqlWithLimitClause',
@@ -452,7 +452,7 @@ class SqlTest extends AbstractTestCase
                 ParseAnalyze::sqlQuery($sqlQuery ?? '', Current::$database)[0],
             ],
         );
-        self::assertEquals($expectedNumRows, $result);
+        self::assertSame($expectedNumRows, $result);
         $this->dummyDbi->assertAllQueriesConsumed();
     }
 

--- a/tests/classes/StorageEngineTest.php
+++ b/tests/classes/StorageEngineTest.php
@@ -69,7 +69,7 @@ class StorageEngineTest extends AbstractTestCase
     #[RunInSeparateProcess]
     public function testGetStorageEngines(): void
     {
-        self::assertEquals(
+        self::assertSame(
             [
                 'dummy' => ['Engine' => 'dummy', 'Support' => 'YES', 'Comment' => 'dummy comment'],
                 'dummy2' => ['Engine' => 'dummy2', 'Support' => 'NO', 'Comment' => 'dummy2 comment'],
@@ -88,7 +88,7 @@ class StorageEngineTest extends AbstractTestCase
     {
         $actual = $this->object->getArray();
 
-        self::assertEquals(
+        self::assertSame(
             ['dummy' => ['name' => 'dummy', 'comment' => 'dummy comment', 'is_default' => false]],
             $actual,
         );
@@ -156,7 +156,7 @@ class StorageEngineTest extends AbstractTestCase
      */
     public function testGetPage(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '',
             $this->object->getPage('Foo'),
         );
@@ -167,7 +167,7 @@ class StorageEngineTest extends AbstractTestCase
      */
     public function testGetInfoPages(): void
     {
-        self::assertEquals(
+        self::assertSame(
             [],
             $this->object->getInfoPages(),
         );
@@ -178,7 +178,7 @@ class StorageEngineTest extends AbstractTestCase
      */
     public function testGetVariablesLikePattern(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '',
             $this->object->getVariablesLikePattern(),
         );
@@ -189,7 +189,7 @@ class StorageEngineTest extends AbstractTestCase
      */
     public function testGetMysqlHelpPage(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'dummy-storage-engine',
             $this->object->getMysqlHelpPage(),
         );
@@ -200,7 +200,7 @@ class StorageEngineTest extends AbstractTestCase
      */
     public function testGetVariables(): void
     {
-        self::assertEquals(
+        self::assertSame(
             [],
             $this->object->getVariables(),
         );
@@ -211,25 +211,25 @@ class StorageEngineTest extends AbstractTestCase
      */
     public function testGetSupportInformationMessage(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'dummy is available on this MySQL server.',
             $this->object->getSupportInformationMessage(),
         );
 
         $this->object->support = 1;
-        self::assertEquals(
+        self::assertSame(
             'dummy has been disabled for this MySQL server.',
             $this->object->getSupportInformationMessage(),
         );
 
         $this->object->support = 2;
-        self::assertEquals(
+        self::assertSame(
             'dummy is available on this MySQL server.',
             $this->object->getSupportInformationMessage(),
         );
 
         $this->object->support = 3;
-        self::assertEquals(
+        self::assertSame(
             'dummy is the default storage engine on this MySQL server.',
             $this->object->getSupportInformationMessage(),
         );
@@ -240,7 +240,7 @@ class StorageEngineTest extends AbstractTestCase
      */
     public function testGetComment(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'dummy comment',
             $this->object->getComment(),
         );
@@ -251,7 +251,7 @@ class StorageEngineTest extends AbstractTestCase
      */
     public function testGetTitle(): void
     {
-        self::assertEquals(
+        self::assertSame(
             'dummy',
             $this->object->getTitle(),
         );

--- a/tests/classes/SystemDatabaseTest.php
+++ b/tests/classes/SystemDatabaseTest.php
@@ -109,7 +109,7 @@ class SystemDatabaseTest extends AbstractTestCase
             . "('PMA_db', 'view_name', 'column_name', 'comment', 'mimetype', "
             . "'transformation', 'transformation_options')";
 
-        self::assertEquals($sql, $ret);
+        self::assertSame($sql, $ret);
     }
 
     public function testGetColumnMapFromSql(): void

--- a/tests/classes/Table/IndexesTest.php
+++ b/tests/classes/Table/IndexesTest.php
@@ -76,7 +76,7 @@ class IndexesTest extends AbstractTestCase
         $sqlQueryExpected = 'ALTER TABLE `pma_db`.`pma_table` DROP PRIMARY KEY, ADD PRIMARY KEY (`id`);';
 
         $_POST['old_index'] = 'PRIMARY';
-        self::assertEquals(
+        self::assertSame(
             $sqlQueryExpected,
             $indexes->getSqlQueryForIndexCreateOrEdit('PRIMARY', $index, $db, $table),
         );

--- a/tests/classes/Table/SearchTest.php
+++ b/tests/classes/Table/SearchTest.php
@@ -32,14 +32,14 @@ class SearchTest extends AbstractTestCase
         $_POST['order'] = 'asc';
         $_POST['customWhereClause'] = "name='pma'";
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT DISTINCT *  FROM `PMA` WHERE name=\'pma\' ORDER BY `name` asc',
             $this->search->buildSqlQuery(),
         );
 
         unset($_POST['customWhereClause']);
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT DISTINCT *  FROM `PMA` ORDER BY `name` asc',
             $this->search->buildSqlQuery(),
         );
@@ -62,7 +62,7 @@ class SearchTest extends AbstractTestCase
             . ' AND `id` > value2 AND `index` IS NULL AND `index2` LIKE \'%value4%\''
             . ' AND `index3` REGEXP ^value5$ AND `index4` IN (value6) AND `index5`'
             . ' BETWEEN value7 AND value8 ORDER BY `name` asc';
-        self::assertEquals(
+        self::assertSame(
             $expected,
             $this->search->buildSqlQuery(),
         );
@@ -73,14 +73,14 @@ class SearchTest extends AbstractTestCase
         $_POST['zoom_submit'] = true;
         $_POST['table'] = 'PMA';
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT *  FROM `PMA`',
             $this->search->buildSqlQuery(),
         );
 
         $_POST['customWhereClause'] = '`table` = \'WhereClause\'';
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT *  FROM `PMA` WHERE `table` = \'WhereClause\'',
             $this->search->buildSqlQuery(),
         );
@@ -91,7 +91,7 @@ class SearchTest extends AbstractTestCase
         $_POST['criteriaValues'] = ['10', '2', '', ''];
         $_POST['criteriaColumnTypes'] = ['int(11)', 'int(11)', 'int(11)', 'int(11)'];
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT *  FROM `PMA` WHERE `b` <= 10 AND `a` = 2 AND `c` IS NULL AND `d` IS NOT NULL',
             $this->search->buildSqlQuery(),
         );
@@ -102,14 +102,14 @@ class SearchTest extends AbstractTestCase
         $_POST['zoom_submit'] = true;
         $_POST['table'] = 'PMA';
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT *  FROM `PMA`',
             $this->search->buildSqlQuery(),
         );
 
         $_POST['customWhereClause'] = '`table` = \'WhereClause\'';
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT *  FROM `PMA` WHERE `table` = \'WhereClause\'',
             $this->search->buildSqlQuery(),
         );
@@ -121,7 +121,7 @@ class SearchTest extends AbstractTestCase
         $_POST['criteriaValues'] = ['1'];
         $_POST['criteriaColumnTypes'] = ['geometry'];
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT *  FROM `PMA` WHERE Dimension(`b`) = \'1\'',
             $this->search->buildSqlQuery(),
         );
@@ -132,14 +132,14 @@ class SearchTest extends AbstractTestCase
         $_POST['zoom_submit'] = true;
         $_POST['table'] = 'PMA';
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT *  FROM `PMA`',
             $this->search->buildSqlQuery(),
         );
 
         $_POST['customWhereClause'] = '`table` = \'WhereClause\'';
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT *  FROM `PMA` WHERE `table` = \'WhereClause\'',
             $this->search->buildSqlQuery(),
         );
@@ -151,7 +151,7 @@ class SearchTest extends AbstractTestCase
         $_POST['criteriaValues'] = ['PG-13'];
         $_POST['criteriaColumnTypes'] = ['enum(\'G\', \'PG\', \'PG-13\', \'R\', \'NC-17\')'];
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT *  FROM `PMA` WHERE `rating` = \'PG-13\'',
             $this->search->buildSqlQuery(),
         );
@@ -162,14 +162,14 @@ class SearchTest extends AbstractTestCase
         $_POST['zoom_submit'] = true;
         $_POST['table'] = 'PMA';
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT *  FROM `PMA`',
             $this->search->buildSqlQuery(),
         );
 
         $_POST['customWhereClause'] = '';
 
-        self::assertEquals(
+        self::assertSame(
             'SELECT *  FROM `PMA`',
             $this->search->buildSqlQuery(),
         );
@@ -181,7 +181,7 @@ class SearchTest extends AbstractTestCase
         $_POST['criteriaValues'] = ['07ca1fdd-4805-11ed-a4dc-0242ac110002'];
         $_POST['criteriaColumnTypes'] = ['uuid'];
 
-        self::assertEquals(
+        self::assertSame(
             "SELECT *  FROM `PMA` WHERE `id` = '07ca1fdd-4805-11ed-a4dc-0242ac110002'",
             $this->search->buildSqlQuery(),
         );

--- a/tests/classes/Table/TableTest.php
+++ b/tests/classes/Table/TableTest.php
@@ -296,19 +296,19 @@ class TableTest extends AbstractTestCase
     public function testConstruct(): void
     {
         $table = new Table('PMA_BookMark', 'PMA', $this->mockedDbi);
-        self::assertEquals(
+        self::assertSame(
             'PMA_BookMark',
             $table->__toString(),
         );
-        self::assertEquals(
+        self::assertSame(
             'PMA_BookMark',
             $table->getName(),
         );
-        self::assertEquals(
+        self::assertSame(
             'PMA',
             $table->getDbName(),
         );
-        self::assertEquals(
+        self::assertSame(
             'PMA.PMA_BookMark',
             $table->getFullName(),
         );
@@ -320,19 +320,19 @@ class TableTest extends AbstractTestCase
     public function testGetName(): void
     {
         $table = new Table('table1', 'pma_test', $this->mockedDbi);
-        self::assertEquals(
+        self::assertSame(
             'table1',
             $table->getName(),
         );
-        self::assertEquals(
+        self::assertSame(
             '`table1`',
             $table->getName(true),
         );
-        self::assertEquals(
+        self::assertSame(
             'pma_test',
             $table->getDbName(),
         );
-        self::assertEquals(
+        self::assertSame(
             '`pma_test`',
             $table->getDbName(true),
         );
@@ -352,23 +352,23 @@ class TableTest extends AbstractTestCase
         $table->messages[] = 'messages2';
         $table->messages[] = 'messages3';
 
-        self::assertEquals(
+        self::assertSame(
             'error3',
             $table->getLastError(),
         );
-        self::assertEquals(
+        self::assertSame(
             'messages3',
             $table->getLastMessage(),
         );
 
         $table->errors = [];
-        self::assertEquals(
+        self::assertSame(
             '',
             $table->getLastError(),
         );
 
         $table->messages = [];
-        self::assertEquals(
+        self::assertSame(
             '',
             $table->getLastMessage(),
         );
@@ -384,7 +384,7 @@ class TableTest extends AbstractTestCase
     #[DataProvider('dataValidateName')]
     public function testValidateName(string $name, bool $result, bool $isBackquoted = false): void
     {
-        self::assertEquals(
+        self::assertSame(
             $result,
             Table::isValidName($name, $isBackquoted),
         );
@@ -464,7 +464,7 @@ class TableTest extends AbstractTestCase
             $expression,
             $moveTo,
         );
-        self::assertEquals(
+        self::assertSame(
             '`PMA_name` BIT(12) PMA_attribute NULL DEFAULT b\'10\' AUTO_INCREMENT COMMENT \'PMA_comment\' FIRST',
             $query,
         );
@@ -486,7 +486,7 @@ class TableTest extends AbstractTestCase
             $expression,
             $moveTo,
         );
-        self::assertEquals(
+        self::assertSame(
             '`PMA_name` DOUBLE(12) PMA_attribute NULL DEFAULT \'12\' AUTO_INCREMENT COMMENT \'PMA_comment\' FIRST',
             $query,
         );
@@ -508,7 +508,7 @@ class TableTest extends AbstractTestCase
             $expression,
             $moveTo,
         );
-        self::assertEquals(
+        self::assertSame(
             '`PMA_name` BOOLEAN PMA_attribute NULL DEFAULT TRUE AUTO_INCREMENT COMMENT \'PMA_comment\' FIRST',
             $query,
         );
@@ -530,7 +530,7 @@ class TableTest extends AbstractTestCase
             $expression,
             $moveTo,
         );
-        self::assertEquals(
+        self::assertSame(
             '`PMA_name` BOOLEAN PMA_attribute NULL DEFAULT NULL AUTO_INCREMENT COMMENT \'PMA_comment\' FIRST',
             $query,
         );
@@ -552,7 +552,7 @@ class TableTest extends AbstractTestCase
             $expression,
             $moveTo,
         );
-        self::assertEquals(
+        self::assertSame(
             '`PMA_name` BOOLEAN PMA_attribute NULL DEFAULT CURRENT_TIMESTAMP '
             . "AUTO_INCREMENT COMMENT 'PMA_comment' FIRST",
             $query,
@@ -575,7 +575,7 @@ class TableTest extends AbstractTestCase
             $expression,
             $moveTo,
         );
-        self::assertEquals(
+        self::assertSame(
             '`PMA_name` BOOLEAN PMA_attribute NULL DEFAULT current_timestamp() '
             . "AUTO_INCREMENT COMMENT 'PMA_comment' FIRST",
             $query,
@@ -601,7 +601,7 @@ class TableTest extends AbstractTestCase
             $expression,
             $moveTo,
         );
-        self::assertEquals(
+        self::assertSame(
             '`PMA_name` TIMESTAMP(3) PMA_attribute NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT \'PMA_comment\' FIRST',
             $query,
         );
@@ -626,7 +626,7 @@ class TableTest extends AbstractTestCase
             $expression,
             $moveTo,
         );
-        self::assertEquals(
+        self::assertSame(
             '`PMA_name` TIMESTAMP PMA_attribute NULL DEFAULT \'0000-00-00 00:00:00\' COMMENT \'PMA_comment\' FIRST',
             $query,
         );
@@ -651,7 +651,7 @@ class TableTest extends AbstractTestCase
             $expression,
             $moveTo,
         );
-        self::assertEquals(
+        self::assertSame(
             '`PMA_name` TIMESTAMP PMA_attribute NULL DEFAULT \'0000-00-00 00:00:00.0\' COMMENT \'PMA_comment\' FIRST',
             $query,
         );
@@ -676,7 +676,7 @@ class TableTest extends AbstractTestCase
             $expression,
             $moveTo,
         );
-        self::assertEquals(
+        self::assertSame(
             '`PMA_name` TIMESTAMP PMA_attribute NULL DEFAULT \'0000-00-00 00:00:00.000000\' '
             . "COMMENT 'PMA_comment' FIRST",
             $query,
@@ -701,7 +701,7 @@ class TableTest extends AbstractTestCase
             $expression,
             $moveTo,
         );
-        self::assertEquals('`PMA_name` UUID PMA_attribute NULL DEFAULT uuid()', $query);
+        self::assertSame('`PMA_name` UUID PMA_attribute NULL DEFAULT uuid()', $query);
 
         //$default_type is uuid()
         $type = 'UUID';
@@ -722,7 +722,7 @@ class TableTest extends AbstractTestCase
             $expression,
             $moveTo,
         );
-        self::assertEquals('`PMA_name` UUID PMA_attribute NULL DEFAULT uuid()', $query);
+        self::assertSame('`PMA_name` UUID PMA_attribute NULL DEFAULT uuid()', $query);
 
         //$default_type is NONE
         $type = 'BOOLEAN';
@@ -744,7 +744,7 @@ class TableTest extends AbstractTestCase
             $expression,
             $moveTo,
         );
-        self::assertEquals('`PMA_name` BOOLEAN PMA_attribute NULL INCREMENT COMMENT \'PMA_comment\' FIRST', $query);
+        self::assertSame('`PMA_name` BOOLEAN PMA_attribute NULL INCREMENT COMMENT \'PMA_comment\' FIRST', $query);
 
         $defaultType = 'NONE';
         $moveTo = '-first';
@@ -765,7 +765,7 @@ class TableTest extends AbstractTestCase
             ['id'],
             'id',
         );
-        self::assertEquals('`ids` INT(11) PMA_attribute NULL AUTO_INCREMENT COMMENT \'PMA_comment\' FIRST', $query);
+        self::assertSame('`ids` INT(11) PMA_attribute NULL AUTO_INCREMENT COMMENT \'PMA_comment\' FIRST', $query);
 
         $defaultType = 'NONE';
         $moveTo = '-first';
@@ -787,7 +787,7 @@ class TableTest extends AbstractTestCase
             'id',
         );
         // Add primary key for AUTO_INCREMENT if missing
-        self::assertEquals(
+        self::assertSame(
             '`ids` INT(11) PMA_attribute NULL AUTO_INCREMENT '
             . "COMMENT 'PMA_comment' FIRST, add PRIMARY KEY (`ids`)",
             $query,
@@ -813,7 +813,7 @@ class TableTest extends AbstractTestCase
             'id',
         );
         // Do not add PK
-        self::assertEquals('`id` INT(11) PMA_attribute NULL DEF COMMENT \'PMA_comment\' FIRST', $query);
+        self::assertSame('`id` INT(11) PMA_attribute NULL DEF COMMENT \'PMA_comment\' FIRST', $query);
 
         $defaultType = 'NONE';
         $moveTo = '-first';
@@ -835,7 +835,7 @@ class TableTest extends AbstractTestCase
             'id',
         );
         // Do not add PK
-        self::assertEquals('`ids` INT(11) PMA_attribute NULL DEF COMMENT \'PMA_comment\' FIRST', $query);
+        self::assertSame('`ids` INT(11) PMA_attribute NULL DEF COMMENT \'PMA_comment\' FIRST', $query);
 
         $defaultType = 'NONE';
         $moveTo = '-first';
@@ -857,7 +857,7 @@ class TableTest extends AbstractTestCase
             'id',
         );
         // Add it beaucause it is missing
-        self::assertEquals(
+        self::assertSame(
             '`ids` INT(11) PMA_attribute NULL DEF COMMENT \'PMA_comment\' FIRST, add PRIMARY KEY (`ids`)',
             $query,
         );
@@ -882,7 +882,7 @@ class TableTest extends AbstractTestCase
             'id',
         );
         // Do not add PK since it is not a AUTO_INCREMENT
-        self::assertEquals(
+        self::assertSame(
             '`ids` INT(11) PMA_attribute AS (1) VIRTUAL NULL USER_DEFINED COMMENT \'PMA_comment\' FIRST',
             $query,
         );
@@ -1020,7 +1020,7 @@ class TableTest extends AbstractTestCase
             . "charset1 NULL DEFAULT 'VARCHAR' "
             . "AUTO_INCREMENT COMMENT 'PMA comment' AFTER `new_name`";
 
-        self::assertEquals($expect, $result);
+        self::assertSame($expect, $result);
     }
 
     /**
@@ -1057,7 +1057,7 @@ class TableTest extends AbstractTestCase
         self::assertTrue($result);
 
         //message
-        self::assertEquals(
+        self::assertSame(
             'Table PMA_BookMark has been renamed to PMA_.BookMark.',
             $table->getLastMessage(),
         );
@@ -1067,7 +1067,7 @@ class TableTest extends AbstractTestCase
         $result = $table->rename($tableNew, $dbNew);
         self::assertTrue($result);
         //message
-        self::assertEquals(
+        self::assertSame(
             'Table PMA_.BookMark has been renamed to PMA_BookMark_new.',
             $table->getLastMessage(),
         );
@@ -1084,7 +1084,7 @@ class TableTest extends AbstractTestCase
         $table = new Table($table, $db, $this->mockedDbi);
         $return = $table->getUniqueColumns();
         $expect = ['`PMA`.`PMA_BookMark`.`index1`', '`PMA`.`PMA_BookMark`.`index3`', '`PMA`.`PMA_BookMark`.`index5`'];
-        self::assertEquals($expect, $return);
+        self::assertSame($expect, $return);
     }
 
     /**
@@ -1105,7 +1105,7 @@ class TableTest extends AbstractTestCase
             '`PMA`.`PMA_BookMark`.`ADD`',
             '`PMA`.`PMA_BookMark`.`ALL`',
         ];
-        self::assertEquals($expect, $return);
+        self::assertSame($expect, $return);
     }
 
     /**
@@ -1133,7 +1133,7 @@ class TableTest extends AbstractTestCase
 
         $tableObj = new Table('table', 'db', $dbi);
 
-        self::assertEquals(
+        self::assertSame(
             $tableObj->getColumnsMeta(),
             ['aNonValidExampleToRefactor'],
         );
@@ -1161,7 +1161,7 @@ class TableTest extends AbstractTestCase
         $sqlExcepted = 'ALTER TABLE `PMA_table` ADD  '
             . 'FOREIGN KEY (`PMA_field1`, `PMA_field2`) REFERENCES '
             . '`foreignDb`.`foreignTable`(`foreignField1`, `foreignField2`);';
-        self::assertEquals($sqlExcepted, $sql);
+        self::assertSame($sqlExcepted, $sql);
 
         // Exclude db name when relations are made between table in the same db
         $sql = $this->callFunction(
@@ -1173,7 +1173,7 @@ class TableTest extends AbstractTestCase
         $sqlExcepted = 'ALTER TABLE `PMA_table` ADD  '
             . 'FOREIGN KEY (`PMA_field1`, `PMA_field2`) REFERENCES '
             . '`foreignTable`(`foreignField1`, `foreignField2`);';
-        self::assertEquals($sqlExcepted, $sql);
+        self::assertSame($sqlExcepted, $sql);
     }
 
     /**
@@ -1195,11 +1195,11 @@ class TableTest extends AbstractTestCase
             '`PMA`.`PMA_BookMark`.`ADD`',
             '`PMA`.`PMA_BookMark`.`ALL`',
         ];
-        self::assertEquals($expect, $return);
+        self::assertSame($expect, $return);
 
         $return = $table->getReservedColumnNames();
         $expect = ['ACCESSIBLE', 'ADD', 'ALL'];
-        self::assertEquals($expect, $return);
+        self::assertSame($expect, $return);
     }
 
     /**
@@ -1239,17 +1239,17 @@ class TableTest extends AbstractTestCase
         // Case 1 : Check if table is non-empty
         $return = $tableObj->checkIfMinRecordsExist();
         $expect = true;
-        self::assertEquals($expect, $return);
+        self::assertSame($expect, $return);
 
         // Case 2 : Check if table contains at least 100
         $return = $tableObj->checkIfMinRecordsExist(100);
         $expect = false;
-        self::assertEquals($expect, $return);
+        self::assertSame($expect, $return);
 
         // Case 3 : Check if table contains at least 100
         $return = $tableObj->checkIfMinRecordsExist(100);
         $expect = true;
-        self::assertEquals($expect, $return);
+        self::assertSame($expect, $return);
 
         DatabaseInterface::$instance = $oldDbi;
     }
@@ -1272,7 +1272,7 @@ class TableTest extends AbstractTestCase
         $db = 'PMA';
         $tableObj = new Table($table, $db, $dbi);
 
-        self::assertEquals(
+        self::assertSame(
             20,
             $tableObj->countRecords(true),
         );
@@ -1294,7 +1294,7 @@ class TableTest extends AbstractTestCase
         $table->setUiProp($property, $value, $tableCreateTime);
 
         //set UI prop successfully
-        self::assertEquals($value, $table->uiprefs[$property]);
+        self::assertSame($value, $table->uiprefs[$property]);
 
         //removeUiProp
         $table->removeUiProp($property);
@@ -1333,7 +1333,7 @@ class TableTest extends AbstractTestCase
 
         //successfully
         $expect = true;
-        self::assertEquals($expect, $return);
+        self::assertSame($expect, $return);
         $sqlQuery = 'INSERT INTO `PMA_new`.`PMA_BookMark_new`(`COLUMN_NAME1`)'
             . ' SELECT `COLUMN_NAME1` FROM '
             . '`PMA`.`PMA_BookMark`';
@@ -1345,7 +1345,7 @@ class TableTest extends AbstractTestCase
 
         //successfully
         $expect = true;
-        self::assertEquals($expect, $return);
+        self::assertSame($expect, $return);
         $sqlQuery = 'INSERT INTO `PMA_new`.`PMA_BookMark_new`(`COLUMN_NAME1`)'
             . ' SELECT `COLUMN_NAME1` FROM '
             . '`PMA`.`PMA_BookMark`';
@@ -1408,7 +1408,7 @@ class TableTest extends AbstractTestCase
         $tblObject->getStatusInfo(null);
         $expect = 'DBIDUMMY';
         $tblStorageEngine = $dbi->getTable($targetDb, $targetTable)->getStorageEngine();
-        self::assertEquals($expect, $tblStorageEngine);
+        self::assertSame($expect, $tblStorageEngine);
     }
 
     /**
@@ -1424,7 +1424,7 @@ class TableTest extends AbstractTestCase
         $tblObject->getStatusInfo(null);
         $expect = 'Test comment for "table1" in \'pma_test\'';
         $showComment = $dbi->getTable($targetDb, $targetTable)->getComment();
-        self::assertEquals($expect, $showComment);
+        self::assertSame($expect, $showComment);
     }
 
     /**
@@ -1440,7 +1440,7 @@ class TableTest extends AbstractTestCase
         $tblObject->getStatusInfo(null);
         $expect = 'utf8mb4_general_ci';
         $tblCollation = $dbi->getTable($targetDb, $targetTable)->getCollation();
-        self::assertEquals($expect, $tblCollation);
+        self::assertSame($expect, $tblCollation);
     }
 
     /**
@@ -1456,7 +1456,7 @@ class TableTest extends AbstractTestCase
         $tblObject->getStatusInfo(null);
         $expect = 'Redundant';
         $rowFormat = $dbi->getTable($targetDb, $targetTable)->getRowFormat();
-        self::assertEquals($expect, $rowFormat);
+        self::assertSame($expect, $rowFormat);
     }
 
     /**
@@ -1472,7 +1472,7 @@ class TableTest extends AbstractTestCase
         $tblObject->getStatusInfo(null);
         $expect = '5';
         $autoIncrement = $dbi->getTable($targetDb, $targetTable)->getAutoIncrement();
-        self::assertEquals($expect, $autoIncrement);
+        self::assertSame($expect, $autoIncrement);
     }
 
     /**

--- a/tests/classes/TemplateTest.php
+++ b/tests/classes/TemplateTest.php
@@ -79,7 +79,7 @@ class TemplateTest extends AbstractTestCase
     #[DataProvider('providerTestDynamicRender')]
     public function testDynamicRender(string $templateFile, string $key, string $value): void
     {
-        self::assertEquals(
+        self::assertSame(
             $value,
             $this->template->render($templateFile, [$key => $value]),
         );
@@ -113,7 +113,7 @@ class TemplateTest extends AbstractTestCase
     #[DataProvider('providerTestRender')]
     public function testRender(string $templateFile, string $expectedResult): void
     {
-        self::assertEquals(
+        self::assertSame(
             $expectedResult,
             $this->template->render($templateFile),
         );
@@ -139,7 +139,7 @@ class TemplateTest extends AbstractTestCase
     #[DataProvider('providerTestRenderGettext')]
     public function testRenderGettext(string $templateFile, array $renderParams, string $expectedResult): void
     {
-        self::assertEquals(
+        self::assertSame(
             $expectedResult,
             $this->template->render($templateFile, $renderParams),
         );

--- a/tests/classes/Theme/ThemeManagerTest.php
+++ b/tests/classes/Theme/ThemeManagerTest.php
@@ -35,7 +35,7 @@ class ThemeManagerTest extends AbstractTestCase
     public function testCookieName(): void
     {
         $tm = new ThemeManager();
-        self::assertEquals('pma_theme', $tm->getThemeCookieName());
+        self::assertSame('pma_theme', $tm->getThemeCookieName());
     }
 
     /**
@@ -45,7 +45,7 @@ class ThemeManagerTest extends AbstractTestCase
     {
         $tm = new ThemeManager();
         $tm->setThemePerServer(true);
-        self::assertEquals('pma_theme-99', $tm->getThemeCookieName());
+        self::assertSame('pma_theme-99', $tm->getThemeCookieName());
     }
 
     public function testGetThemesArray(): void

--- a/tests/classes/Theme/ThemeTest.php
+++ b/tests/classes/Theme/ThemeTest.php
@@ -65,8 +65,8 @@ class ThemeTest extends AbstractTestCase
     {
         $this->object->setFsPath(TEST_PATH . 'tests/classes/_data/gen_version_info/');
         self::assertTrue($this->object->loadInfo());
-        self::assertEquals('Test Theme', $this->object->getName());
-        self::assertEquals('6.0', $this->object->getVersion());
+        self::assertSame('Test Theme', $this->object->getName());
+        self::assertSame('6.0', $this->object->getVersion());
     }
 
     /**
@@ -78,7 +78,7 @@ class ThemeTest extends AbstractTestCase
         $infofile = $this->object->getFsPath() . 'theme.json';
         self::assertTrue($this->object->loadInfo());
 
-        self::assertEquals(
+        self::assertSame(
             filemtime($infofile),
             $this->object->mtimeInfo,
         );
@@ -86,7 +86,7 @@ class ThemeTest extends AbstractTestCase
         $this->object->setPath(ROOT_PATH . 'public/themes/original');
         $this->object->mtimeInfo = (int) filemtime($infofile);
         self::assertTrue($this->object->loadInfo());
-        self::assertEquals('Original', $this->object->getName());
+        self::assertSame('Original', $this->object->getName());
     }
 
     /**
@@ -143,7 +143,7 @@ class ThemeTest extends AbstractTestCase
         self::assertEmpty($this->object->getPath());
         $this->object->setPath(ROOT_PATH . 'themes/original');
 
-        self::assertEquals(ROOT_PATH . 'themes/original', $this->object->getPath());
+        self::assertSame(ROOT_PATH . 'themes/original', $this->object->getPath());
     }
 
     /**
@@ -152,14 +152,14 @@ class ThemeTest extends AbstractTestCase
     #[Depends('testLoadInfo')]
     public function testGetSetCheckVersion(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '0.0.0.0',
             $this->object->getVersion(),
             'Version 0.0.0.0 by default',
         );
 
         $this->object->setVersion('1.2.3.4');
-        self::assertEquals('1.2.3.4', $this->object->getVersion());
+        self::assertSame('1.2.3.4', $this->object->getVersion());
 
         self::assertFalse($this->object->checkVersion('0.0.1.1'));
         self::assertTrue($this->object->checkVersion('2.0.1.1'));
@@ -173,7 +173,7 @@ class ThemeTest extends AbstractTestCase
         self::assertEmpty($this->object->getName(), 'Name is empty by default');
         $this->object->setName('New Theme Name');
 
-        self::assertEquals('New Theme Name', $this->object->getName());
+        self::assertSame('New Theme Name', $this->object->getName());
     }
 
     /**
@@ -184,7 +184,7 @@ class ThemeTest extends AbstractTestCase
         self::assertEmpty($this->object->getId(), 'ID is empty by default');
         $this->object->setId('NewID');
 
-        self::assertEquals('NewID', $this->object->getId());
+        self::assertSame('NewID', $this->object->getId());
     }
 
     /**
@@ -198,7 +198,7 @@ class ThemeTest extends AbstractTestCase
         );
         $this->object->setImgPath('/new/path');
 
-        self::assertEquals('/new/path', $this->object->getImgPath());
+        self::assertSame('/new/path', $this->object->getImgPath());
     }
 
     /**
@@ -211,7 +211,7 @@ class ThemeTest extends AbstractTestCase
     #[DataProvider('providerForGetImgPath')]
     public function testGetImgPath(string|null $file, string|null $fallback, string $output): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->object->getImgPath($file, $fallback),
             $output,
         );

--- a/tests/classes/Tracking/TrackerTest.php
+++ b/tests/classes/Tracking/TrackerTest.php
@@ -140,7 +140,7 @@ class TrackerTest extends AbstractTestCase
         $date = Util::date('Y-m-d H:i:s');
         Config::getInstance()->selectedServer['user'] = 'pma_test_user';
 
-        self::assertEquals(
+        self::assertSame(
             '# log ' . $date . " pma_test_user\n",
             Tracker::getLogComment(),
         );
@@ -323,21 +323,21 @@ class TrackerTest extends AbstractTestCase
     ): void {
         $result = Tracker::parseQuery($query);
 
-        self::assertEquals($type, $result['type']);
+        self::assertSame($type, $result['type']);
 
-        self::assertEquals($identifier, $result['identifier']);
+        self::assertSame($identifier, $result['identifier']);
 
-        self::assertEquals($tableName, $result['tablename']);
+        self::assertSame($tableName, $result['tablename']);
 
         if ($db !== null && $db !== '') {
-            self::assertEquals($db, Current::$database);
+            self::assertSame($db, Current::$database);
         }
 
         if ($tableNameAfterRename === null || $tableNameAfterRename === '') {
             return;
         }
 
-        self::assertEquals($result['tablename_after_rename'], $tableNameAfterRename);
+        self::assertSame($result['tablename_after_rename'], $tableNameAfterRename);
     }
 
     /**

--- a/tests/classes/Tracking/TrackingCheckerTest.php
+++ b/tests/classes/Tracking/TrackingCheckerTest.php
@@ -48,7 +48,7 @@ class TrackingCheckerTest extends AbstractTestCase
         self::assertFalse(Tracker::isEnabled());
 
         $actual = $this->trackingChecker->getTrackedTables('dummyDb');
-        self::assertEquals([], $actual);
+        self::assertSame([], $actual);
 
         Tracker::enable();
 
@@ -68,12 +68,12 @@ class TrackingCheckerTest extends AbstractTestCase
 
         $expectation = ['0', 'actor', 'untrackedTable'];
         $actual = $this->trackingChecker->getUntrackedTableNames('dummyDb');
-        self::assertEquals($expectation, $actual);
+        self::assertSame($expectation, $actual);
 
         Tracker::enable();
 
         $expectation = ['untrackedTable'];
         $actual = $this->trackingChecker->getUntrackedTableNames('dummyDb');
-        self::assertEquals($expectation, $actual);
+        self::assertSame($expectation, $actual);
     }
 }

--- a/tests/classes/Tracking/TrackingTest.php
+++ b/tests/classes/Tracking/TrackingTest.php
@@ -93,8 +93,8 @@ class TrackingTest extends AbstractTestCase
             new DateTimeImmutable('2020-01-01 12:34:56'),
         );
 
-        self::assertEquals('username1', $ret[0]['username']);
-        self::assertEquals('statement1', $ret[0]['statement']);
+        self::assertSame('username1', $ret[0]['username']);
+        self::assertSame('statement1', $ret[0]['statement']);
     }
 
     public function testGetHtmlForMain(): void
@@ -408,7 +408,7 @@ class TrackingTest extends AbstractTestCase
             $html,
         );
 
-        self::assertEquals(2, $count);
+        self::assertSame(2, $count);
     }
 
     /**
@@ -500,7 +500,7 @@ class TrackingTest extends AbstractTestCase
         $_POST['truncate'] = true;
 
         $trackingSet = $this->tracking->getTrackingSet();
-        self::assertEquals('RENAME TABLE,CREATE TABLE,DROP TABLE,DROP INDEX,INSERT,DELETE,TRUNCATE', $trackingSet);
+        self::assertSame('RENAME TABLE,CREATE TABLE,DROP TABLE,DROP INDEX,INSERT,DELETE,TRUNCATE', $trackingSet);
 
         //other set to true
         $_POST['alter_table'] = true;
@@ -515,7 +515,7 @@ class TrackingTest extends AbstractTestCase
         $_POST['truncate'] = false;
 
         $trackingSet = $this->tracking->getTrackingSet();
-        self::assertEquals('ALTER TABLE,CREATE INDEX,UPDATE', $trackingSet);
+        self::assertSame('ALTER TABLE,CREATE INDEX,UPDATE', $trackingSet);
     }
 
     /**
@@ -540,8 +540,8 @@ class TrackingTest extends AbstractTestCase
             new DateTimeImmutable('2010-01-01 12:34:56'),
             new DateTimeImmutable('2020-01-01 12:34:56'),
         );
-        self::assertEquals('username3', $entries[0]['username']);
-        self::assertEquals('statement1', $entries[0]['statement']);
+        self::assertSame('username3', $entries[0]['username']);
+        self::assertSame('statement1', $entries[0]['statement']);
     }
 
     public function testGetDownloadInfoForExport(): void

--- a/tests/classes/TransformationsTest.php
+++ b/tests/classes/TransformationsTest.php
@@ -55,7 +55,7 @@ class TransformationsTest extends AbstractTestCase
     #[DataProvider('getOptionsData')]
     public function testGetOptions(string $input, array $expected): void
     {
-        self::assertEquals(
+        self::assertSame(
             $expected,
             $this->transformations->getOptions($input),
         );
@@ -177,7 +177,7 @@ class TransformationsTest extends AbstractTestCase
             'column_info' => 'column_info',
         ]);
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
-        self::assertEquals(
+        self::assertSame(
             [
                 'o' => [
                     'column_name' => 'o',
@@ -247,7 +247,7 @@ class TransformationsTest extends AbstractTestCase
     #[DataProvider('fixupData')]
     public function testFixup(string $value, string $expected): void
     {
-        self::assertEquals(
+        self::assertSame(
             $expected,
             $this->transformations->fixUpMime($value),
         );
@@ -274,7 +274,7 @@ class TransformationsTest extends AbstractTestCase
     #[DataProvider('providerGetDescription')]
     public function testGetDescription(string $file, string $expectedDescription): void
     {
-        self::assertEquals(
+        self::assertSame(
             $expectedDescription,
             $this->transformations->getDescription($file),
         );
@@ -299,7 +299,7 @@ class TransformationsTest extends AbstractTestCase
     #[DataProvider('providerGetName')]
     public function testGetName(string $file, string $expectedName): void
     {
-        self::assertEquals(
+        self::assertSame(
             $expectedName,
             $this->transformations->getName($file),
         );

--- a/tests/classes/Triggers/TriggersTest.php
+++ b/tests/classes/Triggers/TriggersTest.php
@@ -70,7 +70,7 @@ class TriggersTest extends AbstractTestCase
         $_POST['item_table'] = $table;
         $_POST['item_definition'] = $definition;
 
-        self::assertEquals($query, $this->triggers->getQueryFromRequest());
+        self::assertSame($query, $this->triggers->getQueryFromRequest());
         self::assertCount($numErr, $GLOBALS['errors']);
     }
 

--- a/tests/classes/TwoFactorTest.php
+++ b/tests/classes/TwoFactorTest.php
@@ -154,13 +154,13 @@ class TwoFactorTest extends AbstractTestCase
         $request = new ServerRequest(self::createStub(ServerRequestInterface::class));
         $object = $this->getTwoFactorAndLoadConfig('user', ['type' => 'db']);
         $backend = $object->getBackend();
-        self::assertEquals('', $backend::$id);
+        self::assertSame('', $backend::$id);
         // Is always valid
         self::assertTrue($object->check($request, true));
         // Test session persistence
         self::assertTrue($object->check($request));
         self::assertTrue($object->check($request));
-        self::assertEquals('', $object->render($request));
+        self::assertSame('', $object->render($request));
 
         $this->dummyDbi->assertAllQueriesConsumed();
 
@@ -168,7 +168,7 @@ class TwoFactorTest extends AbstractTestCase
         $this->loadQueriesForConfigure('');
 
         self::assertTrue($object->configure($request, ''));
-        self::assertEquals('', $object->setup($request));
+        self::assertSame('', $object->setup($request));
     }
 
     public function testSimple(): void
@@ -178,7 +178,7 @@ class TwoFactorTest extends AbstractTestCase
         $config->settings['DBG']['simple2fa'] = true;
         $object = $this->getTwoFactorAndLoadConfig('user', ['type' => 'db', 'backend' => 'simple']);
         $backend = $object->getBackend();
-        self::assertEquals('simple', $backend::$id);
+        self::assertSame('simple', $backend::$id);
         $config->settings['DBG']['simple2fa'] = false;
 
         unset($_POST['2fa_confirm']);
@@ -190,14 +190,14 @@ class TwoFactorTest extends AbstractTestCase
 
         /* Test rendering */
         self::assertNotEquals('', $object->render($request));
-        self::assertEquals('', $object->setup($request));
+        self::assertSame('', $object->setup($request));
     }
 
     public function testLoad(): void
     {
         $object = $this->getTwoFactorAndLoadConfig('user', null);
         $backend = $object->getBackend();
-        self::assertEquals('', $backend::$id);
+        self::assertSame('', $backend::$id);
     }
 
     public function testConfigureSimple(): void
@@ -214,7 +214,7 @@ class TwoFactorTest extends AbstractTestCase
 
         self::assertTrue($object->configure($request, 'simple'));
         $backend = $object->getBackend();
-        self::assertEquals('simple', $backend::$id);
+        self::assertSame('simple', $backend::$id);
 
         $this->dummyDbi->assertAllQueriesConsumed();
 
@@ -223,7 +223,7 @@ class TwoFactorTest extends AbstractTestCase
 
         self::assertTrue($object->configure($request, ''));
         $backend = $object->getBackend();
-        self::assertEquals('', $backend::$id);
+        self::assertSame('', $backend::$id);
 
         $this->dummyDbi->assertAllQueriesConsumed();
 
@@ -341,19 +341,19 @@ class TwoFactorTest extends AbstractTestCase
         $config = Config::getInstance();
         $object = $this->getTwoFactorAndLoadConfig('user', null);
         $config->set('PmaAbsoluteUri', 'http://demo.example.com');
-        self::assertEquals('http://demo.example.com', $object->getBackend()->getAppId(true));
-        self::assertEquals('demo.example.com', $object->getBackend()->getAppId(false));
+        self::assertSame('http://demo.example.com', $object->getBackend()->getAppId(true));
+        self::assertSame('demo.example.com', $object->getBackend()->getAppId(false));
         $config->set('PmaAbsoluteUri', 'https://demo.example.com:123');
-        self::assertEquals('https://demo.example.com:123', $object->getBackend()->getAppId(true));
-        self::assertEquals('demo.example.com', $object->getBackend()->getAppId(false));
+        self::assertSame('https://demo.example.com:123', $object->getBackend()->getAppId(true));
+        self::assertSame('demo.example.com', $object->getBackend()->getAppId(false));
         $config->set('PmaAbsoluteUri', '');
         $config->set('is_https', true);
         $_SERVER['HTTP_HOST'] = 'pma.example.com';
-        self::assertEquals('https://pma.example.com', $object->getBackend()->getAppId(true));
-        self::assertEquals('pma.example.com', $object->getBackend()->getAppId(false));
+        self::assertSame('https://pma.example.com', $object->getBackend()->getAppId(true));
+        self::assertSame('pma.example.com', $object->getBackend()->getAppId(false));
         $config->set('is_https', false);
-        self::assertEquals('http://pma.example.com', $object->getBackend()->getAppId(true));
-        self::assertEquals('pma.example.com', $object->getBackend()->getAppId(false));
+        self::assertSame('http://pma.example.com', $object->getBackend()->getAppId(true));
+        self::assertSame('pma.example.com', $object->getBackend()->getAppId(false));
     }
 
     /**

--- a/tests/classes/TypesByDatabaseVersionTest.php
+++ b/tests/classes/TypesByDatabaseVersionTest.php
@@ -606,7 +606,7 @@ class TypesByDatabaseVersionTest extends AbstractTestCase
     {
         $this->createObject($database, $dbVersion);
 
-        self::assertEquals($expected, $this->object->getColumns());
+        self::assertSame($expected, $this->object->getColumns());
     }
 
     /**

--- a/tests/classes/TypesTest.php
+++ b/tests/classes/TypesTest.php
@@ -40,7 +40,7 @@ class TypesTest extends AbstractTestCase
      */
     public function testGetUnaryOperators(): void
     {
-        self::assertEquals(
+        self::assertSame(
             ['IS NULL', 'IS NOT NULL', "= ''", "!= ''"],
             $this->object->getUnaryOperators(),
         );
@@ -51,7 +51,7 @@ class TypesTest extends AbstractTestCase
      */
     public function testGetNullOperators(): void
     {
-        self::assertEquals(
+        self::assertSame(
             ['IS NULL', 'IS NOT NULL'],
             $this->object->getNullOperators(),
         );
@@ -62,7 +62,7 @@ class TypesTest extends AbstractTestCase
      */
     public function testGetEnumOperators(): void
     {
-        self::assertEquals(
+        self::assertSame(
             ['=', '!='],
             $this->object->getEnumOperators(),
         );
@@ -73,7 +73,7 @@ class TypesTest extends AbstractTestCase
      */
     public function testgetTextOperators(): void
     {
-        self::assertEquals(
+        self::assertSame(
             [
                 'LIKE',
                 'LIKE %...%',
@@ -100,7 +100,7 @@ class TypesTest extends AbstractTestCase
      */
     public function testGetNumberOperators(): void
     {
-        self::assertEquals(
+        self::assertSame(
             [
                 '=',
                 '>',
@@ -126,7 +126,7 @@ class TypesTest extends AbstractTestCase
      */
     public function testGetUUIDOperators(): void
     {
-        self::assertEquals(
+        self::assertSame(
             ['=', '!=', 'LIKE', 'LIKE %...%', 'NOT LIKE', 'NOT LIKE %...%', 'IN (...)', 'NOT IN (...)'],
             $this->object->getUUIDOperators(),
         );
@@ -142,7 +142,7 @@ class TypesTest extends AbstractTestCase
     #[DataProvider('providerForGetTypeOperators')]
     public function testGetTypeOperators(string $type, bool $null, string|array $output): void
     {
-        self::assertEquals(
+        self::assertSame(
             $output,
             $this->object->getTypeOperators($type, $null),
         );
@@ -239,7 +239,7 @@ class TypesTest extends AbstractTestCase
         string $selectedOperator,
         string $output,
     ): void {
-        self::assertEquals(
+        self::assertSame(
             $output,
             $this->object->getTypeOperatorsHtml($type, $null, $selectedOperator),
         );
@@ -276,7 +276,7 @@ class TypesTest extends AbstractTestCase
      */
     public function testGetUnknownTypeDescription(): void
     {
-        self::assertEquals(
+        self::assertSame(
             '',
             $this->object->getTypeDescription('UNKNOWN'),
         );
@@ -342,7 +342,7 @@ class TypesTest extends AbstractTestCase
     #[DataProvider('providerFortTestGetFunctionsClass')]
     public function testGetFunctionsClass(string $class, array $output): void
     {
-        self::assertEquals(
+        self::assertSame(
             $output,
             $this->object->getFunctionsClass($class),
         );
@@ -501,7 +501,7 @@ class TypesTest extends AbstractTestCase
      */
     public function testGetFunctions(): void
     {
-        self::assertEquals(
+        self::assertSame(
             [
                 'AES_DECRYPT',
                 'AES_ENCRYPT',
@@ -548,7 +548,7 @@ class TypesTest extends AbstractTestCase
      */
     public function testGetAllFunctions(): void
     {
-        self::assertEquals(
+        self::assertSame(
             [
                 'ABS',
                 'ACOS',
@@ -678,7 +678,7 @@ class TypesTest extends AbstractTestCase
      */
     public function testGetAttributes(): void
     {
-        self::assertEquals(
+        self::assertSame(
             ['', 'BINARY', 'UNSIGNED', 'UNSIGNED ZEROFILL', 'on update CURRENT_TIMESTAMP'],
             $this->object->getAttributes(),
         );
@@ -689,7 +689,7 @@ class TypesTest extends AbstractTestCase
      */
     public function testGetColumns(): void
     {
-        self::assertEquals(
+        self::assertSame(
             [
                 0 => 'INT',
                 1 => 'VARCHAR',
@@ -755,7 +755,7 @@ class TypesTest extends AbstractTestCase
     #[DataProvider('providerFortTestGetTypeClass')]
     public function testGetTypeClass(string $type, string $output): void
     {
-        self::assertEquals(
+        self::assertSame(
             $output,
             $this->object->getTypeClass($type),
         );

--- a/tests/classes/UniqueConditionTest.php
+++ b/tests/classes/UniqueConditionTest.php
@@ -34,14 +34,14 @@ class UniqueConditionTest extends AbstractTestCase
         Config::getInstance()->selectedServer['DisableIS'] = false;
 
         $actual = new UniqueCondition([], []);
-        self::assertEquals(['', false, []], [
+        self::assertSame(['', false, []], [
             $actual->getWhereClause(),
             $actual->isClauseUnique(),
             $actual->getConditionArray(),
         ]);
 
         $actual = new UniqueCondition([], [], true);
-        self::assertEquals(['', true, []], [
+        self::assertSame(['', true, []], [
             $actual->getWhereClause(),
             $actual->isClauseUnique(),
             $actual->getConditionArray(),
@@ -149,7 +149,7 @@ class UniqueConditionTest extends AbstractTestCase
             'value',
             0x1,
         ], false, 'table');
-        self::assertEquals(
+        self::assertSame(
             [
                 '`table`.`field1` IS NULL AND `table`.`field2` = \'value\\\'s\' AND `table`.`field3` = 123456'
                 . ' AND `table`.`field4` = 123.456 AND `table`.`field5` = CAST(0x76616c7565 AS BINARY)'
@@ -188,7 +188,7 @@ class UniqueConditionTest extends AbstractTestCase
         ];
 
         $actual = new UniqueCondition($meta, [str_repeat('*', 1001)]);
-        self::assertEquals(
+        self::assertSame(
             ['CHAR_LENGTH(`table`.`field`)  = 1001', false, ['`table`.`field`' => ' = 1001']],
             [$actual->getWhereClause(), $actual->isClauseUnique(), $actual->getConditionArray()],
         );
@@ -215,7 +215,7 @@ class UniqueConditionTest extends AbstractTestCase
         ];
 
         $actual = new UniqueCondition($meta, [1, 'value']);
-        self::assertEquals(['`table`.`id` = 1', true, ['`table`.`id`' => '= 1']], [
+        self::assertSame(['`table`.`id` = 1', true, ['`table`.`id`' => '= 1']], [
             $actual->getWhereClause(),
             $actual->isClauseUnique(),
             $actual->getConditionArray(),
@@ -243,7 +243,7 @@ class UniqueConditionTest extends AbstractTestCase
         ];
 
         $actual = new UniqueCondition($meta, ['unique', 'value']);
-        self::assertEquals(['`table`.`id` = \'unique\'', true, ['`table`.`id`' => '= \'unique\'']], [
+        self::assertSame(['`table`.`id` = \'unique\'', true, ['`table`.`id`' => '= \'unique\'']], [
             $actual->getWhereClause(),
             $actual->isClauseUnique(),
             $actual->getConditionArray(),
@@ -267,7 +267,7 @@ class UniqueConditionTest extends AbstractTestCase
 
         $actual = new UniqueCondition($meta, $row);
 
-        self::assertEquals($expected, [
+        self::assertSame($expected, [
             $actual->getWhereClause(),
             $actual->isClauseUnique(),
             $actual->getConditionArray(),

--- a/tests/classes/UrlTest.php
+++ b/tests/classes/UrlTest.php
@@ -51,7 +51,7 @@ class UrlTest extends AbstractTestCase
         $expected = '?db=db'
             . $separator . $expected;
 
-        self::assertEquals($expected, Url::getCommon(['db' => 'db']));
+        self::assertSame($expected, Url::getCommon(['db' => 'db']));
     }
 
     /**
@@ -69,7 +69,7 @@ class UrlTest extends AbstractTestCase
             . $separator . 'table=table'
             . $separator . $expected;
         $params = ['db' => 'db', 'table' => 'table'];
-        self::assertEquals($expected, Url::getCommon($params));
+        self::assertSame($expected, Url::getCommon($params));
     }
 
     /**
@@ -85,7 +85,7 @@ class UrlTest extends AbstractTestCase
 
         $expected = '#ABC#db=db' . $separator . 'table=table' . $separator
             . $expected;
-        self::assertEquals(
+        self::assertSame(
             $expected,
             Url::getCommonRaw(
                 ['db' => 'db', 'table' => 'table'],
@@ -104,7 +104,7 @@ class UrlTest extends AbstractTestCase
 
         $separator = Url::getArgSeparator();
         $expected = '?server=2' . $separator . 'lang=en';
-        self::assertEquals($expected, Url::getCommon());
+        self::assertSame($expected, Url::getCommon());
     }
 
     /**
@@ -118,7 +118,7 @@ class UrlTest extends AbstractTestCase
             'field' => '%1\$s',
             'change_column' => 1,
         ]);
-        self::assertEquals(
+        self::assertSame(
             'index.php?route=/test&db=%253%5C%24s&table=%252%5C%24s&field=%251%5C%24s&change_column=1&lang=en',
             $generatedUrl,
         );
@@ -137,9 +137,9 @@ class UrlTest extends AbstractTestCase
         ]);
         $expectedUrl = 'index.php?route=/test&db=%26test%3D_database%3D'
         . '&table=%26test%3D_database%3D&field=%26test%3D_database%3D&change_column=1&lang=en';
-        self::assertEquals($expectedUrl, $generatedUrl);
+        self::assertSame($expectedUrl, $generatedUrl);
 
-        self::assertEquals(
+        self::assertSame(
             'index.php?route=/test&db=&test=_database=&table=&'
             . 'test=_database=&field=&test=_database=&change_column=1&lang=en',
             urldecode(
@@ -161,7 +161,7 @@ class UrlTest extends AbstractTestCase
             'book' => false,
             'worm' => false,
         ]);
-        self::assertEquals(
+        self::assertSame(
             'index.php?route=/test&db=%3Cscript+src%3D%22https%3A%2F%2Fdomain.tld%2Fsvn'
             . '%2Ftrunk%2Fhtml5.js%22%3E%3C%2Fscript%3E&table=%3Cscript+src%3D%22'
             . 'https%3A%2F%2Fdomain.tld%2Fmaybeweshouldusegit%2Ftrunk%2Fhtml5.js%22%3E%3C%2F'
@@ -186,7 +186,7 @@ class UrlTest extends AbstractTestCase
     {
         Config::getInstance()->set('URLQueryEncryption', false);
         $params = ['db' => 'test_db', 'table' => 'test_table', 'pos' => 0];
-        self::assertEquals('db=test_db&table=test_table&pos=0', Url::buildHttpQuery($params));
+        self::assertSame('db=test_db&table=test_table&pos=0', Url::buildHttpQuery($params));
     }
 
     public function testBuildHttpQueryWithUrlQueryEncryptionEnabled(): void

--- a/tests/classes/UserPreferencesTest.php
+++ b/tests/classes/UserPreferencesTest.php
@@ -54,7 +54,7 @@ class UserPreferencesTest extends AbstractTestCase
         $userPreferences = new UserPreferences($dbi, new Relation($dbi), new Template());
         $userPreferences->pageInit(new ConfigFile());
 
-        self::assertEquals(
+        self::assertSame(
             ['Servers' => [1 => ['hide_db' => 'testval123']]],
             $_SESSION['ConfigFile' . Current::$server],
         );
@@ -76,7 +76,7 @@ class UserPreferencesTest extends AbstractTestCase
 
         self::assertCount(3, $result);
 
-        self::assertEquals(
+        self::assertSame(
             [],
             $result['config_data'],
         );
@@ -88,7 +88,7 @@ class UserPreferencesTest extends AbstractTestCase
             '',
         );
 
-        self::assertEquals('session', $result['type']);
+        self::assertSame('session', $result['type']);
 
         // case 2
         $relationParameters = RelationParameters::fromArray([
@@ -117,7 +117,7 @@ class UserPreferencesTest extends AbstractTestCase
         $userPreferences = new UserPreferences($dbi, new Relation($dbi), new Template());
         $result = $userPreferences->load();
 
-        self::assertEquals(
+        self::assertSame(
             ['config_data' => [1, 2], 'mtime' => 123, 'type' => 'db'],
             $result,
         );
@@ -142,7 +142,7 @@ class UserPreferencesTest extends AbstractTestCase
 
         self::assertCount(2, $_SESSION['userconfig']);
 
-        self::assertEquals(
+        self::assertSame(
             [1],
             $_SESSION['userconfig']['db'],
         );
@@ -233,7 +233,7 @@ class UserPreferencesTest extends AbstractTestCase
         $result = $userPreferences->save([1]);
 
         self::assertInstanceOf(Message::class, $result);
-        self::assertEquals(
+        self::assertSame(
             'Could not save configuration<br><br>err1'
             . '<br><br>The phpMyAdmin configuration storage database could not be accessed.',
             $result->getMessage(),
@@ -280,7 +280,7 @@ class UserPreferencesTest extends AbstractTestCase
             ['DBG/sql' => true],
         );
 
-        self::assertEquals(
+        self::assertSame(
             ['DBG' => ['sql' => true]],
             $result,
         );
@@ -350,7 +350,7 @@ class UserPreferencesTest extends AbstractTestCase
 
         $dbi = DatabaseInterface::getInstance();
         $userPreferences = new UserPreferences($dbi, new Relation($dbi), new Template());
-        self::assertEquals(
+        self::assertSame(
             '',
             $userPreferences->autoloadGetHeader(),
         );

--- a/tests/classes/UtilTest.php
+++ b/tests/classes/UtilTest.php
@@ -79,7 +79,7 @@ class UtilTest extends AbstractTestCase
     #[DataProvider('charsetQueryData')]
     public function testGenerateCharsetQueryPart(string $collation, string $expected): void
     {
-        self::assertEquals(
+        self::assertSame(
             $expected,
             Util::getCharsetQueryPart($collation),
         );
@@ -100,8 +100,8 @@ class UtilTest extends AbstractTestCase
      */
     public function testGenerateRandom(): void
     {
-        self::assertEquals(32, strlen(Util::generateRandom(32)));
-        self::assertEquals(16, strlen(Util::generateRandom(16)));
+        self::assertSame(32, strlen(Util::generateRandom(32)));
+        self::assertSame(16, strlen(Util::generateRandom(16)));
     }
 
     public function testClearUserCache(): void
@@ -109,10 +109,10 @@ class UtilTest extends AbstractTestCase
         Config::getInstance()->selectedServer['user'] = null;
         Current::$server = 2;
         SessionCache::set('is_superuser', 'yes');
-        self::assertEquals('yes', $_SESSION['cache']['server_2']['is_superuser']);
+        self::assertSame('yes', $_SESSION['cache']['server_2']['is_superuser']);
 
         SessionCache::set('mysql_cur_user', 'mysql');
-        self::assertEquals('mysql', $_SESSION['cache']['server_2']['mysql_cur_user']);
+        self::assertSame('mysql', $_SESSION['cache']['server_2']['mysql_cur_user']);
 
         Util::clearUserCache();
         self::assertArrayNotHasKey('is_superuser', $_SESSION['cache']['server_2']);
@@ -128,7 +128,7 @@ class UtilTest extends AbstractTestCase
     #[DataProvider('providerConvertBitDefaultValue')]
     public function testConvertBitDefaultValue(string|null $bit, string $val): void
     {
-        self::assertEquals(
+        self::assertSame(
             $val,
             Util::convertBitDefaultValue($bit),
         );
@@ -170,12 +170,12 @@ class UtilTest extends AbstractTestCase
         Current::$database = 'database';
         Current::$table = 'table';
 
-        self::assertEquals(
+        self::assertSame(
             $out,
             Util::expandUserString($in),
         );
 
-        self::assertEquals(
+        self::assertSame(
             htmlspecialchars($out),
             Util::expandUserString(
                 $in,
@@ -357,7 +357,7 @@ class UtilTest extends AbstractTestCase
     #[DataProvider('providerParseEnumSetValues')]
     public function testParseEnumSetValues(string $in, bool $escapeHTML, array $out): void
     {
-        self::assertEquals(
+        self::assertSame(
             $out,
             Util::parseEnumSetValues($in, $escapeHTML),
         );
@@ -477,7 +477,7 @@ class UtilTest extends AbstractTestCase
     #[DataProvider('providerExtractValueFromFormattedSize')]
     public function testExtractValueFromFormattedSize(int|string $size, int|float $expected): void
     {
-        self::assertEquals(
+        self::assertSame(
             $expected,
             Util::extractValueFromFormattedSize($size),
         );
@@ -548,7 +548,7 @@ class UtilTest extends AbstractTestCase
      */
     private function assertFormatNumber(float|int|string $a, int $b, int $c, string $d): void
     {
-        self::assertEquals(
+        self::assertSame(
             $d,
             Util::formatNumber(
                 $a,
@@ -650,7 +650,7 @@ class UtilTest extends AbstractTestCase
     #[DataProvider('providerGetFormattedMaximumUploadSize')]
     public function testGetFormattedMaximumUploadSize(int|float|string $size, string $unit, string $res): void
     {
-        self::assertEquals(
+        self::assertSame(
             '(' . __('Max: ') . $res . $unit . ')',
             Util::getFormattedMaximumUploadSize($size),
         );
@@ -692,7 +692,7 @@ class UtilTest extends AbstractTestCase
     #[DataProvider('providerGetTitleForTarget')]
     public function testGetTitleForTarget(string $target, string $result): void
     {
-        self::assertEquals(
+        self::assertSame(
             $result,
             Util::getTitleForTarget($target),
         );
@@ -739,7 +739,7 @@ class UtilTest extends AbstractTestCase
         $tmpTimezone = date_default_timezone_get();
         date_default_timezone_set($tz);
 
-        self::assertEquals(
+        self::assertSame(
             $e,
             Util::localisedDate($a, $b),
         );
@@ -818,7 +818,7 @@ class UtilTest extends AbstractTestCase
         $tmpTimezone = date_default_timezone_get();
         date_default_timezone_set('Europe/London');
 
-        self::assertEquals(
+        self::assertSame(
             $e,
             Util::timespanFormat($a),
         );
@@ -849,7 +849,7 @@ class UtilTest extends AbstractTestCase
     #[DataProvider('providerPrintableBitValue')]
     public function testPrintableBitValue(int $a, int $b, string $e): void
     {
-        self::assertEquals(
+        self::assertSame(
             $e,
             Util::printableBitValue($a, $b),
         );
@@ -877,7 +877,7 @@ class UtilTest extends AbstractTestCase
     #[DataProvider('providerUnQuote')]
     public function testUnQuote(string $param, string $expected): void
     {
-        self::assertEquals(
+        self::assertSame(
             $expected,
             Util::unQuote($param),
         );
@@ -902,7 +902,7 @@ class UtilTest extends AbstractTestCase
     #[DataProvider('providerUnQuoteSelectedChar')]
     public function testUnQuoteSelectedChar(string $param, string $expected): void
     {
-        self::assertEquals(
+        self::assertSame(
             $expected,
             Util::unQuote($param, '"'),
         );
@@ -966,7 +966,7 @@ class UtilTest extends AbstractTestCase
     {
         Config::getInstance()->selectedServer['user'] = 'root';
 
-        self::assertEquals($e, Util::userDir($a));
+        self::assertSame($e, Util::userDir($a));
     }
 
     /**
@@ -988,7 +988,7 @@ class UtilTest extends AbstractTestCase
     #[DataProvider('providerDuplicateFirstNewline')]
     public function testDuplicateFirstNewline(string $a, string $e): void
     {
-        self::assertEquals(
+        self::assertSame(
             $e,
             Util::duplicateFirstNewline($a),
         );
@@ -1007,7 +1007,7 @@ class UtilTest extends AbstractTestCase
     public function testUnsupportedDatatypes(): void
     {
         $noSupportTypes = [];
-        self::assertEquals(
+        self::assertSame(
             $noSupportTypes,
             Util::unsupportedDatatypes(),
         );
@@ -1015,10 +1015,10 @@ class UtilTest extends AbstractTestCase
 
     public function testGetPageFromPosition(): void
     {
-        self::assertEquals(Util::getPageFromPosition(0, 1), 1);
-        self::assertEquals(Util::getPageFromPosition(1, 1), 2);
-        self::assertEquals(Util::getPageFromPosition(1, 2), 1);
-        self::assertEquals(Util::getPageFromPosition(1, 6), 1);
+        self::assertSame(Util::getPageFromPosition(0, 1), 1);
+        self::assertSame(Util::getPageFromPosition(1, 1), 2);
+        self::assertSame(Util::getPageFromPosition(1, 2), 1);
+        self::assertSame(Util::getPageFromPosition(1, 6), 1);
     }
 
     /**
@@ -1031,7 +1031,7 @@ class UtilTest extends AbstractTestCase
     public function testIsInteger(bool $expected, mixed $input): void
     {
         $isInteger = Util::isInteger($input);
-        self::assertEquals($expected, $isInteger);
+        self::assertSame($expected, $isInteger);
     }
 
     /**
@@ -1054,7 +1054,7 @@ class UtilTest extends AbstractTestCase
     public function testGetProtoFromForwardedHeader(string $header, string $proto): void
     {
         $protocolDetected = Util::getProtoFromForwardedHeader($header);
-        self::assertEquals($proto, $protocolDetected);
+        self::assertSame($proto, $protocolDetected);
     }
 
     /**
@@ -1543,7 +1543,7 @@ SQL;
             ->willReturn($version);
 
         DatabaseInterface::$instance = $dbi;
-        self::assertEquals(Util::isUUIDSupported(), $expected);
+        self::assertSame(Util::isUUIDSupported(), $expected);
         DatabaseInterface::$instance = null;
     }
 

--- a/tests/classes/Utils/ForeignKeyTest.php
+++ b/tests/classes/Utils/ForeignKeyTest.php
@@ -30,7 +30,7 @@ class ForeignKeyTest extends AbstractTestCase
     #[DataProvider('providerIsSupported')]
     public function testIsSupported(string $a, bool $e): void
     {
-        self::assertEquals(
+        self::assertSame(
             $e,
             ForeignKey::isSupported($a),
         );

--- a/tests/classes/Utils/FormatConverterTest.php
+++ b/tests/classes/Utils/FormatConverterTest.php
@@ -25,7 +25,7 @@ class FormatConverterTest extends AbstractTestCase
     public function testBinaryToIp(string $expected, string $input, bool $isBinary): void
     {
         $result = FormatConverter::binaryToIp($input, $isBinary);
-        self::assertEquals($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -60,7 +60,7 @@ class FormatConverterTest extends AbstractTestCase
     public function testIpToBinary(string $expected, string $input): void
     {
         $result = FormatConverter::ipToBinary($input);
-        self::assertEquals($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -106,7 +106,7 @@ class FormatConverterTest extends AbstractTestCase
     public function testLongToIp(string $expected, string $input): void
     {
         $result = FormatConverter::longToIp($input);
-        self::assertEquals($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**

--- a/tests/classes/Utils/GisTest.php
+++ b/tests/classes/Utils/GisTest.php
@@ -140,14 +140,14 @@ class GisTest extends AbstractTestCase
 
     public function testCreateDataOldMysql(): void
     {
-        self::assertEquals('abc', Gis::createData('abc', 50500));
-        self::assertEquals('GeomFromText(\'POINT()\',10)', Gis::createData('\'POINT()\',10', 50500));
+        self::assertSame('abc', Gis::createData('abc', 50500));
+        self::assertSame('GeomFromText(\'POINT()\',10)', Gis::createData('\'POINT()\',10', 50500));
     }
 
     public function testCreateDataNewMysql(): void
     {
-        self::assertEquals('abc', Gis::createData('abc', 50600));
-        self::assertEquals('ST_GeomFromText(\'POINT()\',10)', Gis::createData('\'POINT()\',10', 50600));
+        self::assertSame('abc', Gis::createData('abc', 50600));
+        self::assertSame('ST_GeomFromText(\'POINT()\',10)', Gis::createData('\'POINT()\',10', 50600));
     }
 
     public function testGetFunctions(): void

--- a/tests/classes/Utils/SessionCacheTest.php
+++ b/tests/classes/Utils/SessionCacheTest.php
@@ -49,9 +49,9 @@ class SessionCacheTest extends TestCase
 
         SessionCache::set('test_data', 25);
         SessionCache::set('test_data', 5);
-        self::assertEquals(5, $_SESSION['cache']['server_2']['test_data']);
+        self::assertSame(5, $_SESSION['cache']['server_2']['test_data']);
         SessionCache::set('test_data_3', 3);
-        self::assertEquals(3, $_SESSION['cache']['server_2']['test_data_3']);
+        self::assertSame(3, $_SESSION['cache']['server_2']['test_data_3']);
     }
 
     public function testHas(): void

--- a/tests/classes/VersionInformationTest.php
+++ b/tests/classes/VersionInformationTest.php
@@ -65,7 +65,7 @@ class VersionInformationTest extends AbstractTestCase
     public function testVersionToInt(string $version, int $numeric): void
     {
         $versionInformation = new VersionInformation();
-        self::assertEquals(
+        self::assertSame(
             $numeric,
             $versionInformation->versionToInt($version),
         );
@@ -114,7 +114,7 @@ class VersionInformationTest extends AbstractTestCase
 
         $compatible = $mockVersionInfo->getLatestCompatibleVersion($this->releases);
         self::assertInstanceOf(Release::class, $compatible);
-        self::assertEquals('4.4.14.1', $compatible->version);
+        self::assertSame('4.4.14.1', $compatible->version);
     }
 
     /**
@@ -130,7 +130,7 @@ class VersionInformationTest extends AbstractTestCase
 
         $compatible = $mockVersionInfo->getLatestCompatibleVersion($this->releases);
         self::assertInstanceOf(Release::class, $compatible);
-        self::assertEquals('4.4.14.1', $compatible->version);
+        self::assertSame('4.4.14.1', $compatible->version);
     }
 
     /**
@@ -146,7 +146,7 @@ class VersionInformationTest extends AbstractTestCase
 
         $compatible = $mockVersionInfo->getLatestCompatibleVersion($this->releases);
         self::assertInstanceOf(Release::class, $compatible);
-        self::assertEquals('4.0.10.10', $compatible->version);
+        self::assertSame('4.0.10.10', $compatible->version);
     }
 
     /**
@@ -169,7 +169,7 @@ class VersionInformationTest extends AbstractTestCase
         $mockVersionInfo->expects(self::never())->method('getMySQLVersion');
 
         $compatible = $mockVersionInfo->getLatestCompatibleVersion($versions);
-        self::assertEquals($matchedLastVersion, $compatible->version ?? null);
+        self::assertSame($matchedLastVersion, $compatible->version ?? null);
     }
 
     /**

--- a/tests/classes/WebAuthn/WebauthnLibServerTest.php
+++ b/tests/classes/WebAuthn/WebauthnLibServerTest.php
@@ -73,7 +73,7 @@ class WebauthnLibServerTest extends TestCase
         $options = $server->getCredentialRequestOptions('user_name', 'userHandle1', 'test.localhost', []);
         self::assertNotEmpty($options['challenge']);
         self::assertSame('test.localhost', $options['rpId']);
-        self::assertEquals(
+        self::assertSame(
             [['type' => 'public-key', 'id' => 'cHVibGljS2V5Q3JlZGVudGlhbElkMQ==']],
             $options['allowCredentials'],
         );

--- a/tests/classes/ZipExtensionTest.php
+++ b/tests/classes/ZipExtensionTest.php
@@ -38,7 +38,7 @@ class ZipExtensionTest extends AbstractTestCase
     #[DataProvider('provideTestGetContents')]
     public function testGetContents(string $file, string|null $specificEntry, array $output): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->zipExtension->getContents($file, $specificEntry),
             $output,
         );
@@ -80,7 +80,7 @@ class ZipExtensionTest extends AbstractTestCase
     #[DataProvider('provideTestFindFile')]
     public function testFindFile(string $file, string $fileRegexp, string|bool $output): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->zipExtension->findFile($file, $fileRegexp),
             $output,
         );
@@ -105,7 +105,7 @@ class ZipExtensionTest extends AbstractTestCase
      */
     public function testGetNumberOfFiles(): void
     {
-        self::assertEquals(
+        self::assertSame(
             $this->zipExtension->getNumberOfFiles('./tests/test_data/test.zip'),
             1,
         );
@@ -122,7 +122,7 @@ class ZipExtensionTest extends AbstractTestCase
                 'wrongName',
             ),
         );
-        self::assertEquals(
+        self::assertSame(
             "TEST FILE\n",
             $this->zipExtension->extract(
                 './tests/test_data/test.zip',
@@ -149,7 +149,7 @@ class ZipExtensionTest extends AbstractTestCase
             $zip->open($tmp),
         );
 
-        self::assertEquals(0, $zip->locateName('test.txt'));
+        self::assertSame(0, $zip->locateName('test.txt'));
 
         $zip->close();
         unlink($tmp);
@@ -189,8 +189,8 @@ class ZipExtensionTest extends AbstractTestCase
             $zip->open($tmp),
         );
 
-        self::assertEquals(0, $zip->locateName('name1.txt'));
-        self::assertEquals(1, $zip->locateName('name2.txt'));
+        self::assertSame(0, $zip->locateName('name1.txt'));
+        self::assertSame(1, $zip->locateName('name2.txt'));
 
         $zip->close();
         unlink($tmp);


### PR DESCRIPTION
Only replaces assertEquals with assertSame where it doesn't causes the test to fail.
