### PR TITLE
Fix PHPUnit 11 deprecations

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13483,9 +13483,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Gis/GisGeometryTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMockForAbstractClass]]></code>
-    </DeprecatedMethod>
     <MixedAssignment>
       <code><![CDATA[$extent]]></code>
       <code><![CDATA[$points]]></code>
@@ -13892,7 +13889,6 @@
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
-      <code><![CDATA[getMockForAbstractClass]]></code>
     </DeprecatedMethod>
   </file>
   <file src="tests/unit/Navigation/Nodes/NodeDatabaseTest.php">
@@ -14392,31 +14388,6 @@
       <code><![CDATA[assertIsArray]]></code>
     </RedundantCondition>
   </file>
-  <file src="tests/unit/Properties/Options/OptionsPropertyGroupTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMockForAbstractClass]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="tests/unit/Properties/Options/OptionsPropertyItemTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMockForAbstractClass]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="tests/unit/Properties/Options/OptionsPropertyOneItemTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMockForAbstractClass]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="tests/unit/Properties/Plugins/PluginPropertyItemTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMockForAbstractClass]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="tests/unit/Properties/PropertyItemTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMockForAbstractClass]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="tests/unit/Query/CompatibilityTest.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[providerForTestHasAccountLocking]]></code>
@@ -14587,9 +14558,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/StorageEngineTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMockForAbstractClass]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[providerGetEngine]]></code>
     </PossiblyUnusedMethod>

--- a/tests/end-to-end/ChangePasswordTest.php
+++ b/tests/end-to-end/ChangePasswordTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Selenium;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 use function trim;
 
 #[CoversNothing]
