### PR TITLE
Fix #18593 - drop db line included in server export if exporting only data

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -69,6 +69,7 @@ phpMyAdmin - ChangeLog
 - issue #15670 Fix case where the data is truncated after changing a longtext column's collation
 - issue #18865 Fix missing text-nowrap for timestamps columns
 - issue #19022 Fix case where tables from wrong database is loaded in navigation tree
+- issue #18593 Fix drop db line included in server export if exporting only data
 
 5.2.1 (2023-02-07)
 - issue #17522 Fix case where the routes cache file is invalid

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -855,7 +855,9 @@ class ExportSql extends ExportPlugin
             $compat = 'NONE';
         }
 
-        if (isset($GLOBALS['sql_drop_database'])) {
+        $exportStructure = ! isset($GLOBALS['sql_structure_or_data'])
+            || in_array($GLOBALS['sql_structure_or_data'], ['structure', 'structure_and_data'], true);
+        if ($exportStructure && isset($GLOBALS['sql_drop_database'])) {
             if (
                 ! $this->export->outputHandler(
                     'DROP DATABASE IF EXISTS '

--- a/po/mk.po
+++ b/po/mk.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: phpMyAdmin 5.2.2-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
 "POT-Creation-Date: 2023-11-12 15:23-0300\n"
-"PO-Revision-Date: 2024-02-24 02:49+0000\n"
+"PO-Revision-Date: 2024-03-06 04:39+0000\n"
 "Last-Translator: \"Kristijan \\\"Fremen\\\" Velkovski\" <me@krisfremen.com>\n"
 "Language-Team: Macedonian <https://hosted.weblate.org/projects/phpmyadmin/"
 "5-2/mk/>\n"
@@ -14691,7 +14691,7 @@ msgid ""
 "[doc@faq3-11]FAQ 3.11[/doc]."
 msgstr ""
 "Може да биде приближно. Кликнете на бројот за да добиете точна бројка. "
-"Видете [doc@faq3-11]ЧПП 3.11[/doc]"
+"Видете [doc@faq3-11]ЧПП 3.11[/doc]."
 
 #: templates/database/structure/table_header.twig:36
 #: templates/table/index_form.twig:144
@@ -16407,9 +16407,8 @@ msgid "Create database"
 msgstr "Креирај нова база на податоци"
 
 #: templates/server/databases/index.twig:50
-#, fuzzy
 msgid "No privileges to create databases"
-msgstr "Провери привилегии за базата на податоци \"%s\"."
+msgstr "Нема привилегии за создавање бази на податоци"
 
 #: templates/server/databases/index.twig:156
 #: templates/server/replication/index.twig:18
@@ -16467,18 +16466,16 @@ msgid "Storage Engine"
 msgstr "Вид на складиште"
 
 #: templates/server/engines/show.twig:45
-#, fuzzy
 msgid "Unknown storage engine."
-msgstr "Видови на складишта"
+msgstr "Непознат мотор за складирање."
 
 #: templates/server/export/index.twig:26
 msgid "@SERVER@ will become the server name."
 msgstr ""
 
 #: templates/server/export/index.twig:3
-#, fuzzy
 msgid "Exporting databases from the current server"
-msgstr "Дозволува заклучување на табели на тековните процеси."
+msgstr "Извезување бази на податоци од тековниот сервер"
 
 #: templates/server/import/index.twig:3
 #, fuzzy
@@ -16595,10 +16592,9 @@ msgstr ""
 #: templates/server/privileges/edit_routine_privileges.twig:51
 #: templates/server/privileges/privileges_table.twig:10
 #: templates/server/privileges/privileges_table.twig:272
-#, fuzzy
 msgid "Note: MySQL privilege names are expressed in English."
 msgstr ""
-"Напомена: MySQL имињата на привилегите мора да бидат со латинични букви"
+"Забелешка: Имињата на привилегиите на MySQL се изразени на англиски јазик."
 
 #: templates/server/privileges/edit_routine_privileges.twig:63
 #: templates/server/privileges/edit_routine_privileges.twig:67
@@ -16861,14 +16857,12 @@ msgstr ""
 "еден час."
 
 #: templates/server/privileges/privileges_table.twig:784
-#, fuzzy
 msgid "Does not require SSL-encrypted connections."
-msgstr "Конекции"
+msgstr "Не треба врски енкриптирани со SSL."
 
 #: templates/server/privileges/privileges_table.twig:793
-#, fuzzy
 msgid "Requires SSL-encrypted connections."
-msgstr "Конекции"
+msgstr "Потребни се врски енкриптирани со SSL."
 
 #: templates/server/privileges/privileges_table.twig:802
 msgid "Requires a valid X509 certificate."
@@ -16987,15 +16981,13 @@ msgid ""
 msgstr ""
 
 #: templates/server/replication/index.twig:43
-#, fuzzy
 msgid "No privileges"
-msgstr "Нема привилегии."
+msgstr "Нема привилегии"
 
 #: templates/server/replication/primary_add_replica_user.twig:6
 #: templates/server/replication/primary_replication.twig:44
-#, fuzzy
 msgid "Add replica replication user"
-msgstr "Потребно заради помошните сервери за репликација."
+msgstr "Додајте корисник за репликација на реплика"
 
 #: templates/server/replication/primary_add_replica_user.twig:21
 #: templates/server/replication/primary_add_replica_user.twig:40

--- a/po/pl.po
+++ b/po/pl.po
@@ -4,8 +4,8 @@ msgstr ""
 "Project-Id-Version: phpMyAdmin 5.2.2-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
 "POT-Creation-Date: 2023-11-12 15:23-0300\n"
-"PO-Revision-Date: 2024-02-20 22:32+0000\n"
-"Last-Translator: Andrzej Pauli <andrzej.pauli@gmail.com>\n"
+"PO-Revision-Date: 2024-03-04 20:01+0000\n"
+"Last-Translator: Szymon John <szymonjohnpl@gmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/phpmyadmin/5-2/pl/"
 ">\n"
 "Language: pl\n"
@@ -3294,9 +3294,8 @@ msgstr "Usuń znaki nowej linii z kolumn"
 #: libraries/classes/Config/Descriptions.php:798
 #: libraries/classes/Config/Descriptions.php:805
 #: libraries/classes/Plugins/Import/ImportCsv.php:651
-#, fuzzy
 msgid "Columns terminated with"
-msgstr "Kolumny zakończone"
+msgstr "Kolumny zakończone z"
 
 #: libraries/classes/Config/Descriptions.php:666
 #: libraries/classes/Config/Descriptions.php:793
@@ -4955,7 +4954,6 @@ msgstr ""
 "konfiguracji phpMyAdmin!"
 
 #: libraries/classes/Config/Validator.php:358
-#, fuzzy
 msgid ""
 "Empty phpMyAdmin control user password while using phpMyAdmin configuration "
 "storage!"

--- a/po/uk.po
+++ b/po/uk.po
@@ -4,8 +4,8 @@ msgstr ""
 "Project-Id-Version: phpMyAdmin 5.2.2-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
 "POT-Creation-Date: 2023-11-12 15:23-0300\n"
-"PO-Revision-Date: 2023-09-20 11:57+0000\n"
-"Last-Translator: Kipя <yankirill@icloud.com>\n"
+"PO-Revision-Date: 2024-03-04 08:03+0000\n"
+"Last-Translator: Ivan <ivan47044704@gmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/phpmyadmin/5-2/"
 "uk/>\n"
 "Language: uk\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 5.1-dev\n"
+"X-Generator: Weblate 5.5-dev\n"
 
 #: libraries/advisory_rules_generic.php:9
 msgid "Uptime below one day"
@@ -7294,10 +7294,8 @@ msgid "up to date"
 msgstr "оновлено"
 
 #: libraries/classes/Controllers/JavaScriptMessagesController.php:611
-#, fuzzy
-#| msgid "There was an error importing the ESRI shape file: \"%s\"."
 msgid "There was an error in loading the Git information."
-msgstr "При імпорті файлу ESRI сталася помилка: \"%s\"."
+msgstr "Сталася помилка під час завантаження інформації Git."
 
 #: libraries/classes/Controllers/JavaScriptMessagesController.php:614
 msgid ""
@@ -10696,10 +10694,8 @@ msgid "The table name is empty!"
 msgstr "Порожня назва таблиці!"
 
 #: libraries/classes/Partitioning/Maintenance.php:141
-#, fuzzy
-#| msgid "This is a read-only variable and can not be edited"
 msgid "This table is a view, it can not be truncated."
-msgstr "Це змінна тільки для читання і не можуть бути змінена"
+msgstr "Ця таблиця є виглядом, і вона не може бути обрізана."
 
 #: libraries/classes/Pdf.php:136
 msgid "Error while creating PDF:"


### PR DESCRIPTION
Signed-off-by: Lennert Hofman <hofmanlennert@gmail.com>

### Description

When doing an SQL server export, if only exporting data, don't include the "drop database" line.

Fixes #18593

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
