### PR TITLE
Fix Error When adding a user on MariaDB

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13182,7 +13182,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:quoteString\\(\\) expects string, mixed given\\.$#"
-			count: 4
+			count: 5
 			path: src/Server/Privileges.php
 
 		-
@@ -13233,11 +13233,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$userGroup of method PhpMyAdmin\\\\Server\\\\Privileges\\:\\:setUserGroup\\(\\) expects string, mixed given\\.$#"
 			count: 2
-			path: src/Server/Privileges.php
-
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
-			count: 1
 			path: src/Server/Privileges.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10350,6 +10350,7 @@
       <code><![CDATA[$_REQUEST['hostname']]]></code>
       <code><![CDATA[$_REQUEST['username']]]></code>
       <code>$dbname[0]</code>
+      <code>$hashedPassword</code>
       <code>$oldUserGroup</code>
     </PossiblyInvalidCast>
     <PossiblyInvalidOperand>

--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -3123,7 +3123,12 @@ class Privileges
             $passwordSetReal = sprintf($passwordSetStmt, $slashedUsername, $slashedHostname, "''");
         } else {
             $hashedPassword = $this->getHashedPassword($_POST['pma_pw']);
-            $passwordSetReal = sprintf($passwordSetStmt, $slashedUsername, $slashedHostname, $this->dbi->quoteString($hashedPassword));
+            $passwordSetReal = sprintf(
+                $passwordSetStmt,
+                $slashedUsername,
+                $slashedHostname,
+                $this->dbi->quoteString($hashedPassword),
+            );
         }
 
         $alterRealSqlQuery = '';

--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -3111,7 +3111,7 @@ class Privileges
                     $hashedPassword = $_POST['pma_pw'];
                 }
 
-                $createUserReal = sprintf($createUserStmt, $hashedPassword);
+                $createUserReal = sprintf($createUserStmt, $this->dbi->quoteString($hashedPassword));
             }
 
             $createUserShow = sprintf($createUserStmt, '\'***\'');
@@ -3123,7 +3123,7 @@ class Privileges
             $passwordSetReal = sprintf($passwordSetStmt, $slashedUsername, $slashedHostname, "''");
         } else {
             $hashedPassword = $this->getHashedPassword($_POST['pma_pw']);
-            $passwordSetReal = sprintf($passwordSetStmt, $slashedUsername, $slashedHostname, $hashedPassword);
+            $passwordSetReal = sprintf($passwordSetStmt, $slashedUsername, $slashedHostname, $this->dbi->quoteString($hashedPassword));
         }
 
         $alterRealSqlQuery = '';


### PR DESCRIPTION
### Description

The issue arose due to missing quotes around the password. I resolved this by ensuring that single quotes are added, correcting the syntax.

**Original Statement:**
```
CREATE USER 'robert'@'%' IDENTIFIED VIA mysql_native_password USING *B517E71BB243BBDCBD474F2015E063394EC6719D;
//This is actuall throwing syntax error becaues the quotes are not found "#1064 - You have an error in your SQL syntax;"
```

**Corrected Statement with Quotes:**
```
CREATE USER 'robert'@'%' IDENTIFIED VIA mysql_native_password USING '*B517E71BB243BBDCBD474F2015E063394EC6719D';
//This is the corrected version
```

Fixes #18989