### PR TITLE
Display correct effective size

### DIFF
--- a/libraries/classes/Controllers/Table/StructureController.php
+++ b/libraries/classes/Controllers/Table/StructureController.php
@@ -321,17 +321,17 @@ class StructureController extends AbstractController
 
         if (isset($showtable['Data_free'])) {
             [$free_size, $free_unit] = Util::formatByteDown($showtable['Data_free'], $max_digits, $decimals);
-            [$effect_size, $effect_unit] = Util::formatByteDown(
-                $showtable['Data_length']
-                + $showtable['Index_length']
-                - $showtable['Data_free'],
-                $max_digits,
-                $decimals
-            );
+            $effective = $showtable['Data_length'] + $showtable['Index_length'];
+            if ($tbl_storage_engine === 'INNODB') {
+                $effective += $showtable['Data_free'];
+            } else {
+                $effective -= $showtable['Data_free'];
+            }
+
+            [$effect_size, $effect_unit] = Util::formatByteDown($effective, $max_digits, $decimals);
         } else {
             [$effect_size, $effect_unit] = Util::formatByteDown(
-                $showtable['Data_length']
-                + $showtable['Index_length'],
+                $showtable['Data_length'] + $showtable['Index_length'],
                 $max_digits,
                 $decimals
             );
@@ -347,9 +347,7 @@ class StructureController extends AbstractController
         $avg_unit = '';
         if ($table_info_num_rows > 0) {
             [$avg_size, $avg_unit] = Util::formatByteDown(
-                ($showtable['Data_length']
-                + $showtable['Index_length'])
-                / $showtable['Rows'],
+                ($showtable['Data_length'] + $showtable['Index_length']) / $showtable['Rows'],
                 6,
                 1
             );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11142,7 +11142,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$value of static method PhpMyAdmin\\\\Util\\:\\:formatByteDown\\(\\) expects float\\|int\\|string\\|null, \\(array\\|float\\|int\\) given\\.$#"
-			count: 2
+			count: 3
 			path: libraries/classes/Controllers/Table/StructureController.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3979,6 +3979,7 @@
   <file src="libraries/classes/Controllers/Table/StructureController.php">
     <MixedArgument occurrences="13">
       <code>$db</code>
+      <code>$effective</code>
       <code>$field['Collation'] ?? ''</code>
       <code>$field['Extra']</code>
       <code>$field['Field']</code>
@@ -3986,8 +3987,10 @@
       <code>$showtable['Data_free']</code>
       <code>$showtable['Data_length']</code>
       <code>$showtable['Data_length'] + $showtable['Index_length']</code>
+      <code>$showtable['Data_length'] + $showtable['Index_length']</code>
       <code>$showtable['Index_length']</code>
       <code>$tbl_collation</code>
+      <code>($showtable['Data_length'] + $showtable['Index_length']) / $showtable['Rows']</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$url_params</code>
@@ -4013,19 +4016,25 @@
       <code>$comments_map[$field['Field']]</code>
       <code>$comments_map[$field['Field']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="10">
       <code>$attributes[$rownum]</code>
       <code>$columns_list[]</code>
+      <code>$effective</code>
+      <code>$effective</code>
+      <code>$effective</code>
       <code>$field</code>
       <code>$reread_info</code>
       <code>$row_comments[$rownum]</code>
       <code>$showtable</code>
       <code>$showtable</code>
     </MixedAssignment>
-    <MixedOperand occurrences="7">
+    <MixedOperand occurrences="9">
       <code>$displayed_fields[$rownum]-&gt;icon</code>
       <code>$displayed_fields[$rownum]-&gt;icon</code>
+      <code>$effective</code>
+      <code>$effective</code>
       <code>$showtable['Data_length']</code>
+      <code>$showtable['Data_length'] + $showtable['Index_length']</code>
       <code>$showtable['Index_length']</code>
       <code>$showtable['Index_length']</code>
       <code>$showtable['Index_length']</code>

--- a/templates/table/structure/display_table_stats.twig
+++ b/templates/table/structure/display_table_stats.twig
@@ -27,6 +27,14 @@
                     </tr>
                 {% endif %}
 
+                {% if tot_size is defined and mergetable == false %}
+                    <tr>
+                        <th class="name">{% trans 'Total' %}</th>
+                        <td class="value">{{ tot_size }}</td>
+                        <td class="unit">{{ tot_unit }}</td>
+                    </tr>
+                {% endif %}
+
                 {% if free_size is defined %}
                     <tr>
                         <th class="name">{% trans 'Overhead' %}</th>
@@ -40,13 +48,6 @@
                     </tr>
                 {% endif %}
 
-                {% if tot_size is defined and mergetable == false %}
-                    <tr>
-                        <th class="name">{% trans 'Total' %}</th>
-                        <td class="value">{{ tot_size }}</td>
-                        <td class="unit">{{ tot_unit }}</td>
-                    </tr>
-                {% endif %}
                 </tbody>
 
                 {# Optimize link if overhead #}


### PR DESCRIPTION
Fixes #18771

`Total` is the space needed for index and data, `Effective` is the file size on disk, which includes `'Data_free'`, so it should be added instead of subtracted.