### PR TITLE
Replace function casts with normal casts

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2627,7 +2627,7 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to int\\.$#"
-			count: 3
+			count: 4
 			path: src/Controllers/Import/ImportController.php
 
 		-
@@ -2687,11 +2687,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function mb_strlen expects string, mixed given\\.$#"
-			count: 1
-			path: src/Controllers/Import/ImportController.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/Import/ImportController.php
 
@@ -2856,7 +2851,7 @@ parameters:
 			path: src/Controllers/NavigationController.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: src/Controllers/Normalization/CreateNewColumnController.php
 
@@ -3861,7 +3856,7 @@ parameters:
 			path: src/Controllers/Setup/ValidateController.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function strval expects bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			message: "#^Cannot cast mixed to string\\.$#"
 			count: 2
 			path: src/Controllers/Sql/EnumValuesController.php
 
@@ -3871,7 +3866,7 @@ parameters:
 			path: src/Controllers/Sql/RelationalValuesController.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function strval expects bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			message: "#^Cannot cast mixed to string\\.$#"
 			count: 2
 			path: src/Controllers/Sql/RelationalValuesController.php
 
@@ -4221,18 +4216,13 @@ parameters:
 			path: src/Controllers/Table/CreateController.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
-			count: 1
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 5
 			path: src/Controllers/Table/CreateController.php
 
 		-
 			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
 			count: 1
-			path: src/Controllers/Table/CreateController.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
-			count: 5
 			path: src/Controllers/Table/CreateController.php
 
 		-
@@ -4971,6 +4961,11 @@ parameters:
 			path: src/Controllers/Table/SearchController.php
 
 		-
+			message: "#^Casting to int something that's already int\\<1, max\\>\\.$#"
+			count: 1
+			path: src/Controllers/Table/SearchController.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: src/Controllers/Table/SearchController.php
@@ -5581,7 +5576,17 @@ parameters:
 			path: src/Controllers/Table/ZoomSearchController.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Controllers/Table/ZoomSearchController.php
+
+		-
 			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: src/Controllers/Table/ZoomSearchController.php
+
+		-
+			message: "#^Casting to int something that's already int\\<1, max\\>\\.$#"
 			count: 1
 			path: src/Controllers/Table/ZoomSearchController.php
 
@@ -5652,11 +5657,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$type of method PhpMyAdmin\\\\Types\\:\\:getTypeOperatorsHtml\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Controllers/Table/ZoomSearchController.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/Table/ZoomSearchController.php
 
@@ -6381,6 +6381,11 @@ parameters:
 			path: src/Database/Events.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Database/Events.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 13
 			path: src/Database/Events.php
@@ -6417,11 +6422,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Database/Events.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Database/Events.php
 
@@ -7042,6 +7042,11 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to int\\.$#"
+			count: 6
+			path: src/Display/Results.php
+
+		-
+			message: "#^Casting to int something that's already int\\<1, max\\>\\.$#"
 			count: 1
 			path: src/Display/Results.php
 
@@ -7173,11 +7178,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 2
-			path: src/Display/Results.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
-			count: 5
 			path: src/Display/Results.php
 
 		-
@@ -9596,6 +9596,11 @@ parameters:
 			path: src/Normalization.php
 
 		-
+			message: "#^Casting to int something that's already int\\<1, max\\>\\.$#"
+			count: 1
+			path: src/Normalization.php
+
+		-
 			message: "#^Casting to string something that's already string\\.$#"
 			count: 1
 			path: src/Normalization.php
@@ -10141,6 +10146,11 @@ parameters:
 			path: src/Plugins/Auth/AuthenticationCookie.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Plugins/Auth/AuthenticationCookie.php
+
+		-
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 1
 			path: src/Plugins/Auth/AuthenticationCookie.php
@@ -10197,11 +10207,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
-			count: 1
-			path: src/Plugins/Auth/AuthenticationCookie.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Plugins/Auth/AuthenticationCookie.php
 
@@ -10316,7 +10321,17 @@ parameters:
 			path: src/Plugins/AuthenticationPlugin.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Plugins/AuthenticationPlugin.php
+
+		-
 			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: src/Plugins/AuthenticationPlugin.php
+
+		-
+			message: "#^Casting to int something that's already int\\<1, max\\>\\.$#"
 			count: 1
 			path: src/Plugins/AuthenticationPlugin.php
 
@@ -10327,11 +10342,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$url of method PhpMyAdmin\\\\ResponseRenderer\\:\\:redirect\\(\\) expects non\\-empty\\-string, string given\\.$#"
-			count: 1
-			path: src/Plugins/AuthenticationPlugin.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Plugins/AuthenticationPlugin.php
 
@@ -12311,7 +12321,7 @@ parameters:
 			path: src/Plugins/Transformations/Abs/ExternalTransformationsPlugin.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: src/Plugins/Transformations/Abs/HexTransformationsPlugin.php
 
@@ -12321,7 +12331,7 @@ parameters:
 			path: src/Plugins/Transformations/Abs/ImageLinkTransformationsPlugin.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			message: "#^Cannot cast mixed to int\\.$#"
 			count: 2
 			path: src/Plugins/Transformations/Abs/ImageUploadTransformationsPlugin.php
 
@@ -13501,6 +13511,16 @@ parameters:
 			path: src/Server/Status/Processes.php
 
 		-
