### PR TITLE
Fix #18962 - Moving columns with ENUM() datatype and DEFAULT value causes invalid SQL

### DIFF
--- a/libraries/classes/Controllers/Table/Structure/MoveColumnsController.php
+++ b/libraries/classes/Controllers/Table/Structure/MoveColumnsController.php
@@ -77,6 +77,16 @@ final class MoveColumnsController extends AbstractController
                 unset($data['Extra']);
             }
 
+             // If the database is MariaDB and the field type is enum, retrieve the default value using a different query to avoid additional quotes.
+             if ($this->dbi->isMariaDB() && $data['Field'] == 'enum') {
+                $db = Util::backquote($this->db);
+                $table = Util::backquote($this->table);
+                $query = "SHOW COLUMNS FROM " . $table . " FROM " . $db . " WHERE Field = 'enum'";
+                $row = $this->dbi->fetchSingleRow($query);
+                if (!empty($row))
+                    $data['Default'] = $row['Default'];
+            }
+
             $timeType = $data['Type'] === 'timestamp' || $data['Type'] === 'datetime';
             $timeDefault = $data['Default'] === 'CURRENT_TIMESTAMP' || $data['Default'] === 'current_timestamp()';
             $current_timestamp = $timeType && $timeDefault;

--- a/libraries/classes/Controllers/Table/Structure/MoveColumnsController.php
+++ b/libraries/classes/Controllers/Table/Structure/MoveColumnsController.php
@@ -78,7 +78,7 @@ final class MoveColumnsController extends AbstractController
             }
 
              // If the database is MariaDB and the field type is enum, retrieve the default value using a different query to avoid additional quotes.
-             if ($this->dbi->isMariaDB() && $data['Field'] == 'enum') {
+             if ($this->dbi->isMariaDB() && $data['Field'] === 'enum') {
                 $db = Util::backquote($this->db);
                 $table = Util::backquote($this->table);
                 $query = "SHOW COLUMNS FROM " . $table . " FROM " . $db . " WHERE Field = 'enum'";


### PR DESCRIPTION
### Description

```
 SELECT
    `COLUMN_NAME` AS `Field`,
    `COLUMN_TYPE` AS `Type`,
    `COLLATION_NAME` AS `Collation`,
    `IS_NULLABLE` AS `Null`,
    `COLUMN_KEY` AS `Key`,
    `COLUMN_DEFAULT` AS `Default`,
    `EXTRA` AS `Extra`,
    `PRIVILEGES` AS `Privileges`,
    `COLUMN_COMMENT` AS `Comment`
FROM
    `information_schema`.`COLUMNS`  where `TABLE_SCHEMA` = 'test'  AND `TABLE_NAME` = 'test' ;;
```

When executing this query on MariaDB, the COLUMN_DEFAULT column returns default values enclosed in single quotes on both sides, causing an issue. However, in MySQL, this behavior is not observed. To address the inconsistency, I needed to trim off any extra single quotes that might exist in the COLUMN_DEFAULT values using TRIM('\\'' FROM COLUMN_DEFAULT`). Now, the issue is resolved.

Fixes #18962

You can see how the data appeared before the query modifications in the image below.
[
![Issue](https://github.com/phpmyadmin/phpmyadmin/assets/6673892/0032a921-5a5a-409d-b5a5-4b1172e89263)
]