### PR TITLE
Fix linter for sql query box with multiple statements

### DIFF
--- a/js/src/database/events.js
+++ b/js/src/database/events.js
@@ -334,8 +334,7 @@ const DatabaseEvents = {
                  *                 the Definition textarea.
                  */
                 var $elm = $('textarea[name=item_definition]').last();
-                var linterOptions = {};
-                linterOptions.eventEditor = true;
+                var linterOptions = { editorType: 'event' };
                 that.syntaxHiglighter = Functions.getSqlEditor($elm, {}, 'both', linterOptions);
             } else {
                 Functions.ajaxShowMessage(data.error, false);

--- a/js/src/database/routines.js
+++ b/js/src/database/routines.js
@@ -347,8 +347,7 @@ const DatabaseRoutines = {
                  *                 the Definition textarea.
                  */
                 var $elm = $('textarea[name=item_definition]').last();
-                var linterOptions = {};
-                linterOptions.routineEditor = true;
+                var linterOptions = { editorType: 'routine' };
                 that.syntaxHiglighter = Functions.getSqlEditor($elm, {}, 'both', linterOptions);
 
                 // Execute item-specific code

--- a/js/src/database/triggers.js
+++ b/js/src/database/triggers.js
@@ -339,8 +339,7 @@ const DatabaseTriggers = {
                  *                 the Definition textarea.
                  */
                 var $elm = $('textarea[name=item_definition]').last();
-                var linterOptions = {};
-                linterOptions.triggerEditor = true;
+                var linterOptions = { editorType: 'trigger' };
                 that.syntaxHiglighter = Functions.getSqlEditor($elm, {}, 'both', linterOptions);
             } else {
                 Functions.ajaxShowMessage(data.error, false);

--- a/libraries/classes/Controllers/LintController.php
+++ b/libraries/classes/Controllers/LintController.php
@@ -48,14 +48,14 @@ class LintController extends AbstractController
             $options = $params['options'];
 
             if (! empty($options['routineEditor'])) {
-                $sqlQuery = 'CREATE PROCEDURE `a`() ' . $sqlQuery;
+                $sqlQuery = "DELIMITER $$\nCREATE PROCEDURE `a`() " . $sqlQuery;
             } elseif (! empty($options['triggerEditor'])) {
-                $sqlQuery = 'CREATE TRIGGER `a` AFTER INSERT ON `b` FOR EACH ROW ' . $sqlQuery;
+                $sqlQuery = "DELIMITER $$\nCREATE TRIGGER `a` AFTER INSERT ON `b` FOR EACH ROW " . $sqlQuery;
             } elseif (! empty($options['eventEditor'])) {
-                $sqlQuery = 'CREATE EVENT `a` ON SCHEDULE EVERY MINUTE DO ' . $sqlQuery;
+                $sqlQuery = "DELIMITER $$\nCREATE EVENT `a` ON SCHEDULE EVERY MINUTE DO " . $sqlQuery;
             }
         }
 
-        echo json_encode(Linter::lint("DELIMITER $$\n" . $sqlQuery . "$$\nDELIMITER ;\n"));
+        echo json_encode(Linter::lint($sqlQuery));
     }
 }

--- a/libraries/classes/Controllers/LintController.php
+++ b/libraries/classes/Controllers/LintController.php
@@ -10,6 +10,8 @@ namespace PhpMyAdmin\Controllers;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\Linter;
 
