### PR TITLE
Extracts loadTableInfo method from controller constructors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5001,17 +5001,7 @@ parameters:
 			path: src/Controllers/Table/SearchController.php
 
 		-
-			message: "#^Parameter \\#1 \\$identifier of static method PhpMyAdmin\\\\Util\\:\\:backquote\\(\\) expects string\\|Stringable\\|null, mixed given\\.$#"
-			count: 2
-			path: src/Controllers/Table/SearchController.php
-
-		-
 			message: "#^Parameter \\#1 \\$params of static method PhpMyAdmin\\\\Url\\:\\:getCommon\\(\\) expects array\\<string, bool\\|int\\|string\\>, mixed given\\.$#"
-			count: 1
-			path: src/Controllers/Table/SearchController.php
-
-		-
-			message: "#^Parameter \\#1 \\$sqlQuery of static method PhpMyAdmin\\\\Core\\:\\:checkSqlQuerySignature\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/Table/SearchController.php
 
@@ -5032,11 +5022,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$foreignField of method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:foreignDropdown\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Controllers/Table/SearchController.php
-
-		-
-			message: "#^Parameter \\#2 \\$signature of static method PhpMyAdmin\\\\Core\\:\\:checkSqlQuerySignature\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/Table/SearchController.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4971,11 +4971,6 @@ parameters:
 			path: src/Controllers/Table/SearchController.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Table\\\\SearchController\\:\\:getColumnMinMax\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Controllers/Table/SearchController.php
-
-		-
 			message: "#^Only booleans are allowed in &&, array given on the left side\\.$#"
 			count: 1
 			path: src/Controllers/Table/SearchController.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13116,11 +13116,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="tests/unit/Controllers/Table/SearchControllerTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[Config::getInstance()]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="tests/unit/Controllers/Table/SqlControllerTest.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3628,20 +3628,11 @@
     </MixedAssignment>
     <PossiblyInvalidArgument>
       <code><![CDATA[$_POST['column']]]></code>
-      <code><![CDATA[$_POST['db']]]></code>
-      <code><![CDATA[$_POST['table']]]></code>
-      <code><![CDATA[$_POST['where_clause']]]></code>
-      <code><![CDATA[$_POST['where_clause_sign']]]></code>
       <code><![CDATA[$selectedOperator]]></code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast>
       <code><![CDATA[$_POST['column']]]></code>
-      <code><![CDATA[$_POST['where_clause']]]></code>
-      <code><![CDATA[$_POST['where_clause_sign']]]></code>
     </PossiblyInvalidCast>
-    <PossiblyInvalidOperand>
-      <code><![CDATA[$_POST['where_clause']]]></code>
-    </PossiblyInvalidOperand>
     <PossiblyUnusedMethod>
       <code><![CDATA[getColumnProperties]]></code>
     </PossiblyUnusedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13035,13 +13035,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="tests/unit/Controllers/Table/FindReplaceControllerTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[Config::getInstance()]]></code>
-      <code><![CDATA[DatabaseInterface::getInstance()]]></code>
-      <code><![CDATA[DatabaseInterface::getInstance()]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="tests/unit/Controllers/Table/ImportControllerTest.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3633,9 +3633,6 @@
     <PossiblyInvalidCast>
       <code><![CDATA[$_POST['column']]]></code>
     </PossiblyInvalidCast>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[getColumnProperties]]></code>
-    </PossiblyUnusedMethod>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(int) $config->settings['MaxRows']]]></code>
     </RedundantCastGivenDocblockType>

--- a/resources/templates/table/search/index.twig
+++ b/resources/templates/table/search/index.twig
@@ -43,7 +43,7 @@
               </tr>
             </thead>
             <tbody>
