### PR TITLE
Fix #18674 - formatted sql in grid should be inline text

### DIFF
--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -2188,7 +2188,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
 
     // wrap all truncated data cells with span indicating the original length
     // todo update the original length after a grid edit
-    $(t).find('td.data.truncated:not(:has(span))')
+    $(t).find('td.data.truncated:not(:has(>span))')
         .filter(function () {
             return $(this).data('originallength') !== undefined;
         })
@@ -2198,7 +2198,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
         });
 
     // wrap remaining cells, except actions cell, with span
-    $(t).find('th, td:not(:has(span))')
+    $(t).find('th, td:not(:has(>span))')
         .wrapInner('<span></span>');
 
     // create grid elements


### PR DESCRIPTION
### Description

The css expects all table cells to have a wrapping span, but the wrapping was only done when no span existed in the cell. If the formatting is done before the wrapping there already exist nested spans and no top-level span is created. In this case the style that makes the sql displayed inline did not apply.

Fixes #18674
