### PR TITLE
Remove trigger_error from Template class

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -14426,11 +14426,6 @@ parameters:
 			path: src/Table/Table.php
 
 		-
-			message: "#^Dead catch \\- RuntimeException is never thrown in the try block\\.$#"
-			count: 1
-			path: src/Template.php
-
-		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
 			path: src/Theme/Theme.php

--- a/src/Template.php
+++ b/src/Template.php
@@ -26,12 +26,6 @@ use Twig\Loader\FilesystemLoader;
 use Twig\RuntimeLoader\ContainerRuntimeLoader;
 use Twig\TemplateWrapper;
 
-use function __;
-use function sprintf;
-use function trigger_error;
-
-use const E_USER_WARNING;
-
 /**
  * Handle front end templating
  */
@@ -106,23 +100,13 @@ class Template
         }
 
         try {
-            $template = static::$twig->load($templateName . '.twig');
-        } catch (RuntimeException $e) {
+            return static::$twig->load($templateName . '.twig');
+        } catch (RuntimeException) { // @phpstan-ignore-line thrown by Twig\Cache\FilesystemCache
             /* Retry with disabled cache */
             static::$twig->setCache(false);
-            $template = static::$twig->load($templateName . '.twig');
-            // The trigger error is intentionally after second load
-            // to avoid triggering error when disabling cache does not solve it.
-            trigger_error(
-                sprintf(
-                    __('Error while working with template cache: %s'),
-                    $e->getMessage(),
-                ),
-                E_USER_WARNING,
-            );
-        }
 
-        return $template;
+            return static::$twig->load($templateName . '.twig');
+        }
     }
 
     /**


### PR DESCRIPTION
This will remove the error:

> Error while working with template cache: Unable to create the cache directory

This does not fix the cache issue, but removes the warning.

The current behavior is to disable the cache when there's an issue with it. However this has bad performance.

The issue is that sometimes Twig generates a different cache key than the warmed up one and tries to write a new cache, but that's not the desired behavior.

- Related to https://github.com/phpmyadmin/website/issues/172
