### PR TITLE
Fixing PHPUnit performance

### DIFF
--- a/tests/unit/Controllers/JavaScriptMessagesControllerTest.php
+++ b/tests/unit/Controllers/JavaScriptMessagesControllerTest.php
@@ -8,7 +8,6 @@ use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Controllers\JavaScriptMessagesController;
 use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 use function json_decode;
@@ -18,7 +17,6 @@ use function substr;
 #[CoversClass(JavaScriptMessagesController::class)]
 class JavaScriptMessagesControllerTest extends TestCase
 {
-    #[RunInSeparateProcess]
     public function testIndex(): void
     {
         $response = (new JavaScriptMessagesController(ResponseFactory::create()))();

--- a/tests/unit/Controllers/SchemaExportControllerTest.php
+++ b/tests/unit/Controllers/SchemaExportControllerTest.php
@@ -11,12 +11,10 @@ use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 #[CoversClass(SchemaExportController::class)]
 class SchemaExportControllerTest extends AbstractTestCase
 {
-    #[RunInSeparateProcess]
     public function testExport(): void
     {
         DatabaseInterface::$instance = $this->createDatabaseInterface();

--- a/tests/unit/Controllers/Table/GetFieldControllerTest.php
+++ b/tests/unit/Controllers/Table/GetFieldControllerTest.php
@@ -13,16 +13,12 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 use function bin2hex;
 
 #[CoversClass(GetFieldController::class)]
 class GetFieldControllerTest extends AbstractTestCase
 {
-    #[PreserveGlobalState(false)]
-    #[RunInSeparateProcess]
     public function testGetFieldController(): void
     {
         Current::$database = 'test_db';

--- a/tests/unit/Controllers/ThemeSetControllerTest.php
+++ b/tests/unit/Controllers/ThemeSetControllerTest.php
@@ -15,8 +15,6 @@ use PhpMyAdmin\Theme\ThemeManager;
 use PhpMyAdmin\UserPreferences;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 #[CoversClass(ThemeSetController::class)]
 class ThemeSetControllerTest extends AbstractTestCase
@@ -28,8 +26,6 @@ class ThemeSetControllerTest extends AbstractTestCase
         DatabaseInterface::$instance = $this->createDatabaseInterface();
     }
 
-    #[PreserveGlobalState(false)]
-    #[RunInSeparateProcess]
     public function testSetTheme(): void
     {
         Config::getInstance()->settings['ThemeManager'] = true;
@@ -52,8 +48,6 @@ class ThemeSetControllerTest extends AbstractTestCase
 
     /** @param string[]|string|null $themeName */
     #[DataProvider('providerForTestWithoutTheme')]
-    #[PreserveGlobalState(false)]
-    #[RunInSeparateProcess]
     public function testWithoutTheme(bool $hasThemes, array|string|null $themeName): void
     {
         Config::getInstance()->settings['ThemeManager'] = $hasThemes;

--- a/tests/unit/Http/Factory/ServerRequestFactoryTest.php
+++ b/tests/unit/Http/Factory/ServerRequestFactoryTest.php
@@ -110,8 +110,6 @@ final class ServerRequestFactoryTest extends TestCase
      * @psalm-param class-string<UriInterface> $expectedUri
      */
     #[DataProvider('providerForTestFromGlobals')]
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testFromGlobals(string $provider, string $uriFactoryProvider, string $expectedUri): void
     {
         $this->skipIfNotAvailable($provider);
@@ -149,8 +147,6 @@ final class ServerRequestFactoryTest extends TestCase
      * @psalm-param class-string<UriInterface> $expectedUri
      */
     #[DataProvider('providerForTestFromGlobals')]
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testFromGlobals2(string $provider, string $uriFactoryProvider, string $expectedUri): void
     {
         $this->skipIfNotAvailable($provider);
@@ -203,8 +199,6 @@ final class ServerRequestFactoryTest extends TestCase
      * @psalm-param class-string<UriInterface> $expectedUri
      */
     #[DataProvider('providerForTestFromGlobals')]
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testFromGlobals3(string $provider, string $uriFactoryProvider, string $expectedUri): void
     {
         $this->skipIfNotAvailable($provider);

--- a/tests/unit/Plugins/Auth/AuthenticationConfigTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationConfigTest.php
@@ -13,8 +13,6 @@ use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Medium;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use ReflectionProperty;
 use Throwable;
 
@@ -57,8 +55,6 @@ class AuthenticationConfigTest extends AbstractTestCase
         unset($this->object);
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuth(): void
     {
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
@@ -82,8 +78,6 @@ class AuthenticationConfigTest extends AbstractTestCase
         );
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthFails(): void
     {
         Config::getInstance()->settings['Servers'] = [1];

--- a/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
@@ -16,8 +16,6 @@ use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseRendererStub;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Medium;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use ReflectionException;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -74,8 +72,6 @@ class AuthenticationCookieTest extends AbstractTestCase
         unset($this->object);
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthErrorAJAX(): void
     {
         $GLOBALS['conn_error'] = true;
@@ -113,8 +109,6 @@ class AuthenticationCookieTest extends AbstractTestCase
         ErrorHandler::$instance = $mockErrorHandler;
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthError(): void
     {
         $_REQUEST = [];
@@ -189,8 +183,6 @@ class AuthenticationCookieTest extends AbstractTestCase
         self::assertStringContainsString('<input type="hidden" name="table" value="testTable">', $result);
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthCaptcha(): void
     {
         $_REQUEST['old_usr'] = '';
@@ -251,8 +243,6 @@ class AuthenticationCookieTest extends AbstractTestCase
         );
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthCaptchaCheckbox(): void
     {
         $_REQUEST['old_usr'] = '';
@@ -315,8 +305,6 @@ class AuthenticationCookieTest extends AbstractTestCase
         );
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthHeader(): void
     {
         $config = Config::getInstance();
@@ -336,8 +324,6 @@ class AuthenticationCookieTest extends AbstractTestCase
         self::assertSame(302, $response->getStatusCode());
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthHeaderPartial(): void
     {
         $config = Config::getInstance();
@@ -377,8 +363,6 @@ class AuthenticationCookieTest extends AbstractTestCase
         self::assertSame('Missing Captcha verification, maybe it has been blocked by adblock?', $GLOBALS['conn_error']);
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testLogoutDelete(): void
     {
         $responseStub = new ResponseRendererStub();
@@ -406,8 +390,6 @@ class AuthenticationCookieTest extends AbstractTestCase
         self::assertArrayNotHasKey('pmaAuth-0', $_COOKIE);
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testLogout(): void
     {
         $responseStub = new ResponseRendererStub();
@@ -657,8 +639,6 @@ class AuthenticationCookieTest extends AbstractTestCase
         $this->object->rememberCredentials();
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthFailsNoPass(): void
     {
         $this->object = $this->getMockBuilder(AuthenticationCookie::class)
@@ -727,8 +707,6 @@ class AuthenticationCookieTest extends AbstractTestCase
         self::assertSame($GLOBALS['conn_error'], $connError);
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthFailsDeny(): void
     {
         $this->object = $this->getMockBuilder(AuthenticationCookie::class)
@@ -759,8 +737,6 @@ class AuthenticationCookieTest extends AbstractTestCase
         self::assertSame($GLOBALS['conn_error'], 'Access denied!');
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthFailsActivity(): void
     {
         $this->object = $this->getMockBuilder(AuthenticationCookie::class)
@@ -798,8 +774,6 @@ class AuthenticationCookieTest extends AbstractTestCase
         );
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthFailsDBI(): void
     {
         $this->object = $this->getMockBuilder(AuthenticationCookie::class)
@@ -841,8 +815,6 @@ class AuthenticationCookieTest extends AbstractTestCase
         self::assertSame($GLOBALS['conn_error'], '#42 Cannot log in to the MySQL server');
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthFailsErrno(): void
     {
         $this->object = $this->getMockBuilder(AuthenticationCookie::class)
@@ -1007,8 +979,6 @@ class AuthenticationCookieTest extends AbstractTestCase
      * @param mixed[] $rules    rules
      * @param string  $expected expected result
      */
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     #[DataProvider('checkRulesProvider')]
     public function testCheckRules(
         string $user,

--- a/tests/unit/Plugins/Auth/AuthenticationHttpTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationHttpTest.php
@@ -15,8 +15,6 @@ use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseRendererStub;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Medium;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use ReflectionProperty;
 use Throwable;
 
@@ -59,8 +57,6 @@ class AuthenticationHttpTest extends AbstractTestCase
         unset($this->object);
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthLogoutUrl(): void
     {
         $config = Config::getInstance();
@@ -77,8 +73,6 @@ class AuthenticationHttpTest extends AbstractTestCase
         self::assertSame(302, $response->getStatusCode());
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthVerbose(): void
     {
         $config = Config::getInstance();
@@ -99,8 +93,6 @@ class AuthenticationHttpTest extends AbstractTestCase
         self::assertSame(401, $response->getStatusCode());
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthHost(): void
     {
         $config = Config::getInstance();
@@ -122,8 +114,6 @@ class AuthenticationHttpTest extends AbstractTestCase
         self::assertSame(401, $response->getStatusCode());
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthRealm(): void
     {
         $config = Config::getInstance();
@@ -276,8 +266,6 @@ class AuthenticationHttpTest extends AbstractTestCase
         self::assertSame(3, Current::$server);
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthFails(): void
     {
         $config = Config::getInstance();

--- a/tests/unit/Plugins/Auth/AuthenticationSignonTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationSignonTest.php
@@ -14,8 +14,6 @@ use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseRendererStub;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use ReflectionProperty;
 use Throwable;
 
@@ -57,8 +55,6 @@ class AuthenticationSignonTest extends AbstractTestCase
         unset($this->object);
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuth(): void
     {
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
@@ -81,8 +77,6 @@ class AuthenticationSignonTest extends AbstractTestCase
         self::assertStringContainsString('You must set SignonURL!', $result);
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthLogoutURL(): void
     {
         $responseStub = new ResponseRendererStub();
@@ -99,8 +93,6 @@ class AuthenticationSignonTest extends AbstractTestCase
         self::assertSame(302, $response->getStatusCode());
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthLogout(): void
     {
         $responseStub = new ResponseRendererStub();
@@ -151,8 +143,6 @@ class AuthenticationSignonTest extends AbstractTestCase
         self::assertSame('https://example.com/SignonURL', $_SESSION['LAST_SIGNON_URL']);
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testAuthCheckToken(): void
     {
         $_SESSION = [' PMA_token ' => 'eefefef'];

--- a/tests/unit/SessionTest.php
+++ b/tests/unit/SessionTest.php
@@ -6,15 +6,11 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Session;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Session::class)]
 final class SessionTest extends TestCase
 {
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testSecure(): void
     {
         $_SESSION[' PMA_token '] = null;

--- a/tests/unit/Setup/FormProcessingTest.php
+++ b/tests/unit/Setup/FormProcessingTest.php
@@ -14,8 +14,6 @@ use PhpMyAdmin\Setup\FormProcessing;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseRendererStub;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use ReflectionProperty;
 use Throwable;
 
@@ -39,8 +37,6 @@ class FormProcessingTest extends AbstractTestCase
         Config::getInstance()->settings['ServerDefault'] = 1;
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testProcessFormSet(): void
     {
         DatabaseInterface::$instance = $this->createDatabaseInterface();

--- a/tests/unit/StorageEngineTest.php
+++ b/tests/unit/StorageEngineTest.php
@@ -22,8 +22,6 @@ use PhpMyAdmin\StorageEngine;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 use function json_encode;
 
@@ -61,8 +59,6 @@ class StorageEngineTest extends AbstractTestCase
         unset($this->object);
     }
 
-    #[PreserveGlobalState(false)]
-    #[RunInSeparateProcess]
     public function testGetStorageEngines(): void
     {
         self::assertSame(

--- a/tests/unit/TemplateTest.php
+++ b/tests/unit/TemplateTest.php
@@ -9,8 +9,6 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Twig\Extensions\Node\TransNode;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use ReflectionProperty;
 use Twig\Cache\CacheInterface;
 use Twig\Environment;
@@ -163,8 +161,6 @@ class TemplateTest extends AbstractTestCase
         ];
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testLoadingTwigEnvOnlyOnce(): void
     {
         $twigEnvCacheProperty = new ReflectionProperty(Template::class, 'twig');

--- a/tests/unit/TransformationsTest.php
+++ b/tests/unit/TransformationsTest.php
@@ -13,8 +13,6 @@ use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use ReflectionProperty;
 
 #[CoversClass(Transformations::class)]
@@ -76,8 +74,6 @@ class TransformationsTest extends AbstractTestCase
         ];
     }
 
-    #[PreserveGlobalState(false)]
-    #[RunInSeparateProcess]
     public function testGetTypes(): void
     {
         self::assertEquals(


### PR DESCRIPTION
I am trying to investigate why PHPUnit tests are so slow. It seems like the biggest cause is the separation of certain tests due to singletons/globals. I am opening this PR to test if we can remove some of the separation. 