### PR TITLE
Add `t` (trans) function to Twig\I18nExtension

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14959,6 +14959,12 @@
       <code><![CDATA[providerGetQueryFromRequest]]></code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="tests/unit/Twig/Node/Expression/TransExpressionTest.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[transExpressionsProvider]]></code>
+      <code><![CDATA[transExpressionsWithErrorProvider]]></code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="tests/unit/TwoFactorTest.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>

--- a/src/Twig/I18nExtension.php
+++ b/src/Twig/I18nExtension.php
@@ -6,7 +6,11 @@ namespace PhpMyAdmin\Twig;
 
 use PhpMyAdmin\Twig\Extensions\I18nExtension as TwigI18nExtension;
 use PhpMyAdmin\Twig\Extensions\Node\TransNode;
+use PhpMyAdmin\Twig\Node\Expression\TransExpression;
 use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+use function _gettext;
 
 class I18nExtension extends TwigI18nExtension
 {
@@ -25,7 +29,13 @@ class I18nExtension extends TwigI18nExtension
     {
         return [
             // This is just a performance override
-            new TwigFilter('trans', '_gettext'),
+            new TwigFilter('trans', _gettext(...)),
         ];
+    }
+
+    /** @inheritdoc */
+    public function getFunctions(): array
+    {
+        return [new TwigFunction('t', null, ['node_class' => TransExpression::class])];
     }
 }

