### PR TITLE
Fix Can't create a UNIQUE key from More dropdown

### DIFF
--- a/resources/templates/table/structure/display_structure.twig
+++ b/resources/templates/table/structure/display_structure.twig
@@ -148,7 +148,7 @@
                         </li>
 
                         <li class="{{ not hide_structure_actions ? 'nav-item ' }}add_unique unique text-nowrap">
-                          {% if type == 'text' or type == 'blob' or tbl_storage_engine == 'ARCHIVE' or field_name in columns_with_unique_index %}
+                          {% if type == 'text' or type == 'blob' or tbl_storage_engine == 'ARCHIVE' %}
                             <span class="{{ hide_structure_actions ? 'dropdown-item-text' : 'nav-link px-1' }} disabled">{{ get_icon('bd_unique', 'Unique'|trans) }}</span>
                           {% else %}
                             <a rel="samepage" class="{{ hide_structure_actions ? 'dropdown-item' : 'nav-link px-1' }} ajax add_key d-print-none add_unique_anchor" href="{{ url('/table/structure/add-key') }}" data-post="{{ get_common({

--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -3082,7 +3082,7 @@ class Privileges
             // MariaDB uses 'USING' whereas MySQL uses 'AS'
             // but MariaDB with validation plugin needs cleartext password
             if (Compatibility::isMariaDb() && ! $isMariaDBPwdPluginActive) {
-                $createUserStmt .= ' USING %s';
+                $createUserStmt .= ' USING \'%s\'';
             } elseif (Compatibility::isMariaDb()) {
                 $createUserStmt .= ' IDENTIFIED BY %s';
             } elseif (Compatibility::isMySqlOrPerconaDb() && $serverVersion >= 80011) {


### PR DESCRIPTION
### Description
There was a logic implemented to disable the 'unique' button if the column already had a unique key.  I have now removed that logic and it works fine now . 

Fixes #18940
