### PR TITLE
Add ROCKSDB (tablesize) support

### DIFF
--- a/libraries/classes/Controllers/Database/StructureController.php
+++ b/libraries/classes/Controllers/Database/StructureController.php
@@ -720,6 +720,7 @@ class StructureController extends AbstractController
             case 'InnoDB':
             case 'PBMS':
             case 'TokuDB':
+            case 'ROCKSDB':
                 // InnoDB table: Row count is not accurate but data and index sizes are.
                 // PBMS table in Drizzle: TABLE_ROWS is taken from table cache,
                 // so it may be unavailable

--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -1470,6 +1470,7 @@ class Import
             'XTRADB',
             'SEQUENCE',
             'BDB',
+            'ROCKSDB',
         ];
 
         // Query to check if table is 'Transactional'.

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -2245,14 +2245,14 @@ class DbiDummy implements DbiExtension
             [
                 'query' => 'SELECT `ENGINE` FROM `information_schema`.`tables` WHERE `table_name` = "table_1"'
                     . ' AND `table_schema` = "PMA" AND UPPER(`engine`)'
-                    . ' IN ("INNODB", "FALCON", "NDB", "INFINIDB", "TOKUDB", "XTRADB", "SEQUENCE", "BDB")',
+                    . ' IN ("INNODB", "FALCON", "NDB", "INFINIDB", "TOKUDB", "XTRADB", "SEQUENCE", "BDB", "ROCKSDB")',
                 'columns' => ['ENGINE'],
                 'result' => [['INNODB']],
             ],
             [
                 'query' => 'SELECT `ENGINE` FROM `information_schema`.`tables` WHERE `table_name` = "table_2"'
                     . ' AND `table_schema` = "PMA" AND UPPER(`engine`)'
-                    . ' IN ("INNODB", "FALCON", "NDB", "INFINIDB", "TOKUDB", "XTRADB", "SEQUENCE", "BDB")',
+                    . ' IN ("INNODB", "FALCON", "NDB", "INFINIDB", "TOKUDB", "XTRADB", "SEQUENCE", "BDB", "ROCKSDB")',
                 'columns' => ['ENGINE'],
                 'result' => [['INNODB']],
             ],


### PR DESCRIPTION
### Description

This fixes the 'unknown' table filesizes in the main overview for ROCKSDB tables. 

Fixes #19023 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.

Not sure if this needs any tests. I tested the change on my own database, and filesizes are now shown properly.

Current:
<img width="508" alt="afbeelding" src="https://github.com/phpmyadmin/phpmyadmin/assets/668007/3e4a2ec3-3734-467a-9b58-d2260aef4f68">
With fix:
<img width="495" alt="main-rocksdb-fixed-filesize" src="https://github.com/phpmyadmin/phpmyadmin/assets/668007/07c178e8-cdc6-42f7-9e5a-c489bdbb4b20">