--- a/src/Twig/Node/Expression/TransExpression.php
+++ b/src/Twig/Node/Expression/TransExpression.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Twig\Node\Expression;
+
+use Twig\Compiler;
+use Twig\Error\SyntaxError;
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Node;
+
+use function in_array;
+use function is_string;
+use function sprintf;
+use function str_replace;
+use function trim;
+
+final class TransExpression extends AbstractExpression
+{
+    public function __construct(string $name, Node $arguments, int $lineno)
+    {
+        parent::__construct(['arguments' => $arguments], ['name' => $name, 'is_defined_test' => false], $lineno);
+    }
+
+    /** @throws SyntaxError */
+    public function compile(Compiler $compiler): void
+    {
+        $parameters = $this->getParameters();
+
+        if (isset($parameters['notes'])) {
+            $this->compileNotes($compiler, $parameters);
+        }
+
+        if (
+            isset($parameters['singular'])
+            || isset($parameters['plural'])
+            || isset($parameters['count'])
+            || isset($parameters[1])
+            || isset($parameters[2])
+        ) {
+            $this->compilePlural($compiler, $parameters);
+
+            return;
+        }
+
+        if (isset($parameters['context'])) {
+            $this->compileContext($compiler, $parameters);
+
+            return;
+        }
+
+        $this->compileMessage($compiler, $parameters);
+    }
+
+    /**
+     * @return Node[]
+     *
+     * @throws SyntaxError
+     */
+    private function getParameters(): array
+    {
+        $parameters = [];
+
+        /**
+         * @var int|string $name
+         * @var Node $argument
+         */
+        foreach ($this->getNode('arguments') as $name => $argument) {
+            if (! in_array($name, [0, 1, 2, 'message', 'singular', 'plural', 'count', 'context', 'notes'], true)) {
+                throw $this->unknownArgumentSyntaxError($name);
+            }
+
+            $parameters[$name] = $argument;
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * @param Node[] $parameters
+     *
+     * @throws SyntaxError
+     */
+    private function compileNotes(Compiler $compiler, array $parameters): void
+    {
+        $notes = $this->getStringFromNode('notes', $parameters['notes'] ?? null);
+
+        // line breaks are not allowed because we want a single line comment
+        $notes = trim(str_replace(["\n", "\r"], ' ', $notes));
+        if ($notes === '') {
+            throw $this->nonEmptyLiteralStringSyntaxError('notes');
+        }
+
+        $compiler->raw("\n// l10n: " . $notes . "\n");
+    }
+
+    /**
+     * @param Node[] $parameters
+     *
+     * @throws SyntaxError
+     */
+    private function compilePlural(Compiler $compiler, array $parameters): void
+    {
+        if (isset($parameters[0], $parameters['singular'])) {
+            throw $this->duplicateArgumentSyntaxError('singular');
+        }
+
+        if (isset($parameters[1], $parameters['plural'])) {
+            throw $this->duplicateArgumentSyntaxError('plural');
+        }
+
+        if (isset($parameters[2], $parameters['count'])) {
+            throw $this->duplicateArgumentSyntaxError('count');
+        }
+
+        $singular = $this->getStringFromNode('singular', $parameters[0] ?? $parameters['singular'] ?? null);
+        $plural = $this->getStringFromNode('plural', $parameters[1] ?? $parameters['plural'] ?? null);
+        $count = $parameters[2] ?? $parameters['count'] ?? null;
+        if ($count === null) {
+            throw $this->missingArgumentSyntaxError('count');
+        }
+
+        $compiler->raw('\\_ngettext(');
+        $compiler->string($singular);
+        $compiler->raw(', ');
+        $compiler->string($plural);
+        $compiler->raw(', ');
+        $compiler->subcompile($count);
+        $compiler->raw(isset($parameters['notes']) ? ")\n" : ')');
+    }
+
+    /**
+     * @param Node[] $parameters
+     *
+     * @throws SyntaxError
+     */
+    private function compileContext(Compiler $compiler, array $parameters): void
+    {
+        if (isset($parameters[0], $parameters['message'])) {
+            throw $this->duplicateArgumentSyntaxError('message');
+        }
+
+        $message = $this->getStringFromNode('message', $parameters[0] ?? $parameters['message'] ?? null);
+        $context = $this->getStringFromNode('context', $parameters['context'] ?? null);
+
+        $compiler->raw('\\_pgettext(');
+        $compiler->string($context);
+        $compiler->raw(', ');
+        $compiler->string($message);
+        $compiler->raw(isset($parameters['notes']) ? ")\n" : ')');
+    }
+
+    /**
+     * @param Node[] $parameters
+     *
+     * @throws SyntaxError
+     */
+    private function compileMessage(Compiler $compiler, array $parameters): void
+    {
+        if (isset($parameters[0], $parameters['message'])) {
+            throw $this->duplicateArgumentSyntaxError('message');
+        }
+
+        $message = $this->getStringFromNode('message', $parameters[0] ?? $parameters['message'] ?? null);
+
+        $compiler->raw('\\_gettext(');
+        $compiler->string($message);
+        $compiler->raw(isset($parameters['notes']) ? ")\n" : ')');
+    }
+
+    /**
+     * @psalm-return non-empty-string
+     *
+     * @throws SyntaxError
+     */
+    private function getStringFromNode(int|string $name, Node|null $node): string
+    {
+        if (! ($node instanceof ConstantExpression)) {
+            throw $this->nonEmptyLiteralStringSyntaxError($name);
+        }
+
+        $value = $node->getAttribute('value');
+        if (! is_string($value) || $value === '') {
+            throw $this->nonEmptyLiteralStringSyntaxError($name);
+        }
+
+        return $value;
+    }
+
+    private function unknownArgumentSyntaxError(int|string $name): SyntaxError
+    {
+        return new SyntaxError(
+            sprintf('Unknown argument "%s".', $name),
+            $this->getTemplateLine(),
+            $this->getSourceContext(),
+        );
+    }
+
+    private function duplicateArgumentSyntaxError(int|string $name): SyntaxError
+    {
+        return new SyntaxError(
+            sprintf('Argument "%s" is defined twice.', $name),
+            $this->getTemplateLine(),
+            $this->getSourceContext(),
+        );
+    }
+
+    private function nonEmptyLiteralStringSyntaxError(int|string $name): SyntaxError
+    {
+        return new SyntaxError(
+            sprintf('Value for argument "%s" must be a non-empty literal string.', $name),
+            $this->getTemplateLine(),
+            $this->getSourceContext(),
+        );
+    }
+
+    private function missingArgumentSyntaxError(int|string $name): SyntaxError
+    {
+        return new SyntaxError(
+            sprintf('Value for argument "%s" is required.', $name),
+            $this->getTemplateLine(),
+            $this->getSourceContext(),
+        );
+    }
+}

--- a/tests/unit/Twig/I18nExtensionTest.php
+++ b/tests/unit/Twig/I18nExtensionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Twig;
+
+use PhpMyAdmin\Config;
+use PhpMyAdmin\Template;
+use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Twig\I18nExtension;
+use PhpMyAdmin\Twig\Node\Expression\TransExpression;
+use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionProperty;
+use Twig\Loader\FilesystemLoader;
+
+use const TEST_PATH;
+
+#[CoversClass(I18nExtension::class)]
+#[CoversClass(TransExpression::class)]
+final class I18nExtensionTest extends AbstractTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $twigEnvironment = Template::getTwigEnvironment(null, true);
+        $twigEnvironment->setLoader(new FilesystemLoader(TEST_PATH . 'tests/unit/_data/templates'));
+        (new ReflectionProperty(Template::class, 'twig'))->setValue(null, $twigEnvironment);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        (new ReflectionProperty(Template::class, 'twig'))->setValue(null, null);
+    }
+
+    public function testMessage(): void
+    {
+        $expected = <<<'HTML'
+Message
+Message
+Message
+Message
+
+HTML;
+
+        self::assertSame($expected, (new Template(new Config()))->render('i18n_extension/message', []));
+    }
+
+    public function testContext(): void
+    {
+        $expected = <<<'HTML'
+Message
+Message
+Message
+Message
+
+HTML;
+
+        self::assertSame($expected, (new Template(new Config()))->render('i18n_extension/context', []));
+    }
+
+    public function testPlural(): void
+    {
+        $expected = <<<'HTML'
+One apple
+One apple
+One apple
+One apple
+One apple
+One apple
+
+HTML;
+
+        self::assertSame(
+            $expected,
+            (new Template(new Config()))->render('i18n_extension/plural', ['number_of_apples' => 1]),
+        );
+    }
+
+    public function testPlural2(): void
+    {
+        $expected = <<<'HTML'
+2 apples
+2 apples
+2 apples
+2 apples
+2 apples
+2 apples
+
+HTML;
+
+        self::assertSame(
+            $expected,
+            (new Template(new Config()))->render('i18n_extension/plural', ['number_of_apples' => 2]),
+        );
+    }
+}

