### PR TITLE
Fix process list toggle of full sql

### DIFF
--- a/src/Controllers/Server/Status/ProcessesController.php
+++ b/src/Controllers/Server/Status/ProcessesController.php
@@ -29,7 +29,7 @@ class ProcessesController extends AbstractController
         $GLOBALS['errorUrl'] = Url::getFromRoute('/');
 
         $showExecuting = $request->hasBodyParam('showExecuting');
-        $full = $request->hasBodyParam('full');
+        $full = $request->getParsedBodyParam('full') === '1';
         $orderByField = (string) $request->getParsedBodyParam('order_by_field', '');
         $sortOrder = (string) $request->getParsedBodyParam('sort_order', '');
 

--- a/tests/unit/Controllers/Server/Status/ProcessesControllerTest.php
+++ b/tests/unit/Controllers/Server/Status/ProcessesControllerTest.php
@@ -88,10 +88,11 @@ class ProcessesControllerTest extends AbstractTestCase
         $request = self::createStub(ServerRequest::class);
         $request->method('getParsedBodyParam')->willReturnMap([
             ['column_name', '', 'Database'],
+            ['full', null, '1'],
             ['order_by_field', '', 'Db'],
             ['sort_order', '', 'ASC'],
         ]);
-        $request->method('hasBodyParam')->willReturnMap([['full', true], ['showExecuting', false]]);
+        $request->method('hasBodyParam')->willReturnMap([['showExecuting', false]]);
 
         $this->dummyDbi->addSelectDb('mysql');
         $controller($request);
@@ -105,10 +106,11 @@ class ProcessesControllerTest extends AbstractTestCase
         $request = self::createStub(ServerRequest::class);
         $request->method('getParsedBodyParam')->willReturnMap([
             ['column_name', '', 'Host'],
+            ['full', null, '1'],
             ['order_by_field', '', 'Host'],
             ['sort_order', '', 'DESC'],
         ]);
-        $request->method('hasBodyParam')->willReturnMap([['full', true], ['showExecuting', false]]);
+        $request->method('hasBodyParam')->willReturnMap([['showExecuting', false]]);
 
         $this->dummyDbi->addSelectDb('mysql');
         $controller($request);


### PR DESCRIPTION
### Description

Toggling from full to truncated sql in proccesses view did not work in master, works in QA_5_2.
'full' is always set and is transmitted as either `''` or `'1'`