### PR TITLE
Split $createDb from buildSql() method

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8601,6 +8601,11 @@ parameters:
 			path: src/Import/Import.php
 
 		-
+			message: "#^Method PhpMyAdmin\\\\Import\\\\Import\\:\\:createDatabase\\(\\) should return array\\<string\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Import/Import.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\Import\\\\Import\\:\\:detectSize\\(\\) should return int\\|string but returns mixed\\.$#"
 			count: 3
 			path: src/Import/Import.php
@@ -11396,11 +11401,6 @@ parameters:
 			path: src/Plugins/Import/ImportCsv.php
 
 		-
-			message: "#^Parameter \\#1 \\$dbName of method PhpMyAdmin\\\\Import\\\\Import\\:\\:buildSql\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Plugins/Import/ImportCsv.php
-
-		-
 			message: "#^Parameter \\#1 \\$serverMessage of static method PhpMyAdmin\\\\Html\\\\Generator\\:\\:mysqlDie\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Plugins/Import/ImportCsv.php
@@ -11437,6 +11437,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#3 \\$rows of class PhpMyAdmin\\\\Import\\\\ImportTable constructor expects array\\<int, array\\<int, mixed\\>\\>, array\\<int\\<0, max\\>, array\\> given\\.$#"
+			count: 1
+			path: src/Plugins/Import/ImportCsv.php
+
+		-
+			message: "#^Parameter \\#4 \\$sqlData of method PhpMyAdmin\\\\Import\\\\Import\\:\\:createDatabase\\(\\) expects array\\<string\\>, mixed given\\.$#"
 			count: 1
 			path: src/Plugins/Import/ImportCsv.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6428,8 +6428,6 @@
     <MixedAssignment>
       <code><![CDATA[$active]]></code>
       <code><![CDATA[$cellValue]]></code>
-      <code><![CDATA[$charset]]></code>
-      <code><![CDATA[$collation]]></code>
       <code><![CDATA[$importPlugin]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
@@ -6440,10 +6438,6 @@
       <code><![CDATA[getProperties]]></code>
     </MixedMethodCall>
     <MixedOperand>
-      <code><![CDATA[$charset]]></code>
-      <code><![CDATA[$charset]]></code>
-      <code><![CDATA[$collation]]></code>
-      <code><![CDATA[$collation]]></code>
       <code><![CDATA[$importPlugin->getProperties()->getExtension()]]></code>
       <code><![CDATA[$size[self::D]]]></code>
       <code><![CDATA[ImportSettings::$maximumTime]]></code>
@@ -8702,13 +8696,9 @@
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
       <code><![CDATA[$fields[]]]></code>
     </MixedAssignment>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$dbName]]></code>
-    </PossiblyInvalidArgument>
     <PossiblyInvalidCast>
       <code><![CDATA[$_REQUEST['csv_new_db_name']]]></code>
       <code><![CDATA[$_REQUEST['csv_new_tbl_name']]]></code>
-      <code><![CDATA[$dbName]]></code>
     </PossiblyInvalidCast>
     <PossiblyInvalidOperand>
       <code><![CDATA[$maxLines]]></code>

--- a/src/Plugins/Import/ImportCsv.php
+++ b/src/Plugins/Import/ImportCsv.php
@@ -22,6 +22,7 @@ use PhpMyAdmin\Properties\Options\Items\NumberPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\TextPropertyItem;
 use PhpMyAdmin\Properties\Plugins\ImportPluginProperties;
 use PhpMyAdmin\Util;
+use Webmozart\Assert\Assert;
 
 use function __;
 use function array_pad;
@@ -590,6 +591,7 @@ class ImportCsv extends AbstractImportCsv
              */
             if (isset($_REQUEST['csv_new_db_name']) && (string) $_REQUEST['csv_new_db_name'] !== '') {
                 $newDb = $_REQUEST['csv_new_db_name'];
+                Assert::string($newDb);
             } else {
                 $result = $dbi->fetchResult('SHOW DATABASES');
 
@@ -599,7 +601,11 @@ class ImportCsv extends AbstractImportCsv
             $dbName = Current::$database !== '' ? Current::$database : $newDb;
             $createDb = Current::$database === '';
 
-            $this->import->buildSql($dbName, [$table], [$analysis], createDb:$createDb, sqlData:$sqlStatements);
+            if ($createDb) {
+                $sqlStatements = $this->import->createDatabase($dbName, 'utf8', 'utf8_general_ci', $sqlStatements);
+            }
+
+            $this->import->buildSql($dbName, [$table], [$analysis], sqlData: $sqlStatements);
         }
 
         // Commit any possible data in buffers

--- a/src/Plugins/Import/ImportMediawiki.php
+++ b/src/Plugins/Import/ImportMediawiki.php
@@ -305,11 +305,16 @@ class ImportMediawiki extends ImportPlugin
             // Obtain the best-fit MySQL types for each column
             $analysis = $this->import->analyzeTable($table);
 
