### PR TITLE
Change referrer policy to same-origin

### DIFF
--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -494,7 +494,7 @@ class Header
             $headers['X-Frame-Options'] = 'DENY';
         }
 
-        $headers['Referrer-Policy'] = 'no-referrer';
+        $headers['Referrer-Policy'] = 'same-origin';
 
         $headers = array_merge($headers, $this->getCspHeaders());
 

--- a/templates/header.twig
+++ b/templates/header.twig
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="referrer" content="no-referrer">
+  <meta name="referrer" content="same-origin">
   <meta name="robots" content="noindex,nofollow,notranslate">
   <meta name="google" content="notranslate">
   {% if not allow_third_party_framing -%}

--- a/test/classes/HeaderTest.php
+++ b/test/classes/HeaderTest.php
@@ -162,7 +162,7 @@ class HeaderTest extends AbstractTestCase
 
         $expected = [
             'X-Frame-Options' => $expectedFrameOptions,
-            'Referrer-Policy' => 'no-referrer',
+            'Referrer-Policy' => 'same-origin',
             'Content-Security-Policy' => $expectedCsp,
             'X-Content-Security-Policy' => $expectedXCsp,
             'X-WebKit-CSP' => $expectedWebKitCsp,


### PR DESCRIPTION
The `no-referrer` setting is blocked by Azure http_auth integration used in AppService and ContainerApps, resulting in a 403 and not reaching phpmyadmin.

I think `same-origin` is a good fit when I compare the types: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy

Related issues: [#17240](https://github.com/phpmyadmin/phpmyadmin/issues/17240) and [phpmyadmin/docker#420](https://github.com/phpmyadmin/docker/issues/420)

### Description

Please describe your pull request.

Fixes #

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