+			message: "#^Method PhpMyAdmin\\\\Server\\\\SysInfo\\\\Linux\\:\\:memory\\(\\) should return array\\<string, int\\> but returns array\\<int\\>\\.$#"
+			count: 1
+			path: src/Server/SysInfo/Linux.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(mixed\\)\\: mixed\\)\\|null, Closure\\(array\\|bool\\|float\\|int\\|resource\\|string\\|null, int\\=\\)\\: int given\\.$#"
+			count: 1
+			path: src/Server/SysInfo/Linux.php
+
+		-
 			message: "#^Parameter \\#1 \\$keys of function array_combine expects array\\<int\\|string\\>, mixed given\\.$#"
 			count: 1
 			path: src/Server/SysInfo/Linux.php
@@ -13973,6 +13993,11 @@ parameters:
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 2
+			path: src/Table/ColumnsDefinition.php
+
+		-
+			message: "#^Casting to int something that's already int\\<1, max\\>\\.$#"
+			count: 1
 			path: src/Table/ColumnsDefinition.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2924,20 +2924,12 @@
     </UnusedParam>
   </file>
   <file src="src/Controllers/Sql/EnumValuesController.php">
-    <MixedArgument>
-      <code><![CDATA[$column]]></code>
-      <code><![CDATA[$currValue]]></code>
-    </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$column]]></code>
       <code><![CDATA[$currValue]]></code>
     </MixedAssignment>
   </file>
   <file src="src/Controllers/Sql/RelationalValuesController.php">
-    <MixedArgument>
-      <code><![CDATA[$column]]></code>
-      <code><![CDATA[$currValue]]></code>
-    </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$_SESSION['tmpval']['relational_display']]]></code>
     </MixedArrayAccess>
@@ -3653,6 +3645,9 @@
     <PossiblyUnusedMethod>
       <code><![CDATA[getColumnProperties]]></code>
     </PossiblyUnusedMethod>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(int) $config->settings['MaxRows']]]></code>
+    </RedundantCastGivenDocblockType>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$searchColumnInForeigners]]></code>
       <code><![CDATA[empty($row->collation)]]></code>
@@ -4032,6 +4027,12 @@
       <code><![CDATA[$_POST['maxPlotLimit']]]></code>
       <code><![CDATA[$_POST['where_clause']]]></code>
     </PossiblyInvalidOperand>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(int) $config->settings['maxRowPlotLimit']]]></code>
+    </RedundantCastGivenDocblockType>
+    <RiskyCast>
+      <code><![CDATA[$_POST['maxPlotLimit']]]></code>
+    </RiskyCast>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$searchColumnInForeigners]]></code>
       <code><![CDATA[empty($_POST['maxPlotLimit'])]]></code>
@@ -4642,6 +4643,9 @@
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$GLOBALS['errors']]]></code>
     </PossiblyUndefinedArrayOffset>
+    <RiskyCast>
+      <code><![CDATA[$_POST['item_interval_value']]]></code>
+    </RiskyCast>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($_POST['editor_process_edit'])]]></code>
       <code><![CDATA[empty($_POST['item_comment'])]]></code>
@@ -5350,6 +5354,9 @@
       <code><![CDATA[$o->expr->expr]]></code>
       <code><![CDATA[$order->expr->column]]></code>
     </PossiblyNullPropertyFetch>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(int) $this->config->settings['MaxRows']]]></code>
+    </RedundantCastGivenDocblockType>
     <RedundantCondition>
       <code><![CDATA[! empty($added[$orgFullTableName])]]></code>
       <code><![CDATA[empty($statementInfo->statement->from)]]></code>
@@ -7098,6 +7105,9 @@
     <RedundantCast>
       <code><![CDATA[(string) $dependon]]></code>
     </RedundantCast>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(int) $this->config->settings['MaxRows']]]></code>
+    </RedundantCastGivenDocblockType>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$dropCols]]></code>
     </RiskyTruthyFalsyComparison>
@@ -7554,6 +7564,9 @@
     <RedundantCast>
       <code><![CDATA[(string) $GLOBALS['conn_error']]]></code>
     </RedundantCast>
+    <RiskyCast>
+      <code><![CDATA[$_GET['session_expired']]]></code>
+    </RiskyCast>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($GLOBALS['conn_error'])]]></code>
       <code><![CDATA[empty($_POST[$config->settings['CaptchaResponseParam']])]]></code>
@@ -7640,6 +7653,12 @@
     <PossiblyInvalidCast>
       <code><![CDATA[$_REQUEST['guid']]]></code>
     </PossiblyInvalidCast>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(int) Config::getInstance()->settings['LoginCookieValidity']]]></code>
+    </RedundantCastGivenDocblockType>
+    <RiskyCast>
+      <code><![CDATA[$_REQUEST['access_time']]]></code>
+    </RiskyCast>
   </file>
   <file src="src/Plugins/AuthenticationPluginFactory.php">
     <DeprecatedMethod>
@@ -10987,6 +11006,9 @@
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$columnMeta['DefaultValue']]]></code>
     </PossiblyUndefinedArrayOffset>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(int) $config->settings['MaxRows']]]></code>
+    </RedundantCastGivenDocblockType>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[! $columnMeta['column_status']['isEditable']]]></code>
       <code><![CDATA[! $columnMeta['column_status']['isEditable']]]></code>