+use function is_array;
+use function is_string;
 use function json_encode;
 
 /**
@@ -17,45 +19,48 @@ use function json_encode;
  */
 class LintController extends AbstractController
 {
+    public const EDITOR_SQL_PREFIX = [
+        'event' => "DELIMITER $$ CREATE EVENT `a` ON SCHEDULE EVERY MINUTE DO\n",
+        'routine' => "DELIMITER $$ CREATE PROCEDURE `a`()\n",
+        'trigger' => "DELIMITER $$ CREATE TRIGGER `a` AFTER INSERT ON `b` FOR EACH ROW\n",
+    ];
+
     public function __invoke(): void
     {
-        $params = [
-            'sql_query' => $_POST['sql_query'] ?? null,
-            'options' => $_POST['options'] ?? null,
-        ];
+        $sqlQueryParam = $_POST['sql_query'] ?? null;
+        $options = $_POST['options'] ?? null;
 
         /**
          * The SQL query to be analyzed.
          *
-         * This does not need to be checked again XSS or MySQL injections because it is
+         * This does not need to be checked against XSS or MySQL injections because it is
          * never executed, just parsed.
          *
          * The client, which will receive the JSON response will decode the message and
          * and any HTML fragments that are displayed to the user will be encoded anyway.
-         *
-         * @var string
          */
-        $sqlQuery = ! empty($params['sql_query']) ? $params['sql_query'] : '';
+        $sqlQuery = is_string($sqlQueryParam) ? $sqlQueryParam : '';
 
-        $this->response->setAjax(true);
+        $editorType = is_array($options) ? ($options['editorType'] ?? null) : null;
+        $prefix = is_string($editorType) ? self::EDITOR_SQL_PREFIX[$editorType] ?? '' : '';
 
-        // Disabling standard response.
-        $this->response->disable();
+        $lints = Linter::lint($prefix . $sqlQuery);
+        if ($prefix !== '') {
+            // Adjust positions to account for prefix
+            foreach ($lints as $i => $lint) {
+                if ($lint['fromLine'] === 0) {
+                    continue;
+                }
 
-        Core::headerJSON();
-
-        if (! empty($params['options'])) {
-            $options = $params['options'];
-
-            if (! empty($options['routineEditor'])) {
-                $sqlQuery = "DELIMITER $$\nCREATE PROCEDURE `a`() " . $sqlQuery;
-            } elseif (! empty($options['triggerEditor'])) {
-                $sqlQuery = "DELIMITER $$\nCREATE TRIGGER `a` AFTER INSERT ON `b` FOR EACH ROW " . $sqlQuery;
-            } elseif (! empty($options['eventEditor'])) {
-                $sqlQuery = "DELIMITER $$\nCREATE EVENT `a` ON SCHEDULE EVERY MINUTE DO " . $sqlQuery;
+                $lints[$i]['fromLine'] -= 1;
+                $lints[$i]['toLine'] -= 1;
             }
         }
 
-        echo json_encode(Linter::lint($sqlQuery));
+        $this->response->setAjax(true);
+        // Disabling standard response.
+        $this->response->disable();
+        Core::headerJSON();
+        echo json_encode($lints);
     }
 }

--- a/libraries/classes/Linter.php
+++ b/libraries/classes/Linter.php
@@ -29,7 +29,8 @@ class Linter
      *
      * @param string|UtfString $str String to be analyzed.
      *
-     * @return array
+     * @return array<int,int>
+     * @psalm-return list<int>
      */
     public static function getLines($str)
     {
@@ -72,8 +73,10 @@ class Linter
      *
      * @param array $lines The starting position of each line.
      * @param int   $pos   The absolute position
+     * @psalm-param list<int> $lines
      *
      * @return array
+     * @psalm-return array{int, int}
      */
     public static function findLineNumberAndColumn(array $lines, $pos)
     {
@@ -98,6 +101,14 @@ class Linter
      * @param string $query The query to be checked.
      *
      * @return array
+     * @psalm-return list<array{
+     *   message: string,
+     *   fromLine: int,
+     *   fromColumn: int,
+     *   toLine: int,
+     *   toColumn: int,
+     *   severity: string,
+     * }>
      */
     public static function lint($query)
     {
@@ -132,8 +143,6 @@ class Linter
 
         /**
          * The response containing of all errors.
-         *
-         * @var array
          */
         $response = [];
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5186,31 +5186,6 @@ parameters:
 			path: libraries/classes/Linter.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Linter\\:\\:findLineNumberAndColumn\\(\\) has parameter \\$lines with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Linter.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Linter\\:\\:findLineNumberAndColumn\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Linter.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Linter\\:\\:getLines\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Linter.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Linter\\:\\:lint\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Linter.php
-
-		-
-			message: "#^PHPDoc tag @var has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Linter.php
-
-		-
 			message: "#^Parameter \\#2 \\$pos of static method PhpMyAdmin\\\\Linter\\:\\:findLineNumberAndColumn\\(\\) expects int, int\\|string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Linter.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8355,12 +8355,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$error[3]</code>
     </InvalidScalarArgument>
-    <MixedAssignment occurrences="1">
-      <code>$lineStart</code>
-    </MixedAssignment>
-    <MixedOperand occurrences="1">
-      <code>$lines[$line]</code>
-    </MixedOperand>
     <PossiblyInvalidOperand occurrences="1">
       <code>$error[3]</code>
     </PossiblyInvalidOperand>


### PR DESCRIPTION
### Description

Only change the delimiter for routine/event/trigger editor. The query editor should use the default delimiter.

Fixes #18389, fixes  #18487, fixes #18511,