### PR TITLE
Remove ResponseRenderer::disable() from controllers

### DIFF
--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -616,7 +616,7 @@ return [
         ],
         SchemaExportController::class => [
             'class' => SchemaExportController::class,
-            'arguments' => ['$export' => '@export', '$response' => '@response'],
+            'arguments' => ['@export', '@response', '@' . ResponseFactory::class],
         ],
         Server\BinlogController::class => [
             'class' => Server\BinlogController::class,

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -1260,6 +1260,7 @@ return [
                 '$tracking' => '@tracking',
                 '$trackingChecker' => '@tracking_checker',
                 '$dbTableExists' => '@' . DbTableExists::class,
+                '$responseFactory' => '@' . ResponseFactory::class,
             ],
         ],
         Triggers\IndexController::class => [

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -1315,6 +1315,7 @@ return [
                 '$relation' => '@relation',
                 '$dbi' => '@dbi',
                 '$dbTableExists' => '@' . DbTableExists::class,
+                '$responseFactory' => '@' . ResponseFactory::class,
             ],
         ],
         UserPasswordController::class => [

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -219,7 +219,7 @@ return [
         ],
         Database\Structure\AddPrefixController::class => [
             'class' => Database\Structure\AddPrefixController::class,
-            'arguments' => ['$response' => '@response'],
+            'arguments' => ['@response', '@' . ResponseFactory::class, '@template'],
         ],
         Database\Structure\AddPrefixTableController::class => [
             'class' => Database\Structure\AddPrefixTableController::class,

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -255,7 +255,7 @@ return [
         ],
         Database\Structure\CopyFormController::class => [
             'class' => Database\Structure\CopyFormController::class,
-            'arguments' => ['$response' => '@response'],
+            'arguments' => ['@response', '@' . ResponseFactory::class, '@template'],
         ],
         Database\Structure\CopyTableController::class => [
             'class' => Database\Structure\CopyTableController::class,

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -450,10 +450,7 @@ return [
             'class' => LicenseController::class,
             'arguments' => ['@response', '@' . ResponseFactory::class],
         ],
-        LintController::class => [
-            'class' => LintController::class,
-            'arguments' => ['$response' => '@response'],
-        ],
+        LintController::class => ['class' => LintController::class, 'arguments' => ['@' . ResponseFactory::class]],
         LogoutController::class => [
             'class' => LogoutController::class,
             'arguments' => ['@' . AuthenticationPluginFactory::class],

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -541,7 +541,7 @@ return [
         ],
         PhpInfoController::class => [
             'class' => PhpInfoController::class,
-            'arguments' => ['$response' => '@response'],
+            'arguments' => ['@response', '@' . ResponseFactory::class, '@config'],
         ],
         Preferences\ExportController::class => [
             'class' => Preferences\ExportController::class,

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -995,6 +995,7 @@ return [
                 '$template' => '@template',
                 '$dbi' => '@dbi',
                 '$dbTableExists' => '@' . DbTableExists::class,
+                '$responseFactory' => '@' . ResponseFactory::class,
             ],
         ],
         Table\ImportController::class => [

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -448,7 +448,7 @@ return [
         ],
         LicenseController::class => [
             'class' => LicenseController::class,
-            'arguments' => ['$response' => '@response'],
+            'arguments' => ['@response', '@' . ResponseFactory::class],
         ],
         LintController::class => [
             'class' => LintController::class,

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -57,7 +57,7 @@ return [
         ],
         ChangeLogController::class => [
             'class' => ChangeLogController::class,
-            'arguments' => ['$response' => '@response', '$config' => '@config'],
+            'arguments' => ['@response', '@config', '@' . ResponseFactory::class, '@template'],
         ],
         CheckRelationsController::class => [
             'class' => CheckRelationsController::class,

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -588,6 +588,7 @@ return [
                 '$relation' => '@relation',
                 '$config' => '@config',
                 '$themeManager' => '@' . PhpMyAdmin\Theme\ThemeManager::class,
+                '$responseFactory' => '@' . ResponseFactory::class,
             ],
         ],
         Preferences\NavigationController::class => [

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -986,7 +986,7 @@ return [
         ],
         Table\GetFieldController::class => [
             'class' => Table\GetFieldController::class,
-            'arguments' => ['$response' => '@response', '$dbi' => '@dbi'],
+            'arguments' => ['@response', '@dbi', '@' . ResponseFactory::class],
         ],
         Table\GisVisualizationController::class => [
             'class' => Table\GisVisualizationController::class,

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -251,7 +251,7 @@ return [
         ],
         Database\Structure\ChangePrefixFormController::class => [
             'class' => Database\Structure\ChangePrefixFormController::class,
-            'arguments' => ['$response' => '@response'],
+            'arguments' => ['@response', '@' . ResponseFactory::class, '@template'],
         ],
         Database\Structure\CopyFormController::class => [
             'class' => Database\Structure\CopyFormController::class,

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -1323,7 +1323,7 @@ return [
         ],
         VersionCheckController::class => [
             'class' => VersionCheckController::class,
-            'arguments' => ['$response' => '@response', '$versionInformation' => '@version_information'],
+            'arguments' => ['@version_information', '@' . ResponseFactory::class],
         ],
         View\CreateController::class => [
             'class' => View\CreateController::class,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4381,16 +4381,6 @@ parameters:
 			path: src/Controllers/Table/GetFieldController.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function mb_strlen expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Controllers/Table/GetFieldController.php
-
-		-
-			message: "#^Parameter \\#1 \\$test of static method PhpMyAdmin\\\\Mime\\:\\:detect\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Controllers/Table/GetFieldController.php
-
-		-
 			message: "#^Cannot access offset 'back' on mixed\\.$#"
 			count: 1
 			path: src/Controllers/Table/GisVisualizationController.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2786,7 +2786,7 @@ parameters:
 			path: src/Controllers/LicenseController.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function printf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$path of function basename expects string, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/LicenseController.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2040,11 +2040,6 @@
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="src/Controllers/LicenseController.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[__construct]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="src/Controllers/LintController.php">
     <MixedAssignment>
       <code><![CDATA[$editorType]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4167,9 +4167,6 @@
       <code><![CDATA[$toggleActivation]]></code>
       <code><![CDATA[$version]]></code>
     </MixedAssignment>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/ZoomSearchController.php">
     <DeprecatedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1333,9 +1333,6 @@
     <DeprecatedMethod>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[__construct]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="src/Controllers/Database/Structure/CopyTableController.php">
     <MixedArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2322,14 +2322,6 @@
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="src/Controllers/PhpInfoController.php">
-    <DeprecatedMethod>
-      <code><![CDATA[Config::getInstance()]]></code>
-    </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[__construct]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="src/Controllers/Preferences/ExportController.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
@@ -12949,6 +12941,11 @@
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$config->settings]]></code>
     </InvalidPropertyAssignmentValue>
+  </file>
+  <file src="tests/unit/Controllers/PhpInfoControllerTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[Config::getInstance()]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="tests/unit/Controllers/Server/BinlogControllerTest.php">
     <DeprecatedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3474,14 +3474,6 @@
       <code><![CDATA[Response|null]]></code>
     </PossiblyUnusedReturnValue>
   </file>
-  <file src="src/Controllers/Table/GetFieldController.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$result]]></code>
-    </PossiblyNullArgument>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
-  </file>
   <file src="src/Controllers/Table/GisVisualizationController.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2503,11 +2503,6 @@
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="src/Controllers/SchemaExportController.php">
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
-  </file>
   <file src="src/Controllers/Server/BinlogController.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2032,9 +2032,6 @@
       <code><![CDATA[$editorType]]></code>
       <code><![CDATA[$options]]></code>
     </MixedAssignment>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/LogoutController.php">
     <PossiblyUnusedReturnValue>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1300,11 +1300,6 @@
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="src/Controllers/Database/Structure/AddPrefixController.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[__construct]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="src/Controllers/Database/Structure/AddPrefixTableController.php">
     <MixedOperand>
       <code><![CDATA[$request->getParsedBodyParam('add_prefix', '')]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1329,11 +1329,6 @@
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="src/Controllers/Database/Structure/ChangePrefixFormController.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[__construct]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="src/Controllers/Database/Structure/CopyFormController.php">
     <DeprecatedMethod>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -811,11 +811,6 @@
       <code><![CDATA[Response|null]]></code>
     </PossiblyUnusedReturnValue>
   </file>
-  <file src="src/Controllers/ChangeLogController.php">
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
-  </file>
   <file src="src/Controllers/CheckRelationsController.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4343,11 +4343,6 @@
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="src/Controllers/VersionCheckController.php">
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
-  </file>
   <file src="src/Controllers/View/CreateController.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3490,9 +3490,6 @@
     <PossiblyInvalidCast>
       <code><![CDATA[$_GET['fileFormat']]]></code>
     </PossiblyInvalidCast>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
     <RiskyCast>
       <code><![CDATA[$_POST['pos'] ?? $_GET['pos'] ?? $_SESSION['tmpval']['pos']]]></code>
       <code><![CDATA[$_POST['session_max_rows'] ?? $_GET['session_max_rows']]]></code>

--- a/resources/templates/javascript/redirect.twig
+++ b/resources/templates/javascript/redirect.twig
@@ -3,3 +3,4 @@
         window.location = '{{ url|escape('js') }}';
     };
 </script>
+{{ t('Taking you to the target site.') }}

--- a/src/Application.php
+++ b/src/Application.php
@@ -103,7 +103,7 @@ class Application
         $requestHandler->add(new RequestProblemChecking($this->template, $this->responseFactory));
         $requestHandler->add(new CurrentServerGlobalSetting($this->config));
         $requestHandler->add(new ThemeInitialization());
-        $requestHandler->add(new UrlRedirection($this->config));
+        $requestHandler->add(new UrlRedirection($this->config, $this->template, $this->responseFactory));
         $requestHandler->add(new SetupPageRedirection($this->config, $this->responseFactory));
         $requestHandler->add(new MinimumCommonRedirection($this->config, $this->responseFactory));
         $requestHandler->add(new LanguageAndThemeCookieSaving($this->config));

--- a/src/Controllers/Database/Structure/AddPrefixController.php
+++ b/src/Controllers/Database/Structure/AddPrefixController.php
@@ -6,16 +6,21 @@ namespace PhpMyAdmin\Controllers\Database\Structure;
 
 use PhpMyAdmin\Controllers\InvocableController;
 use PhpMyAdmin\Current;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\ResponseRenderer;
+use PhpMyAdmin\Template;
 
 use function __;
 
 final class AddPrefixController implements InvocableController
 {
-    public function __construct(private readonly ResponseRenderer $response)
-    {
+    public function __construct(
+        private readonly ResponseRenderer $response,
+        private readonly ResponseFactory $responseFactory,
+        private readonly Template $template,
+    ) {
     }
 
     public function __invoke(ServerRequest $request): Response|null
@@ -35,9 +40,11 @@ final class AddPrefixController implements InvocableController
             $params['selected'][] = $selectedValue;
         }
 
-        $this->response->disable();
-        $this->response->render('database/structure/add_prefix', ['url_params' => $params]);
+        $response = $this->responseFactory->createResponse();
+        foreach ($this->response->getHeader()->getHttpHeaders() as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
 
-        return null;
+        return $response->write($this->template->render('database/structure/add_prefix', ['url_params' => $params]));
     }
 }

--- a/src/Controllers/Database/Structure/ChangePrefixFormController.php
+++ b/src/Controllers/Database/Structure/ChangePrefixFormController.php
@@ -6,16 +6,21 @@ namespace PhpMyAdmin\Controllers\Database\Structure;
 
 use PhpMyAdmin\Controllers\InvocableController;
 use PhpMyAdmin\Current;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\ResponseRenderer;
+use PhpMyAdmin\Template;
 
 use function __;
 
 final class ChangePrefixFormController implements InvocableController
 {
-    public function __construct(private readonly ResponseRenderer $response)
-    {
+    public function __construct(
+        private readonly ResponseRenderer $response,
+        private readonly ResponseFactory $responseFactory,
+        private readonly Template $template,
+    ) {
     }
 
     public function __invoke(ServerRequest $request): Response|null
@@ -40,12 +45,14 @@ final class ChangePrefixFormController implements InvocableController
             $urlParams['selected'][] = $selectedValue;
         }
 
-        $this->response->disable();
-        $this->response->render('database/structure/change_prefix_form', [
+        $response = $this->responseFactory->createResponse();
+        foreach ($this->response->getHeader()->getHttpHeaders() as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+
+        return $response->write($this->template->render('database/structure/change_prefix_form', [
             'route' => $route,
             'url_params' => $urlParams,
-        ]);
-
-        return null;
+        ]));
     }
 }

--- a/src/Controllers/Database/Structure/CopyFormController.php
+++ b/src/Controllers/Database/Structure/CopyFormController.php
@@ -7,16 +7,21 @@ namespace PhpMyAdmin\Controllers\Database\Structure;
 use PhpMyAdmin\Controllers\InvocableController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\ResponseRenderer;
+use PhpMyAdmin\Template;
 
 use function __;
 
 final class CopyFormController implements InvocableController
 {
-    public function __construct(private readonly ResponseRenderer $response)
-    {
+    public function __construct(
+        private readonly ResponseRenderer $response,
+        private readonly ResponseFactory $responseFactory,
+        private readonly Template $template,
+    ) {
     }
 
     public function __invoke(ServerRequest $request): Response|null
@@ -44,12 +49,14 @@ final class CopyFormController implements InvocableController
             }
         }
 
-        $this->response->disable();
-        $this->response->render('database/structure/copy_form', [
+        $response = $this->responseFactory->createResponse();
+        foreach ($this->response->getHeader()->getHttpHeaders() as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+
+        return $response->write($this->template->render('database/structure/copy_form', [
             'url_params' => $urlParams,
             'options' => $databasesList->getList(),
-        ]);
-
-        return null;
+        ]));
     }
 }

--- a/src/Controllers/LicenseController.php
+++ b/src/Controllers/LicenseController.php
@@ -1,52 +1,59 @@
 <?php
-/**
- * Simple script to set correct charset for the license
- */
 
 declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers;
 
+use PhpMyAdmin\Core;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\ResponseRenderer;
 
 use function __;
+use function basename;
 use function is_readable;
-use function printf;
+use function ob_get_clean;
+use function ob_start;
 use function readfile;
+use function sprintf;
 
 /**
  * Simple script to set correct charset for the license
  */
 final class LicenseController implements InvocableController
 {
-    public function __construct(private readonly ResponseRenderer $response)
-    {
+    public function __construct(
+        private readonly ResponseRenderer $response,
+        private readonly ResponseFactory $responseFactory,
+    ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
-        $this->response->disable();
-        $this->response->addHeader('Content-Type', 'text/plain; charset=utf-8');
+        $response = $this->responseFactory->createResponse();
+        foreach ($this->response->getHeader()->getHttpHeaders() as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
 
         $filename = LICENSE_FILE;
 
         // Check if the file is available, some distributions remove these.
-        if (@is_readable($filename)) {
-            readfile($filename);
-
-            return null;
+        if (! @is_readable($filename)) {
+            return $response->write(sprintf(
+                __('The %s file is not available on this system, please visit %s for more information.'),
+                basename($filename),
+                '<a href="' . Core::linkURL('https://www.phpmyadmin.net/')
+                . '" rel="noopener noreferrer" target="_blank">phpmyadmin.net</a>',
+            ));
         }
 
-        printf(
-            __(
-                'The %s file is not available on this system, please visit %s for more information.',
-            ),
-            $filename,
-            'https://www.phpmyadmin.net/',
-        );
+        $response = $response->withHeader('Content-Type', 'text/plain; charset=utf-8');
 
-        return null;
+        ob_start();
+        readfile($filename);
+        $license = (string) ob_get_clean();
+
+        return $response->write($license);
     }
 }

--- a/src/Controllers/LintController.php
+++ b/src/Controllers/LintController.php
@@ -1,23 +1,18 @@
 <?php
-/**
- * Represents the interface between the linter and the query editor.
- */
 
 declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers;
 
 use PhpMyAdmin\Core;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Linter;
-use PhpMyAdmin\ResponseRenderer;
 
-use function header;
 use function is_array;
 use function is_string;
 use function json_encode;
-use function sprintf;
 
 /**
  * Represents the interface between the linter and the query editor.
@@ -30,7 +25,7 @@ final class LintController implements InvocableController
         'trigger' => "DELIMITER $$ CREATE TRIGGER `a` AFTER INSERT ON `b` FOR EACH ROW\n",
     ];
 
-    public function __construct(private readonly ResponseRenderer $response)
+    public function __construct(private readonly ResponseFactory $responseFactory)
     {
     }
 
@@ -70,15 +65,11 @@ final class LintController implements InvocableController
             }
         }
 
-        // Disabling standard response.
-        $this->response->disable();
-
+        $response = $this->responseFactory->createResponse();
         foreach (Core::headerJSON() as $name => $value) {
-            header(sprintf('%s: %s', $name, $value));
+            $response = $response->withHeader($name, $value);
         }
 
-        echo json_encode($lints);
-
-        return null;
+        return $response->write((string) json_encode($lints));
     }
 }

--- a/src/Controllers/SchemaExportController.php
+++ b/src/Controllers/SchemaExportController.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\Core;
 use PhpMyAdmin\Exceptions\ExportException;
 use PhpMyAdmin\Export\Export;
 use PhpMyAdmin\Html\MySQLDocumentation;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Identifiers\DatabaseName;
@@ -23,8 +24,11 @@ use function mb_strlen;
  */
 final class SchemaExportController implements InvocableController
 {
-    public function __construct(private readonly Export $export, private readonly ResponseRenderer $response)
-    {
+    public function __construct(
+        private readonly Export $export,
+        private readonly ResponseRenderer $response,
+        private readonly ResponseFactory $responseFactory,
+    ) {
     }
 
     public function __invoke(ServerRequest $request): Response|null
@@ -54,14 +58,13 @@ final class SchemaExportController implements InvocableController
             return null;
         }
 
-        $this->response->disable();
+        $response = $this->responseFactory->createResponse();
         Core::downloadHeader(
             $exportInfo['fileName'],
             $exportInfo['mediaType'],
             mb_strlen($exportInfo['fileData'], '8bit'),
         );
-        echo $exportInfo['fileData'];
 
-        return null;
+        return $response->write($exportInfo['fileData']);
     }
 }

--- a/src/Controllers/Table/TrackingController.php
+++ b/src/Controllers/Table/TrackingController.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\Controllers\InvocableController;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DbTableExists;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Identifiers\DatabaseName;
@@ -42,6 +43,7 @@ final class TrackingController implements InvocableController
         private readonly Tracking $tracking,
         private readonly TrackingChecker $trackingChecker,
         private readonly DbTableExists $dbTableExists,
+        private readonly ResponseFactory $responseFactory,
     ) {
     }
 
@@ -138,11 +140,10 @@ final class TrackingController implements InvocableController
                 // Export as file download
                 if ($reportExportType === 'sqldumpfile') {
                     $downloadInfo = $this->tracking->getDownloadInfoForExport($tableParam, $entries);
-                    $this->response->disable();
+                    $response = $this->responseFactory->createResponse();
                     Core::downloadHeader($downloadInfo['filename'], 'text/x-sql', mb_strlen($downloadInfo['dump']));
-                    echo $downloadInfo['dump'];
 
-                    return null;
+                    return $response->write($downloadInfo['dump']);
                 }
 
                 // Export as SQL execution

--- a/src/Controllers/Transformation/WrapperController.php
+++ b/src/Controllers/Transformation/WrapperController.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\Controllers\InvocableController;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\DbTableExists;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Identifiers\DatabaseName;
@@ -24,6 +25,8 @@ use function __;
 use function htmlspecialchars;
 use function is_numeric;
 use function is_string;
+use function ob_get_clean;
+use function ob_start;
 use function round;
 use function sprintf;
 use function str_contains;
@@ -42,6 +45,7 @@ final class WrapperController implements InvocableController
         private readonly Relation $relation,
         private readonly DatabaseInterface $dbi,
         private readonly DbTableExists $dbTableExists,
+        private readonly ResponseFactory $responseFactory,
     ) {
     }
 
@@ -107,9 +111,10 @@ final class WrapperController implements InvocableController
             }
         }
 
-        // Disabling standard response, we are sending binary here
-        $this->response->disable();
-        $this->response->getHeader()->sendHttpHeaders();
+        $response = $this->responseFactory->createResponse();
+        foreach ($this->response->getHeader()->getHttpHeaders() as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
 
         /** @psalm-suppress MixedAssignment */
         $contentType = $request->getParam('ct');
@@ -133,19 +138,15 @@ final class WrapperController implements InvocableController
         $resize = $request->getParam('resize');
         if ($resize !== 'jpeg' && $resize !== 'png') {
             if (str_contains(strtolower($contentMediaType), 'html')) {
-                echo htmlspecialchars($row[$transformKey]);
-
-                return null;
+                return $response->write(htmlspecialchars($row[$transformKey]));
             }
 
-            echo $row[$transformKey];
-
-            return null;
+            return $response->write($row[$transformKey]);
         }
 
         $srcImage = ImageWrapper::fromString($row[$transformKey]);
         if ($srcImage === null) {
-            return null;
+            return $response;
         }
 
         $newHeight = $this->formatSize($request->getParam('newHeight'));
@@ -172,18 +173,21 @@ final class WrapperController implements InvocableController
 
         $destImage = ImageWrapper::create($destWidth, $destHeight);
         if ($destImage === null) {
-            return null;
+            return $response;
         }
 
         $destImage->copyResampled($srcImage, 0, 0, 0, 0, $destWidth, $destHeight, $srcWidth, $srcHeight);
 
+        ob_start();
         if ($resize === 'jpeg') {
             $destImage->jpeg(null, 75);
         } else {
             $destImage->png();
         }
 
-        return null;
+        $output = ob_get_clean();
+
+        return $response->write((string) $output);
     }
 
     private function formatSize(mixed $size): int

--- a/src/ResponseRenderer.php
+++ b/src/ResponseRenderer.php
@@ -429,20 +429,25 @@ class ResponseRenderer
     }
 
     /**
+     * Avoid relative path redirect problems in case user entered URL
+     * like /phpmyadmin/index.php/ which some web servers happily accept.
+     */
+    public function fixRelativeUrlForRedirect(string $url): string
+    {
+        if (! str_starts_with($url, '.')) {
+            return $url;
+        }
+
+        return $this->config->getRootPath() . substr($url, 2);
+    }
+
+    /**
      * @psalm-param non-empty-string $url
      * @psalm-param StatusCodeInterface::STATUS_* $statusCode
      */
     public function redirect(string $url, int $statusCode = StatusCodeInterface::STATUS_FOUND): void
     {
-        /**
-         * Avoid relative path redirect problems in case user entered URL
-         * like /phpmyadmin/index.php/ which some web servers happily accept.
-         */
-        if (str_starts_with($url, '.')) {
-            $url = $this->config->getRootPath() . substr($url, 2);
-        }
-
-        $this->addHeader('Location', $url);
+        $this->addHeader('Location', $this->fixRelativeUrlForRedirect($url));
         $this->setStatusCode($statusCode);
     }
 

--- a/src/UrlRedirector.php
+++ b/src/UrlRedirector.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
-use PhpMyAdmin\Container\ContainerBuilder;
+use Fig\Http\Message\StatusCodeInterface;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Response;
 
-use function __;
+use function is_string;
 use function preg_match;
 
 /**
@@ -15,37 +16,36 @@ use function preg_match;
  */
 final class UrlRedirector
 {
-    public static function redirect(string $url): Response
+    public function __construct(
+        private readonly ResponseRenderer $response,
+        private readonly Template $template,
+        private readonly ResponseFactory $responseFactory,
+    ) {
+    }
+
+    public function redirect(mixed $urlParam): Response
     {
-        $container = ContainerBuilder::getContainer();
+        $response = $this->responseFactory->createResponse();
+        foreach ($this->response->getHeader()->getHttpHeaders() as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
 
-        // Only output the http headers
-        $response = ResponseRenderer::getInstance();
-        $response->getHeader()->sendHttpHeaders();
-        $response->disable();
-
+        $url = is_string($urlParam) ? $urlParam : '';
         if (
             $url === ''
             || ! preg_match('/^https:\/\/[^\n\r]*$/', $url)
             || ! Core::isAllowedDomain($url)
         ) {
-            $response->redirect('./');
+            $response = $response->withHeader('Location', $this->response->fixRelativeUrlForRedirect('./'));
 
-            return $response->response();
+            return $response->withStatus(StatusCodeInterface::STATUS_FOUND);
         }
 
         /**
          * JavaScript redirection is necessary. Because if header() is used then web browser sometimes does not change
          * the HTTP_REFERER field and so with old URL as Referer, token also goes to external site.
-         *
-         * @var Template $template
          */
-        $template = $container->get('template');
-        echo $template->render('javascript/redirect', ['url' => $url]);
-        // Display redirecting msg on screen.
-        // Do not display the value of $_GET['url'] to avoid showing injected content
-        echo __('Taking you to the target site.');
 
-        return $response->response();
+        return $response->write($this->template->render('javascript/redirect', ['url' => $url]));
     }
 }

--- a/tests/unit/Controllers/ChangeLogControllerTest.php
+++ b/tests/unit/Controllers/ChangeLogControllerTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers;
 
+use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\ChangeLogController;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Factory\ServerRequestFactory;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -27,34 +29,33 @@ final class ChangeLogControllerTest extends AbstractTestCase
 
         $responseRenderer = new ResponseRenderer();
         $template = new Template();
-        $controller = new ChangeLogController($responseRenderer, $config);
-        $controller($request);
+        $controller = new ChangeLogController($responseRenderer, $config, ResponseFactory::create(), $template);
+        $response = $controller($request);
 
-        self::assertTrue($responseRenderer->isDisabled());
-        $response = $responseRenderer->getResponse();
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
         self::assertSame(['text/html; charset=utf-8'], $response->getHeader('Content-Type'));
 
         // phpcs:disable Generic.Files.LineLength.TooLong
         $changelog = <<<'HTML'
-phpMyAdmin - ChangeLog
-======================
+            phpMyAdmin - ChangeLog
+            ======================
 
-5.2.2 (not yet released)
-- <a target="_blank" rel="noopener noreferrer" href="index.php?route=/url&lang=en&url=https://github.com/phpmyadmin/phpmyadmin/issues/17522">issue #17522</a> Fix case where the routes cache file is invalid
-- issue        Upgrade slim/psr7 to 1.4.1 for <a target="_blank" rel="noopener noreferrer" href="index.php?route=/url&lang=en&url=https://www.cve.org/CVERecord?id=CVE-2023-30536">CVE-2023-30536</a> - GHSA-q2qj-628g-vhfw
+            5.2.2 (not yet released)
+            - <a target="_blank" rel="noopener noreferrer" href="index.php?route=/url&lang=en&url=https://github.com/phpmyadmin/phpmyadmin/issues/17522">issue #17522</a> Fix case where the routes cache file is invalid
+            - issue        Upgrade slim/psr7 to 1.4.1 for <a target="_blank" rel="noopener noreferrer" href="index.php?route=/url&lang=en&url=https://www.cve.org/CVERecord?id=CVE-2023-30536">CVE-2023-30536</a> - GHSA-q2qj-628g-vhfw
 
-5.2.1 (2023-02-07)
-- <a target="_blank" rel="noopener noreferrer" href="index.php?route=/url&lang=en&url=https://github.com/phpmyadmin/phpmyadmin/issues/16418">issue #16418</a> Fix <a target="_blank" rel="noopener noreferrer" href="index.php?route=/url&lang=en&url=https://docs.phpmyadmin.net/en/latest/faq.html#faq1-44">FAQ 1.44</a> about manually removing vendor folders
-- issue        [security] Fix an XSS attack through the drag-and-drop upload feature (<a target="_blank" rel="noopener noreferrer" href="index.php?route=/url&lang=en&url=https://www.phpmyadmin.net/security/PMASA-2023-01/">PMASA-2023-01</a>)
+            5.2.1 (2023-02-07)
+            - <a target="_blank" rel="noopener noreferrer" href="index.php?route=/url&lang=en&url=https://github.com/phpmyadmin/phpmyadmin/issues/16418">issue #16418</a> Fix <a target="_blank" rel="noopener noreferrer" href="index.php?route=/url&lang=en&url=https://docs.phpmyadmin.net/en/latest/faq.html#faq1-44">FAQ 1.44</a> about manually removing vendor folders
+            - issue        [security] Fix an XSS attack through the drag-and-drop upload feature (<a target="_blank" rel="noopener noreferrer" href="index.php?route=/url&lang=en&url=https://www.phpmyadmin.net/security/PMASA-2023-01/">PMASA-2023-01</a>)
 
-         --- Older ChangeLogs can be found on our project website ---
-                     <a target="_blank" rel="noopener noreferrer" href="index.php?route=/url&lang=en&url=https://www.phpmyadmin.net/old-stuff/ChangeLogs/">https://www.phpmyadmin.net/old-stuff/ChangeLogs/</a>
+                     --- Older ChangeLogs can be found on our project website ---
+                                 <a target="_blank" rel="noopener noreferrer" href="index.php?route=/url&lang=en&url=https://www.phpmyadmin.net/old-stuff/ChangeLogs/">https://www.phpmyadmin.net/old-stuff/ChangeLogs/</a>
 
-HTML;
+            HTML;
         // phpcs:enable
         $expected = $template->render('changelog', ['changelog' => $changelog]);
 
-        self::assertSame($expected, $responseRenderer->getHTMLResult());
+        self::assertSame($expected, (string) $response->getBody());
     }
 
     #[RequiresPhpExtension('zlib')]
@@ -66,16 +67,18 @@ HTML;
         $request = ServerRequestFactory::create()->createServerRequest('GET', 'http://example.com/');
 
         $responseRenderer = new ResponseRenderer();
-        $controller = new ChangeLogController($responseRenderer, $config);
-        $controller($request);
+        $controller = new ChangeLogController($responseRenderer, $config, ResponseFactory::create(), new Template());
+        $response = $controller($request);
 
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
+        self::assertSame(['text/html; charset=utf-8'], $response->getHeader('Content-Type'));
         self::assertStringContainsString(
             '- <a target="_blank" rel="noopener noreferrer"'
             . ' href="index.php?route=/url&lang=en&url=https://github.com/phpmyadmin/phpmyadmin/issues/16418">'
             . 'issue #16418</a> Fix <a target="_blank" rel="noopener noreferrer"'
             . ' href="index.php?route=/url&lang=en&url=https://docs.phpmyadmin.net/en/latest/faq.html#faq1-44">'
             . 'FAQ 1.44</a> about manually removing vendor folders',
-            $responseRenderer->getHTMLResult(),
+            (string) $response->getBody(),
         );
     }
 
@@ -87,15 +90,16 @@ HTML;
         $request = ServerRequestFactory::create()->createServerRequest('GET', 'http://example.com/');
 
         $responseRenderer = new ResponseRenderer();
-        $controller = new ChangeLogController($responseRenderer, $config);
-        $controller($request);
+        $controller = new ChangeLogController($responseRenderer, $config, ResponseFactory::create(), new Template());
+        $response = $controller($request);
 
-        self::assertSame('', $responseRenderer->getHTMLResult());
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
+        self::assertSame(['text/html; charset=utf-8'], $response->getHeader('Content-Type'));
         self::assertSame(
             'The InvalidChangeLog file is not available on this system, please visit'
             . ' <a href="index.php?route=/url&url=https%3A%2F%2Fwww.phpmyadmin.net%2F"'
             . ' rel="noopener noreferrer" target="_blank">phpmyadmin.net</a> for more information.',
-            self::getActualOutputForAssertion(),
+            (string) $response->getBody(),
         );
     }
 }

--- a/tests/unit/Controllers/Database/Structure/AddPrefixControllerTest.php
+++ b/tests/unit/Controllers/Database/Structure/AddPrefixControllerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Controllers\Database\Structure;
+
+use Fig\Http\Message\StatusCodeInterface;
+use PhpMyAdmin\Controllers\Database\Structure\AddPrefixController;
+use PhpMyAdmin\Current;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
+use PhpMyAdmin\Http\Factory\ServerRequestFactory;
+use PhpMyAdmin\Template;
+use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(AddPrefixController::class)]
+final class AddPrefixControllerTest extends AbstractTestCase
+{
+    public function testAddPrefixModal(): void
+    {
+        Current::$database = 'test_db';
+
+        $request = ServerRequestFactory::create()->createServerRequest('POST', 'http://example.com/')
+            ->withQueryParams(['db' => 'test_db'])
+            ->withParsedBody(['selected_tbl' => ['test_table']]);
+
+        $template = new Template();
+        $controller = new AddPrefixController(new ResponseRenderer(), ResponseFactory::create(), $template);
+        $response = $controller($request);
+
+        $expected = $template->render(
+            'database/structure/add_prefix',
+            ['url_params' => ['db' => 'test_db', 'selected' => ['test_table']]],
+        );
+
+        self::assertNotNull($response);
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
+        self::assertSame(['text/html; charset=utf-8'], $response->getHeader('Content-Type'));
+        self::assertSame($expected, (string) $response->getBody());
+    }
+}

--- a/tests/unit/Controllers/Database/Structure/ChangePrefixFormControllerTest.php
+++ b/tests/unit/Controllers/Database/Structure/ChangePrefixFormControllerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Controllers\Database\Structure;
+
+use Fig\Http\Message\StatusCodeInterface;
+use PhpMyAdmin\Controllers\Database\Structure\ChangePrefixFormController;
+use PhpMyAdmin\Current;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
+use PhpMyAdmin\Http\Factory\ServerRequestFactory;
+use PhpMyAdmin\Template;
+use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(ChangePrefixFormController::class)]
+final class ChangePrefixFormControllerTest extends AbstractTestCase
+{
+    public function testChangePrefixModal(): void
+    {
+        Current::$database = 'test_db';
+
+        $request = ServerRequestFactory::create()->createServerRequest('POST', 'http://example.com/')
+            ->withQueryParams(['db' => 'test_db'])
+            ->withParsedBody(['selected_tbl' => ['test_table']]);
+
+        $template = new Template();
+        $controller = new ChangePrefixFormController(new ResponseRenderer(), ResponseFactory::create(), $template);
+        $response = $controller($request);
+
+        $expected = $template->render('database/structure/change_prefix_form', [
+            'route' => '/database/structure/replace-prefix',
+            'url_params' => ['db' => 'test_db', 'selected' => ['test_table']],
+        ]);
+
+        self::assertNotNull($response);
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
+        self::assertSame(['text/html; charset=utf-8'], $response->getHeader('Content-Type'));
+        self::assertSame($expected, (string) $response->getBody());
+    }
+}

