### PR TITLE
Refactor Operations::getWarningMessagesArray

### DIFF
--- a/app/services.php
+++ b/app/services.php
@@ -169,7 +169,6 @@ return [
                 '@dbi',
                 '@relation',
                 '@relation_cleanup',
-                '@operations',
                 '@transformations',
                 '@template',
                 '@bookmarkRepository',

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -339,7 +339,6 @@ return [
                 '$dbi' => '@dbi',
                 '$relation' => '@relation',
                 '$relationCleanup' => '@relation_cleanup',
-                '$operations' => '@operations',
                 '$flash' => '@flash',
                 '$structureController' => '@' . Database\StructureController::class,
             ],
@@ -1605,7 +1604,6 @@ return [
             'arguments' => [
                 '$response' => '@response',
                 '$template' => '@template',
-                '$operations' => '@operations',
                 '$dbi' => '@dbi',
                 '$dbTableExists' => '@' . DbTableExists::class,
             ],

--- a/src/Controllers/Database/Structure/EmptyTableController.php
+++ b/src/Controllers/Database/Structure/EmptyTableController.php
@@ -15,7 +15,6 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\FlashMessages;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Message;
-use PhpMyAdmin\Operations;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Sql;
 use PhpMyAdmin\Table\Table;
@@ -34,7 +33,6 @@ final class EmptyTableController extends AbstractController
         private DatabaseInterface $dbi,
         private Relation $relation,
         private RelationCleanup $relationCleanup,
-        private Operations $operations,
         private FlashMessages $flash,
         private StructureController $structureController,
     ) {
@@ -77,7 +75,6 @@ final class EmptyTableController extends AbstractController
                 $this->dbi,
                 $this->relation,
                 $this->relationCleanup,
-                $this->operations,
                 new Transformations(),
                 $this->template,
                 new BookmarkRepository($this->dbi, $this->relation),

--- a/src/Controllers/Operations/TableController.php
+++ b/src/Controllers/Operations/TableController.php
@@ -258,7 +258,7 @@ class TableController extends AbstractController
                 $this->dbi->query($GLOBALS['sql_query']);
                 $result = true;
                 $rereadInfo = true;
-                $warningMessages = $this->operations->getWarningMessagesArray();
+                $warningMessages = $this->operations->getWarningMessagesArray($newTableStorageEngine);
             }
 
             /** @var mixed $tableCollationParam */

--- a/src/Controllers/Operations/ViewController.php
+++ b/src/Controllers/Operations/ViewController.php
@@ -14,14 +14,15 @@ use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Identifiers\TableName;
 use PhpMyAdmin\Message;
-use PhpMyAdmin\Operations;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
 
 use function __;
+use function array_map;
 use function is_string;
+use function strval;
 
 /**
  * View manipulations
@@ -31,7 +32,6 @@ class ViewController extends AbstractController
     public function __construct(
         ResponseRenderer $response,
         Template $template,
-        private Operations $operations,
         private DatabaseInterface $dbi,
         private readonly DbTableExists $dbTableExists,
     ) {
@@ -105,7 +105,7 @@ class ViewController extends AbstractController
                 $result = false;
             }
 
-            $warningMessages = $this->operations->getWarningMessagesArray();
+            $warningMessages = array_map(strval(...), $this->dbi->getWarnings());
         }
 
         if (isset($result)) {

--- a/src/Controllers/Table/DeleteRowsController.php
+++ b/src/Controllers/Table/DeleteRowsController.php
@@ -12,7 +12,6 @@ use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
-use PhpMyAdmin\Operations;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Sql;
 use PhpMyAdmin\Template;
@@ -47,7 +46,6 @@ final class DeleteRowsController extends AbstractController
             $this->dbi,
             $relation,
             new RelationCleanup($this->dbi, $relation),
-            new Operations($this->dbi, $relation),
             new Transformations(),
             $this->template,
             new BookmarkRepository($this->dbi, $relation),

--- a/src/Controllers/Table/SearchController.php
+++ b/src/Controllers/Table/SearchController.php
@@ -16,7 +16,6 @@ use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Identifiers\TableName;
 use PhpMyAdmin\Message;
-use PhpMyAdmin\Operations;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Sql;
 use PhpMyAdmin\Table\Search;
@@ -240,7 +239,6 @@ class SearchController extends AbstractController
             $this->dbi,
             $this->relation,
             new RelationCleanup($this->dbi, $this->relation),
-            new Operations($this->dbi, $this->relation),
             new Transformations(),
             $this->template,
             new BookmarkRepository($this->dbi, $this->relation),

--- a/src/Database/MultiTableQuery.php
+++ b/src/Database/MultiTableQuery.php
@@ -12,7 +12,6 @@ use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Operations;
 use PhpMyAdmin\ParseAnalyze;
 use PhpMyAdmin\Sql;
 use PhpMyAdmin\Template;
@@ -81,7 +80,6 @@ class MultiTableQuery
             $dbi,
             $relation,
             new RelationCleanup($dbi, $relation),
-            new Operations($dbi, $relation),
             new Transformations(),
             new Template(),
             $bookmarkRepository,

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -707,7 +707,7 @@ class Operations
      *
      * @return string[]
      */
-    public function getWarningMessagesArray(): array
+    public function getWarningMessagesArray(mixed $newTableStorageEngine): array
     {
         $warningMessages = [];
         foreach ($this->dbi->getWarnings() as $warning) {
@@ -718,8 +718,7 @@ class Operations
             // I just ignore it. But there are other 1478 messages
             // that it's better to show.
             if (
-                isset($_POST['new_tbl_storage_engine'])
-                && $_POST['new_tbl_storage_engine'] === 'MyISAM'
+                $newTableStorageEngine === 'MyISAM'
                 && $warning->code === 1478
                 && $warning->level === 'Error'
             ) {

--- a/src/Sql.php
+++ b/src/Sql.php
@@ -54,7 +54,6 @@ class Sql
         private DatabaseInterface $dbi,
         private Relation $relation,
         private RelationCleanup $relationCleanup,
-        private Operations $operations,
         private Transformations $transformations,
         private Template $template,
         private readonly BookmarkRepository $bookmarkRepository,
@@ -1571,7 +1570,7 @@ class Sql
             $sqlQueryForBookmark,
         );
 
-        $warningMessages = $this->operations->getWarningMessagesArray();
+        $warningMessages = $this->dbi->getWarnings();
 
         // No rows returned -> move back to the calling page
         if (($numRows == 0 && $unlimNumRows == 0) || $statementInfo->flags->isAffected || $result === false) {
@@ -1611,7 +1610,7 @@ class Sql
         ForeignKey::handleDisableCheckCleanup($defaultFkCheck);
 
         foreach ($warningMessages as $warning) {
-            $message = Message::notice(htmlspecialchars($warning));
+            $message = Message::notice(htmlspecialchars((string) $warning));
             $htmlOutput .= $message->getDisplay();
         }
 

--- a/tests/unit/Controllers/Import/ImportControllerTest.php
+++ b/tests/unit/Controllers/Import/ImportControllerTest.php
@@ -13,7 +13,6 @@ use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Import\Import;
-use PhpMyAdmin\Operations;
 use PhpMyAdmin\Sql;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -90,7 +89,6 @@ class ImportControllerTest extends AbstractTestCase
             $this->dbi,
             $relation,
             self::createStub(RelationCleanup::class),
-            self::createStub(Operations::class),
             self::createStub(Transformations::class),
             $template,
             $bookmarkRepository,

--- a/tests/unit/Controllers/Sql/EnumValuesControllerTest.php
+++ b/tests/unit/Controllers/Sql/EnumValuesControllerTest.php
@@ -12,7 +12,6 @@ use PhpMyAdmin\Controllers\Sql\EnumValuesController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
-use PhpMyAdmin\Operations;
 use PhpMyAdmin\Sql;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -61,7 +60,6 @@ class EnumValuesControllerTest extends AbstractTestCase
             $this->dbi,
             $relation,
             self::createStub(RelationCleanup::class),
-            self::createStub(Operations::class),
             self::createStub(Transformations::class),
             $template,
             $bookmarkRepository,
@@ -113,7 +111,6 @@ class EnumValuesControllerTest extends AbstractTestCase
             $this->dbi,
             $relation,
             self::createStub(RelationCleanup::class),
-            self::createStub(Operations::class),
             self::createStub(Transformations::class),
             $template,
             $bookmarkRepository,

--- a/tests/unit/Controllers/Sql/SetValuesControllerTest.php
+++ b/tests/unit/Controllers/Sql/SetValuesControllerTest.php
@@ -12,7 +12,6 @@ use PhpMyAdmin\Controllers\Sql\SetValuesController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
-use PhpMyAdmin\Operations;
 use PhpMyAdmin\Sql;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -62,7 +61,6 @@ class SetValuesControllerTest extends AbstractTestCase
             $this->dbi,
             $relation,
             self::createStub(RelationCleanup::class),
-            self::createStub(Operations::class),
             self::createStub(Transformations::class),
             $template,
             $bookmarkRepository,
@@ -115,7 +113,6 @@ class SetValuesControllerTest extends AbstractTestCase
             $this->dbi,
             $relation,
             self::createStub(RelationCleanup::class),
-            self::createStub(Operations::class),
             self::createStub(Transformations::class),
             $template,
             $bookmarkRepository,

--- a/tests/unit/Controllers/Table/ReplaceControllerTest.php
+++ b/tests/unit/Controllers/Table/ReplaceControllerTest.php
@@ -20,7 +20,6 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\FileListing;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\InsertEdit;
-use PhpMyAdmin\Operations;
 use PhpMyAdmin\Sql;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -109,7 +108,6 @@ class ReplaceControllerTest extends AbstractTestCase
                 $dbi,
                 $relation,
                 new RelationCleanup($dbi, $relation),
-                new Operations($dbi, $relation),
                 $transformations,
                 $template,
                 $bookmarkRepository,

--- a/tests/unit/SqlTest.php
+++ b/tests/unit/SqlTest.php
@@ -10,7 +10,6 @@ use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Operations;
 use PhpMyAdmin\ParseAnalyze;
 use PhpMyAdmin\Sql;
 use PhpMyAdmin\Template;
@@ -67,7 +66,6 @@ class SqlTest extends AbstractTestCase
             $this->dbi,
             $relation,
             new RelationCleanup($this->dbi, $relation),
-            new Operations($this->dbi, $relation),
             new Transformations(),
             new Template(),
             new BookmarkRepository($this->dbi, $relation),


### PR DESCRIPTION
It seems this method was used accidentally back when it was a global function. 