### PR TITLE
Fix #18240 - inserting value with UNIX_TIMESTAMP() without param

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1614,7 +1614,7 @@ class InsertEdit
 
         if (
             ! in_array($multiEditFuncs[$key], $funcNoParam)
-            || ($currentValue != "''"
+            || ($currentValue !== ''
                 && in_array($multiEditFuncs[$key], $funcOptionalParam))
         ) {
             if (


### PR DESCRIPTION
### Description

At this point the value has not been escaped so to check whether the textfield was empty compare to empty `''` string instead of a quoted empty string `"''"`.

Was introduced here: [`6d0a30a`](https://github.com/phpmyadmin/phpmyadmin/commit/6d0a30a391cfb78cb51a476b4f925a625070c4b6#diff-97b13ff1169ee3b4fa17e6067276e7950186fa99e1056282568fc82d63350fb3L1613-L1629)

Fixes #18240