--- a/tests/unit/Controllers/Database/Structure/CopyFormControllerTest.php
+++ b/tests/unit/Controllers/Database/Structure/CopyFormControllerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Controllers\Database\Structure;
+
+use Fig\Http\Message\StatusCodeInterface;
+use PhpMyAdmin\Controllers\Database\Structure\CopyFormController;
+use PhpMyAdmin\Current;
+use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
+use PhpMyAdmin\Http\Factory\ServerRequestFactory;
+use PhpMyAdmin\Template;
+use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(CopyFormController::class)]
+final class CopyFormControllerTest extends AbstractTestCase
+{
+    public function testCopyFormModal(): void
+    {
+        $dbiDummy = $this->createDbiDummy();
+        $dbiDummy->addResult(
+            'SELECT `SCHEMA_NAME` FROM `INFORMATION_SCHEMA`.`SCHEMATA`',
+            [['test_db'], ['test_db_1'], ['test_db_2']],
+            ['SCHEMA_NAME'],
+        );
+
+        DatabaseInterface::$instance = $this->createDatabaseInterface($dbiDummy);
+        Current::$database = 'test_db';
+
+        $request = ServerRequestFactory::create()->createServerRequest('POST', 'http://example.com/')
+            ->withQueryParams(['db' => 'test_db'])
+            ->withParsedBody(['selected_tbl' => ['test_table']]);
+
+        $template = new Template();
+        $controller = new CopyFormController(new ResponseRenderer(), ResponseFactory::create(), $template);
+        $response = $controller($request);
+
+        $expected = $template->render('database/structure/copy_form', [
+            'url_params' => ['db' => 'test_db', 'selected' => ['test_table']],
+            'options' => [
+                ['name' => 'test_db_1', 'is_selected' => false],
+                ['name' => 'test_db_2', 'is_selected' => false],
+            ],
+        ]);
+
+        self::assertNotNull($response);
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
+        self::assertSame(['text/html; charset=utf-8'], $response->getHeader('Content-Type'));
+        self::assertSame($expected, (string) $response->getBody());
+
+        $dbiDummy->assertAllQueriesConsumed();
+    }
+}