--- a/tests/unit/Twig/Node/Expression/TransExpressionTest.php
+++ b/tests/unit/Twig/Node/Expression/TransExpressionTest.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Twig\Node\Expression;
+
+use PhpMyAdmin\Template;
+use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Twig\Node\Expression\TransExpression;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Twig\Compiler;
+use Twig\Error\SyntaxError;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\NameExpression;
+use Twig\Node\Node;
+
+#[CoversClass(TransExpression::class)]
+final class TransExpressionTest extends AbstractTestCase
+{
+    /** @param Node[] $arguments */
+    #[DataProvider('transExpressionsProvider')]
+    public function testTransExpressions(array $arguments, string $expected): void
+    {
+        $compiler = self::getCompiler();
+        (new TransExpression('t', new Node($arguments), 1))->compile($compiler);
+        self::assertSame($expected, $compiler->getSource());
+    }
+
+    /** @psalm-return iterable<string, array{Node[], non-empty-string}> */
+    public static function transExpressionsProvider(): iterable
+    {
+        yield 't("Message")' => [[self::getConstantExpression('Message')], '\\_gettext("Message")'];
+        yield 't(message = "Message")' => [
+            ['message' => self::getConstantExpression('Message')],
+            '\\_gettext("Message")',
+        ];
+
+        yield 't("Message", notes = "Notes")' => [
+            [self::getConstantExpression('Message'), 'notes' => self::getConstantExpression('Notes')],
+            "\n" . '// l10n: Notes' . "\n" . '\\_gettext("Message")' . "\n",
+        ];
+
+        yield 't(message = "Message", notes = "Notes")' => [
+            ['message' => self::getConstantExpression('Message'), 'notes' => self::getConstantExpression('Notes')],
+            "\n" . '// l10n: Notes' . "\n" . '\\_gettext("Message")' . "\n",
+        ];
+
+        yield 't("Message", notes = " \n\rNotes\rwith line\nbreaks \n ")' => [
+            [
+                0 => self::getConstantExpression('Message'),
+                'notes' => self::getConstantExpression(" \n\rNotes\rwith line\nbreaks \n "),
+            ],
+            "\n" . '// l10n: Notes with line breaks' . "\n" . '\\_gettext("Message")' . "\n",
+        ];
+
+        yield 't("Message", context = "Context")' => [
+            [self::getConstantExpression('Message'), 'context' => self::getConstantExpression('Context')],
+            '\\_pgettext("Context", "Message")',
+        ];
+
+        yield 't(message = "Message", context = "Context")' => [
+            ['message' => self::getConstantExpression('Message'), 'context' => self::getConstantExpression('Context')],
+            '\\_pgettext("Context", "Message")',
+        ];
+
+        yield 't("Message", context = "Context", notes = "Notes")' => [
+            [
+                0 => self::getConstantExpression('Message'),
+                'context' => self::getConstantExpression('Context'),
+                'notes' => self::getConstantExpression('Notes'),
+            ],
+            "\n" . '// l10n: Notes' . "\n" . '\\_pgettext("Context", "Message")' . "\n",
+        ];
+
+        yield 't(message = "Message", context = "Context", notes = "Notes")' => [
+            [
+                'message' => self::getConstantExpression('Message'),
+                'context' => self::getConstantExpression('Context'),
+                'notes' => self::getConstantExpression('Notes'),
+            ],
+            "\n" . '// l10n: Notes' . "\n" . '\\_pgettext("Context", "Message")' . "\n",
+        ];
+
+        yield 't("One apple", "%d apples", number_of_apples)' => [
+            [
+                self::getConstantExpression('One apple'),
+                self::getConstantExpression('%d apples'),
+                self::getNameExpression('number_of_apples'),
+            ],
+            '\\_ngettext("One apple", "%d apples", // line 1' . "\n" . '($context["number_of_apples"] ?? null))',
+        ];
+
+        yield 't("One apple", "%d apples", count = number_of_apples)' => [
+            [
+                0 => self::getConstantExpression('One apple'),
+                1 => self::getConstantExpression('%d apples'),
+                'count' => self::getNameExpression('number_of_apples'),
+            ],
+            '\\_ngettext("One apple", "%d apples", // line 1' . "\n" . '($context["number_of_apples"] ?? null))',
+        ];
+
+        yield 't("One apple", plural = "%d apples", count = number_of_apples)' => [
+            [
+                0 => self::getConstantExpression('One apple'),
+                'plural' => self::getConstantExpression('%d apples'),
+                'count' => self::getNameExpression('number_of_apples'),
+            ],
+            '\\_ngettext("One apple", "%d apples", // line 1' . "\n" . '($context["number_of_apples"] ?? null))',
+        ];
+
+        yield 't(singular = "One apple", plural = "%d apples", count = number_of_apples)' => [
+            [
+                'singular' => self::getConstantExpression('One apple'),
+                'plural' => self::getConstantExpression('%d apples'),
+                'count' => self::getNameExpression('number_of_apples'),
+            ],
+            '\\_ngettext("One apple", "%d apples", // line 1' . "\n" . '($context["number_of_apples"] ?? null))',
+        ];
+
+        yield 't("One apple", "%d apples", 3, notes = "Notes")' => [
+            [
+                0 => self::getConstantExpression('One apple'),
+                1 => self::getConstantExpression('%d apples'),
+                2 => self::getConstantExpression(3),
+                'notes' => self::getConstantExpression('Notes'),
+            ],
+            "\n" . '// l10n: Notes' . "\n"
+                . '\\_ngettext("One apple", "%d apples", 3)' . "\n",
+        ];
+
+        yield 't(singular = "One apple", plural = "%d apples", count = 3, notes = "Notes")' => [
+            [
+                'singular' => self::getConstantExpression('One apple'),
+                'plural' => self::getConstantExpression('%d apples'),
+                'count' => self::getConstantExpression(3),
+                'notes' => self::getConstantExpression('Notes'),
+            ],
+            "\n" . '// l10n: Notes' . "\n"
+                . '\\_ngettext("One apple", "%d apples", 3)' . "\n",
+        ];
+    }
+
+    /** @param Node[] $arguments */
+    #[DataProvider('transExpressionsWithErrorProvider')]
+    public function testTransExpressionsWithError(array $arguments, string $expected): void
+    {
+        self::expectException(SyntaxError::class);
+        self::expectExceptionMessage($expected);
+        (new TransExpression('t', new Node($arguments), 1))->compile(self::getCompiler());
+    }
+
+    /** @psalm-return iterable<string, array{Node[], non-empty-string}> */
+    public static function transExpressionsWithErrorProvider(): iterable
+    {
+        yield 't()' => [[], 'Value for argument "message" must be a non-empty literal string at line 1.'];
+        yield 't("")' => [
+            [self::getConstantExpression('')],
+            'Value for argument "message" must be a non-empty literal string at line 1.',
+        ];
+
+        yield 't(message = "")' => [
+            ['message' => self::getConstantExpression('')],
+            'Value for argument "message" must be a non-empty literal string at line 1.',
+        ];
+
+        yield 't(notes = "Notes")' => [
+            ['message' => self::getConstantExpression('')],
+            'Value for argument "message" must be a non-empty literal string at line 1.',
+        ];
+
+        yield 't(variable_name)' => [
+            [self::getNameExpression('variable_name')],
+            'Value for argument "message" must be a non-empty literal string at line 1.',
+        ];
+
+        yield 't(message = variable_name)' => [
+            ['message' => self::getNameExpression('variable_name')],
+            'Value for argument "message" must be a non-empty literal string at line 1.',
+        ];
+
+        yield 't("Message", unknown = "Unknown argument")' => [
+            [self::getConstantExpression('Message'), 'unknown' => self::getConstantExpression('Unknown argument')],
+            'Unknown argument "unknown" at line 1.',
+        ];
+
+        yield 't("Message", notes = variable_name)' => [
+            [self::getConstantExpression('Message'), 'notes' => self::getNameExpression('variable_name')],
+            'Value for argument "notes" must be a non-empty literal string at line 1.',
+        ];
+
+        yield 't("Message", notes = "")' => [
+            [self::getConstantExpression('Message'), 'notes' => self::getConstantExpression('')],
+            'Value for argument "notes" must be a non-empty literal string at line 1.',
+        ];
+
+        yield 't("Message", notes = " \n ")' => [
+            [self::getConstantExpression('Message'), 'notes' => self::getConstantExpression(" \n\r ")],
+            'Value for argument "notes" must be a non-empty literal string at line 1.',
+        ];
+
+        yield 't("Message", context = variable_name)' => [
+            [self::getConstantExpression('Message'), 'context' => self::getNameExpression('variable_name')],
+            'Value for argument "context" must be a non-empty literal string at line 1.',
+        ];
+
+        yield 't("Message", context = "")' => [
+            [self::getConstantExpression('Message'), 'context' => self::getConstantExpression('')],
+            'Value for argument "context" must be a non-empty literal string at line 1.',
+        ];
+
+        yield 't("Message", message = "Message")' => [
+            [self::getConstantExpression('Message'), 'message' => self::getConstantExpression('Message')],
+            'Argument "message" is defined twice at line 1.',
+        ];
+
+        yield 't("Message", context = "Context", message = "Message")' => [
+            [
+                0 => self::getConstantExpression('Message'),
+                'context' => self::getConstantExpression('Context'),
+                'message' => self::getConstantExpression('Message'),
+            ],
+            'Argument "message" is defined twice at line 1.',
+        ];
+
+        yield 't("", "%d apples", 3)' => [
+            [
+                self::getConstantExpression(''),
+                self::getConstantExpression('%d apples'),
+                self::getConstantExpression(3),
+            ],
+            'Value for argument "singular" must be a non-empty literal string at line 1.',
+        ];
+
+        yield 't(variable_name, "%d apples", 3)' => [
+            [
+                self::getNameExpression('variable_name'),
+                self::getConstantExpression('%d apples'),
+                self::getConstantExpression(3),
+            ],
+            'Value for argument "singular" must be a non-empty literal string at line 1.',
+        ];
+
+        yield 't("One apple", "", 3)' => [
+            [
+                self::getConstantExpression('One apple'),
+                self::getConstantExpression(''),
+                self::getConstantExpression(3),
+            ],
+            'Value for argument "plural" must be a non-empty literal string at line 1.',
+        ];
+
+        yield 't("One apple", variable_name, 3)' => [
+            [
+                self::getConstantExpression('One apple'),
+                self::getNameExpression('variable_name'),
+                self::getConstantExpression(3),
+            ],
+            'Value for argument "plural" must be a non-empty literal string at line 1.',
+        ];
+
+        yield 't("One apple", "%d apples")' => [
+            [
+                self::getConstantExpression('One apple'),
+                self::getConstantExpression('%d apples'),
+            ],
+            'Value for argument "count" is required at line 1.',
+        ];
+
+        yield 't("One apple", "%d apples", 3, singular = "One apple")' => [
+            [
+                0 => self::getConstantExpression('One apple'),
+                1 => self::getConstantExpression('%d apples'),
+                2 => self::getConstantExpression(3),
+                'singular' => self::getConstantExpression('One apple'),
+            ],
+            'Argument "singular" is defined twice at line 1.',
+        ];
+
+        yield 't("One apple", "%d apples", 3, plural = "%d apples")' => [
+            [
+                0 => self::getConstantExpression('One apple'),
+                1 => self::getConstantExpression('%d apples'),
+                2 => self::getConstantExpression(3),
+                'plural' => self::getConstantExpression('%d apples'),
+            ],
+            'Argument "plural" is defined twice at line 1.',
+        ];
+
+        yield 't("One apple", "%d apples", 3, count = 3)' => [
+            [
+                0 => self::getConstantExpression('One apple'),
+                1 => self::getConstantExpression('%d apples'),
+                2 => self::getConstantExpression(3),
+                'count' => self::getConstantExpression(3),
+            ],
+            'Argument "count" is defined twice at line 1.',
+        ];
+    }
+
+    private static function getConstantExpression(mixed $value): ConstantExpression
+    {
+        return new ConstantExpression($value, 1);
+    }
+
+    private static function getNameExpression(string $name): NameExpression
+    {
+        return new NameExpression($name, 1);
+    }
+
+    private static function getCompiler(): Compiler
+    {
+        return (new Compiler(Template::getTwigEnvironment(null, false)))->reset();
+    }
+}