+            $dbName = Current::$database !== '' ? Current::$database : 'mediawiki_DB';
+
+            if (Current::$database === '') {
+                $sqlStatements = $this->import->createDatabase($dbName, 'utf8', 'utf8_general_ci', $sqlStatements);
+            }
+
             $this->import->buildSql(
-                Current::$database !== '' ? Current::$database : 'mediawiki_DB',
+                $dbName,
                 [$table],
                 [$analysis],
-                createDb: Current::$database === '',
                 sqlData: $sqlStatements,
             );
         }

--- a/src/Plugins/Import/ImportOds.php
+++ b/src/Plugins/Import/ImportOds.php
@@ -167,8 +167,12 @@ class ImportOds extends ImportPlugin
         $dbName = Current::$database !== '' ? Current::$database : 'ODS_DB';
         $createDb = Current::$database === '';
 
+        if ($createDb) {
+            $sqlStatements = $this->import->createDatabase($dbName, 'utf8', 'utf8_general_ci', $sqlStatements);
+        }
+
         /* Created and execute necessary SQL statements from data */
-        $this->import->buildSql($dbName, $tables, $analyses, createDb:$createDb, sqlData:$sqlStatements);
+        $this->import->buildSql($dbName, $tables, $analyses, sqlData: $sqlStatements);
 
         /* Commit any possible data in buffers */
         $this->import->runQuery('', $sqlStatements);

--- a/src/Plugins/Import/ImportShp.php
+++ b/src/Plugins/Import/ImportShp.php
@@ -288,7 +288,11 @@ class ImportShp extends ImportPlugin
 
         // Created and execute necessary SQL statements from data
         $sqlStatements = [];
-        $this->import->buildSql($dbName, [$table], [$analysis], createDb:$createDb, sqlData:$sqlStatements);
+        if ($createDb) {
+            $sqlStatements = $this->import->createDatabase($dbName, 'utf8', 'utf8_general_ci', []);
+        }
+
+        $this->import->buildSql($dbName, [$table], [$analysis], sqlData: $sqlStatements);
 
         ImportSettings::$finished = true;
         $GLOBALS['error'] = false;

--- a/src/Plugins/Import/ImportXml.php
+++ b/src/Plugins/Import/ImportXml.php
@@ -240,21 +240,23 @@ class ImportXml extends ImportPlugin
             $create = null;
         }
 
+        /* Created and execute necessary SQL statements from data */
+        $sqlStatements = [];
+
         /* Set database name to the currently selected one, if applicable */
         if (Current::$database !== '') {
             /* Override the database name in the XML file, if one is selected */
             $dbName = Current::$database;
-            $options = null;
         } else {
-            /* Set database collation/charset */
-            $options = ['db_collation' => $collation, 'db_charset' => $charset];
+            $sqlStatements = $this->import->createDatabase(
+                $dbName,
+                $charset ?? 'utf8',
+                $collation ?? 'utf8_general_ci',
+                [],
+            );
         }
 
-        $createDb = Current::$database === '';
-
-        /* Created and execute necessary SQL statements from data */
-        $sqlStatements = [];
-        $this->import->buildSql($dbName, $tables, $analyses, $create, $createDb, $options, $sqlStatements);
+        $this->import->buildSql($dbName, $tables, $analyses, $create, $sqlStatements);
 
         /* Commit any possible data in buffers */
         $this->import->runQuery('', $sqlStatements);

--- a/tests/unit/Plugins/Import/ImportCsvTest.php
+++ b/tests/unit/Plugins/Import/ImportCsvTest.php
@@ -261,10 +261,10 @@ class ImportCsvTest extends AbstractTestCase
         $this->object->doImport();
 
         self::assertSame(
-            'CREATE DATABASE IF NOT EXISTS `CSV_DB 1` DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;;'
-            . 'CREATE TABLE IF NOT EXISTS `CSV_DB 1`.`db_test` (`COL 1` varchar(5), `COL 2` varchar(5))'
-            . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;;INSERT INTO `CSV_DB 1`.`db_test`'
-            . ' (`COL 1`, `COL 2`) VALUES (\'Row 1\', \'Row 2\'),' . "\n" . ' (\'123\', \'456\');;',
+            'CREATE DATABASE IF NOT EXISTS `CSV_DB 1` DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;'
+            . 'CREATE TABLE IF NOT EXISTS `CSV_DB 1`.`db_test` (`COL 1` varchar(5), `COL 2` varchar(5));'
+            . 'INSERT INTO `CSV_DB 1`.`db_test`'
+            . ' (`COL 1`, `COL 2`) VALUES (\'Row 1\', \'Row 2\'),' . "\n" . ' (\'123\', \'456\');',
             $GLOBALS['sql_query'],
         );
 