--- a/tests/unit/Controllers/LicenseControllerTest.php
+++ b/tests/unit/Controllers/LicenseControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Controllers;
+
+use Fig\Http\Message\StatusCodeInterface;
+use PhpMyAdmin\Controllers\LicenseController;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
+use PhpMyAdmin\Http\Factory\ServerRequestFactory;
+use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(LicenseController::class)]
+final class LicenseControllerTest extends AbstractTestCase
+{
+    public function testWithValidFile(): void
+    {
+        $request = ServerRequestFactory::create()->createServerRequest('GET', 'http://example.com/');
+
+        $controller = new LicenseController(new ResponseRenderer(), ResponseFactory::create());
+        $response = $controller($request);
+
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
+        self::assertSame(['text/plain; charset=utf-8'], $response->getHeader('Content-Type'));
+
+        $body = (string) $response->getBody();
+        self::assertStringContainsString('GNU GENERAL PUBLIC LICENSE', $body);
+        self::assertStringContainsString('Version 2, June 1991', $body);
+    }
+}

--- a/tests/unit/Controllers/LintControllerTest.php
+++ b/tests/unit/Controllers/LintControllerTest.php
@@ -4,19 +4,18 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers;
 
+use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Controllers\LintController;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
-use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 use function json_encode;
 
 #[CoversClass(LintController::class)]
