### PR TITLE
Add tests for app/services* files

### DIFF
--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -1252,7 +1252,7 @@ return [
             'arguments' => [
                 '$response' => '@response',
                 '$template' => '@template',
-                '$maintenance' => '@partitioning_maintenance',
+                '$model' => '@partitioning_maintenance',
             ],
         ],
         Table\Partition\CheckController::class => [
@@ -1260,7 +1260,7 @@ return [
             'arguments' => [
                 '$response' => '@response',
                 '$template' => '@template',
-                '$maintenance' => '@partitioning_maintenance',
+                '$model' => '@partitioning_maintenance',
             ],
         ],
         Table\Partition\DropController::class => [
@@ -1268,7 +1268,7 @@ return [
             'arguments' => [
                 '$response' => '@response',
                 '$template' => '@template',
-                '$maintenance' => '@partitioning_maintenance',
+                '$model' => '@partitioning_maintenance',
             ],
         ],
         Table\Partition\OptimizeController::class => [
@@ -1276,7 +1276,7 @@ return [
             'arguments' => [
                 '$response' => '@response',
                 '$template' => '@template',
-                '$maintenance' => '@partitioning_maintenance',
+                '$model' => '@partitioning_maintenance',
             ],
         ],
         Table\Partition\RebuildController::class => [
@@ -1284,7 +1284,7 @@ return [
             'arguments' => [
                 '$response' => '@response',
                 '$template' => '@template',
-                '$maintenance' => '@partitioning_maintenance',
+                '$model' => '@partitioning_maintenance',
             ],
         ],
         Table\Partition\RepairController::class => [
@@ -1292,7 +1292,7 @@ return [
             'arguments' => [
                 '$response' => '@response',
                 '$template' => '@template',
-                '$maintenance' => '@partitioning_maintenance',
+                '$model' => '@partitioning_maintenance',
             ],
         ],
         Table\Partition\TruncateController::class => [
@@ -1300,7 +1300,7 @@ return [
             'arguments' => [
                 '$response' => '@response',
                 '$template' => '@template',
-                '$maintenance' => '@partitioning_maintenance',
+                '$model' => '@partitioning_maintenance',
             ],
         ],
         Operations\TableController::class => [

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -12596,6 +12596,11 @@
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="tests/unit/Container/ContainerBuilderTest.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[servicesProvider]]></code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="tests/unit/Controllers/BrowseForeignersControllerTest.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>

--- a/tests/unit/Container/ContainerBuilderTest.php
+++ b/tests/unit/Container/ContainerBuilderTest.php
@@ -5,11 +5,17 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Container;
 
 use PhpMyAdmin\Container\ContainerBuilder;
+use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+use function array_keys;
+use function array_map;
+use function array_merge;
 
 #[CoversClass(ContainerBuilder::class)]
-final class ContainerBuilderTest extends TestCase
+final class ContainerBuilderTest extends AbstractTestCase
 {
     public function testGetContainer(): void
     {
@@ -19,5 +25,29 @@ final class ContainerBuilderTest extends TestCase
         ContainerBuilder::$container = null;
         self::assertNotSame($container, ContainerBuilder::getContainer());
         ContainerBuilder::$container = null;
+    }
+
+    #[DataProvider('servicesProvider')]
+    public function testContainerEntries(string $service): void
+    {
+        $GLOBALS['lang'] = 'en';
+        DatabaseInterface::$instance = $this->createDatabaseInterface();
+        $container = ContainerBuilder::getContainer();
+        self::assertNotNull($container->get($service));
+        ContainerBuilder::$container = null;
+    }
+
+    /** @return array<int, array<int, string>> */
+    public static function servicesProvider(): array
+    {
+        /** @psalm-var array{services: array<string, mixed>} $services */
+        $services = include ROOT_PATH . 'app/services.php';
+        /** @psalm-var array{services: array<string, mixed>} $controllerServices */
+        $controllerServices = include ROOT_PATH . 'app/services_controllers.php';
+
+        return array_map(
+            static fn ($service) => [$service],
+            array_merge(array_keys($services['services']), array_keys($controllerServices['services'])),
+        );
     }
 }


### PR DESCRIPTION
Tests each service if it's possible to create it.

- Removes some initialization methods from constructor
- Fixes error introduced by https://github.com/phpmyadmin/phpmyadmin/pull/18625