@@ -306,10 +306,10 @@ class ImportCsvTest extends AbstractTestCase
         $this->object->doImport();
 
         self::assertSame(
-            'CREATE DATABASE IF NOT EXISTS `CSV_DB 1` DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;;'
-            . 'CREATE TABLE IF NOT EXISTS `CSV_DB 1`.`db_test` (`Row 1` int(3), `Row 2` int(3))'
-            . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;;INSERT INTO `CSV_DB 1`.`db_test`'
-            . ' (`Row 1`, `Row 2`) VALUES (123, 456);;',
+            'CREATE DATABASE IF NOT EXISTS `CSV_DB 1` DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;'
+            . 'CREATE TABLE IF NOT EXISTS `CSV_DB 1`.`db_test` (`Row 1` int(3), `Row 2` int(3));'
+            . 'INSERT INTO `CSV_DB 1`.`db_test`'
+            . ' (`Row 1`, `Row 2`) VALUES (123, 456);',
             $GLOBALS['sql_query'],
         );
 

--- a/tests/unit/Plugins/Import/ImportOdsTest.php
+++ b/tests/unit/Plugins/Import/ImportOdsTest.php
@@ -185,28 +185,26 @@ class ImportOdsTest extends AbstractTestCase
         // The process could probably detect that all the values for columns V to BL are empty
         // That would make the empty columns not needed and would create a cleaner structure
 
-        $endOfSql = ');;';
+        $endOfSql = ');';
 
         if (! $odsEmptyRowsMode) {
             $fullCols = 'NULL' . str_repeat(', NULL', 18);// 19 empty cells
-            $endOfSql = '),' . "\n" . ' (' . $fullCols . '),' . "\n" . ' (' . $fullCols . ');;';
+            $endOfSql = '),' . "\n" . ' (' . $fullCols . '),' . "\n" . ' (' . $fullCols . ');';
         }
 
         //Test function called
         $this->object->doImport($importHandle);
 
         self::assertSame(
-            'CREATE DATABASE IF NOT EXISTS `ODS_DB` DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;;'
+            'CREATE DATABASE IF NOT EXISTS `ODS_DB` DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;'
             . 'CREATE TABLE IF NOT EXISTS `ODS_DB`.`Shop` ('
             . '`Artikelnummer` varchar(7), `Name` varchar(41), `keywords` varchar(15), `EK_Preis` varchar(21),'
             . ' `Preis` varchar(23), `Details` varchar(10), `addInfo` varchar(22), `Einheit` varchar(3),'
             . ' `Wirkstoff` varchar(10), `verkuerztHaltbar` varchar(21), `kuehlkette` varchar(7),'
             . ' `Gebinde` varchar(71), `Verbrauchsnachweis` varchar(7), `Genehmigungspflichtig` varchar(7),'
             . ' `Gefahrstoff` varchar(11), `GefahrArbeitsbereich` varchar(14), `Verwendungszweck` varchar(10),'
-            . ' `Verbrauch` varchar(10), `showLagerbestand` varchar(7)) '
-            . 'DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;;'
-            . 'CREATE TABLE IF NOT EXISTS `ODS_DB`.`Feuille 1` (`value` varchar(19)) '
-            . 'DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;;'
+            . ' `Verbrauch` varchar(10), `showLagerbestand` varchar(7));'
+            . 'CREATE TABLE IF NOT EXISTS `ODS_DB`.`Feuille 1` (`value` varchar(19));'
             . 'INSERT INTO `ODS_DB`.`Shop` ('
             . '`Artikelnummer`, `Name`, `keywords`, `EK_Preis`, `Preis`, `Details`, `addInfo`, `Einheit`,'
             . ' `Wirkstoff`, `verkuerztHaltbar`, `kuehlkette`, `Gebinde`, `Verbrauchsnachweis`,'
@@ -247,7 +245,7 @@ class ImportOdsTest extends AbstractTestCase
              . ' (\'true\'),' . "\n"
              . ' (\'12\')'
              . ($odsEmptyRowsMode ? '' : ',' . "\n" . ' (NULL)')
-             . ($odsEmptyRowsMode ? ';;' : ',' . "\n" . ' (NULL);;'),
+             . ($odsEmptyRowsMode ? ';' : ',' . "\n" . ' (NULL);'),
             $GLOBALS['sql_query'],
         );
 

--- a/tests/unit/Plugins/Import/ImportShpTest.php
+++ b/tests/unit/Plugins/Import/ImportShpTest.php
@@ -181,8 +181,7 @@ class ImportShpTest extends AbstractTestCase
         if (extension_loaded('dbase')) {
             self::assertStringContainsString(
                 'CREATE TABLE IF NOT EXISTS `SHP_DB`.`TBL_NAME` '
-                . '(`SPATIAL` geometry, `ID` int(2), `AUTHORITY` varchar(25), `NAME` varchar(42)) '
-                . 'DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;',
+                . '(`SPATIAL` geometry, `ID` int(2), `AUTHORITY` varchar(25), `NAME` varchar(42));',
                 $GLOBALS['sql_query'],
             );
 


### PR DESCRIPTION
The charset and collation were also used in the creation of the tables. However, the value was almost always hardcoded to `utf8` except for XML import. In the case of XML the value was different only if XML is creating the database too. If the database sets its own default charset then the table can just inherit it. In all other cases, hardcoding it to `utf8` seems wrong. The value should be inherited from the default setting of the selected database. 