-#[RunTestsInSeparateProcesses]
-class LintControllerTest extends AbstractTestCase
+final class LintControllerTest extends AbstractTestCase
 {
     protected function setUp(): void
     {
@@ -31,9 +30,12 @@ class LintControllerTest extends AbstractTestCase
         $request->method('isAjax')->willReturn(true);
         $request->method('getParsedBodyParam')->willReturnMap([['sql_query', '', ''], ['options', null, null]]);
 
-        $this->getLintController()($request);
+        $response = $this->getLintController()($request);
 
-        $output = $this->getActualOutputForAssertion();
+        self::assertNotNull($response);
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
+        self::assertSame(['application/json; charset=UTF-8'], $response->getHeader('Content-Type'));
+        $output = (string) $response->getBody();
         self::assertJson($output);
         self::assertJsonStringEqualsJsonString('[]', $output);
     }
@@ -47,9 +49,12 @@ class LintControllerTest extends AbstractTestCase
             ['options', null, null],
         ]);
 
-        $this->getLintController()($request);
+        $response = $this->getLintController()($request);
 
-        $output = $this->getActualOutputForAssertion();
+        self::assertNotNull($response);
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
+        self::assertSame(['application/json; charset=UTF-8'], $response->getHeader('Content-Type'));
+        $output = (string) $response->getBody();
         self::assertJson($output);
         self::assertJsonStringEqualsJsonString('[]', $output);
     }
