### PR TITLE
Fix #19125 - CodeMirror tooltip is below modals

### DIFF
--- a/themes/bootstrap/scss/_codemirror.scss
+++ b/themes/bootstrap/scss/_codemirror.scss
@@ -96,7 +96,7 @@ span {
 }
 
 .CodeMirror-lint-tooltip {
-  z-index: 200;
+  z-index: 2000;
   font-family: inherit;
 
   code {

--- a/themes/metro/scss/_codemirror.scss
+++ b/themes/metro/scss/_codemirror.scss
@@ -103,3 +103,13 @@ span {
 .CodeMirror-hints {
   z-index: 1999;
 }
+
+.CodeMirror-lint-tooltip {
+  z-index: 2000;
+  font-family: inherit;
+
+  code {
+    font-family: monospace;
+    font-weight: bold;
+  }
+}

--- a/themes/pmahomme/scss/_codemirror.scss
+++ b/themes/pmahomme/scss/_codemirror.scss
@@ -93,7 +93,7 @@ span {
 }
 
 .CodeMirror-lint-tooltip {
-  z-index: 200;
+  z-index: 2000;
   font-family: inherit;
 
   code {


### PR DESCRIPTION
### Description

Add higher z-index to codemirror tooltips so it is in the foreground

Fixes #19125

 z-index of 2000 so it is above `.CodeMirror-hints { z-index: 1999; }`
