### PR TITLE
Refactor name generation of file imports

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11522,7 +11522,7 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
-			count: 2
+			count: 1
 			path: src/Plugins/Import/ImportOds.php
 
 		-
@@ -11611,42 +11611,12 @@ parameters:
 			path: src/Plugins/Import/ImportSql.php
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 1
-			path: src/Plugins/Import/ImportXml.php
-
-		-
-			message: "#^Cannot access property \\$database on mixed\\.$#"
-			count: 1
-			path: src/Plugins/Import/ImportXml.php
-
-		-
 			message: "#^Cannot cast mixed to string\\.$#"
-			count: 10
+			count: 6
 			path: src/Plugins/Import/ImportXml.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportXml\\:\\:doImport\\(\\) should return array\\<string\\> but returns mixed\\.$#"
-			count: 1
-			path: src/Plugins/Import/ImportXml.php
-
-		-
-			message: "#^Only booleans are allowed in &&, \\(SimpleXMLElement\\|null\\) given on the left side\\.$#"
-			count: 1
-			path: src/Plugins/Import/ImportXml.php
-
-		-
-			message: "#^Only booleans are allowed in &&, int given on the right side\\.$#"
-			count: 1
-			path: src/Plugins/Import/ImportXml.php
-
-		-
-			message: "#^Variable property access on \\(SimpleXMLElement\\|null\\)\\.$#"
-			count: 1
-			path: src/Plugins/Import/ImportXml.php
-
-		-
-			message: "#^Variable property access on mixed\\.$#"
 			count: 1
 			path: src/Plugins/Import/ImportXml.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6426,7 +6426,6 @@
       <code>DatabaseInterface::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
     <DocblockTypeContradiction>
       <code>$nameArray === false</code>
@@ -8850,7 +8849,6 @@
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess>
       <code><![CDATA[$tblAttr['name']]]></code>
-      <code><![CDATA[$tblAttr['name']]]></code>
     </PossiblyNullArrayAccess>
     <PossiblyNullPropertyFetch>
       <code><![CDATA[$xml->children('office', true)->body]]></code>
@@ -8938,23 +8936,13 @@
   <file src="src/Plugins/Import/ImportXml.php">
     <MixedArrayAccess>
       <code><![CDATA[$attrs['name']]]></code>
-      <code><![CDATA[$rowAttr['name']]]></code>
-      <code><![CDATA[$rowAttr['name']]]></code>
-      <code><![CDATA[$tblAttr['name']]]></code>
-      <code><![CDATA[$tblAttr['name']]]></code>
-      <code><![CDATA[$tblAttr['name']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$attrs</code>
-      <code>$rowAttr</code>
-      <code>$tblAttr</code>
-      <code>$v2</code>
       <code>$val2</code>
       <code>$val3</code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>attributes</code>
-      <code>attributes</code>
       <code>attributes</code>
     </MixedMethodCall>
     <PossiblyNullArrayAccess>
@@ -8963,17 +8951,15 @@
       <code><![CDATA[$dbAttr['name']]]></code>
       <code><![CDATA[$dbAttr['name']]]></code>
     </PossiblyNullArrayAccess>
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$xml->children($namespaces['pma'] ?? null)->structure_schemas]]></code>
+    </PossiblyNullPropertyFetch>
     <PossiblyNullReference>
       <code>attributes</code>
-      <code>children</code>
-      <code>count</code>
     </PossiblyNullReference>
     <PossiblyUnusedReturnValue>
       <code>string[]</code>
     </PossiblyUnusedReturnValue>
-    <RiskyTruthyFalsyComparison>
-      <code>$xml</code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Plugins/Import/ShapeFileImport.php">
     <InvalidArrayOffset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6425,8 +6425,11 @@
       <code>DatabaseInterface::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
+      <code>DatabaseInterface::getInstance()</code>
+      <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
     <DocblockTypeContradiction>
+      <code>$nameArray === false</code>
       <code><![CDATA[empty($parser->statements[0])]]></code>
     </DocblockTypeContradiction>
     <MixedArgument>
@@ -8692,11 +8695,7 @@
     <DeprecatedMethod>
       <code>DatabaseInterface::getInstance()</code>
       <code>DatabaseInterface::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
-    <DocblockTypeContradiction>
-      <code>$nameArray === false</code>
-    </DocblockTypeContradiction>
     <InvalidArgument>
       <code><![CDATA[$GLOBALS['csv_columns']]]></code>
       <code>$colNames</code>
@@ -8796,9 +8795,6 @@
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Plugins/Import/ImportMediawiki.php">
-    <DeprecatedMethod>
-      <code>DatabaseInterface::getInstance()</code>
-    </DeprecatedMethod>
     <InvalidNullableReturnType>
       <code>string</code>
     </InvalidNullableReturnType>
@@ -8871,7 +8867,6 @@
   <file src="src/Plugins/Import/ImportShp.php">
     <DeprecatedMethod>
       <code>Config::getInstance()</code>
-      <code>DatabaseInterface::getInstance()</code>
     </DeprecatedMethod>
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['buffer']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8696,7 +8696,6 @@
     </DeprecatedMethod>
     <DocblockTypeContradiction>
       <code>$nameArray === false</code>
-      <code>$nameArray === false</code>
     </DocblockTypeContradiction>
     <InvalidArgument>
       <code><![CDATA[$GLOBALS['csv_columns']]]></code>
