### PR TITLE
Fix #19037 - Link to privilege on table or db without an existing grant

### DIFF
--- a/templates/database/privileges/index.twig
+++ b/templates/database/privileges/index.twig
@@ -73,7 +73,7 @@
                         <a class="edit_user_anchor" href="{{ url('/server/privileges', {
                           'username': privilege.user,
                           'hostname': privilege.host,
-                          'dbname': priv.database != '*' ? priv.database,
+                          'dbname': priv.database != '*' ? priv.database : db,
                           'tablename': '',
                           'routinename': priv.routine ?? ''
                         }) }}">

--- a/templates/table/privileges/index.twig
+++ b/templates/table/privileges/index.twig
@@ -77,8 +77,8 @@
                       <a class="edit_user_anchor" href="{{ url('/server/privileges', {
                         'username': privilege.user,
                         'hostname': privilege.host,
-                        'dbname': priv.database != '*' ? priv.database,
-                        'tablename': priv.table is defined and priv.table != '*' ? priv.table,
+                        'dbname': priv.database != '*' ? priv.database : db,
+                        'tablename': priv.table is defined and priv.table != '*' ? priv.table : table,
                         'routinename': priv.routine ?? ''
                       }) }}">
                         {{ get_icon('b_usredit', 'Edit privileges'|trans) }}


### PR DESCRIPTION
… edit privilege

Fixes the tableName and DatabaseName not appearing in the query params

Please describe your pull request.

Fixes #19037 