### PR TITLE
Fix #18451 - When editing inline central column, Null is always preselected

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -70,6 +70,7 @@ phpMyAdmin - ChangeLog
 - issue #18865 Fix missing text-nowrap for timestamps columns
 - issue #19022 Fix case where tables from wrong database is loaded in navigation tree
 - issue #18049 Also check that curl_exec is enabled for the new version check
+- issue #18451 Fix when editing inline central column, Null is always preselected
 
 5.2.1 (2023-02-07)
 - issue #17522 Fix case where the routes cache file is invalid

--- a/templates/database/central_columns/edit_table_row.twig
+++ b/templates/database/central_columns/edit_table_row.twig
@@ -75,11 +75,11 @@
 
   <td class="text-nowrap" name="col_isNull">
     <input name="field_null[{{ row_num }}]" id="field_{{ row_num }}_6" type="checkbox" value="YES" class="allow_null"
-      {{- row['col_isNull'] is not empty and row['col_isNull'] != 'NO' and row['col_isNull'] != 'NOT NULL' ? ' checked' }}>
+      {{- row['col_isNull'] is not empty and row['col_isNull'] != 'NO' and row['col_isNull'] != 'NOT NULL' and row['col_isNull'] != 0 ? ' checked' }}>
   </td>
 
   <td class="text-nowrap" name="col_extra">
     <input name="col_extra[{{ row_num }}]" id="field_{{ row_num }}_7" type="checkbox" value="auto_increment"
-      {{- row['col_extra'] is not empty and row['col_extra'] == 'auto_increment' }}>
+      {{- row['col_extra'] is not empty and row['col_extra'] == 'auto_increment' ? ' checked' }}>
   </td>
 </tr>

--- a/templates/database/central_columns/main.twig
+++ b/templates/database/central_columns/main.twig
@@ -355,7 +355,7 @@
                             <td class="text-nowrap" name="col_isNull">
                                 <span>{{ row['col_isNull'] ? 'Yes' | trans : 'No' | trans }}</span>
                                 <input name="field_null[{{ row_num }}]" id="field_{{ row_num }}_6" type="checkbox" value="YES" class="allow_null"
-                                  {{- row['col_isNull'] is not empty and row['col_isNull'] != 'NO' and row['col_isNull'] != 'NOT NULL' ? ' checked' }}>
+                                  {{- row['col_isNull'] is not empty and row['col_isNull'] != 'NO' and row['col_isNull'] != 'NOT NULL' and row['col_isNull'] != 0 ? ' checked' }}>
                             </td>
                             <td class="text-nowrap" name="col_extra">
                               <span>{{ row['col_extra'] }}</span>


### PR DESCRIPTION
### Description

Fix #18451 - When editing inline central column, Null is always preselected

Fixes #18451

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