@@ -99,15 +104,18 @@ class LintControllerTest extends AbstractTestCase
             ['options', null, null],
         ]);
 
-        $this->getLintController()($request);
+        $response = $this->getLintController()($request);
 
-        $output = $this->getActualOutputForAssertion();
+        self::assertNotNull($response);
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
+        self::assertSame(['application/json; charset=UTF-8'], $response->getHeader('Content-Type'));
+        $output = (string) $response->getBody();
         self::assertJson($output);
         self::assertJsonStringEqualsJsonString($expectedJson, $output);
     }
 
     private function getLintController(): LintController
     {
-        return new LintController(new ResponseRenderer());
+        return new LintController(ResponseFactory::create());
     }
 }

--- a/tests/unit/Controllers/PhpInfoControllerTest.php
+++ b/tests/unit/Controllers/PhpInfoControllerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Controllers;
+
+use Fig\Http\Message\StatusCodeInterface;
+use PhpMyAdmin\Config;
+use PhpMyAdmin\Controllers\PhpInfoController;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
+use PhpMyAdmin\Http\Factory\ServerRequestFactory;
+use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+use function ob_get_clean;
+use function ob_start;
+use function phpinfo;
+
+use const INFO_CONFIGURATION;
+use const INFO_GENERAL;
+use const INFO_MODULES;
+
+#[CoversClass(PhpInfoController::class)]
+final class PhpInfoControllerTest extends AbstractTestCase
+{
+    public function testWithShowPhpInfoEqualsTrue(): void
+    {
+        $config = new Config();
+        $config->settings['ShowPhpInfo'] = true;
+
+        $request = ServerRequestFactory::create()->createServerRequest('GET', 'http://example.com/');
+
+        $controller = new PhpInfoController(new ResponseRenderer(), ResponseFactory::create(), $config);
+        $response = $controller($request);
+
+        ob_start();
+        phpinfo(INFO_GENERAL | INFO_CONFIGURATION | INFO_MODULES);
+        $expected = (string) ob_get_clean();
+
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
+        self::assertSame(['text/html; charset=utf-8'], $response->getHeader('Content-Type'));
+        self::assertSame($expected, (string) $response->getBody());
+    }
+
+    public function testWithShowPhpInfoEqualsFalse(): void
+    {
+        $config = Config::getInstance();
+        $config->settings['ShowPhpInfo'] = false;
+        $config->settings['PmaAbsoluteUri'] = 'http://localhost/phpmyadmin';
+
+        $request = ServerRequestFactory::create()->createServerRequest('GET', 'http://example.com/');
+
+        $controller = new PhpInfoController(new ResponseRenderer(), ResponseFactory::create(), $config);
+        $response = $controller($request);
+
+        self::assertSame(StatusCodeInterface::STATUS_FOUND, $response->getStatusCode());
+        self::assertSame('/phpmyadmin/', $response->getHeaderLine('Location'));
+    }
+}