+#[Large]
 class ChangePasswordTest extends TestBase
 {
     /**
@@ -20,7 +21,6 @@ class ChangePasswordTest extends TestBase
     /**
      * Tests the changing of the password
      */
-    #[Group('large')]
     public function testChangePassword(): void
     {
         $this->login();

--- a/tests/end-to-end/CreateDropDatabaseTest.php
+++ b/tests/end-to-end/CreateDropDatabaseTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Selenium;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversNothing]
+#[Large]
 class CreateDropDatabaseTest extends TestBase
 {
     /**
@@ -25,7 +26,6 @@ class CreateDropDatabaseTest extends TestBase
     /**
      * Creates a database and drops it
      */
-    #[Group('large')]
     public function testCreateDropDatabase(): void
     {
         $this->dbQuery('DROP DATABASE IF EXISTS `' . $this->databaseName . '`;');

--- a/tests/end-to-end/CreateRemoveUserTest.php
+++ b/tests/end-to-end/CreateRemoveUserTest.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Selenium;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 use function bin2hex;
 use function random_bytes;
 
 #[CoversNothing]
+#[Large]
 class CreateRemoveUserTest extends TestBase
 {
     /**
@@ -44,7 +45,6 @@ class CreateRemoveUserTest extends TestBase
     /**
      * Creates and removes a user
      */
-    #[Group('large')]
     public function testCreateRemoveUser(): void
     {
         $this->waitForElement('partialLinkText', 'User accounts')->click();

--- a/tests/end-to-end/Database/EventsTest.php
+++ b/tests/end-to-end/Database/EventsTest.php
@@ -7,13 +7,14 @@ namespace PhpMyAdmin\Tests\Selenium\Database;
 use PhpMyAdmin\Tests\Selenium\TestBase;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Depends;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 use function date;
 use function sleep;
 use function strtotime;
 
 #[CoversNothing]
+#[Large]
 class EventsTest extends TestBase
 {
     /**
@@ -76,7 +77,6 @@ class EventsTest extends TestBase
     /**
      * Create an event
      */
-    #[Group('large')]
     public function testAddEvent(): void
     {
         $this->waitForElement('partialLinkText', 'Events')->click();
@@ -158,7 +158,6 @@ class EventsTest extends TestBase
      * Test for editing events
      */
     #[Depends('testAddEvent')]
-    #[Group('large')]
     public function testEditEvents(): void
     {
         $this->eventSQL();
@@ -193,7 +192,6 @@ class EventsTest extends TestBase
      * Test for dropping event
      */
     #[Depends('testAddEvent')]
-    #[Group('large')]
     public function testDropEvent(): void
     {
         $this->eventSQL();

--- a/tests/end-to-end/Database/OperationsTest.php
+++ b/tests/end-to-end/Database/OperationsTest.php
@@ -6,9 +6,10 @@ namespace PhpMyAdmin\Tests\Selenium\Database;
 
 use PhpMyAdmin\Tests\Selenium\TestBase;
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversNothing]
+#[Large]
 class OperationsTest extends TestBase
 {
     /**
@@ -34,7 +35,6 @@ class OperationsTest extends TestBase
     /**
      * Test for adding database comment
      */
-    #[Group('large')]
     public function testDbComment(): void
     {
         $this->skipIfNotPMADB();
@@ -54,7 +54,6 @@ class OperationsTest extends TestBase
     /**
      * Test for renaming database
      */
-    #[Group('large')]
     public function testRenameDB(): void
     {
         $this->getToDBOperations();
@@ -93,7 +92,6 @@ class OperationsTest extends TestBase
     /**
      * Test for copying database
      */
-    #[Group('large')]
     public function testCopyDb(): void
     {
         $this->getToDBOperations();

--- a/tests/end-to-end/Database/ProceduresTest.php
+++ b/tests/end-to-end/Database/ProceduresTest.php
@@ -6,12 +6,13 @@ namespace PhpMyAdmin\Tests\Selenium\Database;
 
 use PhpMyAdmin\Tests\Selenium\TestBase;
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 use function sleep;
 use function str_replace;
 
 #[CoversNothing]
+#[Large]
 class ProceduresTest extends TestBase
 {
     /**
@@ -108,7 +109,6 @@ class ProceduresTest extends TestBase
     /**
      * Create a procedure
      */
-    #[Group('large')]
     public function testAddProcedure(): void
     {
         $this->waitForElement('partialLinkText', 'Routines')->click();
@@ -172,7 +172,6 @@ class ProceduresTest extends TestBase
     /**
      * Test for editing procedure
      */
-    #[Group('large')]
     public function testEditProcedure(): void
     {
         $this->procedureSQL();
@@ -197,7 +196,6 @@ class ProceduresTest extends TestBase
     /**
      * Test for dropping procedure
      */
-    #[Group('large')]
     public function testDropProcedure(): void
     {
         $this->procedureSQL();

--- a/tests/end-to-end/Database/StructureTest.php
+++ b/tests/end-to-end/Database/StructureTest.php
@@ -6,9 +6,10 @@ namespace PhpMyAdmin\Tests\Selenium\Database;
 
 use PhpMyAdmin\Tests\Selenium\TestBase;
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversNothing]
+#[Large]
 class StructureTest extends TestBase
 {
     /**
@@ -44,7 +45,6 @@ class StructureTest extends TestBase
     /**
      * Test for truncating a table
      */
-    #[Group('large')]
     public function testTruncateTable(): void
     {
         $this->byXPath("(//a[contains(., 'Empty')])[1]")->click();
@@ -67,7 +67,6 @@ class StructureTest extends TestBase
     /**
      * Tests for dropping multiple tables
      */
-    #[Group('large')]
     public function testDropMultipleTables(): void
     {
         $this->byCssSelector("label[for='tablesForm_checkall']")->click();

--- a/tests/end-to-end/ExportTest.php
+++ b/tests/end-to-end/ExportTest.php
@@ -6,11 +6,12 @@ namespace PhpMyAdmin\Tests\Selenium;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 use function strtolower;
 
 #[CoversNothing]
+#[Large]
 class ExportTest extends TestBase
 {
     /**
@@ -40,7 +41,6 @@ class ExportTest extends TestBase
      * @param string[] $expected Array of expected strings
      */
     #[DataProvider('exportDataProvider')]
-    #[Group('large')]
     public function testServerExport(string $plugin, array $expected): void
     {
         $text = $this->doExport('server', $plugin);
@@ -57,7 +57,6 @@ class ExportTest extends TestBase
      * @param string[] $expected Array of expected strings
      */
     #[DataProvider('exportDataProvider')]
-    #[Group('large')]
     public function testDbExport(string $plugin, array $expected): void
     {
         $this->navigateDatabase($this->databaseName);
@@ -76,7 +75,6 @@ class ExportTest extends TestBase
      * @param string[] $expected Array of expected strings
      */
     #[DataProvider('exportDataProvider')]
-    #[Group('large')]
     public function testTableExport(string $plugin, array $expected): void
     {
         $this->dbQuery('INSERT INTO `' . $this->databaseName . '`.`test_table` (val) VALUES (3);');

--- a/tests/end-to-end/ImportTest.php
+++ b/tests/end-to-end/ImportTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Selenium;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversNothing]
+#[Large]
 class ImportTest extends TestBase
 {
     /**
@@ -23,7 +24,6 @@ class ImportTest extends TestBase
     /**
      * Test for server level import
      */
-    #[Group('large')]
     public function testServerImport(): void
     {
         $this->doImport('server');
@@ -42,7 +42,6 @@ class ImportTest extends TestBase
     /**
      * Test for db level import
      */
-    #[Group('large')]
     public function testDbImport(): void
     {
         $this->dbQuery('CREATE DATABASE IF NOT EXISTS `' . $this->databaseName . '`');
@@ -63,7 +62,6 @@ class ImportTest extends TestBase
     /**
      * Test for table level import
      */
-    #[Group('large')]
     public function testTableImport(): void
     {
         // setup the db

--- a/tests/end-to-end/LoginTest.php
+++ b/tests/end-to-end/LoginTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Selenium;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversNothing]
+#[Large]
 class LoginTest extends TestBase
 {
     /**
@@ -25,7 +26,6 @@ class LoginTest extends TestBase
     /**
      * Test for successful login
      */
-    #[Group('large')]
     public function testSuccessfulLogin(): void
     {
         $this->login();
@@ -37,7 +37,6 @@ class LoginTest extends TestBase
     /**
      * Test for unsuccessful login
      */
-    #[Group('large')]
     public function testLoginWithWrongPassword(): void
     {
         $this->login('Admin', 'Admin');

--- a/tests/end-to-end/NormalizationTest.php
+++ b/tests/end-to-end/NormalizationTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Selenium;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversNothing]
+#[Large]
 class NormalizationTest extends TestBase
 {
     /**
@@ -41,7 +42,6 @@ class NormalizationTest extends TestBase
     /**
      * Test for normalization to 1NF
      */
-    #[Group('large')]
     public function testNormalizationTo1NF(): void
     {
         self::assertEquals(

--- a/tests/end-to-end/ServerSettingsTest.php
+++ b/tests/end-to-end/ServerSettingsTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Selenium;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 use function sleep;
 
 #[CoversNothing]
+#[Large]
 class ServerSettingsTest extends TestBase
 {
     /**
@@ -52,7 +53,6 @@ class ServerSettingsTest extends TestBase
     /**
      * Tests whether hiding a database works or not
      */
-    #[Group('large')]
     public function testHideDatabase(): void
     {
         $this->createDatabase();
@@ -83,7 +83,6 @@ class ServerSettingsTest extends TestBase
     /**
      * Tests whether the various settings tabs are displayed when clicked
      */
-    #[Group('large')]
     public function testSettingsTabsAreDisplayed(): void
     {
         $this->byPartialLinkText('SQL queries')->click();
@@ -111,7 +110,6 @@ class ServerSettingsTest extends TestBase
     /**
      * Tests if hiding the logo works or not
      */
-    #[Group('large')]
     public function testHideLogo(): void
     {
         $this->byPartialLinkText('Navigation panel')->click();

--- a/tests/end-to-end/Table/BrowseTest.php
+++ b/tests/end-to-end/Table/BrowseTest.php
@@ -7,9 +7,10 @@ namespace PhpMyAdmin\Tests\Selenium\Table;
 use Facebook\WebDriver\WebDriverKeys;
 use PhpMyAdmin\Tests\Selenium\TestBase;
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversNothing]
+#[Large]
 class BrowseTest extends TestBase
 {
     /**
@@ -42,7 +43,6 @@ class BrowseTest extends TestBase
     /**
      * Test sorting of records in browse table
      */
-    #[Group('large')]
     public function testSortRecords(): void
     {
         // case 1
@@ -126,7 +126,6 @@ class BrowseTest extends TestBase
     /**
      * Test Edit Record
      */
-    #[Group('large')]
     public function testChangeRecords(): void
     {
         $ele = $this->byCssSelector('table.table_results tbody tr:nth-child(2) td:nth-child(2)');
@@ -181,7 +180,6 @@ class BrowseTest extends TestBase
     /**
      * Test edit record by double click
      */
-    #[Group('large')]
     public function testChangeRecordsByDoubleClick(): void
     {
         $element = $this->byCssSelector('table.table_results tbody tr:nth-child(1) td:nth-child(6)');
@@ -215,7 +213,6 @@ class BrowseTest extends TestBase
     /**
      * Test copy and insert record
      */
-    #[Group('large')]
     public function testCopyRecords(): void
     {
         $ele = $this->byCssSelector('table.table_results tbody tr:nth-child(3) td:nth-child(3)');
@@ -259,7 +256,6 @@ class BrowseTest extends TestBase
     /**
      * Test search table
      */
-    #[Group('large')]
     public function testSearchRecords(): void
     {
         $this->expandMore();
@@ -296,7 +292,6 @@ class BrowseTest extends TestBase
     /**
      * Test delete multiple records
      */
-    #[Group('large')]
     public function testDeleteRecords(): void
     {
         $this->byId('id_rows_to_delete1_left')->click();

--- a/tests/end-to-end/Table/CreateTest.php
+++ b/tests/end-to-end/Table/CreateTest.php
@@ -6,11 +6,12 @@ namespace PhpMyAdmin\Tests\Selenium\Table;
 
 use PhpMyAdmin\Tests\Selenium\TestBase;
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 use function sleep;
 
 #[CoversNothing]
+#[Large]
 class CreateTest extends TestBase
 {
     protected function setUp(): void
@@ -24,7 +25,6 @@ class CreateTest extends TestBase
     /**
      * Creates a table
      */
-    #[Group('large')]
     public function testCreateTable(): void
     {
         $this->waitAjax();

--- a/tests/end-to-end/Table/InsertTest.php
+++ b/tests/end-to-end/Table/InsertTest.php
@@ -6,9 +6,10 @@ namespace PhpMyAdmin\Tests\Selenium\Table;
 
 use PhpMyAdmin\Tests\Selenium\TestBase;
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversNothing]
+#[Large]
 class InsertTest extends TestBase
 {
     /**
@@ -36,7 +37,6 @@ class InsertTest extends TestBase
     /**
      * Insert data into table
      */
-    #[Group('large')]
     public function testAddData(): void
     {
         if ($this->isSafari()) {

--- a/tests/end-to-end/Table/OperationsTest.php
+++ b/tests/end-to-end/Table/OperationsTest.php
@@ -6,9 +6,10 @@ namespace PhpMyAdmin\Tests\Selenium\Table;
 
 use PhpMyAdmin\Tests\Selenium\TestBase;
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversNothing]
+#[Large]
 class OperationsTest extends TestBase
 {
     /**
@@ -49,7 +50,6 @@ class OperationsTest extends TestBase
     /**
      * Test for changing a table order
      */
-    #[Group('large')]
     public function testChangeTableOrder(): void
     {
         $this->selectByLabel(
@@ -79,7 +79,6 @@ class OperationsTest extends TestBase
     /**
      * Test for moving a table
      */
-    #[Group('large')]
     public function testMoveTable(): void
     {
         $this->byCssSelector("form#moveTableForm input[name='new_name']")
@@ -108,7 +107,6 @@ class OperationsTest extends TestBase
     /**
      * Test for renaming a table
      */
-    #[Group('large')]
     public function testRenameTable(): void
     {
         $this->byCssSelector("form#tableOptionsForm input[name='new_name']")
@@ -137,7 +135,6 @@ class OperationsTest extends TestBase
     /**
      * Test for copying a table
      */
-    #[Group('large')]
     public function testCopyTable(): void
     {
         $this->scrollIntoView('copyTable');
@@ -166,7 +163,6 @@ class OperationsTest extends TestBase
     /**
      * Test for truncating a table
      */
-    #[Group('large')]
     public function testTruncateTable(): void
     {
         $this->scrollToBottom();
@@ -190,7 +186,6 @@ class OperationsTest extends TestBase
     /**
      * Test for dropping a table
      */
-    #[Group('large')]
     public function testDropTable(): void
     {
         $dropLink = $this->waitUntilElementIsVisible('partialLinkText', 'Delete the table (DROP)', 30);

--- a/tests/end-to-end/Table/StructureTest.php
+++ b/tests/end-to-end/Table/StructureTest.php
@@ -6,9 +6,10 @@ namespace PhpMyAdmin\Tests\Selenium\Table;
 
 use PhpMyAdmin\Tests\Selenium\TestBase;
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversNothing]
+#[Large]
 class StructureTest extends TestBase
 {
     /**
@@ -40,7 +41,6 @@ class StructureTest extends TestBase
     /**
      * Test for adding a new column
      */
-    #[Group('large')]
     public function testAddColumn(): void
     {
         $this->waitForElement('cssSelector', "#addColumns > input[value='Go']")->click();
@@ -71,7 +71,6 @@ class StructureTest extends TestBase
     /**
      * Test for changing a column
      */
-    #[Group('large')]
     public function testChangeColumn(): void
     {
         $this->byCssSelector('#tablestructure tbody tr:nth-child(2) td:nth-child(11)')->click();
@@ -98,7 +97,6 @@ class StructureTest extends TestBase
     /**
      * Test for dropping columns
      */
-    #[Group('large')]
     public function testDropColumns(): void
     {
         $this->waitForElement('cssSelector', 'label[for=checkbox_row_2]')->click();

--- a/tests/end-to-end/TrackingTest.php
+++ b/tests/end-to-end/TrackingTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Selenium;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversNothing]
+#[Large]
 class TrackingTest extends TestBase
 {
     /**
@@ -53,7 +54,6 @@ class TrackingTest extends TestBase
     /**
      * Tests basic tracking functionality
      */
-    #[Group('large')]
     public function testTrackingData(): void
     {
         $this->executeSqlAndReturnToTableTracking();
@@ -127,7 +127,6 @@ class TrackingTest extends TestBase
     /**
      * Tests deactivation of tracking
      */
-    #[Group('large')]
     public function testDeactivateTracking(): void
     {
         $this->byCssSelector("input[value='Deactivate now']")->click();
@@ -141,7 +140,6 @@ class TrackingTest extends TestBase
     /**
      * Tests dropping a tracking
      */
-    #[Group('large')]
     public function testDropTracking(): void
     {
         $this->navigateDatabase($this->databaseName, true);
@@ -183,7 +181,6 @@ class TrackingTest extends TestBase
     /**
      * Tests structure snapshot of a tracking
      */
-    #[Group('large')]
     public function testStructureSnapshot(): void
     {
         $this->byPartialLinkText('Structure snapshot')->click();

--- a/tests/end-to-end/TriggersTest.php
+++ b/tests/end-to-end/TriggersTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Selenium;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversNothing]
+#[Large]
 class TriggersTest extends TestBase
 {
     /**
@@ -59,7 +60,6 @@ class TriggersTest extends TestBase
     /**
      * Create a Trigger
      */
-    #[Group('large')]
     public function testAddTrigger(): void
     {
         $this->expandMore();
@@ -126,7 +126,6 @@ class TriggersTest extends TestBase
     /**
      * Test for editing Triggers
      */
-    #[Group('large')]
     public function testEditTriggers(): void
     {
         $this->expandMore();
@@ -163,7 +162,6 @@ class TriggersTest extends TestBase
     /**
      * Test for dropping Trigger
      */
-    #[Group('large')]
     public function testDropTrigger(): void
     {
         $this->expandMore();

--- a/tests/end-to-end/XssTest.php
+++ b/tests/end-to-end/XssTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Selenium;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversNothing]
+#[Large]
 class XssTest extends TestBase
 {
     /**
@@ -25,7 +26,6 @@ class XssTest extends TestBase
     /**
      * Tests the SQL query tab with a null query
      */
-    #[Group('large')]
     public function testQueryTabWithNullValue(): void
     {
         if ($this->isSafari()) {

--- a/tests/unit/Config/ServerConfigChecksTest.php
+++ b/tests/unit/Config/ServerConfigChecksTest.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\Config\ConfigFile;
 use PhpMyAdmin\Config\ServerConfigChecks;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use ReflectionException;
 use ReflectionProperty;
 
@@ -130,10 +131,8 @@ class ServerConfigChecksTest extends AbstractTestCase
         self::assertArrayNotHasKey('error', $messages);
     }
 
-    /**
-     * @requires extension bz2
-     * @requires extension zip
-     */
+    #[RequiresPhpExtension('bz2')]
+    #[RequiresPhpExtension('zip')]
     public function testBlowfishWithInvalidSecret(): void
     {
         $_SESSION[$this->sessionID] = [];
@@ -160,10 +159,8 @@ class ServerConfigChecksTest extends AbstractTestCase
         self::assertArrayNotHasKey('error', $messages);
     }
 
-    /**
-     * @requires extension bz2
-     * @requires extension zip
-     */
+    #[RequiresPhpExtension('bz2')]
+    #[RequiresPhpExtension('zip')]
     public function testBlowfishWithValidSecret(): void
     {
         $_SESSION[$this->sessionID] = [];

--- a/tests/unit/ConfigStorage/RelationTest.php
+++ b/tests/unit/ConfigStorage/RelationTest.php
@@ -15,13 +15,13 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionProperty;
 
 use function implode;
 
 #[CoversClass(Relation::class)]
-#[Group('medium')]
+#[Medium]
 class RelationTest extends AbstractTestCase
 {
     /**

--- a/tests/unit/Controllers/Table/ImportControllerTest.php
+++ b/tests/unit/Controllers/Table/ImportControllerTest.php
@@ -22,14 +22,13 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\UserPreferences;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 #[CoversClass(ImportController::class)]
 class ImportControllerTest extends AbstractTestCase
 {
-    /**
-     * @requires extension bz2
-     * @requires extension zip
-     */
+    #[RequiresPhpExtension('bz2')]
+    #[RequiresPhpExtension('zip')]
     public function testImportController(): void
     {
         Current::$database = 'test_db';

--- a/tests/unit/Export/ExportTest.php
+++ b/tests/unit/Export/ExportTest.php
@@ -17,14 +17,14 @@ use PhpMyAdmin\Plugins\Export\ExportSql;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 use function htmlspecialchars;
 
 use const ENT_COMPAT;
 
 #[CoversClass(Export::class)]
-#[Group('large')]
+#[Large]
 class ExportTest extends AbstractTestCase
 {
     public function testMergeAliases(): void

--- a/tests/unit/Gis/GisGeometryTest.php
+++ b/tests/unit/Gis/GisGeometryTest.php
@@ -25,7 +25,18 @@ class GisGeometryTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->object = $this->getMockForAbstractClass(GisGeometry::class);
+        $this->object = $this->getMockBuilder(GisGeometry::class)
+            ->onlyMethods([
+                'prepareRowAsSvg',
+                'prepareRowAsPng',
+                'prepareRowAsPdf',
+                'prepareRowAsOl',
+                'getExtent',
+                'generateWkt',
+                'getCoordinateParams',
+                'getType',
+            ])
+            ->getMock();
     }
 
     /**

--- a/tests/unit/HeaderTest.php
+++ b/tests/unit/HeaderTest.php
@@ -14,7 +14,7 @@ use PhpMyAdmin\Header;
 use PhpMyAdmin\Template;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionProperty;
 
 use function gmdate;
@@ -22,7 +22,7 @@ use function gmdate;
 use const DATE_RFC1123;
 
 #[CoversClass(Header::class)]
-#[Group('medium')]
+#[Medium]
 class HeaderTest extends AbstractTestCase
 {
     /**

--- a/tests/unit/InsertEditTest.php
+++ b/tests/unit/InsertEditTest.php
@@ -24,7 +24,7 @@ use PhpMyAdmin\Transformations;
 use PhpMyAdmin\Url;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionProperty;
 
 use function hash;
@@ -44,7 +44,7 @@ use const MYSQLI_TYPE_TINY;
 #[CoversClass(InsertEdit::class)]
 #[CoversClass(EditField::class)]
 #[CoversClass(InsertEditColumn::class)]
-#[Group('medium')]
+#[Medium]
 class InsertEditTest extends AbstractTestCase
 {
     protected DatabaseInterface $dbi;

--- a/tests/unit/Navigation/Nodes/NodeDatabaseChildTest.php
+++ b/tests/unit/Navigation/Nodes/NodeDatabaseChildTest.php
@@ -39,7 +39,10 @@ class NodeDatabaseChildTest extends AbstractTestCase
             'navigationhiding' => 'navigationhiding',
         ]);
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
-        $this->object = $this->getMockForAbstractClass(NodeDatabaseChild::class, [$config, 'child']);
+        $this->object = $this->getMockBuilder(NodeDatabaseChild::class)
+            ->setConstructorArgs([$config, 'child'])
+            ->onlyMethods(['getItemType'])
+            ->getMock();
     }
 
     /**

--- a/tests/unit/PdfTest.php
+++ b/tests/unit/PdfTest.php
@@ -6,9 +6,10 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Pdf;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversClass(Pdf::class)]
+#[Large]
 class PdfTest extends AbstractTestCase
 {
     /**
@@ -24,7 +25,6 @@ class PdfTest extends AbstractTestCase
     /**
      * Test for Pdf::getPDFData
      */
-    #[Group('large')]
     public function testBasic(): void
     {
         $arr = new Pdf();
@@ -34,7 +34,6 @@ class PdfTest extends AbstractTestCase
     /**
      * Test for Pdf::getPDFData
      */
-    #[Group('large')]
     public function testAlias(): void
     {
         $arr = new Pdf();
@@ -45,7 +44,6 @@ class PdfTest extends AbstractTestCase
     /**
      * Test for Pdf::getPDFData
      */
-    #[Group('large')]
     public function testDocument(): void
     {
         $pdf = new Pdf();

--- a/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
@@ -15,7 +15,6 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseRendererStub;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -75,7 +74,6 @@ class AuthenticationCookieTest extends AbstractTestCase
         unset($this->object);
     }
 
-    #[Group('medium')]
     #[RunInSeparateProcess]
     #[PreserveGlobalState(false)]
     public function testAuthErrorAJAX(): void
@@ -117,7 +115,6 @@ class AuthenticationCookieTest extends AbstractTestCase
 
     #[RunInSeparateProcess]
     #[PreserveGlobalState(false)]
-    #[Group('medium')]
     public function testAuthError(): void
     {
         $_REQUEST = [];
@@ -194,7 +191,6 @@ class AuthenticationCookieTest extends AbstractTestCase
 
     #[RunInSeparateProcess]
     #[PreserveGlobalState(false)]
-    #[Group('medium')]
     public function testAuthCaptcha(): void
     {
         $_REQUEST['old_usr'] = '';
@@ -257,7 +253,6 @@ class AuthenticationCookieTest extends AbstractTestCase
 
     #[RunInSeparateProcess]
     #[PreserveGlobalState(false)]
-    #[Group('medium')]
     public function testAuthCaptchaCheckbox(): void
     {
         $_REQUEST['old_usr'] = '';

--- a/tests/unit/Plugins/Auth/AuthenticationHttpTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationHttpTest.php
@@ -14,7 +14,6 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseRendererStub;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -277,7 +276,6 @@ class AuthenticationHttpTest extends AbstractTestCase
         self::assertSame(3, Current::$server);
     }
 
-    #[Group('medium')]
     #[RunInSeparateProcess]
     #[PreserveGlobalState(false)]
     public function testAuthFails(): void

--- a/tests/unit/Plugins/Export/ExportCodegenTest.php
+++ b/tests/unit/Plugins/Export/ExportCodegenTest.php
@@ -16,7 +16,7 @@ use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -24,7 +24,7 @@ use function ob_get_clean;
 use function ob_start;
 
 #[CoversClass(ExportCodegen::class)]
-#[Group('medium')]
+#[Medium]
 class ExportCodegenTest extends AbstractTestCase
 {
     protected ExportCodegen $object;

--- a/tests/unit/Plugins/Export/ExportCsvTest.php
+++ b/tests/unit/Plugins/Export/ExportCsvTest.php
@@ -18,7 +18,7 @@ use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -26,7 +26,7 @@ use function ob_get_clean;
 use function ob_start;
 
 #[CoversClass(ExportCsv::class)]
-#[Group('medium')]
+#[Medium]
 class ExportCsvTest extends AbstractTestCase
 {
     protected ExportCsv $object;

--- a/tests/unit/Plugins/Export/ExportExcelTest.php
+++ b/tests/unit/Plugins/Export/ExportExcelTest.php
@@ -18,12 +18,12 @@ use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionMethod;
 use ReflectionProperty;
 
 #[CoversClass(ExportExcel::class)]
-#[Group('medium')]
+#[Medium]
 class ExportExcelTest extends AbstractTestCase
 {
     protected ExportExcel $object;

--- a/tests/unit/Plugins/Export/ExportHtmlwordTest.php
+++ b/tests/unit/Plugins/Export/ExportHtmlwordTest.php
@@ -28,7 +28,7 @@ use PhpMyAdmin\Triggers\Event;
 use PhpMyAdmin\Triggers\Timing;
 use PhpMyAdmin\Triggers\Trigger;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -37,7 +37,7 @@ use function ob_get_clean;
 use function ob_start;
 
 #[CoversClass(ExportHtmlword::class)]
-#[Group('medium')]
+#[Medium]
 class ExportHtmlwordTest extends AbstractTestCase
 {
     protected DatabaseInterface $dbi;

--- a/tests/unit/Plugins/Export/ExportJsonTest.php
+++ b/tests/unit/Plugins/Export/ExportJsonTest.php
@@ -16,12 +16,12 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Transformations;
 use PhpMyAdmin\Version;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionMethod;
 use ReflectionProperty;
 
 #[CoversClass(ExportJson::class)]
-#[Group('medium')]
+#[Medium]
 class ExportJsonTest extends AbstractTestCase
 {
     protected ExportJson $object;

--- a/tests/unit/Plugins/Export/ExportLatexTest.php
+++ b/tests/unit/Plugins/Export/ExportLatexTest.php
@@ -22,7 +22,7 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -31,7 +31,7 @@ use function ob_get_clean;
 use function ob_start;
 
 #[CoversClass(ExportLatex::class)]
-#[Group('medium')]
+#[Medium]
 class ExportLatexTest extends AbstractTestCase
 {
     protected ExportLatex $object;

--- a/tests/unit/Plugins/Export/ExportMediawikiTest.php
+++ b/tests/unit/Plugins/Export/ExportMediawikiTest.php
@@ -19,7 +19,7 @@ use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -28,7 +28,7 @@ use function ob_get_clean;
 use function ob_start;
 
 #[CoversClass(ExportMediawiki::class)]
-#[Group('medium')]
+#[Medium]
 class ExportMediawikiTest extends AbstractTestCase
 {
     protected ExportMediawiki $object;

--- a/tests/unit/Plugins/Export/ExportOdsTest.php
+++ b/tests/unit/Plugins/Export/ExportOdsTest.php
@@ -20,7 +20,7 @@ use PhpMyAdmin\Tests\FieldHelper;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -36,7 +36,7 @@ use const MYSQLI_TYPE_TIME;
 use const MYSQLI_TYPE_TINY_BLOB;
 
 #[CoversClass(ExportOds::class)]
-#[Group('medium')]
+#[Medium]
 #[RequiresPhpExtension('zip')]
 class ExportOdsTest extends AbstractTestCase
 {

--- a/tests/unit/Plugins/Export/ExportOdtTest.php
+++ b/tests/unit/Plugins/Export/ExportOdtTest.php
@@ -29,7 +29,7 @@ use PhpMyAdmin\Triggers\Event;
 use PhpMyAdmin\Triggers\Timing;
 use PhpMyAdmin\Triggers\Trigger;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -44,7 +44,7 @@ use const MYSQLI_TYPE_DECIMAL;
 use const MYSQLI_TYPE_STRING;
 
 #[CoversClass(ExportOdt::class)]
-#[Group('medium')]
+#[Medium]
 #[RequiresPhpExtension('zip')]
 class ExportOdtTest extends AbstractTestCase
 {

--- a/tests/unit/Plugins/Export/ExportPdfTest.php
+++ b/tests/unit/Plugins/Export/ExportPdfTest.php
@@ -17,14 +17,14 @@ use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionMethod;
 use ReflectionProperty;
 
 use function __;
 
 #[CoversClass(ExportPdf::class)]
-#[Group('medium')]
+#[Medium]
 class ExportPdfTest extends AbstractTestCase
 {
     protected ExportPdf $object;

--- a/tests/unit/Plugins/Export/ExportPhparrayTest.php
+++ b/tests/unit/Plugins/Export/ExportPhparrayTest.php
@@ -16,7 +16,7 @@ use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -24,7 +24,7 @@ use function ob_get_clean;
 use function ob_start;
 
 #[CoversClass(ExportPhparray::class)]
-#[Group('medium')]
+#[Medium]
 class ExportPhparrayTest extends AbstractTestCase
 {
     protected ExportPhparray $object;

--- a/tests/unit/Plugins/Export/ExportSqlTest.php
+++ b/tests/unit/Plugins/Export/ExportSqlTest.php
@@ -29,7 +29,7 @@ use PhpMyAdmin\Tests\FieldHelper;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -45,7 +45,7 @@ use const MYSQLI_TYPE_STRING;
 use const MYSQLI_UNIQUE_KEY_FLAG;
 
 #[CoversClass(ExportSql::class)]
-#[Group('medium')]
+#[Medium]
 class ExportSqlTest extends AbstractTestCase
 {
     protected ExportSql $object;
@@ -93,7 +93,6 @@ class ExportSqlTest extends AbstractTestCase
         unset($this->object);
     }
 
-    #[Group('medium')]
     public function testSetPropertiesWithHideSql(): void
     {
         // test with hide structure and hide sql as true
@@ -108,7 +107,6 @@ class ExportSqlTest extends AbstractTestCase
         self::assertNull($properties->getOptions());
     }
 
-    #[Group('medium')]
     public function testSetProperties(): void
     {
         // test with hide structure and hide sql as false
@@ -740,7 +738,6 @@ class ExportSqlTest extends AbstractTestCase
         );
     }
 
-    #[Group('medium')]
     public function testGetTableDef(): void
     {
         $GLOBALS['sql_compatibility'] = 'MSSQL';
@@ -902,7 +899,6 @@ SQL;
         );
     }
 
-    #[Group('medium')]
     public function testExportStructure(): void
     {
         $GLOBALS['sql_compatibility'] = 'MSSQL';
@@ -1013,7 +1009,6 @@ SQL;
         self::assertStringContainsString('CREATE TABLE `test_table`', $result);
     }
 
-    #[Group('medium')]
     public function testExportData(): void
     {
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
@@ -1124,7 +1119,6 @@ SQL;
         self::assertStringContainsString('SET IDENTITY_INSERT &quot;table&quot; OFF;', $result);
     }
 
-    #[Group('medium')]
     public function testExportDataWithUpdate(): void
     {
         $dbi = $this->getMockBuilder(DatabaseInterface::class)

--- a/tests/unit/Plugins/Export/ExportTexytextTest.php
+++ b/tests/unit/Plugins/Export/ExportTexytextTest.php
@@ -29,7 +29,7 @@ use PhpMyAdmin\Triggers\Event;
 use PhpMyAdmin\Triggers\Timing;
 use PhpMyAdmin\Triggers\Trigger;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -37,7 +37,7 @@ use function ob_get_clean;
 use function ob_start;
 
 #[CoversClass(ExportTexytext::class)]
-#[Group('medium')]
+#[Medium]
 class ExportTexytextTest extends AbstractTestCase
 {
     protected DatabaseInterface $dbi;

--- a/tests/unit/Plugins/Export/ExportXmlTest.php
+++ b/tests/unit/Plugins/Export/ExportXmlTest.php
@@ -19,7 +19,7 @@ use PhpMyAdmin\Table\Table;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -27,7 +27,7 @@ use function ob_get_clean;
 use function ob_start;
 
 #[CoversClass(ExportXml::class)]
-#[Group('medium')]
+#[Medium]
 class ExportXmlTest extends AbstractTestCase
 {
     protected ExportXml $object;
@@ -68,7 +68,6 @@ class ExportXmlTest extends AbstractTestCase
         unset($this->object);
     }
 
-    #[Group('medium')]
     public function testSetProperties(): void
     {
         $method = new ReflectionMethod(ExportXml::class, 'setProperties');
@@ -169,7 +168,6 @@ class ExportXmlTest extends AbstractTestCase
         self::assertInstanceOf(BoolPropertyItem::class, $property);
     }
 
-    #[Group('medium')]
     public function testExportHeader(): void
     {
         $GLOBALS['xml_export_functions'] = 1;

--- a/tests/unit/Plugins/Export/ExportYamlTest.php
+++ b/tests/unit/Plugins/Export/ExportYamlTest.php
@@ -16,7 +16,7 @@ use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -24,7 +24,7 @@ use function ob_get_clean;
 use function ob_start;
 
 #[CoversClass(ExportYaml::class)]
-#[Group('medium')]
+#[Medium]
 class ExportYamlTest extends AbstractTestCase
 {
     protected ExportYaml $object;

--- a/tests/unit/Plugins/Import/ImportCsvTest.php
+++ b/tests/unit/Plugins/Import/ImportCsvTest.php
@@ -14,12 +14,13 @@ use PhpMyAdmin\Plugins\Import\ImportCsv;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 
 use function __;
 use function basename;
 
 #[CoversClass(ImportCsv::class)]
+#[Medium]
 class ImportCsvTest extends AbstractTestCase
 {
     protected DatabaseInterface $dbi;
@@ -104,7 +105,6 @@ class ImportCsvTest extends AbstractTestCase
     /**
      * Test for getProperties
      */
-    #[Group('medium')]
     public function testGetProperties(): void
     {
         $properties = $this->object->getProperties();
@@ -121,7 +121,6 @@ class ImportCsvTest extends AbstractTestCase
     /**
      * Test for doImport
      */
-    #[Group('medium')]
     public function testDoImport(): void
     {
         //$sql_query_disabled will show the import SQL detail
@@ -150,7 +149,6 @@ class ImportCsvTest extends AbstractTestCase
     /**
      * Test for partial import/setting table and database names in doImport
      */
-    #[Group('medium')]
     public function testDoPartialImport(): void
     {
         //$sql_query_disabled will show the import SQL detail
@@ -188,7 +186,6 @@ class ImportCsvTest extends AbstractTestCase
     /**
      * Test for getProperties for Table param
      */
-    #[Group('medium')]
     public function testGetPropertiesForTable(): void
     {
         $properties = $this->object->getProperties();
@@ -205,7 +202,6 @@ class ImportCsvTest extends AbstractTestCase
     /**
      * Test for doImport for _getAnalyze = false, should be OK as well
      */
-    #[Group('medium')]
     public function testDoImportNotAnalysis(): void
     {
         //$sql_query_disabled will show the import SQL detail
@@ -235,7 +231,6 @@ class ImportCsvTest extends AbstractTestCase
     /**
      * Test for doImport in the most basic and normal way
      */
-    #[Group('medium')]
     public function testDoImportNormal(): void
     {
         //$sql_query_disabled will show the import SQL detail
@@ -287,7 +282,6 @@ class ImportCsvTest extends AbstractTestCase
     /**
      * Test for doImport skipping headers
      */
-    #[Group('medium')]
     public function testDoImportSkipHeaders(): void
     {
         //$sql_query_disabled will show the import SQL detail

--- a/tests/unit/Plugins/Import/ImportLdiTest.php
+++ b/tests/unit/Plugins/Import/ImportLdiTest.php
@@ -14,11 +14,12 @@ use PhpMyAdmin\Plugins\Import\ImportLdi;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 
 use function __;
 
 #[CoversClass(ImportLdi::class)]
+#[Medium]
 class ImportLdiTest extends AbstractTestCase
 {
     /**
@@ -64,7 +65,6 @@ class ImportLdiTest extends AbstractTestCase
     /**
      * Test for getProperties
      */
-    #[Group('medium')]
     public function testGetProperties(): void
     {
         $properties = (new ImportLdi())->getProperties();
@@ -81,7 +81,6 @@ class ImportLdiTest extends AbstractTestCase
     /**
      * Test for getProperties for ldi_local_option = auto
      */
-    #[Group('medium')]
     public function testGetPropertiesAutoLdi(): void
     {
         $dbi = self::createMock(DatabaseInterface::class);
@@ -115,7 +114,6 @@ class ImportLdiTest extends AbstractTestCase
     /**
      * Test for doImport
      */
-    #[Group('medium')]
     public function testDoImport(): void
     {
         //$sql_query_disabled will show the import SQL detail
@@ -144,7 +142,6 @@ class ImportLdiTest extends AbstractTestCase
     /**
      * Test for doImport : invalid import file
      */
-    #[Group('medium')]
     public function testDoImportInvalidFile(): void
     {
         ImportSettings::$importFile = 'none';
@@ -164,7 +161,6 @@ class ImportLdiTest extends AbstractTestCase
     /**
      * Test for doImport with LDI setting
      */
-    #[Group('medium')]
     public function testDoImportLDISetting(): void
     {
         //$sql_query_disabled will show the import SQL detail

--- a/tests/unit/Plugins/Import/ImportMediawikiTest.php
+++ b/tests/unit/Plugins/Import/ImportMediawikiTest.php
@@ -138,11 +138,7 @@ class ImportMediawikiTest extends AbstractTestCase
         self::assertTrue(ImportSettings::$finished);
     }
 
-    /**
-     * Test for doImport
-     *
-     * @group medium
-     */
+    #[Group('medium')]
     public function testDoImportWithEmptyTable(): void
     {
         //Mock DBI

--- a/tests/unit/Plugins/Import/ImportMediawikiTest.php
+++ b/tests/unit/Plugins/Import/ImportMediawikiTest.php
@@ -12,11 +12,12 @@ use PhpMyAdmin\Import\ImportSettings;
 use PhpMyAdmin\Plugins\Import\ImportMediawiki;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 
 use function __;
 
 #[CoversClass(ImportMediawiki::class)]
+#[Medium]
 class ImportMediawikiTest extends AbstractTestCase
 {
     protected ImportMediawiki $object;
@@ -70,7 +71,6 @@ class ImportMediawikiTest extends AbstractTestCase
     /**
      * Test for getProperties
      */
-    #[Group('medium')]
     public function testGetProperties(): void
     {
         $properties = $this->object->getProperties();
@@ -96,7 +96,6 @@ class ImportMediawikiTest extends AbstractTestCase
     /**
      * Test for doImport
      */
-    #[Group('medium')]
     public function testDoImport(): void
     {
         //$import_notice will show the import detail result
@@ -138,7 +137,6 @@ class ImportMediawikiTest extends AbstractTestCase
         self::assertTrue(ImportSettings::$finished);
     }
 
-    #[Group('medium')]
     public function testDoImportWithEmptyTable(): void
     {
         //Mock DBI

--- a/tests/unit/Plugins/Import/ImportOdsTest.php
+++ b/tests/unit/Plugins/Import/ImportOdsTest.php
@@ -14,7 +14,7 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 use function __;
@@ -22,6 +22,7 @@ use function str_repeat;
 
 #[CoversClass(ImportOds::class)]
 #[RequiresPhpExtension('zip')]
+#[Medium]
 class ImportOdsTest extends AbstractTestCase
 {
     protected DatabaseInterface $dbi;
@@ -82,7 +83,6 @@ class ImportOdsTest extends AbstractTestCase
     /**
      * Test for getProperties
      */
-    #[Group('medium')]
     public function testGetProperties(): void
     {
         $properties = $this->object->getProperties();
@@ -103,7 +103,6 @@ class ImportOdsTest extends AbstractTestCase
     /**
      * Test for doImport
      */
-    #[Group('medium')]
     public function testDoImport(): void
     {
         //$sql_query_disabled will show the import SQL detail
@@ -159,7 +158,6 @@ class ImportOdsTest extends AbstractTestCase
      * Test for doImport using second dataset
      */
     #[DataProvider('dataProviderOdsEmptyRows')]
-    #[Group('medium')]
     #[RequiresPhpExtension('simplexml')]
     public function testDoImportDataset2(bool $odsEmptyRowsMode): void
     {

--- a/tests/unit/Plugins/Import/ImportShpTest.php
+++ b/tests/unit/Plugins/Import/ImportShpTest.php
@@ -13,6 +13,7 @@ use PhpMyAdmin\Plugins\Import\ImportShp;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 use function __;
@@ -20,6 +21,7 @@ use function extension_loaded;
 
 #[CoversClass(ImportShp::class)]
 #[RequiresPhpExtension('zip')]
+#[Medium]
 class ImportShpTest extends AbstractTestCase
 {
     protected ImportShp $object;
@@ -100,7 +102,6 @@ class ImportShpTest extends AbstractTestCase
     /**
      * Test for getProperties
      */
-    #[Group('medium')]
     public function testGetProperties(): void
     {
         $properties = $this->object->getProperties();
@@ -122,7 +123,6 @@ class ImportShpTest extends AbstractTestCase
     /**
      * Test for doImport with complex data
      */
-    #[Group('medium')]
     #[Group('32bit-incompatible')]
     public function testImportOsm(): void
     {
@@ -157,7 +157,6 @@ class ImportShpTest extends AbstractTestCase
     /**
      * Test for doImport
      */
-    #[Group('medium')]
     #[Group('32bit-incompatible')]
     public function testDoImport(): void
     {

--- a/tests/unit/Plugins/Import/ImportSqlTest.php
+++ b/tests/unit/Plugins/Import/ImportSqlTest.php
@@ -11,9 +11,10 @@ use PhpMyAdmin\Import\ImportSettings;
 use PhpMyAdmin\Plugins\Import\ImportSql;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 
 #[CoversClass(ImportSql::class)]
+#[Medium]
 class ImportSqlTest extends AbstractTestCase
 {
     protected ImportSql $object;
@@ -66,7 +67,6 @@ class ImportSqlTest extends AbstractTestCase
     /**
      * Test for doImport
      */
-    #[Group('medium')]
     public function testDoImport(): void
     {
         //$sql_query_disabled will show the import SQL detail

--- a/tests/unit/Plugins/Import/ImportXmlTest.php
+++ b/tests/unit/Plugins/Import/ImportXmlTest.php
@@ -12,7 +12,7 @@ use PhpMyAdmin\Import\ImportSettings;
 use PhpMyAdmin\Plugins\Import\ImportXml;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 use function __;
@@ -20,6 +20,7 @@ use function __;
 #[CoversClass(ImportXml::class)]
 #[RequiresPhpExtension('xml')]
 #[RequiresPhpExtension('xmlwriter')]
+#[Medium]
 class ImportXmlTest extends AbstractTestCase
 {
     protected ImportXml $object;
@@ -74,7 +75,6 @@ class ImportXmlTest extends AbstractTestCase
     /**
      * Test for getProperties
      */
-    #[Group('medium')]
     public function testGetProperties(): void
     {
         $properties = $this->object->getProperties();
@@ -100,7 +100,6 @@ class ImportXmlTest extends AbstractTestCase
     /**
      * Test for doImport
      */
-    #[Group('medium')]
     #[RequiresPhpExtension('simplexml')]
     public function testDoImport(): void
     {

--- a/tests/unit/Plugins/Schema/DiaRelationSchemaTest.php
+++ b/tests/unit/Plugins/Schema/DiaRelationSchemaTest.php
@@ -12,11 +12,12 @@ use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Plugins\Schema\Dia\DiaRelationSchema;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 #[CoversClass(DiaRelationSchema::class)]
 #[RequiresPhpExtension('xmlwriter')]
+#[Medium]
 class DiaRelationSchemaTest extends AbstractTestCase
 {
     protected DiaRelationSchema $object;
@@ -63,7 +64,6 @@ class DiaRelationSchemaTest extends AbstractTestCase
     /**
      * Test for construct, the Property is set correctly
      */
-    #[Group('medium')]
     public function testSetProperty(): void
     {
         self::assertSame(33, $this->object->getPageNumber());

--- a/tests/unit/Plugins/Schema/EpsRelationSchemaTest.php
+++ b/tests/unit/Plugins/Schema/EpsRelationSchemaTest.php
@@ -12,9 +12,10 @@ use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Plugins\Schema\Eps\EpsRelationSchema;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 
 #[CoversClass(EpsRelationSchema::class)]
+#[Medium]
 class EpsRelationSchemaTest extends AbstractTestCase
 {
     protected EpsRelationSchema $object;
@@ -62,7 +63,6 @@ class EpsRelationSchemaTest extends AbstractTestCase
     /**
      * Test for construct
      */
-    #[Group('medium')]
     public function testConstructor(): void
     {
         self::assertSame(33, $this->object->getPageNumber());
@@ -76,7 +76,6 @@ class EpsRelationSchemaTest extends AbstractTestCase
     /**
      * Test for setPageNumber
      */
-    #[Group('medium')]
     public function testSetPageNumber(): void
     {
         $this->object->setPageNumber(33);

--- a/tests/unit/Plugins/Schema/ExportRelationSchemaTest.php
+++ b/tests/unit/Plugins/Schema/ExportRelationSchemaTest.php
@@ -9,9 +9,10 @@ use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Plugins\Schema\ExportRelationSchema;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 
 #[CoversClass(ExportRelationSchema::class)]
+#[Medium]
 class ExportRelationSchemaTest extends AbstractTestCase
 {
     protected ExportRelationSchema $object;
@@ -45,7 +46,6 @@ class ExportRelationSchemaTest extends AbstractTestCase
     /**
      * Test for setPageNumber
      */
-    #[Group('medium')]
     public function testSetPageNumber(): void
     {
         $this->object->setPageNumber(33);
@@ -58,7 +58,6 @@ class ExportRelationSchemaTest extends AbstractTestCase
     /**
      * Test for setShowColor
      */
-    #[Group('medium')]
     public function testSetShowColor(): void
     {
         $this->object->setShowColor(true);
@@ -74,7 +73,6 @@ class ExportRelationSchemaTest extends AbstractTestCase
     /**
      * Test for setOrientation
      */
-    #[Group('medium')]
     public function testSetOrientation(): void
     {
         $this->object->setOrientation('P');
@@ -92,7 +90,6 @@ class ExportRelationSchemaTest extends AbstractTestCase
     /**
      * Test for setTableDimension
      */
-    #[Group('medium')]
     public function testSetTableDimension(): void
     {
         $this->object->setTableDimension(true);
@@ -108,7 +105,6 @@ class ExportRelationSchemaTest extends AbstractTestCase
     /**
      * Test for setPaper
      */
-    #[Group('medium')]
     public function testSetPaper(): void
     {
         $this->object->setPaper('A5');
@@ -126,7 +122,6 @@ class ExportRelationSchemaTest extends AbstractTestCase
     /**
      * Test for setAllTablesSameWidth
      */
-    #[Group('medium')]
     public function testSetAllTablesSameWidth(): void
     {
         $this->object->setAllTablesSameWidth(true);
@@ -142,7 +137,6 @@ class ExportRelationSchemaTest extends AbstractTestCase
     /**
      * Test for setShowKeys
      */
-    #[Group('medium')]
     public function testSetShowKeys(): void
     {
         $this->object->setShowKeys(true);

--- a/tests/unit/Plugins/Schema/PdfRelationSchemaTest.php
+++ b/tests/unit/Plugins/Schema/PdfRelationSchemaTest.php
@@ -12,9 +12,10 @@ use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Plugins\Schema\Pdf\PdfRelationSchema;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Large;
 
 #[CoversClass(PdfRelationSchema::class)]
+#[Large]
 class PdfRelationSchemaTest extends AbstractTestCase
 {
     protected PdfRelationSchema $object;
@@ -65,7 +66,6 @@ class PdfRelationSchemaTest extends AbstractTestCase
     /**
      * Test for construct
      */
-    #[Group('large')]
     public function testConstructor(): void
     {
         self::assertSame(33, $this->object->getPageNumber());

--- a/tests/unit/Plugins/Schema/SvgRelationSchemaTest.php
+++ b/tests/unit/Plugins/Schema/SvgRelationSchemaTest.php
@@ -12,11 +12,12 @@ use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Plugins\Schema\Svg\SvgRelationSchema;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 #[CoversClass(SvgRelationSchema::class)]
 #[RequiresPhpExtension('xmlwriter')]
+#[Medium]
 class SvgRelationSchemaTest extends AbstractTestCase
 {
     protected SvgRelationSchema $object;
@@ -65,7 +66,6 @@ class SvgRelationSchemaTest extends AbstractTestCase
     /**
      * Test for construct
      */
-    #[Group('medium')]
     public function testConstructor(): void
     {
         self::assertSame(33, $this->object->getPageNumber());

--- a/tests/unit/Plugins/Transformations/TransformationPluginsTest.php
+++ b/tests/unit/Plugins/Transformations/TransformationPluginsTest.php
@@ -46,7 +46,7 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\FieldHelper;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use ReflectionMethod;
 
 use function date_default_timezone_set;
@@ -95,6 +95,7 @@ use const MYSQLI_TYPE_TINY;
 #[CoversClass(Text_Plain_Longtoipv4::class)]
 #[CoversClass(Text_Plain_PreApPend::class)]
 #[CoversClass(Text_Plain_Substring::class)]
+#[Medium]
 class TransformationPluginsTest extends AbstractTestCase
 {
     /**
@@ -409,7 +410,6 @@ class TransformationPluginsTest extends AbstractTestCase
      * @param mixed[] $args     the array of arguments
      */
     #[DataProvider('multiDataProvider')]
-    #[Group('medium')]
     public function testGetMulti(object $object, string $method, mixed $expected, array $args = []): void
     {
         if (! method_exists($object, $method)) {
@@ -658,7 +658,6 @@ class TransformationPluginsTest extends AbstractTestCase
      * @psalm-param array{string, array, FieldMetadata|null} $applyArgs
      */
     #[DataProvider('transformationDataProvider')]
-    #[Group('medium')]
     public function testTransformation(
         TransformationsPlugin $object,
         array $applyArgs,

--- a/tests/unit/Properties/Options/OptionsPropertyGroupTest.php
+++ b/tests/unit/Properties/Options/OptionsPropertyGroupTest.php
@@ -22,7 +22,9 @@ class OptionsPropertyGroupTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->stub = $this->getMockForAbstractClass(OptionsPropertyGroup::class);
+        $this->stub = $this->getMockBuilder(OptionsPropertyGroup::class)
+            ->onlyMethods(['getItemType'])
+            ->getMock();
     }
 
     /**

--- a/tests/unit/Properties/Options/OptionsPropertyItemTest.php
+++ b/tests/unit/Properties/Options/OptionsPropertyItemTest.php
@@ -21,7 +21,9 @@ class OptionsPropertyItemTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->stub = $this->getMockForAbstractClass(OptionsPropertyItem::class);
+        $this->stub = $this->getMockBuilder(OptionsPropertyItem::class)
+            ->onlyMethods(['getItemType'])
+            ->getMock();
     }
 
     /**

--- a/tests/unit/Properties/Options/OptionsPropertyOneItemTest.php
+++ b/tests/unit/Properties/Options/OptionsPropertyOneItemTest.php
@@ -21,7 +21,9 @@ class OptionsPropertyOneItemTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->stub = $this->getMockForAbstractClass(OptionsPropertyOneItem::class);
+        $this->stub = $this->getMockBuilder(OptionsPropertyOneItem::class)
+            ->onlyMethods(['getItemType'])
+            ->getMock();
     }
 
     /**

--- a/tests/unit/Properties/Plugins/PluginPropertyItemTest.php
+++ b/tests/unit/Properties/Plugins/PluginPropertyItemTest.php
@@ -20,7 +20,9 @@ class PluginPropertyItemTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->stub = $this->getMockForAbstractClass(PluginPropertyItem::class);
+        $this->stub = $this->getMockBuilder(PluginPropertyItem::class)
+            ->onlyMethods(['getItemType'])
+            ->getMock();
     }
 
     /**

--- a/tests/unit/Properties/PropertyItemTest.php
+++ b/tests/unit/Properties/PropertyItemTest.php
@@ -21,7 +21,9 @@ class PropertyItemTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->stub = $this->getMockForAbstractClass(PropertyItem::class);
+        $this->stub = $this->getMockBuilder(PropertyItem::class)
+            ->onlyMethods(['getItemType', 'getPropertyType'])
+            ->getMock();
     }
 
     /**

--- a/tests/unit/StorageEngineTest.php
+++ b/tests/unit/StorageEngineTest.php
@@ -24,7 +24,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\MockObject\MockObject;
 
 use function json_encode;
 
@@ -35,7 +34,7 @@ class StorageEngineTest extends AbstractTestCase
 
     protected DbiDummy $dummyDbi;
 
-    protected StorageEngine&MockObject $object;
+    protected StorageEngine $object;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -48,10 +47,7 @@ class StorageEngineTest extends AbstractTestCase
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;
-        $this->object = $this->getMockForAbstractClass(
-            StorageEngine::class,
-            ['dummy'],
-        );
+        $this->object = new StorageEngine('dummy');
     }
 
     /**

--- a/tests/unit/Utils/HttpRequestTest.php
+++ b/tests/unit/Utils/HttpRequestTest.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\Utils\HttpRequest;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 use function curl_version;
@@ -20,6 +21,7 @@ use const CURLOPT_CAINFO;
 use const CURLOPT_CAPATH;
 
 #[CoversClass(HttpRequest::class)]
+#[Medium]
 class HttpRequestTest extends AbstractTestCase
 {
     private HttpRequest $httpRequest;
@@ -64,7 +66,6 @@ class HttpRequestTest extends AbstractTestCase
      * @param bool|string|null $expected         expected result
      */
     #[DataProvider('httpRequests')]
-    #[Group('medium')]
     #[Group('network')]
     #[RequiresPhpExtension('curl')]
     public function testCurl(string $url, string $method, bool $returnOnlyStatus, bool|string|null $expected): void
@@ -87,7 +88,6 @@ class HttpRequestTest extends AbstractTestCase
      * @param bool|string|null $expected         expected result
      */
     #[DataProvider('httpRequests')]
-    #[Group('medium')]
     #[Group('network')]
     #[RequiresPhpExtension('curl')]
     public function testCurlCAPath(
@@ -117,7 +117,6 @@ class HttpRequestTest extends AbstractTestCase
      * @param bool|string|null $expected         expected result
      */
     #[DataProvider('httpRequests')]
-    #[Group('medium')]
     #[Group('network')]
     #[RequiresPhpExtension('curl')]
     public function testCurlCAInfo(
@@ -147,7 +146,6 @@ class HttpRequestTest extends AbstractTestCase
      * @param bool|string|null $expected         expected result
      */
     #[DataProvider('httpRequests')]
-    #[Group('medium')]
     #[Group('network')]
     public function testFopen(string $url, string $method, bool $returnOnlyStatus, bool|string|null $expected): void
     {
@@ -173,7 +171,6 @@ class HttpRequestTest extends AbstractTestCase
      * @param bool|string|null $expected         expected result
      */
     #[DataProvider('httpRequests')]
-    #[Group('medium')]
     #[Group('network')]
     #[RequiresPhpExtension('curl')]
     public function testCreate(string $url, string $method, bool $returnOnlyStatus, bool|string|null $expected): void


### PR DESCRIPTION
Remaining:
```
There were 20 PHPUnit test runner warnings:

1) Group name "medium" is not allowed for method PhpMyAdmin\Tests\ConfigStorage\UserGroupsTest::testGetHtmlForUserGroupsTableWithNoUserGroups

2) Group name "medium" is not allowed for method PhpMyAdmin\Tests\ConfigTest::testCheckSystem

3) Group name "medium" is not allowed for method PhpMyAdmin\Tests\Config\ConfigFileTest::testGetFlatDefaultConfig

4) Group name "medium" is not allowed for method PhpMyAdmin\Tests\Config\FormDisplayTest::testRegisterForm

5) Group name "medium" is not allowed for method PhpMyAdmin\Tests\Config\FormDisplayTest::testProcess

6) Group name "medium" is not allowed for method PhpMyAdmin\Tests\Config\FormTest::testContructor

7) Group name "medium" is not allowed for method PhpMyAdmin\Tests\EncodingTest::testNoConversion

8) Group name "medium" is not allowed for method PhpMyAdmin\Tests\Error\ErrorHandlerTest::testCountErrors

9) Group name "medium" is not allowed for method PhpMyAdmin\Tests\Error\ErrorHandlerTest::testSliceErrors

10) Group name "medium" is not allowed for method PhpMyAdmin\Tests\Error\ErrorHandlerTest::testSliceErrorsOtherExample

11) Group name "medium" is not allowed for method PhpMyAdmin\Tests\FooterTest::testGetDebugMessage

12) Group name "medium" is not allowed for method PhpMyAdmin\Tests\FooterTest::testDisplay

13) Group name "medium" is not allowed for method PhpMyAdmin\Tests\Html\GeneratorTest::testGetDbLinkNull

14) Group name "large" is not allowed for method PhpMyAdmin\Tests\LanguageTest::testGettext

15) Group name "medium" is not allowed for method PhpMyAdmin\Tests\Replication\ReplicationGuiTest::testGetHtmlForPrimaryReplication

16) Group name "medium" is not allowed for method PhpMyAdmin\Tests\Server\PrivilegesTest::testGetHtmlToDisplayPrivilegesTable

17) Group name "medium" is not allowed for method PhpMyAdmin\Tests\Server\PrivilegesTest::testGetHtmlForAddUser

18) Group name "medium" is not allowed for method PhpMyAdmin\Tests\Setup\ConfigGeneratorTest::testGetConfigFile

19) Group name "medium" is not allowed for method PhpMyAdmin\Tests\Theme\ThemeTest::testCheckImgPathNotExisted

20) Group name "large" is not allowed for method PhpMyAdmin\Tests\VersionInformationTest::testGetLatestVersion
```