### PR TITLE
Reset ResponseRenderer::$instance after test in ApplicationHandlerTest

### DIFF
--- a/tests/unit/Http/Handler/ApplicationHandlerTest.php
+++ b/tests/unit/Http/Handler/ApplicationHandlerTest.php
@@ -10,7 +10,6 @@ use PhpMyAdmin\Http\Handler\ApplicationHandler;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\ResponseRenderer;
-use PHPUnit\Framework\Attributes\BackupStaticProperties;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -19,12 +18,12 @@ use ReflectionProperty;
 #[CoversClass(ApplicationHandler::class)]
 final class ApplicationHandlerTest extends TestCase
 {
-    #[BackupStaticProperties(true)]
     public function testHandleReturnsResponse(): void
     {
         $responseRendererMock = self::createMock(ResponseRenderer::class);
         $responseRendererMock->expects(self::never())->method('response');
-        (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, $responseRendererMock);
+        $reflectionProperty = new ReflectionProperty(ResponseRenderer::class, 'instance');
+        $reflectionProperty->setValue(null, $responseRendererMock);
         $request = self::createStub(ServerRequest::class);
         $responseStub = new Response(self::createStub(ResponseInterface::class));
         $appMock = self::createMock(Application::class);
@@ -32,35 +31,38 @@ final class ApplicationHandlerTest extends TestCase
         $handler = new ApplicationHandler($appMock);
         $response = $handler->handle($request);
         self::assertSame($response, $responseStub);
+        $reflectionProperty->setValue(null, null);
     }
 
-    #[BackupStaticProperties(true)]
     public function testHandleThrowsExit(): void
     {
         $responseStub = new Response(self::createStub(ResponseInterface::class));
         $responseRendererMock = self::createMock(ResponseRenderer::class);
         $responseRendererMock->expects(self::once())->method('response')->willReturn($responseStub);
-        (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, $responseRendererMock);
+        $reflectionProperty = new ReflectionProperty(ResponseRenderer::class, 'instance');
+        $reflectionProperty->setValue(null, $responseRendererMock);
         $request = self::createStub(ServerRequest::class);
         $appMock = self::createMock(Application::class);
         $appMock->expects(self::once())->method('handle')->with($request)->willThrowException(new ExitException());
         $handler = new ApplicationHandler($appMock);
         $response = $handler->handle($request);
         self::assertSame($response, $responseStub);
+        $reflectionProperty->setValue(null, null);
     }
 
-    #[BackupStaticProperties(true)]
     public function testHandleReturnsNull(): void
     {
         $responseStub = new Response(self::createStub(ResponseInterface::class));
         $responseRendererMock = self::createMock(ResponseRenderer::class);
         $responseRendererMock->expects(self::once())->method('response')->willReturn($responseStub);
-        (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, $responseRendererMock);
+        $reflectionProperty = new ReflectionProperty(ResponseRenderer::class, 'instance');
+        $reflectionProperty->setValue(null, $responseRendererMock);
         $request = self::createStub(ServerRequest::class);
         $appMock = self::createMock(Application::class);
         $appMock->expects(self::once())->method('handle')->with($request)->willReturn(null);
         $handler = new ApplicationHandler($appMock);
         $response = $handler->handle($request);
         self::assertSame($response, $responseStub);
+        $reflectionProperty->setValue(null, null);
     }
 }

--- a/tests/unit/Stubs/ResponseRenderer.php
+++ b/tests/unit/Stubs/ResponseRenderer.php
@@ -16,7 +16,6 @@ use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Console;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Footer;
 use PhpMyAdmin\Header;
 use PhpMyAdmin\Http\Factory\ResponseFactory;
@@ -175,11 +174,6 @@ class ResponseRenderer extends \PhpMyAdmin\ResponseRenderer
     public function isDisabled(): bool
     {
         return $this->isDisabled;
-    }
-
-    public function callExit(string $message = ''): never
-    {
-        throw new ExitException($message);
     }
 
     public function getResponse(): Response


### PR DESCRIPTION
Not resetting this value causes other tests to fail when running them in a specific order.

Example:
https://github.com/phpmyadmin/phpmyadmin/actions/runs/8475283224/job/23223122921?pr=19068#step:8:102
```
1) PhpMyAdmin\Tests\Plugins\Auth\AuthenticationHttpTest::testAuthFails
Failed asserting that an object is an instance of class PhpMyAdmin\Exceptions\ExitException.
```

- Related to #19074

CC @kamil-tekiela 