--- a/src/Command/FixPoTwigCommand.php
+++ b/src/Command/FixPoTwigCommand.php
@@ -11,7 +11,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function file_get_contents;
 use function file_put_contents;
-use function intval;
 use function is_array;
 use function json_decode;
 use function preg_replace_callback;
@@ -55,7 +54,7 @@ final class FixPoTwigCommand extends Command
             '@(twig-templates[0-9a-f/]*.php):([0-9]*)@',
             static function (array $matches) use ($replacements): string {
                 $filename = $matches[1];
-                $line = intval($matches[2]);
+                $line = (int) $matches[2];
                 $replace = $replacements[$filename];
                 foreach ($replace[1] as $cacheLine => $result) {
                     if ($line >= $cacheLine) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -31,7 +31,6 @@ use function function_exists;
 use function gd_info;
 use function implode;
 use function ini_get;
-use function intval;
 use function is_array;
 use function is_bool;
 use function is_dir;
@@ -228,7 +227,7 @@ class Config
             $this->set('PMA_USR_BROWSER_VER', $logVersion[2]);
             $this->set('PMA_USR_BROWSER_AGENT', 'IE');
         } elseif (preg_match('@Trident/(7)\.0@', $httpUserAgent, $logVersion)) {
-            $this->set('PMA_USR_BROWSER_VER', intval($logVersion[1]) + 4);
+            $this->set('PMA_USR_BROWSER_VER', (int) $logVersion[1] + 4);
             $this->set('PMA_USR_BROWSER_AGENT', 'IE');
         } elseif (preg_match('@OmniWeb/([0-9]{1,3})@', $httpUserAgent, $logVersion)) {
             $this->set('PMA_USR_BROWSER_VER', $logVersion[1]);

--- a/src/Config/Validator.php
+++ b/src/Config/Validator.php
@@ -23,7 +23,6 @@ use function error_get_last;
 use function explode;
 use function filter_var;
 use function htmlspecialchars;
-use function intval;
 use function is_array;
 use function is_object;
 use function mb_strpos;
@@ -491,7 +490,7 @@ class Validator
         $value = Util::requestString($values[$path]);
 
         if (
-            intval($value) != $value
+            (int) $value != $value
             || (! $allowNegative && $value < 0)
             || (! $allowZero && $value == 0)
             || $value > $maxValue

--- a/src/Controllers/Database/ImportController.php
+++ b/src/Controllers/Database/ImportController.php
@@ -26,7 +26,6 @@ use PhpMyAdmin\Util;
 use PhpMyAdmin\Utils\ForeignKey;
 
 use function __;
-use function intval;
 use function is_numeric;
 
 final class ImportController extends AbstractController
@@ -88,7 +87,7 @@ final class ImportController extends AbstractController
 
         $offset = null;
         if (isset($_REQUEST['offset']) && is_numeric($_REQUEST['offset'])) {
-            $offset = intval($_REQUEST['offset']);
+            $offset = (int) $_REQUEST['offset'];
         }
 
         $timeoutPassed = $_REQUEST['timeout_passed'] ?? null;

--- a/src/Controllers/Import/ImportController.php
+++ b/src/Controllers/Import/ImportController.php
@@ -36,7 +36,6 @@ use function in_array;
 use function ini_get;
 use function ini_parse_quantity;
 use function ini_set;
-use function intval;
 use function is_array;
 use function is_link;
 use function is_numeric;
@@ -475,7 +474,7 @@ final class ImportController extends AbstractController
 
         // Something to skip? (because timeout has passed)
         if (! $GLOBALS['error'] && $request->hasBodyParam('skip')) {
-            $originalSkip = $skip = intval($request->getParsedBodyParam('skip'));
+            $originalSkip = $skip = (int) $request->getParsedBodyParam('skip');
             while ($skip > 0 && ! ImportSettings::$finished) {
                 $this->import->getNextChunk(
                     $importHandle ?? null,

--- a/src/Controllers/Normalization/CreateNewColumnController.php
+++ b/src/Controllers/Normalization/CreateNewColumnController.php
@@ -13,7 +13,6 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\UserPrivilegesFactory;
 
-use function intval;
 use function min;
 
 final class CreateNewColumnController extends AbstractController
@@ -31,7 +30,7 @@ final class CreateNewColumnController extends AbstractController
     {
         $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
-        $numFields = min(4096, intval($request->getParsedBodyParam('numFields')));
+        $numFields = min(4096, (int) $request->getParsedBodyParam('numFields'));
         $html = $this->normalization->getHtmlForCreateNewColumn(
             $userPrivileges,
             $numFields,

--- a/src/Controllers/Server/ImportController.php
+++ b/src/Controllers/Server/ImportController.php
@@ -24,7 +24,6 @@ use PhpMyAdmin\Util;
 use PhpMyAdmin\Utils\ForeignKey;
 
 use function __;
-use function intval;
 use function is_numeric;
 
 final class ImportController extends AbstractController
@@ -68,7 +67,7 @@ final class ImportController extends AbstractController
 
         $offset = null;
         if (isset($_REQUEST['offset']) && is_numeric($_REQUEST['offset'])) {
-            $offset = intval($_REQUEST['offset']);
+            $offset = (int) $_REQUEST['offset'];
         }
 
         $timeoutPassed = $_REQUEST['timeout_passed'] ?? null;

--- a/src/Controllers/Sql/EnumValuesController.php
+++ b/src/Controllers/Sql/EnumValuesController.php
@@ -12,7 +12,6 @@ use PhpMyAdmin\Sql;
 use PhpMyAdmin\Template;
 
 use function __;
-use function strval;
 
 final class EnumValuesController extends AbstractController
 {
@@ -31,7 +30,7 @@ final class EnumValuesController extends AbstractController
     {
         $column = $request->getParsedBodyParam('column');
         $currValue = $request->getParsedBodyParam('curr_value');
-        $values = $this->sql->getValuesForColumn(Current::$database, Current::$table, strval($column));
+        $values = $this->sql->getValuesForColumn(Current::$database, Current::$table, (string) $column);
 
         if ($values === null) {
             $this->response->addJSON('message', __('Error in processing request'));
@@ -42,7 +41,7 @@ final class EnumValuesController extends AbstractController
 
         $dropdown = $this->template->render('sql/enum_column_dropdown', [
             'values' => $values,
-            'selected_values' => [strval($currValue)],
+            'selected_values' => [(string) $currValue],
         ]);
 
         $this->response->addJSON('dropdown', $dropdown);

--- a/src/Controllers/Sql/RelationalValuesController.php
+++ b/src/Controllers/Sql/RelationalValuesController.php
@@ -11,8 +11,6 @@ use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Sql;
 use PhpMyAdmin\Template;
 
-use function strval;
-
 final class RelationalValuesController extends AbstractController
 {
     public function __construct(
@@ -42,8 +40,8 @@ final class RelationalValuesController extends AbstractController
         $dropdown = $this->sql->getHtmlForRelationalColumnDropdown(
             Current::$database,
             Current::$table,
-            strval($column),
-            strval($currValue),
+            (string) $column,
+            (string) $currValue,
         );
         $this->response->addJSON('dropdown', $dropdown);
     }

--- a/src/Controllers/Table/CreateController.php
+++ b/src/Controllers/Table/CreateController.php
@@ -21,7 +21,6 @@ use PhpMyAdmin\UserPrivilegesFactory;
 
 use function __;
 use function htmlspecialchars;
-use function intval;
 use function is_array;
 use function mb_strtolower;
 use function min;
@@ -112,7 +111,7 @@ class CreateController extends AbstractController
             // Executes the query
             $result = $this->dbi->tryQuery($GLOBALS['sql_query']);
 
-            if ($result) {
+            if ($result !== false) {
                 // Update comment table for mime types [MIME]
                 if (isset($_POST['field_mimetype']) && is_array($_POST['field_mimetype']) && $cfg['BrowseMIME']) {
                     foreach ($_POST['field_mimetype'] as $fieldindex => $mimetype) {
@@ -166,11 +165,11 @@ class CreateController extends AbstractController
         $numFields = $request->getParsedBodyParam('num_fields');
 
         if ($request->hasBodyParam('submit_num_fields')) { // adding new fields
-            $numberOfFields = intval($origNumFields) + intval($request->getParsedBodyParam('added_fields'));
+            $numberOfFields = (int) $origNumFields + (int) $request->getParsedBodyParam('added_fields');
         } elseif ($origNumFields !== null) { // retaining existing fields
-            $numberOfFields = intval($origNumFields);
-        } elseif ($numFields !== null && intval($numFields) > 0) { // new table with specified number of fields
-            $numberOfFields = intval($numFields);
+            $numberOfFields = (int) $origNumFields;
+        } elseif ($numFields !== null && (int) $numFields > 0) { // new table with specified number of fields
+            $numberOfFields = (int) $numFields;
         } else { // new table with unspecified number of fields
             $numberOfFields = 4;
         }

--- a/src/Controllers/Table/ImportController.php
+++ b/src/Controllers/Table/ImportController.php
@@ -27,7 +27,6 @@ use PhpMyAdmin\Util;
 use PhpMyAdmin\Utils\ForeignKey;
 
 use function __;
-use function intval;
 use function is_numeric;
 
 final class ImportController extends AbstractController
@@ -108,7 +107,7 @@ final class ImportController extends AbstractController
 
         $offset = null;
         if (isset($_REQUEST['offset']) && is_numeric($_REQUEST['offset'])) {
-            $offset = intval($_REQUEST['offset']);
+            $offset = (int) $_REQUEST['offset'];
         }
 
         $timeoutPassed = $_REQUEST['timeout_passed'] ?? null;

--- a/src/Controllers/Table/SearchController.php
+++ b/src/Controllers/Table/SearchController.php
@@ -29,7 +29,6 @@ use PhpMyAdmin\Utils\Gis;
 
 use function __;
 use function in_array;
-use function intval;
 use function is_array;
 use function mb_strtolower;
 use function md5;
@@ -315,7 +314,7 @@ class SearchController extends AbstractController
             'column_types' => $this->columnTypes,
             'column_collations' => $this->columnCollations,
             'default_sliders_state' => $config->settings['InitialSlidersState'],
-            'max_rows' => intval($config->settings['MaxRows']),
+            'max_rows' => (int) $config->settings['MaxRows'],
         ]);
     }
 

--- a/src/Controllers/Table/ZoomSearchController.php
+++ b/src/Controllers/Table/ZoomSearchController.php
@@ -28,7 +28,6 @@ use function array_search;
 use function array_values;
 use function htmlspecialchars;
 use function in_array;
-use function intval;
 use function is_array;
 use function is_numeric;
 use function json_encode;
@@ -278,8 +277,8 @@ class ZoomSearchController extends AbstractController
             'criteria_column_names' => $criteriaColumnNames,
             'criteria_column_types' => $_POST['criteriaColumnTypes'] ?? null,
             'max_plot_limit' => ! empty($_POST['maxPlotLimit'])
-                ? intval($_POST['maxPlotLimit'])
-                : intval($config->settings['maxRowPlotLimit']),
+                ? (int) $_POST['maxPlotLimit']
+                : (int) $config->settings['maxRowPlotLimit'],
         ]);
     }
 
@@ -331,7 +330,7 @@ class ZoomSearchController extends AbstractController
 
         $key = array_search($field, $this->columnNames);
         $searchIndex = isset($_POST['it']) && is_numeric($_POST['it'])
-            ? intval($_POST['it']) : 0;
+            ? (int) $_POST['it'] : 0;
 
         $properties = $this->getColumnProperties($searchIndex, $key);
         $this->response->addJSON(

--- a/src/Controllers/Transformation/WrapperController.php
+++ b/src/Controllers/Transformation/WrapperController.php
@@ -22,7 +22,6 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function htmlspecialchars;
-use function intval;
 use function is_numeric;
 use function is_string;
 use function round;
@@ -164,11 +163,11 @@ class WrapperController extends AbstractController
          * stays smaller than the new width and new height
          */
         if ($ratioWidth < $ratioHeight) {
-            $destWidth = intval(round($srcWidth / $ratioHeight));
+            $destWidth = (int) round($srcWidth / $ratioHeight);
             $destHeight = $newHeight;
         } else {
             $destWidth = $newWidth;
-            $destHeight = intval(round($srcHeight / $ratioWidth));
+            $destHeight = (int) round($srcHeight / $ratioWidth);
         }
 
         $destImage = ImageWrapper::create($destWidth, $destHeight);

--- a/src/Core.php
+++ b/src/Core.php
@@ -26,7 +26,6 @@ use function header_remove;
 use function htmlspecialchars;
 use function http_build_query;
 use function in_array;
-use function intval;
 use function is_array;
 use function is_scalar;
 use function is_string;
@@ -656,7 +655,7 @@ class Core
                 case 's':
                     /* string */
                     // parse sting length
-                    $strlen = intval(substr($data, $i + 2));
+                    $strlen = (int) substr($data, $i + 2);
                     // string start
                     $i = strpos($data, ':', $i + 2);
                     if ($i === false) {

--- a/src/Database/Designer/Common.php
+++ b/src/Database/Designer/Common.php
@@ -21,7 +21,6 @@ use function array_keys;
 use function count;
 use function explode;
 use function in_array;
-use function intval;
 use function is_array;
 use function is_string;
 use function json_decode;
@@ -319,7 +318,7 @@ class Common
 
         $defaultPageNo = $this->dbi->fetchValue($query, 0, ConnectionType::ControlUser);
 
-        return is_string($defaultPageNo) ? intval($defaultPageNo) : -1;
+        return is_string($defaultPageNo) ? (int) $defaultPageNo : -1;
     }
 
     /**
@@ -371,7 +370,7 @@ class Common
 
         $minPageNo = $this->dbi->fetchValue($query, 0, ConnectionType::ControlUser);
 
-        return is_string($minPageNo) ? intval($minPageNo) : -1;
+        return is_string($minPageNo) ? (int) $minPageNo : -1;
     }
 
     /**

--- a/src/Database/Events.php
+++ b/src/Database/Events.php
@@ -18,7 +18,6 @@ use function array_multisort;
 use function explode;
 use function htmlspecialchars;
 use function in_array;
-use function intval;
 use function is_string;
 use function sprintf;
 use function str_contains;
@@ -285,7 +284,7 @@ class Events
                     && ! empty($_POST['item_interval_field'])
                     && in_array($_POST['item_interval_field'], $this->interval, true)
                 ) {
-                    $query .= 'EVERY ' . intval($_POST['item_interval_value']) . ' ';
+                    $query .= 'EVERY ' . (int) $_POST['item_interval_value'] . ' ';
                     $query .= $_POST['item_interval_field'] . ' ';
                 } else {
                     $GLOBALS['errors'][] = __('You must provide a valid interval value for the event.');

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -52,7 +52,6 @@ use function floor;
 use function htmlspecialchars;
 use function implode;
 use function in_array;
-use function intval;
 use function is_array;
 use function is_int;
 use function is_numeric;
@@ -641,15 +640,15 @@ class Results
 
         $isLastPage = $this->unlimNumRows !== -1 && $this->unlimNumRows !== false
             && ($isShowingAll
-                || intval($_SESSION['tmpval']['pos']) + intval($_SESSION['tmpval']['max_rows'])
+                || (int) $_SESSION['tmpval']['pos'] + (int) $_SESSION['tmpval']['max_rows']
                 >= $this->unlimNumRows
                 || $this->numRows < $_SESSION['tmpval']['max_rows']);
 
         $onsubmit = ' onsubmit="return '
-            . (intval($_SESSION['tmpval']['pos'])
-            + intval($_SESSION['tmpval']['max_rows'])
+            . ((int) $_SESSION['tmpval']['pos']
+            + (int) $_SESSION['tmpval']['max_rows']
             < $this->unlimNumRows
-            && $this->numRows >= intval($_SESSION['tmpval']['max_rows'])
+            && $this->numRows >= (int) $_SESSION['tmpval']['max_rows']
                 ? 'true'
                 : 'false') . ';"';
 
@@ -657,7 +656,7 @@ class Results
         if (is_numeric($_SESSION['tmpval']['max_rows'])) {
             $posLast = @((int) ceil(
                 (int) $this->unlimNumRows / $_SESSION['tmpval']['max_rows'],
-            ) - 1) * intval($_SESSION['tmpval']['max_rows']);
+            ) - 1) * (int) $_SESSION['tmpval']['max_rows'];
         }
 
         $hiddenFields = [
@@ -2997,7 +2996,7 @@ class Results
             $query['max_rows'] = self::ALL_ROWS;
             unset($_GET['session_max_rows'], $_POST['session_max_rows']);
         } elseif (empty($query['max_rows'])) {
-            $query['max_rows'] = intval($this->config->settings['MaxRows']);
+            $query['max_rows'] = (int) $this->config->settings['MaxRows'];
         }
 
         if (isset($_REQUEST['pos']) && is_numeric($_REQUEST['pos'])) {

--- a/src/Normalization.php
+++ b/src/Normalization.php
@@ -18,7 +18,6 @@ use function explode;
 use function htmlspecialchars;
 use function implode;
 use function in_array;
-use function intval;
 use function is_array;
 use function json_encode;
 use function mb_strtoupper;
@@ -175,7 +174,7 @@ class Normalization
                 $this->dbi->getVersion(),
             ),
             'server_version' => $this->dbi->getVersion(),
-            'max_rows' => intval($this->config->settings['MaxRows']),
+            'max_rows' => (int) $this->config->settings['MaxRows'],
             'char_editing' => $this->config->settings['CharEditing'],
             'attribute_types' => $this->dbi->types->getAttributes(),
             'privs_available' => $userPrivileges->column && $userPrivileges->isReload,

--- a/src/Plugins/Auth/AuthenticationCookie.php
+++ b/src/Plugins/Auth/AuthenticationCookie.php
@@ -34,7 +34,6 @@ use function explode;
 use function function_exists;
 use function in_array;
 use function ini_get;
-use function intval;
 use function is_array;
 use function is_string;
 use function json_decode;
@@ -118,7 +117,7 @@ class AuthenticationCookie extends AuthenticationPlugin
         // Show error message
         if (! empty($GLOBALS['conn_error'])) {
             $errorMessages = Message::rawError((string) $GLOBALS['conn_error'])->getDisplay();
-        } elseif (isset($_GET['session_expired']) && intval($_GET['session_expired']) == 1) {
+        } elseif (isset($_GET['session_expired']) && (int) $_GET['session_expired'] == 1) {
             $errorMessages = Message::rawError(
                 __('Your session has expired. Please log in again.'),
             )->getDisplay();

--- a/src/Plugins/AuthenticationPlugin.php
+++ b/src/Plugins/AuthenticationPlugin.php
@@ -27,7 +27,6 @@ use function __;
 use function array_keys;
 use function defined;
 use function htmlspecialchars;
-use function intval;
 use function max;
 use function min;
 use function session_destroy;
@@ -175,7 +174,7 @@ abstract class AuthenticationPlugin
             return sprintf(
                 __('You have been automatically logged out due to inactivity of %s seconds.'
                 . ' Once you log in again, you should be able to resume the work where you left off.'),
-                intval(Config::getInstance()->settings['LoginCookieValidity']),
+                (int) Config::getInstance()->settings['LoginCookieValidity'],
             );
         }
 
@@ -222,7 +221,7 @@ abstract class AuthenticationPlugin
             // Negative values can cause session expiry extension
             // Too big values can cause overflow and lead to same
             $time = time() - min(
-                max(0, intval($_REQUEST['access_time'])),
+                max(0, (int) $_REQUEST['access_time']),
                 Config::getInstance()->settings['LoginCookieValidity'] + 1,
             );
         } else {

--- a/src/Plugins/Export/ExportSql.php
+++ b/src/Plugins/Export/ExportSql.php
@@ -43,7 +43,6 @@ use function defined;
 use function explode;
 use function implode;
 use function in_array;
-use function intval;
 use function is_array;
 use function mb_strlen;
 use function mb_strpos;
@@ -1109,7 +1108,7 @@ class ExportSql extends ExportPlugin
                         . Util::backquote($relationParameters->pdfFeature->database)
                         . '.' . Util::backquote($relationParameters->pdfFeature->pdfPages)
                         . ' WHERE `db_name` = ' . $dbi->quoteString($db)
-                        . ' AND `page_nr` = ' . intval($page);
+                        . ' AND `page_nr` = ' . (int) $page;
 
                     if (
                         ! $this->exportData(

--- a/src/Plugins/Schema/Pdf/PdfRelationSchema.php
+++ b/src/Plugins/Schema/Pdf/PdfRelationSchema.php
@@ -19,7 +19,6 @@ use function __;
 use function ceil;
 use function getcwd;
 use function in_array;
-use function intval;
 use function max;
 use function min;
 use function rsort;
@@ -391,7 +390,7 @@ class PdfRelationSchema extends ExportRelationSchema
         // Draws horizontal lines
         $innerHeight = $this->pdf->getPageHeight() - $topSpace - $bottomSpace;
         /** @infection-ignore-all */
-        for ($l = 0, $size = intval($innerHeight / $gridSize); $l <= $size; $l++) {
+        for ($l = 0, $size = (int) ($innerHeight / $gridSize); $l <= $size; $l++) {
             $this->pdf->line(
                 0,
                 $l * $gridSize + $topSpace,
@@ -399,7 +398,7 @@ class PdfRelationSchema extends ExportRelationSchema
                 $l * $gridSize + $topSpace,
             );
             // Avoid duplicates
-            if ($l <= 0 || $l > intval(($innerHeight - $labelHeight) / $gridSize)) {
+            if ($l <= 0 || $l > (int) (($innerHeight - $labelHeight) / $gridSize)) {
                 continue;
             }
 
@@ -410,7 +409,7 @@ class PdfRelationSchema extends ExportRelationSchema
 
         // Draws vertical lines
         /** @infection-ignore-all */
-        for ($j = 0, $size = intval($this->pdf->getPageWidth() / $gridSize); $j <= $size; $j++) {
+        for ($j = 0, $size = (int) ($this->pdf->getPageWidth() / $gridSize); $j <= $size; $j++) {
             $this->pdf->line(
                 $j * $gridSize,
                 $topSpace,

--- a/src/Plugins/Transformations/Abs/HexTransformationsPlugin.php
+++ b/src/Plugins/Transformations/Abs/HexTransformationsPlugin.php
@@ -14,7 +14,6 @@ use PhpMyAdmin\Plugins\TransformationsPlugin;
 use function __;
 use function bin2hex;
 use function chunk_split;
-use function intval;
 
 /**
  * Provides common methods for all of the hex transformations plugins.
@@ -45,7 +44,7 @@ abstract class HexTransformationsPlugin extends TransformationsPlugin
         // possibly use a global transform and feed it with special options
         $cfg = Config::getInstance()->settings;
         $options = $this->getOptions($options, $cfg['DefaultTransformations']['Hex']);
-        $options[0] = intval($options[0]);
+        $options[0] = (int) $options[0];
 
         if ($options[0] < 1) {
             return bin2hex($buffer);

--- a/src/Plugins/Transformations/Abs/ImageUploadTransformationsPlugin.php
+++ b/src/Plugins/Transformations/Abs/ImageUploadTransformationsPlugin.php
@@ -13,7 +13,6 @@ use PhpMyAdmin\Url;
 
 use function __;
 use function bin2hex;
-use function intval;
 
 /**
  * Provides common methods for all of the image upload transformations plugins.
@@ -74,8 +73,8 @@ abstract class ImageUploadTransformationsPlugin extends IOTransformationsPlugin
         }
 
         $html .= '<img src="' . $src . '" width="'
-            . (isset($options[0]) ? intval($options[0]) : '100') . '" height="'
-            . (isset($options[1]) ? intval($options[1]) : '100') . '" alt="'
+            . (isset($options[0]) ? (int) $options[0] : '100') . '" height="'
+            . (isset($options[1]) ? (int) $options[1] : '100') . '" alt="'
             . __('Image preview here') . '">';
         $html .= '<br><input type="file" name="fields_upload'
             . $columnNameAppendix . '" accept="image/*" class="image-upload">';

--- a/src/Query/Utilities.php
+++ b/src/Query/Utilities.php
@@ -15,7 +15,6 @@ use function debug_backtrace;
 use function explode;
 use function htmlspecialchars;
 use function htmlspecialchars_decode;
-use function intval;
 use function md5;
 use function sprintf;
 use function str_contains;
@@ -157,7 +156,7 @@ class Utilities
     {
         $match = explode('.', $version);
 
-        return (int) sprintf('%d%02d%02d', $match[0], $match[1], intval($match[2]));
+        return (int) sprintf('%d%02d%02d', $match[0], $match[1], (int) $match[2]);
     }
 
     /**

--- a/src/Server/SysInfo/Linux.php
+++ b/src/Server/SysInfo/Linux.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Server\SysInfo;
 
 use function array_combine;
+use function array_map;
 use function array_merge;
 use function file_get_contents;
 use function intval;
@@ -75,11 +76,7 @@ class Linux extends Base
 
         preg_match_all(SysInfo::MEMORY_REGEXP, $content, $matches);
 
-        /** @var array<string, int>|false $mem */
         $mem = array_combine($matches[1], $matches[2]);
-        if ($mem === false) {
-            return [];
-        }
 
         $defaults = [
             'MemTotal' => 0,
@@ -93,9 +90,7 @@ class Linux extends Base
 
         $mem = array_merge($defaults, $mem);
 
-        foreach ($mem as $idx => $value) {
-            $mem[$idx] = intval($value);
-        }
+        $mem = array_map(intval(...), $mem);
 
         $mem['MemUsed'] = $mem['MemTotal'] - $mem['MemFree'] - $mem['Cached'] - $mem['Buffers'];
         $mem['SwapUsed'] = $mem['SwapTotal'] - $mem['SwapFree'] - $mem['SwapCached'];

--- a/src/Server/SysInfo/WindowsNt.php
+++ b/src/Server/SysInfo/WindowsNt.php
@@ -10,7 +10,6 @@ use Throwable;
 use function array_merge;
 use function class_exists;
 use function intdiv;
-use function intval;
 
 /**
  * Windows NT based SysInfo class
@@ -131,9 +130,9 @@ class WindowsNt extends Base
         $peak = 0;
         foreach ($instances as $instance) {
             // phpcs:disable Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-            $total += intval($instance->AllocatedBaseSize) * 1024; /* @phpstan-ignore-line */
-            $used += intval($instance->CurrentUsage) * 1024; /* @phpstan-ignore-line */
-            $peak += intval($instance->PeakUsage) * 1024; /* @phpstan-ignore-line */
+            $total += (int) $instance->AllocatedBaseSize * 1024; /* @phpstan-ignore-line */
+            $used += (int) $instance->CurrentUsage * 1024; /* @phpstan-ignore-line */
+            $peak += (int) $instance->PeakUsage * 1024; /* @phpstan-ignore-line */
             // phpcs:enable
         }
 

--- a/src/Table/ColumnsDefinition.php
+++ b/src/Table/ColumnsDefinition.php
@@ -23,7 +23,6 @@ use function bin2hex;
 use function count;
 use function explode;
 use function in_array;
-use function intval;
 use function is_array;
 use function mb_strtoupper;
 use function preg_quote;
@@ -354,7 +353,7 @@ final class ColumnsDefinition
                 $this->dbi->getVersion(),
             ),
             'server_version' => $this->dbi->getVersion(),
-            'max_rows' => intval($config->settings['MaxRows']),
+            'max_rows' => (int) $config->settings['MaxRows'],
             'char_editing' => $config->settings['CharEditing'] ?? null,
             'attribute_types' => $this->dbi->types->getAttributes(),
             'privs_available' => $userPrivileges->column && $userPrivileges->isReload,

--- a/src/Tracking/Tracker.php
+++ b/src/Tracking/Tracker.php
@@ -26,7 +26,6 @@ use PhpMyAdmin\SqlParser\Statements\TruncateStatement;
 use PhpMyAdmin\SqlParser\Statements\UpdateStatement;
 use PhpMyAdmin\Util;
 
-use function intval;
 use function preg_quote;
 use function preg_replace;
 use function serialize;
@@ -395,7 +394,7 @@ class Tracker
 
         $row = $result->fetchRow();
 
-        return intval($row[0] ?? -1);
+        return (int) ($row[0] ?? -1);
     }
 
     /**

--- a/src/Util.php
+++ b/src/Util.php
@@ -28,7 +28,6 @@ use function decbin;
 use function explode;
 use function extension_loaded;
 use function fclose;
-use function floatval;
 use function floor;
 use function fread;
 use function function_exists;
@@ -388,7 +387,7 @@ class Util
                 /* l10n: Thousands separator */
                 __(','),
             );
-            if ($originalValue != 0 && floatval($value) == 0) {
+            if ($originalValue != 0 && (float) $value == 0) {
                 return ' <' . (1 / 10 ** $digitsRight);
             }
 
@@ -453,7 +452,7 @@ class Util
             $formattedValue = preg_replace('/' . preg_quote($decimalSep, '/') . '?0+$/', '', $formattedValue);
         }
 
-        if ($originalValue != 0 && floatval($value) == 0) {
+        if ($originalValue != 0 && $value == 0) {
             return ' <' . number_format(1 / 10 ** $digitsRight, $digitsRight, $decimalSep, $thousandsSep) . ' ' . $unit;
         }
 

--- a/src/Utils/HttpRequest.php
+++ b/src/Utils/HttpRequest.php
@@ -16,7 +16,6 @@ use function file_get_contents;
 use function function_exists;
 use function getenv;
 use function ini_get;
-use function intval;
 use function is_array;
 use function is_dir;
 use function parse_url;
@@ -255,7 +254,7 @@ class HttpRequest
         }
 
         preg_match('#HTTP/[0-9\.]+\s+([0-9]+)#', $http_response_header[0], $out);
-        $httpStatus = intval($out[1]);
+        $httpStatus = (int) $out[1];
 
         return $this->response($response, $httpStatus, $returnOnlyStatus);
     }

--- a/src/VersionInformation.php
+++ b/src/VersionInformation.php
@@ -11,7 +11,6 @@ use PhpMyAdmin\Utils\HttpRequest;
 
 use function count;
 use function explode;
-use function intval;
 use function is_array;
 use function is_numeric;
 use function is_string;
@@ -117,7 +116,7 @@ class VersionInformation
             $matches = [];
             if (preg_match('/^(\D+)(\d+)$/', $suffix, $matches)) {
                 $suffix = $matches[1];
-                $result += intval($matches[2]);
+                $result += (int) $matches[2];
             }
 
             switch ($suffix) {


### PR DESCRIPTION
Function casts such as `intval` are designed to be used only with higher-order functions. They are slower and static analysis tools don't parse them as well. Let's replace them with normal casts.