--- a/tests/unit/Controllers/SchemaExportControllerTest.php
+++ b/tests/unit/Controllers/SchemaExportControllerTest.php
@@ -4,16 +4,23 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers;
 
+use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Controllers\SchemaExportController;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Export\Export;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+use function function_exists;
+use function xdebug_get_headers;
 
 #[CoversClass(SchemaExportController::class)]
-class SchemaExportControllerTest extends AbstractTestCase
+#[RunTestsInSeparateProcesses]
+final class SchemaExportControllerTest extends AbstractTestCase
 {
     public function testExport(): void
     {
@@ -28,13 +35,20 @@ class SchemaExportControllerTest extends AbstractTestCase
             'fileData' => 'file data',
         ]);
 
-        $response = new ResponseRenderer();
-        $controller = new SchemaExportController($export, $response);
-        $controller($request);
-        $output = $this->getActualOutputForAssertion();
-        self::assertSame('file data', $output);
-        self::assertTrue($response->isDisabled());
-        self::assertSame('', $response->getHTMLResult());
-        self::assertSame([], $response->getJSONResult());
+        $controller = new SchemaExportController($export, new ResponseRenderer(), ResponseFactory::create());
+        $response = $controller($request);
+
+        self::assertNotNull($response);
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
+        self::assertSame('file data', (string) $response->getBody());
+
+        if (! function_exists('xdebug_get_headers')) {
+            return;
+        }
+
+        $headersList = xdebug_get_headers();
+        self::assertContains('Content-Disposition: attachment; filename="file.svg"', $headersList);
+        self::assertContains('Content-Type: image/svg+xml', $headersList);
+        self::assertContains('Content-Length: 9', $headersList);
     }
 }

