### PR TITLE
Remove $GLOBALS['allowDeny_forbidden']

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7396,9 +7396,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
-    <InvalidArrayOffset>
-      <code><![CDATA[$GLOBALS['allowDeny_forbidden']]]></code>
-    </InvalidArrayOffset>
   </file>
   <file src="src/Plugins/Auth/AuthenticationCookie.php">
     <DeprecatedMethod>

--- a/src/Plugins/Auth/AuthenticationConfig.php
+++ b/src/Plugins/Auth/AuthenticationConfig.php
@@ -21,7 +21,6 @@ use function count;
 use function sprintf;
 use function trigger_error;
 
-use const E_USER_NOTICE;
 use const E_USER_WARNING;
 
 /**
@@ -95,46 +94,43 @@ class AuthenticationConfig extends AuthenticationPlugin
         <tr>
             <td>';
         $config = Config::getInstance();
-        if (isset($GLOBALS['allowDeny_forbidden']) && $GLOBALS['allowDeny_forbidden']) {
-            trigger_error(__('Access denied!'), E_USER_NOTICE);
-        } else {
-            // Check whether user has configured something
-            if ($config->sourceMtime == 0) {
-                echo '<p>' , sprintf(
-                    __(
-                        'You probably did not create a configuration file.'
-                        . ' You might want to use the %1$ssetup script%2$s to'
-                        . ' create one.',
-                    ),
-                    '<a href="setup/">',
-                    '</a>',
-                ) , '</p>' , "\n";
-            } elseif (
-                ! isset($GLOBALS['errno'])
-                || $GLOBALS['errno'] != 2002
-                && $GLOBALS['errno'] != 2003
-            ) {
-                // if we display the "Server not responding" error, do not confuse
-                // users by telling them they have a settings problem
-                // (note: it's true that they could have a badly typed host name,
-                // but anyway the current message tells that the server
-                //  rejected the connection, which is not really what happened)
-                // 2002 is the error given by mysqli
-                // 2003 is the error given by mysql
-                trigger_error(
-                    __(
-                        'phpMyAdmin tried to connect to the MySQL server, and the'
-                        . ' server rejected the connection. You should check the'
-                        . ' host, username and password in your configuration and'
-                        . ' make sure that they correspond to the information given'
-                        . ' by the administrator of the MySQL server.',
-                    ),
-                    E_USER_WARNING,
-                );
-            }
 
-            echo Generator::mysqlDie($connError, '', true, '', false);
+        // Check whether user has configured something
+        if ($config->sourceMtime == 0) {
+            echo '<p>' , sprintf(
+                __(
+                    'You probably did not create a configuration file.'
+                    . ' You might want to use the %1$ssetup script%2$s to'
+                    . ' create one.',
+                ),
+                '<a href="setup/">',
+                '</a>',
+            ) , '</p>' , "\n";
+        } elseif (
+            ! isset($GLOBALS['errno'])
+            || $GLOBALS['errno'] != 2002
+            && $GLOBALS['errno'] != 2003
+        ) {
+            // if we display the "Server not responding" error, do not confuse
+            // users by telling them they have a settings problem
+            // (note: it's true that they could have a badly typed host name,
+            // but anyway the current message tells that the server
+            //  rejected the connection, which is not really what happened)
+            // 2002 is the error given by mysqli
+            // 2003 is the error given by mysql
+            trigger_error(
+                __(
+                    'phpMyAdmin tried to connect to the MySQL server, and the'
+                    . ' server rejected the connection. You should check the'
+                    . ' host, username and password in your configuration and'
+                    . ' make sure that they correspond to the information given'
+                    . ' by the administrator of the MySQL server.',
+                ),
+                E_USER_WARNING,
+            );
         }
+
+        echo Generator::mysqlDie($connError, '', true, '', false);
 
         ErrorHandler::getInstance()->dispUserErrors();
         echo '</td>

--- a/tests/unit/Plugins/Auth/AuthenticationConfigTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationConfigTest.php
@@ -87,7 +87,6 @@ class AuthenticationConfigTest extends AbstractTestCase
     public function testAuthFails(): void
     {
         Config::getInstance()->settings['Servers'] = [1];
-        $GLOBALS['allowDeny_forbidden'] = false;
 
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()

--- a/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
@@ -774,7 +774,6 @@ class AuthenticationCookieTest extends AbstractTestCase
 
         $_COOKIE['pmaAuth-2'] = 'pass';
 
-        $GLOBALS['allowDeny_forbidden'] = '';
         Config::getInstance()->settings['LoginCookieValidity'] = 10;
 
         $responseStub = new ResponseRendererStub();


### PR DESCRIPTION
We never set this global to any truthy value. If it was meant to serve as some sort of hook then it should be implemented properly not as a global. 