@@ -8717,10 +8716,6 @@
     <MixedArgument>
       <code><![CDATA[$GLOBALS['csv_new_line']]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code>$result</code>
-      <code>$result</code>
-    </MixedArgumentTypeCoercion>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['csv_new_line']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>

--- a/src/Import/Import.php
+++ b/src/Import/Import.php
@@ -31,6 +31,7 @@ use function explode;
 use function function_exists;
 use function htmlspecialchars;
 use function implode;
+use function in_array;
 use function is_numeric;
 use function max;
 use function mb_chr;
@@ -41,8 +42,11 @@ use function mb_strpos;
 use function mb_strtoupper;
 use function mb_substr;
 use function mb_substr_count;
+use function preg_grep;
 use function preg_match;
+use function preg_quote;
 use function preg_replace;
+use function rtrim;
 use function sprintf;
 use function str_contains;
 use function str_starts_with;
@@ -1380,5 +1384,35 @@ class Import
             $matcher,
             $active,
         );
+    }
+
+    public function getNextAvailableTableName(string $databaseName, string $proposedTableName): string
+    {
+        if ($proposedTableName === '') {
+            $proposedTableName = 'TABLE';
+        }
+
+        $importFileName = rtrim($proposedTableName);
+        $importFileName = (string) preg_replace('/[^\x{0001}-\x{FFFF}]/u', '_', $importFileName);
+
+        if ($databaseName !== '') {
+            $existingTables = DatabaseInterface::getInstance()->getTables($databaseName);
+
+            // check to see if {filename} as table exist
+            // if no use filename as table name
+            if (! in_array($importFileName, $existingTables, true)) {
+                return $importFileName;
+            }
+
+            // check if {filename}_ as table exist
+            $nameArray = preg_grep('/^' . preg_quote($importFileName, '/') . '_/isU', $existingTables);
+            if ($nameArray === false) {
+                return $importFileName;
+            }
+
+            return $importFileName . '_' . (count($nameArray) + 1);
+        }
+
+        return $importFileName;
     }
 }

--- a/src/Plugins/Import/ImportOds.php
+++ b/src/Plugins/Import/ImportOds.php
@@ -158,27 +158,7 @@ class ImportOds extends ImportPlugin
             }
         }
 
-        [$tables, $rows] = $this->readSheets($sheets, isset($_REQUEST['ods_col_names']));
-
-        /**
-         * Bring accumulated rows into the corresponding table
-         */
-        foreach ($tables as $table) {
-            foreach ($rows as $row) {
-                if ($table->tableName !== $row->tableName) {
-                    continue;
-                }
-
-                if ($table->columns === []) {
-                    $table->columns = $row->columns;
-                }
-
-                $table->rows = $row->rows;
-            }
-        }
-
-        /* No longer needed */
-        unset($rows);
+        $tables = $this->readSheets($sheets, isset($_REQUEST['ods_col_names']));
 
         /* Obtain the best-fit MySQL types for each column */
         $analyses = array_map($this->import->analyzeTable(...), $tables);
@@ -331,11 +311,10 @@ class ImportOds extends ImportPlugin
     /**
      * @param mixed[]|SimpleXMLElement $sheets Sheets of the spreadsheet.
      *
-     * @return array{ImportTable[], ImportTable[]}
+     * @return ImportTable[]
      */
     private function readSheets(array|SimpleXMLElement $sheets, bool $colNamesInFirstRow): array
     {
-        $tables = [];
         $maxCols = 0;
         $rows = [];
 
@@ -367,13 +346,12 @@ class ImportOds extends ImportPlugin
 
             /* Store the table name so we know where to place the row set */
             $tblAttr = $sheet->attributes('table', true);
-            $tables[] = new ImportTable((string) $tblAttr['name']);
 
             /* Store the current sheet in the accumulator */
             $rows[] = new ImportTable((string) $tblAttr['name'], $colNames, $tempRows);
             $maxCols = 0;
         }
 
-        return [$tables, $rows];
+        return $rows;
     }
 }

--- a/src/Plugins/Import/ImportShp.php
+++ b/src/Plugins/Import/ImportShp.php
@@ -9,7 +9,6 @@ namespace PhpMyAdmin\Plugins\Import;
 
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Current;
-use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\File;
 use PhpMyAdmin\Gis\GisFactory;
 use PhpMyAdmin\Gis\GisMultiLineString;
@@ -40,6 +39,7 @@ use function trim;
 use function unlink;
 
 use const LOCK_EX;
+use const PATHINFO_FILENAME;
 
 /**
  * Handles the import for ESRI Shape files
@@ -265,8 +265,10 @@ class ImportShp extends ImportPlugin
 
         // Set table name based on the number of tables
         if (Current::$database !== '') {
-            $result = DatabaseInterface::getInstance()->fetchResult('SHOW TABLES');
-            $tableName = 'TABLE ' . (count($result) + 1);
+            $tableName = $this->import->getNextAvailableTableName(
+                Current::$database,
+                pathinfo(ImportSettings::$importFileName, PATHINFO_FILENAME),
+            );
         } else {
             $tableName = 'TBL_NAME';
         }


### PR DESCRIPTION
This PR changes the behaviour of file import. The table name generation is getting an overhaul. Previously CSV had special logic which used the file name as a basis for the table name. However, only ASCII characters were used without spaces. This could be confusing if the file name was something completely different. 

The new logic is that we use the table name and allow all characters that make up a valid MySQL table name. This means only BMP characters without the NUL byte and no spaces at the end. We then check if the table name is already in use. If it is, we fall back on the old logic of appending a count + 1 and hope that the table name is not in use. The code is moved to `Import` and used in other upload modes that used hardcoded table names. 

Additionally, the XML import gets more refactoring but still suffers from plenty of issues. 