--- a/tests/unit/Controllers/Table/GetFieldControllerTest.php
+++ b/tests/unit/Controllers/Table/GetFieldControllerTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Table;
 
+use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Controllers\Table\GetFieldController;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
@@ -51,7 +53,10 @@ class GetFieldControllerTest extends AbstractTestCase
         $dbi = $this->createDatabaseInterface($dummyDbi);
         DatabaseInterface::$instance = $dbi;
 
-        (new GetFieldController(new ResponseRenderer(), $dbi))($request);
-        $this->expectOutputString('46494c45');
+        $response = (new GetFieldController(new ResponseRenderer(), $dbi, ResponseFactory::create()))($request);
+
+        self::assertNotNull($response);
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
+        self::assertSame('46494c45', (string) $response->getBody());
     }
 }

--- a/tests/unit/Controllers/Table/GisVisualizationControllerTest.php
+++ b/tests/unit/Controllers/Table/GisVisualizationControllerTest.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\Core;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\DbTableExists;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Factory\ServerRequestFactory;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -111,8 +112,17 @@ class GisVisualizationControllerTest extends AbstractTestCase
         $request = ServerRequestFactory::create()->createServerRequest('POST', 'http://example.com/')
             ->withQueryParams(['db' => 'test_db', 'table' => 'test_table']);
 
