### PR TITLE
Disable Twig's text nodes optimization

### DIFF
--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Check Twig templates
         # Allow the previous check to fail but not abort
         if: always()
-        run: composer run twig-lint
+        run: php scripts/console lint:twig --ansi
 
   analyse-php:
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "symfony/polyfill-ctype": "^1.17.0",
         "symfony/polyfill-mbstring": "^1.17.0",
         "symfony/polyfill-php80": "^1.16",
-        "twig/twig": "^3.3.5 <3.9.0",
+        "twig/twig": "^3.4.3",
         "webmozart/assert": "^1.10",
         "williamdes/mariadb-mysql-kbs": "^1.2"
     },

--- a/libraries/classes/Template.php
+++ b/libraries/classes/Template.php
@@ -72,7 +72,16 @@ class Template
         }
 
         $loader = new FilesystemLoader(self::TEMPLATES_FOLDER);
+
+        /**
+         * Disables text nodes optimization added in Twig 3.9.0 as it breaks the i18n extension.
+         *
+         * @see https://github.com/phpmyadmin/phpmyadmin/issues/19112
+         */
+        $optimizations = -1 & ~8;
+
         $twig = new Environment($loader, [
+            'optimizations' => $optimizations,
             'auto_reload' => true,
             'cache' => $cacheDir,
         ]);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1566,6 +1566,11 @@ parameters:
 			path: libraries/classes/Controllers/Table/ReplaceController.php
 
 		-
+			message: "#^Variable \\$extra_data might not be defined\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/ReplaceController.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Table\\\\SearchController\\:\\:getColumnMinMax\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/SearchController.php


### PR DESCRIPTION
The text nodes optimization added in Twig 3.9.0 breaks the i18n extension. So let's disable it until a fix for the extension itself is created.

- Fixes https://github.com/phpmyadmin/phpmyadmin/issues/19112