### PR TITLE
Fix case where tables from wrong db is loaded in navigation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -68,6 +68,7 @@ phpMyAdmin - ChangeLog
 - issue #17363 Fix duplicate route parameter after logging in
 - issue #15670 Fix case where the data is truncated after changing a longtext column's collation
 - issue #18865 Fix missing text-nowrap for timestamps columns
+- issue #19022 Fix case where tables from wrong database is loaded in navigation tree
 
 5.2.1 (2023-02-07)
 - issue #17522 Fix case where the routes cache file is invalid

--- a/libraries/classes/Navigation/Nodes/Node.php
+++ b/libraries/classes/Navigation/Nodes/Node.php
@@ -178,13 +178,13 @@ class Node
     {
         if ($realName) {
             foreach ($this->children as $child) {
-                if ($child->realName == $name) {
+                if ($child->realName === $name) {
                     return $child;
                 }
             }
         } else {
             foreach ($this->children as $child) {
-                if ($child->name == $name && $child->isNew === false) {
+                if ($child->name === $name && $child->isNew === false) {
                     return $child;
                 }
             }

--- a/test/classes/Navigation/Nodes/NodeTest.php
+++ b/test/classes/Navigation/Nodes/NodeTest.php
@@ -76,6 +76,19 @@ class NodeTest extends AbstractTestCase
         );
     }
 
+    public function testGetChild(): void
+    {
+        $parent = NodeFactory::getInstance('Node', 'parent');
+        $childOne = NodeFactory::getInstance('Node', '0');
+        $childTwo = NodeFactory::getInstance('Node', '00');
+        $parent->addChild($childOne);
+        $parent->addChild($childTwo);
+        self::assertSame($childTwo, $parent->getChild('00'));
+        self::assertSame($childOne, $parent->getChild('0'));
+        self::assertSame($childTwo, $parent->getChild('00', true));
+        self::assertSame($childOne, $parent->getChild('0', true));
+    }
+
     /**
      * SetUp for hasChildren
      */


### PR DESCRIPTION
For example, when trying to open a navigation tree of a database named `00`, but a database named `0` already exists, the table list of `0` will be loaded instead of `00`.