-        $response = new ResponseRenderer();
-        (new GisVisualizationController($response, $template, $dbi, new DbTableExists($dbi)))($request);
-        self::assertSame($expected, $response->getHTMLResult());
+        $responseRenderer = new ResponseRenderer();
+        $controller = new GisVisualizationController(
+            $responseRenderer,
+            $template,
+            $dbi,
+            new DbTableExists($dbi),
+            ResponseFactory::create(),
+        );
+        $response = $controller($request);
+
+        self::assertNull($response);
+        self::assertSame($expected, $responseRenderer->getHTMLResult());
     }
 }

--- a/tests/unit/Stubs/ResponseRenderer.php
+++ b/tests/unit/Stubs/ResponseRenderer.php
@@ -172,11 +172,6 @@ class ResponseRenderer extends \PhpMyAdmin\ResponseRenderer
         return $this->isAjax;
     }
 
-    public function isDisabled(): bool
-    {
-        return $this->isDisabled;
-    }
-
     public function getResponse(): Response
     {
         return $this->response;

--- a/tests/unit/UrlRedirectorTest.php
+++ b/tests/unit/UrlRedirectorTest.php
@@ -6,43 +6,44 @@ namespace PhpMyAdmin\Tests;
 
 use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Config;
-use PhpMyAdmin\ResponseRenderer;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
+use PhpMyAdmin\Template;
+use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\UrlRedirector;
 use PHPUnit\Framework\Attributes\CoversClass;
-use ReflectionProperty;
 
 #[CoversClass(UrlRedirector::class)]
 final class UrlRedirectorTest extends AbstractTestCase
 {
     public function testRedirectWithDisallowedUrl(): void
     {
-        (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
-        $GLOBALS['lang'] = 'en';
         $config = Config::getInstance();
         $config->settings['PmaAbsoluteUri'] = 'http://localhost/phpmyadmin';
 
-        $response = UrlRedirector::redirect('https://user:pass@example.com/');
+        $urlRedirector = new UrlRedirector(new ResponseRenderer(), new Template(), ResponseFactory::create());
+
+        $response = $urlRedirector->redirect('https://user:pass@example.com/');
         self::assertSame('/phpmyadmin/', $response->getHeaderLine('Location'));
         self::assertSame(StatusCodeInterface::STATUS_FOUND, $response->getStatusCode());
     }
 
     public function testRedirectWithAllowedUrl(): void
     {
-        (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
-        $GLOBALS['lang'] = 'en';
         $_SERVER['SERVER_NAME'] = 'localhost';
 
-        UrlRedirector::redirect('https://phpmyadmin.net/');
-        $output = self::getActualOutputForAssertion();
-        $expected = <<<'HTML'
-<script>
-    window.onload = function () {
-        window.location = 'https\u003A\/\/phpmyadmin.net\/';
-    };
-</script>
-Taking you to the target site.
-HTML;
+        $urlRedirector = new UrlRedirector(new ResponseRenderer(), new Template(), ResponseFactory::create());
 
-        self::assertSame($expected, $output);
+        $response = $urlRedirector->redirect('https://phpmyadmin.net/');
+        $expected = <<<'HTML'
+            <script>
+                window.onload = function () {
+                    window.location = 'https\u003A\/\/phpmyadmin.net\/';
+                };
+            </script>
+            Taking you to the target site.
+
+            HTML;
+
+        self::assertSame($expected, (string) $response->getBody());
     }
 }


### PR DESCRIPTION
Creates a new Response object instead of using the response object from ResponseRenderer class.

This is an attempt to simplify the ResponseRenderer class by removing the ResponseRenderer::disable() method.