### PR TITLE
Export views after indexes

### DIFF
--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -67,6 +67,9 @@ class ExportSql extends ExportPlugin
      */
     private $sentCharset = false;
 
+    /** @var string */
+    private $sqlViews = '';
+
     protected function init(): void
     {
         // Avoids undefined variables, use NULL so isset() returns false
@@ -980,6 +983,12 @@ class ExportSql extends ExportPlugin
         if (isset($GLOBALS['sql_auto_increments'])) {
             $result = $this->export->outputHandler($GLOBALS['sql_auto_increments']);
             unset($GLOBALS['sql_auto_increments']);
+        }
+
+        //add views to the sql dump file
+        if ($this->sqlViews !== '') {
+            $result = $this->export->outputHandler($this->sqlViews);
+            $this->sqlViews = '';
         }
 
         //add constraints to the sql dump file
@@ -2175,6 +2184,13 @@ class ExportSql extends ExportPlugin
                     }
 
                     $dump .= $this->getTableDefForView($db, $table, $crlf, true, $aliases);
+                }
+
+                if (empty($GLOBALS['sql_views_as_tables'])) {
+                    // Save views, to be inserted after indexes
+                    // in case the view uses USE INDEX syntax
+                    $this->sqlViews .= $dump;
+                    $dump = '';
                 }
 
                 break;

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -22,6 +22,7 @@ use PhpMyAdmin\Table;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use ReflectionMethod;
+use ReflectionProperty;
 use stdClass;
 
 use function array_shift;
@@ -1083,11 +1084,15 @@ class ExportSqlTest extends AbstractTestCase
             )
         );
         $result = ob_get_clean();
+        $sqlViewsProp = new ReflectionProperty(ExportSql::class, 'sqlViews');
+        $sqlViewsProp->setAccessible(true);
+        $sqlViews = $sqlViewsProp->getValue($this->object);
 
-        $this->assertIsString($result);
-        $this->assertStringContainsString('-- Structure for view test_table', $result);
-        $this->assertStringContainsString('DROP TABLE IF EXISTS `test_table`;', $result);
-        $this->assertStringContainsString('CREATE TABLE `test_table`', $result);
+        $this->assertEquals('', $result);
+        $this->assertIsString($sqlViews);
+        $this->assertStringContainsString('-- Structure for view test_table', $sqlViews);
+        $this->assertStringContainsString('DROP TABLE IF EXISTS `test_table`;', $sqlViews);
+        $this->assertStringContainsString('CREATE TABLE `test_table`', $sqlViews);
 
         // case 4
         $GLOBALS['sql_views_as_tables'] = true;


### PR DESCRIPTION
### Description

When a view uses USE INDEX syntax import failed because of the missing index.
Store the view structure sql in a global variable and put them after the indexes. This is handled similarly for the indexes.

Fixes #18566