-              {% for column_index in 0..column_names|length - 1 %}
+              {% for column_index in column_names|keys %}
                 <tr class="noclick">
                   {# If 'Function' column is present trying to change comment #}
                   {% if geom_column_flag %}
@@ -69,19 +69,18 @@
                     {#- Keep this without extra spaces because it is used for a request to build the BETWEEN modal -#}
                     {{- column_names[column_index] -}}
                   </th>
-                  {% set properties = self.getColumnProperties(column_index, column_index) %}
                   <td dir="ltr">
-                    {{ properties['type'] }}
+                    {{ properties[column_index]['type'] }}
                   </td>
                   <td>
-                    {{ properties['collation'] }}
+                    {{ properties[column_index]['collation'] }}
                   </td>
                   <td>
-                    {{ properties['func']|raw }}
+                    {{ properties[column_index]['func']|raw }}
                   </td>
                   {# here, the data-type attribute is needed for a date/time picker #}
-                  <td data-type="{{ properties['type'] }}">
-                    {{ properties['value']|raw }}
+                  <td data-type="{{ properties[column_index]['type'] }}">
+                    {{ properties[column_index]['value']|raw }}
                     {# Displays hidden fields #}
                     <input type="hidden" name="criteriaColumnNames[{{ column_index }}]" value="{{ column_names[column_index] }}">
                     <input type="hidden" name="criteriaColumnTypes[{{ column_index }}]" value="{{ column_types[column_index] }}">

--- a/resources/templates/table/zoom_search/index.twig
+++ b/resources/templates/table/zoom_search/index.twig
@@ -75,12 +75,10 @@
                 </select>
               </th>
               {% if criteria_column_names[i] is defined and criteria_column_names[i] != 'pma_null' %}
-                {% set key = keys[criteria_column_names[i]] %}
-                {% set properties = self.getColumnProperties(i, key) %}
-                {% set type = type|merge({(i): properties['type']}) %}
-                {% set collation = collation|merge({(i): properties['collation']}) %}
-                {% set func = func|merge({(i): properties['func']}) %}
-                {% set value = value|merge({(i): properties['value']}) %}
+                {% set type = type|merge({(i): properties[i]['type']}) %}
+                {% set collation = collation|merge({(i): properties[i]['collation']}) %}
+                {% set func = func|merge({(i): properties[i]['func']}) %}
+                {% set value = value|merge({(i): properties[i]['value']}) %}
               {% endif %}
               {# Column type #}
               <td dir="ltr">

--- a/src/Controllers/Table/SearchController.php
+++ b/src/Controllers/Table/SearchController.php
@@ -9,7 +9,6 @@ use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\Controllers\AbstractController;
-use PhpMyAdmin\Core;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\DbTableExists;
@@ -221,37 +220,6 @@ class SearchController extends AbstractController
         } else {
             $this->doSelectionAction();
         }
-    }
-
-    /**
-     * Get data row action
-     */
-    public function getDataRowAction(): void
-    {
-        if (! Core::checkSqlQuerySignature($_POST['where_clause'], $_POST['where_clause_sign'])) {
-            return;
-        }
-
-        $extraData = [];
-        $rowInfoQuery = 'SELECT * FROM ' . Util::backquote($_POST['db']) . '.'
-            . Util::backquote($_POST['table']) . ' WHERE ' . $_POST['where_clause'];
-        $result = $this->dbi->query($rowInfoQuery . ';');
-        $fieldsMeta = $this->dbi->getFieldsMeta($result);
-        while ($row = $result->fetchAssoc()) {
-            // for bit fields we need to convert them to printable form
-            $i = 0;
-            foreach ($row as $col => $val) {
-                if (isset($fieldsMeta[$i]) && $fieldsMeta[$i]->isMappedTypeBit) {
-                    $row[$col] = Util::printableBitValue((int) $val, $fieldsMeta[$i]->length);
-                }
-
-                $i++;
-            }
-
-            $extraData['row_info'] = $row;
-        }
-
-        $this->response->addJSON($extraData);
     }
 
     /**

--- a/src/Controllers/Table/SearchController.php
+++ b/src/Controllers/Table/SearchController.php
@@ -97,8 +97,6 @@ class SearchController extends AbstractController
         private readonly DbTableExists $dbTableExists,
     ) {
         parent::__construct($response, $template);
-
-        $this->loadTableInfo();
     }
 
     /**
@@ -198,6 +196,8 @@ class SearchController extends AbstractController
             return;
         }
 
+        $this->loadTableInfo();
+
         $this->addScriptFiles([
             'makegrid.js',
             'sql.js',
@@ -226,7 +226,7 @@ class SearchController extends AbstractController
     /**
      * Do selection action
      */
-    public function doSelectionAction(): void
+    private function doSelectionAction(): void
     {
         /**
          * Selection criteria have been submitted -> do the work
@@ -266,7 +266,7 @@ class SearchController extends AbstractController
     /**
      * Display selection form action
      */
-    public function displaySelectionFormAction(): void
+    private function displaySelectionFormAction(): void
     {
         $config = Config::getInstance();
         if (! isset($GLOBALS['goto'])) {
@@ -295,7 +295,7 @@ class SearchController extends AbstractController
     /**
      * Range search action
      */
-    public function rangeSearchAction(): void
+    private function rangeSearchAction(): void
     {
         $minMax = $this->getColumnMinMax($_POST['column']);
         $this->response->addJSON('column_data', $minMax);
@@ -305,8 +305,10 @@ class SearchController extends AbstractController
      * Finds minimum and maximum value of a given column.
      *
      * @param string $column Column name
+     *
+     * @return mixed[]|null
      */
-    public function getColumnMinMax(string $column): array|null
+    private function getColumnMinMax(string $column): array|null
     {
         $sqlQuery = 'SELECT MIN(' . Util::backquote($column) . ') AS `min`, '
             . 'MAX(' . Util::backquote($column) . ') AS `max` '

--- a/src/Controllers/Table/SearchController.php
+++ b/src/Controllers/Table/SearchController.php
@@ -27,6 +27,7 @@ use PhpMyAdmin\Util;
 use PhpMyAdmin\Utils\Gis;
 
 use function __;
+use function array_keys;
 use function in_array;
 use function is_array;
 use function mb_strtolower;
@@ -272,11 +273,16 @@ class SearchController extends AbstractController
             $GLOBALS['goto'] = Util::getScriptNameForOption($config->settings['DefaultTabTable'], 'table');
         }
 
+        $properties = [];
+        foreach (array_keys($this->columnNames) as $columnIndex) {
+            $properties[$columnIndex] = $this->getColumnProperties($columnIndex, $columnIndex);
+        }
+
         $this->render('table/search/index', [
             'db' => Current::$database,
             'table' => Current::$table,
             'goto' => $GLOBALS['goto'],
-            'self' => $this,
+            'properties' => $properties,
             'geom_column_flag' => $this->geomColumnFlag,
             'column_names' => $this->columnNames,
             'column_types' => $this->columnTypes,
@@ -319,7 +325,7 @@ class SearchController extends AbstractController
      *
      * @return mixed[] Array containing column's properties
      */
-    public function getColumnProperties(int $searchIndex, int $columnIndex): array
+    private function getColumnProperties(int $searchIndex, int $columnIndex): array
     {
         $selectedOperator = $_POST['criteriaColumnOperators'][$searchIndex] ?? '';
         $enteredValue = $_POST['criteriaValues'] ?? '';

--- a/src/Controllers/Table/ZoomSearchController.php
+++ b/src/Controllers/Table/ZoomSearchController.php
@@ -77,8 +77,6 @@ class ZoomSearchController extends AbstractController
         private readonly DbTableExists $dbTableExists,
     ) {
         parent::__construct($response, $template);
-
-        $this->loadTableInfo();
     }
 
     public function __invoke(ServerRequest $request): void
@@ -122,6 +120,8 @@ class ZoomSearchController extends AbstractController
 
             return;
         }
+
+        $this->loadTableInfo();
 
         $this->addScriptFiles([
             'makegrid.js',
@@ -243,7 +243,7 @@ class ZoomSearchController extends AbstractController
     /**
      * Display selection form action
      */
-    public function displaySelectionFormAction(string $dataLabel): void
+    private function displaySelectionFormAction(string $dataLabel): void
     {
         $config = Config::getInstance();
         if (! isset($GLOBALS['goto'])) {
@@ -287,7 +287,7 @@ class ZoomSearchController extends AbstractController
     /**
      * Get data row action
      */
-    public function getDataRowAction(): void
+    private function getDataRowAction(): void
     {
         if (! Core::checkSqlQuerySignature($_POST['where_clause'], $_POST['where_clause_sign'])) {
             return;
@@ -318,7 +318,7 @@ class ZoomSearchController extends AbstractController
     /**
      * Change table info action
      */
-    public function changeTableInfoAction(): void
+    private function changeTableInfoAction(): void
     {
         $field = $_POST['field'];
         if ($field === 'pma_null') {
@@ -350,7 +350,7 @@ class ZoomSearchController extends AbstractController
      * @param string $dataLabel Data label
      * @param string $goto      Goto
      */
-    public function zoomSubmitAction(string $dataLabel, string $goto): void
+    private function zoomSubmitAction(string $dataLabel, string $goto): void
     {
         //Query generation part
         $sqlQuery = $this->search->buildSqlQuery();

--- a/src/Controllers/Table/ZoomSearchController.php
+++ b/src/Controllers/Table/ZoomSearchController.php
@@ -251,7 +251,7 @@ class ZoomSearchController extends AbstractController
         }
 
         $criteriaColumnNames = $_POST['criteriaColumnNames'] ?? null;
-        $keys = [];
+        $properties = [];
         /** @infection-ignore-all */
         for ($i = 0; $i < 4; $i++) {
             if (! isset($criteriaColumnNames[$i])) {
@@ -262,18 +262,20 @@ class ZoomSearchController extends AbstractController
                 continue;
             }
 
-            $keys[$criteriaColumnNames[$i]] = array_search($criteriaColumnNames[$i], $this->columnNames);
+            $properties[$i] = $this->getColumnProperties(
+                $i,
+                (int) array_search($criteriaColumnNames[$i], $this->columnNames),
+            );
         }
 
         $this->render('table/zoom_search/index', [
             'db' => Current::$database,
             'table' => Current::$table,
             'goto' => $GLOBALS['goto'],
-            'self' => $this,
+            'properties' => $properties,
             'geom_column_flag' => $this->geomColumnFlag,
             'column_names' => $this->columnNames,
             'data_label' => $dataLabel,
-            'keys' => $keys,
             'criteria_column_names' => $criteriaColumnNames,
             'criteria_column_types' => $_POST['criteriaColumnTypes'] ?? null,
             'max_plot_limit' => ! empty($_POST['maxPlotLimit'])
@@ -438,7 +440,7 @@ class ZoomSearchController extends AbstractController
      *
      * @return mixed[] Array containing column's properties
      */
-    public function getColumnProperties(int $searchIndex, int $columnIndex): array
+    private function getColumnProperties(int $searchIndex, int $columnIndex): array
     {
         $selectedOperator = $_POST['criteriaColumnOperators'][$searchIndex] ?? '';
         $enteredValue = $_POST['criteriaValues'] ?? '';

--- a/tests/unit/Controllers/Table/SearchControllerTest.php
+++ b/tests/unit/Controllers/Table/SearchControllerTest.php
@@ -4,100 +4,50 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Table;
 
-use PhpMyAdmin\ColumnFull;
-use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\Table\SearchController;
 use PhpMyAdmin\Current;
-use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\DbTableExists;
+use PhpMyAdmin\Http\Factory\ServerRequestFactory;
 use PhpMyAdmin\Table\Search;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
-use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseStub;
-use PhpMyAdmin\Types;
+use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
 
 #[CoversClass(SearchController::class)]
-class SearchControllerTest extends AbstractTestCase
+final class SearchControllerTest extends AbstractTestCase
 {
-    private DatabaseInterface&MockObject $mockedDbi;
-
-    private ResponseStub $response;
-
-    private Template $template;
-
-    /**
-     * Setup function for test cases
-     */
-    protected function setUp(): void
+    public function testRangeSearch(): void
     {
-        parent::setUp();
+        Current::$database = 'test_db';
+        Current::$table = 'test_table';
 
-        /**
-         * SET these to avoid undefined index error
-         */
-        $_POST['zoom_submit'] = 'zoom';
-
-        Current::$database = 'PMA';
-        Current::$table = 'PMA_BookMark';
-        Config::getInstance()->selectedServer['DisableIS'] = false;
-
-        $this->mockedDbi = $this->getMockBuilder(DatabaseInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->mockedDbi->types = new Types($this->mockedDbi);
-
-        $columns = [
-            new ColumnFull('Field1', 'Type1', 'Collation1', false, '', null, '', '', ''),
-            new ColumnFull('Field2', 'Type2', 'Collation2', false, '', null, '', '', ''),
-        ];
-        $this->mockedDbi->expects(self::any())->method('getColumns')
-            ->willReturn($columns);
-
-        $showCreateTable = "CREATE TABLE `pma_bookmark` (
-        `id` int(11) NOT NULL AUTO_INCREMENT,
-        `dbase` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-        `user` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-        `label` varchar(255) CHARACTER SET utf8 NOT NULL DEFAULT '',
-        `query` text COLLATE utf8_bin NOT NULL,
-        PRIMARY KEY (`id`),
-        KEY `foreign_field` (`foreign_db`,`foreign_table`)
-        ) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_bin "
-        . "COMMENT='Bookmarks'";
-
-        $this->mockedDbi->expects(self::any())->method('fetchValue')
-            ->willReturn($showCreateTable);
-
-        DatabaseInterface::$instance = $this->mockedDbi;
-
-        $this->response = new ResponseStub();
-        $this->template = new Template();
-    }
-
-    /**
-     * Tests for getColumnMinMax()
-     */
-    public function testGetColumnMinMax(): void
-    {
-        $expected = 'SELECT MIN(`column`) AS `min`, MAX(`column`) AS `max` FROM `PMA`.`PMA_BookMark`';
-
-        $this->mockedDbi->expects(self::any())
-            ->method('fetchSingleRow')
-            ->with($expected)
-            ->willReturn([$expected]);
-
-        $ctrl = new SearchController(
-            $this->response,
-            $this->template,
-            new Search($this->mockedDbi),
-            new Relation($this->mockedDbi),
-            $this->mockedDbi,
-            new DbTableExists($this->mockedDbi),
+        $dbiDummy = $this->createDbiDummy();
+        $dbiDummy->addSelectDb('test_db');
+        $dbiDummy->addResult('SELECT 1 FROM `test_db`.`test_table` LIMIT 1;', [['1']]);
+        $dbiDummy->addResult(
+            'SELECT MIN(`column`) AS `min`, MAX(`column`) AS `max` FROM `test_db`.`test_table`',
+            [['1', '2']],
         );
+        $dbi = $this->createDatabaseInterface($dbiDummy);
 
-        $result = $ctrl->getColumnMinMax('column');
-        self::assertSame([$expected], $result);
+        $_POST['range_search'] = '1';
+        $_POST['column'] = 'column';
+        $request = ServerRequestFactory::create()->createServerRequest('POST', 'http://example.com')
+            ->withParsedBody(['db' => 'test_db', 'table' => 'test_table']);
+
+        $responseRenderer = new ResponseRenderer();
+        $controller = new SearchController(
+            $responseRenderer,
+            new Template(),
+            new Search($dbi),
+            new Relation($dbi),
+            $dbi,
+            new DbTableExists($dbi),
+        );
+        $controller($request);
+
+        self::assertSame(['column_data' => ['1', '2']], $responseRenderer->getJSONResult());
     }
 }


### PR DESCRIPTION
Extracts `loadTableInfo` method from `FindReplaceController`, `Table\SearchController` and `ZoomSearchController` constructors. Makes private methods private. And refactor related tests.

- Related to https://github.com/phpmyadmin/phpmyadmin/pull/19038