### PR TITLE
Fix Error When creating a user on MariaDB #18995

### DIFF
--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -3082,7 +3082,7 @@ class Privileges
             // MariaDB uses 'USING' whereas MySQL uses 'AS'
             // but MariaDB with validation plugin needs cleartext password
             if (Compatibility::isMariaDb() && ! $isMariaDBPwdPluginActive) {
-                $createUserStmt .= ' USING %s';
+                $createUserStmt .= ' USING \'%s\'';
             } elseif (Compatibility::isMariaDb()) {
                 $createUserStmt .= ' IDENTIFIED BY %s';
             } elseif (Compatibility::isMySqlOrPerconaDb() && $serverVersion >= 80011) {


### PR DESCRIPTION
### Description
The issue arose due to missing quotes around the password. I resolved this by ensuring that single quotes are added, correcting the syntax.

**Original Statement:**
```
CREATE USER 'robert'@'%' IDENTIFIED VIA mysql_native_password USING *B517E71BB243BBDCBD474F2015E063394EC6719D;
//This is actuall throwing syntax error becaues the quotes are not found "#1064 - You have an error in your SQL syntax;"
```
**Corrected Statement with Quotes:**
```
CREATE USER 'robert'@'%' IDENTIFIED VIA mysql_native_password USING '*B517E71BB243BBDCBD474F2015E063394EC6719D';
//This is the corrected version
```

Fixes #18989 

