### PR TITLE
#19075 - Sort the combobox by native language name

### DIFF
--- a/src/Language.php
+++ b/src/Language.php
@@ -69,7 +69,7 @@ class Language
     public function getName(): string
     {
         if ($this->native !== '') {
-            return $this->native . ' - ' . $this->name;
+            return $this->name . ' - ' . $this->native;
         }
 
         return $this->name;


### PR DESCRIPTION
### Description

This pull request addresses issue #19075.
The language combobox was challenging to read due to the ordering of languages. To enhance usability, I have restructured the order of languages to align with their English names. This change ensures that languages are sorted more intuitively, making them easier to locate and facilitating a coherent viewing experience.

Changes Made
In src/Language.php, the following modifications were made:
```
public function getName(): string {
    if ($this->native !== '') {
        return $this->name . ' - ' . $this->native;
    }

    return $this->name;
}
```

Fixes
This pull request fixes the readability issue in the language combobox.

Signed-off-by: Anujesh Bansal <anujeshbansaltoo@gmail.com>