--- a/tests/unit/_data/templates/i18n_extension/context.twig
+++ b/tests/unit/_data/templates/i18n_extension/context.twig
@@ -1,0 +1,4 @@
+{{ t('Message', context = 'Context') }}
+{{ t('Message', context = 'Context', notes = 'Localization comments') }}
+{{ t(message = 'Message', context = 'Context') }}
+{{ t(message = 'Message', context = 'Context', notes = 'Localization comments') }}

--- a/tests/unit/_data/templates/i18n_extension/message.twig
+++ b/tests/unit/_data/templates/i18n_extension/message.twig
@@ -1,0 +1,4 @@
+{{ t('Message') }}
+{{ t('Message', notes = 'Localization comments') }}
+{{ t(message = 'Message') }}
+{{ t(message = 'Message', notes = 'Localization comments') }}

--- a/tests/unit/_data/templates/i18n_extension/plural.twig
+++ b/tests/unit/_data/templates/i18n_extension/plural.twig
@@ -1,0 +1,6 @@
+{{ t('One apple', '%d apples', number_of_apples)|format(number_of_apples) }}
+{{ t('One apple', '%d apples', count = number_of_apples)|format(number_of_apples) }}
+{{ t('One apple', plural = '%d apples', count = number_of_apples)|format(number_of_apples) }}
+{{ t(singular = 'One apple', plural = '%d apples', count = number_of_apples)|format(number_of_apples) }}
+{{ t('One apple', '%d apples', number_of_apples, notes = 'Localization comments')|format(number_of_apples) }}
+{{ t(singular = 'One apple', plural = '%d apples', count = number_of_apples, notes = 'Localization comments')|format(number_of_apples) }}


### PR DESCRIPTION
For translations, a Twig function is more versatile than a Twig tag and has the benefit of auto escaping.

As the `phpmyadmin/twig-i18n-extension` package is a fork of the Twig's `I18nExtension`, the custom function was added to the phpMyAdmin main repository, this way the cases not used by phpMyAdmin don't need to be implemented. For example, only the default domain is used and MoTranslator is always available.

The idea is to replace all usage of `trans` tags and filter with this new `t` function.

```diff
- {% trans 'Message' %}
+ {{ t('Message') }}
```

```diff
- {% trans %}Message{% endtrans %}
+ {{ t('Message') }}
```

```diff
- {% trans %}Message{% context %}Context{% endtrans %}
+ {{ t('Message', context = 'Context') }}
```

```diff
- {% trans %}Message{% notes %}Notes{% endtrans %}
+ {{ t('Message', notes = 'Notes') }}
```

```diff
- {% apply format(number_of_tables) %}
-     {% trans %}%d table{% plural number_of_tables %}%s tables{% endtrans %}
- {% endapply %}
+ {{ t('%d table', '%s tables', number_of_tables)|format(number_of_tables) }}
```
