### PR TITLE
Add cookie prefix '-__Secure-' to cookies to help prevent cookie smuggling (issue18608)

### DIFF
--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -1023,7 +1023,7 @@ class Config
      */
     public function getCookieName(string $cookieName): string
     {
-        return $cookieName . ( $this->isHttps() ? '_https' : '' );
+    return ( $this->isHttps() ? '__Secure-' : '’ ) . $cookieName . ( $this->isHttps() ? '_https' : ‘’ );
     }
 
     /**


### PR DESCRIPTION
The aim of this PR is to help prevent cookie smuggling. It will modify the 'GetCookieName' functtion by hard coding the prefix ' __Secure-' to each cookie name when 'isHttps()' is true, Apparently the prefix will be recognised and enforced by most browsers (ignored by the older ones).

### Description
The raison d'aitre for this PR is contained in the issue # 18608.

This PR will replace the line 1026 of the file 'Config.php',  part of the GetCookieName function : 
**return $cookieName . ( $this->isHttps ? '_https' : '' );**

with the amended line:
**return ( $this->isHttps() ? '__Secure-' : '’ ) . $cookieName . ( $this->isHttps() ? '_https' : ‘’ );**

The amendment is on the QA_5_2 branch and path libraries/Classes


Signed-off-by: martin762 <[martin762green@btinternet.com>

- #18608