### PR TITLE
Fix impossible condition from #18630

### DIFF
--- a/src/Table/Search.php
+++ b/src/Table/Search.php
@@ -81,14 +81,12 @@ final class Search
             return ' WHERE ' . $_POST['customWhereClause'];
         }
 
-        // If there are no search criteria set or no unary criteria operators,
-        // return
         if (
-            ! isset($_POST['criteriaColumnOperators'])
-            || (
-                ! isset($_POST['criteriaValues'])
-                && ! isset($_POST['criteriaColumnOperators'])
-                && ! isset($_POST['geom_func'])
+            ! isset(
+                $_POST['criteriaColumnOperators'],
+                $_POST['criteriaValues'],
+                $_POST['criteriaColumnNames'],
+                $_POST['criteriaColumnTypes'],
             )
         ) {
             return '';


### PR DESCRIPTION
This code was changed in #18630 by adding another clause that made the second part of this condition impossible (&& false). I can't say what exactly the purpose of this check is, but it seems like it was meant to check for the existent of all of these POST values, not either one of them. 