### PR TITLE
Fix Cannot create a UNIQUE key from More dropdown

### DIFF
--- a/libraries/classes/Controllers/Table/StructureController.php
+++ b/libraries/classes/Controllers/Table/StructureController.php
@@ -130,15 +130,11 @@ class StructureController extends AbstractController
         $columns_with_index = $this->dbi
             ->getTable($this->db, $this->table)
             ->getColumnsWithIndex(Index::UNIQUE | Index::INDEX | Index::SPATIAL | Index::FULLTEXT);
-        $columns_with_unique_index = $this->dbi
-            ->getTable($this->db, $this->table)
-            ->getColumnsWithIndex(Index::UNIQUE);
 
         $fields = $this->dbi->getColumns($this->db, $this->table, true);
 
         $this->response->addHTML($this->displayStructure(
             $relationParameters,
-            $columns_with_unique_index,
             $primary,
             $fields,
             $columns_with_index,
@@ -149,16 +145,14 @@ class StructureController extends AbstractController
     /**
      * Displays the table structure ('show table' works correct since 3.23.03)
      *
-     * @param array       $columns_with_unique_index Columns with unique index
-     * @param Index|false $primary_index             primary index or false if no one exists
-     * @param array       $fields                    Fields
-     * @param array       $columns_with_index        Columns with index
+     * @param Index|false $primary_index      primary index or false if no one exists
+     * @param array       $fields             Fields
+     * @param array       $columns_with_index Columns with index
      *
      * @return string
      */
     protected function displayStructure(
         RelationParameters $relationParameters,
-        array $columns_with_unique_index,
         $primary_index,
         array $fields,
         array $columns_with_index,
@@ -261,7 +255,6 @@ class StructureController extends AbstractController
             'mime_map' => $mime_map,
             'tbl_storage_engine' => $tbl_storage_engine,
             'primary' => $primary_index,
-            'columns_with_unique_index' => $columns_with_unique_index,
             'columns_list' => $columns_list,
             'table_stats' => $tablestats ?? null,
             'fields' => $fields,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1711,11 +1711,6 @@ parameters:
 			path: libraries/classes/Controllers/Table/StructureController.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Table\\\\StructureController\\:\\:displayStructure\\(\\) has parameter \\$columns_with_unique_index with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/StructureController.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Table\\\\StructureController\\:\\:displayStructure\\(\\) has parameter \\$fields with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/StructureController.php

--- a/templates/table/structure/display_structure.twig
+++ b/templates/table/structure/display_structure.twig
@@ -148,7 +148,7 @@
                         </li>
 
                         <li class="{{ not hide_structure_actions ? 'nav-item ' }}add_unique unique text-nowrap">
-                          {% if type == 'text' or type == 'blob' or tbl_storage_engine == 'ARCHIVE' or field_name in columns_with_unique_index %}
+                          {% if type == 'text' or type == 'blob' or tbl_storage_engine == 'ARCHIVE' %}
                             <span class="{{ hide_structure_actions ? 'dropdown-item-text' : 'nav-link px-1' }} disabled">{{ get_icon('bd_unique', 'Unique'|trans) }}</span>
                           {% else %}
                             <a rel="samepage" class="{{ hide_structure_actions ? 'dropdown-item' : 'nav-link px-1' }} ajax add_key d-print-none add_unique_anchor" href="{{ url('/table/structure/add-key') }}" data-post="{{ get_common({


### PR DESCRIPTION
### Description

There was a logic implemented to disable the 'unique' button if the column already had a unique key. I have now removed that logic and it works fine now .

Fixes #18940
