### PR TITLE
Remove duplicate server and lang param from links

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -1482,7 +1482,7 @@ class Results
             . ($theme instanceof Theme ? $theme->getImgPath($tmpImageFile) : '')
             . '" alt="' . $tmpTxt . '" title="' . $tmpTxt . '">';
 
-        return Generator::linkOrButton(Url::getFromRoute('/sql'), $urlParamsFullText, $tmpImage);
+        return Generator::linkOrButton(Url::getFromRoute('/sql', $urlParamsFullText, false), null, $tmpImage);
     }
 
     /**
@@ -1878,16 +1878,15 @@ class Results
         array $orderUrlParams,
         array $multiOrderUrlParams
     ): string {
-        $urlPath = Url::getFromRoute('/sql');
+        $urlPath = Url::getFromRoute('/sql', $multiOrderUrlParams, false);
         $innerLinkContent = htmlspecialchars($fieldsMeta->name) . $orderImg
             . '<input type="hidden" value="'
             . $urlPath
-            . Url::getCommon($multiOrderUrlParams, str_contains($urlPath, '?') ? '&' : '?', false)
             . '">';
 
         return Generator::linkOrButton(
-            Url::getFromRoute('/sql'),
-            $orderUrlParams,
+            Url::getFromRoute('/sql', $orderUrlParams, false),
+            null,
             $innerLinkContent,
             ['class' => 'sortlink']
         );
@@ -4495,8 +4494,8 @@ class Results
                 }
 
                 $value .= Generator::linkOrButton(
-                    Url::getFromRoute('/sql'),
-                    $urlParams,
+                    Url::getFromRoute('/sql', $urlParams, false),
+                    null,
                     $displayedData,
                     $tagParams
                 );

--- a/libraries/classes/Url.php
+++ b/libraries/classes/Url.php
@@ -349,8 +349,8 @@ class Url
      * @param string $route                Route to use
      * @param array  $additionalParameters Additional URL parameters
      */
-    public static function getFromRoute(string $route, array $additionalParameters = []): string
+    public static function getFromRoute(string $route, array $additionalParameters = [], bool $encrypt = true): string
     {
-        return 'index.php?route=' . $route . self::getCommon($additionalParameters, self::getArgSeparator());
+        return 'index.php?route=' . $route . self::getCommon($additionalParameters, self::getArgSeparator(), $encrypt);
     }
 }

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2615,9 +2615,9 @@ class Util
             $urlParams['tbl_group'] = $_REQUEST['tbl_group'];
         }
 
-        $url = Url::getFromRoute('/database/structure');
+        $url = Url::getFromRoute('/database/structure', $urlParams, false);
 
-        return Generator::linkOrButton($url, $urlParams, $title . $orderImg, $orderLinkParams);
+        return Generator::linkOrButton($url, null, $title . $orderImg, $orderLinkParams);
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3296,11 +3296,6 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Parameter \\#1 \\$params of static method PhpMyAdmin\\\\Url\\:\\:getCommon\\(\\) expects array\\<string, bool\\|int\\|string\\>, array\\<int\\|string, mixed\\> given\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Parameter \\#3 \\$colOrder of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getRowValues\\(\\) expects array\\|false, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5988,9 +5988,8 @@
     </MixedReturnTypeCoercion>
   </file>
   <file src="libraries/classes/Display/Results.php">
-    <InvalidArgument occurrences="3">
+    <InvalidArgument occurrences="2">
       <code>$added[$orgFullTableName]</code>
-      <code>$multiOrderUrlParams</code>
       <code>$sortExpressionNoDirection</code>
     </InvalidArgument>
     <InvalidArrayOffset occurrences="2">

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -1465,12 +1465,12 @@ class ResultsTest extends AbstractTestCase
             'columns' => [
                 [
                     'column_name' => 'id',
-                    'order_link' => '<a href="index.php?route=/sql&server=0&lang=en&db=test_db&table=test_table'
+                    'order_link' => '<a href="index.php?route=/sql&db=test_db&table=test_table'
                         . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60++%0AORDER+BY+%60id%60+ASC'
                         . '&sql_signature=dcfe20b407b35309f6af81f745e77a10f723d39b082d2a8f9cb8e75b17c4d3ce'
                         . '&session_max_rows=25&is_browse_distinct=0&server=0&lang=en" class="sortlink">id'
                         . '<input type="hidden" value="'
-                        . 'index.php?route=/sql&server=0&lang=en&db=test_db&table=test_table'
+                        . 'index.php?route=/sql&db=test_db&table=test_table'
                         . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60++%0AORDER+BY+%60id%60+ASC'
                         . '&sql_signature=dcfe20b407b35309f6af81f745e77a10f723d39b082d2a8f9cb8e75b17c4d3ce'
                         . '&session_max_rows=25&is_browse_distinct=0&server=0&lang=en"></a>'
@@ -1492,12 +1492,12 @@ class ResultsTest extends AbstractTestCase
                 ],
                 [
                     'column_name' => 'name',
-                    'order_link' => '<a href="index.php?route=/sql&server=0&lang=en&db=test_db&table=test_table'
+                    'order_link' => '<a href="index.php?route=/sql&db=test_db&table=test_table'
                         . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60++%0AORDER+BY+%60name%60+ASC'
                         . '&sql_signature=0d06fa8d6795b1c69892cca27d6213c08401bd434145d16cb35c365ab3e03039'
                         . '&session_max_rows=25&is_browse_distinct=0&server=0&lang=en" class="sortlink">name'
                         . '<input type="hidden" value="'
-                        . 'index.php?route=/sql&server=0&lang=en&db=test_db&table=test_table'
+                        . 'index.php?route=/sql&db=test_db&table=test_table'
                         . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60++%0AORDER+BY+%60name%60+ASC'
                         . '&sql_signature=0d06fa8d6795b1c69892cca27d6213c08401bd434145d16cb35c365ab3e03039'
                         . '&session_max_rows=25&is_browse_distinct=0&server=0&lang=en"></a>'
@@ -1519,13 +1519,13 @@ class ResultsTest extends AbstractTestCase
                 ],
                 [
                     'column_name' => 'datetimefield',
-                    'order_link' => '<a href="index.php?route=/sql&server=0&lang=en&db=test_db&table=test_table'
+                    'order_link' => '<a href="index.php?route=/sql&db=test_db&table=test_table'
                         . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60++%0A'
                         . 'ORDER+BY+%60datetimefield%60+DESC'
                         . '&sql_signature=1c46f7e3c625f9e0846fb2de844ca1732319e5fb7fb93e96c89a4b6218579358'
                         . '&session_max_rows=25&is_browse_distinct=0&server=0&lang=en" class="sortlink">datetimefield'
                         . '<input type="hidden" value="'
-                        . 'index.php?route=/sql&server=0&lang=en&db=test_db&table=test_table'
+                        . 'index.php?route=/sql&db=test_db&table=test_table'
                         . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60++%0A'
                         . 'ORDER+BY+%60datetimefield%60+DESC'
                         . '&sql_signature=1c46f7e3c625f9e0846fb2de844ca1732319e5fb7fb93e96c89a4b6218579358'


### PR DESCRIPTION
### Description

Remove duplicate server and lang parameters added by `Url::getCommon` when generating links. 
`Url::fromRoute` calls `Url::getCommon` and `Generator::linkOrButton` also calls `Url::getCommon` when a parameter array is provided. 
