### PR TITLE
Extract Footer::setHistory() into a middleware

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7602,7 +7602,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 4
+			count: 2
 			path: src/Footer.php
 
 		-
@@ -7617,11 +7617,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$params of static method PhpMyAdmin\\\\Url\\:\\:getCommonRaw\\(\\) expects array\\<int\\|string, bool\\|int\\|string\\>, array\\<string, mixed\\> given\\.$#"
-			count: 1
-			path: src/Footer.php
-
-		-
-			message: "#^Parameter \\#4 \\$sqlquery of method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:setHistory\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Footer.php
 
@@ -8229,6 +8224,16 @@ parameters:
 			message: "#^Parameter \\#2 \\$value of method PhpMyAdmin\\\\Config\\:\\:setCookie\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Http/Middleware/SetupPageRedirection.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Http/Middleware/StatementHistory.php
+
+		-
+			message: "#^Parameter \\#4 \\$sqlquery of method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:setHistory\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Http/Middleware/StatementHistory.php
 
 		-
 			message: "#^Parameter \\#1 \\$known_string of function hash_equals expects string, mixed given\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5996,10 +5996,6 @@
     </MixedOperand>
   </file>
   <file src="src/Footer.php">
-    <DeprecatedMethod>
-      <code><![CDATA[DatabaseInterface::getInstance()]]></code>
-      <code><![CDATA[DatabaseInterface::getInstance()]]></code>
-    </DeprecatedMethod>
     <DeprecatedProperty>
       <code><![CDATA[Routing::$route]]></code>
     </DeprecatedProperty>
@@ -6014,13 +6010,8 @@
       <code><![CDATA[array{revision: string, revisionUrl: string, branch: string, branchUrl: string}|[]]]></code>
       <code><![CDATA[is_array($info) ? $info : []]]></code>
     </MixedReturnTypeCoercion>
-    <RedundantCast>
-      <code><![CDATA[(string) $_REQUEST['no_history']]]></code>
-    </RedundantCast>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$object]]></code>
-      <code><![CDATA[empty($GLOBALS['error_message'])]]></code>
-      <code><![CDATA[empty($GLOBALS['sql_query'])]]></code>
       <code><![CDATA[empty($_REQUEST['no_debug'])]]></code>
     </RiskyTruthyFalsyComparison>
     <UnusedReturnValue>
@@ -6521,6 +6512,17 @@
     <DeprecatedMethod>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
+  </file>
+  <file src="src/Http/Middleware/StatementHistory.php">
+    <DeprecatedMethod>
+      <code><![CDATA[DatabaseInterface::getInstance()]]></code>
+    </DeprecatedMethod>
+    <MixedArgument>
+      <code><![CDATA[$GLOBALS['sql_query']]]></code>
+    </MixedArgument>
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[empty($GLOBALS['error_message'])]]></code>
+    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Http/Middleware/TokenRequestParamChecking.php">
     <MixedArgument>

--- a/src/Application.php
+++ b/src/Application.php
@@ -38,6 +38,7 @@ use PhpMyAdmin\Http\Middleware\SessionHandling;
 use PhpMyAdmin\Http\Middleware\SetupPageRedirection;
 use PhpMyAdmin\Http\Middleware\SqlDelimiterSetting;
 use PhpMyAdmin\Http\Middleware\SqlQueryGlobalSetting;
+use PhpMyAdmin\Http\Middleware\StatementHistory;
 use PhpMyAdmin\Http\Middleware\ThemeInitialization;
 use PhpMyAdmin\Http\Middleware\TokenMismatchChecking;
 use PhpMyAdmin\Http\Middleware\TokenRequestParamChecking;
@@ -116,6 +117,7 @@ class Application
         $requestHandler->add(new ProfilingChecking());
         $requestHandler->add(new UserPreferencesLoading($this->config));
         $requestHandler->add(new RecentTableHandling($this->config));
+        $requestHandler->add(new StatementHistory($this->config));
 
         $runner = new RequestHandlerRunner(
             $requestHandler,

--- a/src/Http/Middleware/StatementHistory.php
+++ b/src/Http/Middleware/StatementHistory.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Http\Middleware;
+
+use PhpMyAdmin\Config;
+use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\Current;
+use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Http\ServerRequest;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+use function assert;
+
+final class StatementHistory implements MiddlewareInterface
+{
+    private readonly Relation $relation;
+    private readonly DatabaseInterface $dbi;
+
+    public function __construct(
+        private readonly Config $config,
+        DatabaseInterface|null $dbi = null,
+        Relation|null $relation = null,
+    ) {
+        $this->dbi = $dbi ?? DatabaseInterface::getInstance();
+        $this->relation = $relation ?? new Relation($this->dbi, $this->config);
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        assert($request instanceof ServerRequest);
+        $response = $handler->handle($request);
+
+        if (
+            ! $request->has('no_history')
+            && empty($GLOBALS['error_message'])
+            && $GLOBALS['sql_query'] !== ''
+            && $this->dbi->isConnected()
+        ) {
+            $this->relation->setHistory(
+                Current::$database,
+                Current::$table,
+                $this->config->selectedServer['user'],
+                $GLOBALS['sql_query'],
+            );
+        }
+
+        return $response;
+    }
+}

--- a/tests/unit/Http/Middleware/StatementHistoryTest.php
+++ b/tests/unit/Http/Middleware/StatementHistoryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Http\Middleware;
+
+use PhpMyAdmin\Config;
+use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\Current;
+use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Http\Factory\ServerRequestFactory;
+use PhpMyAdmin\Http\Middleware\StatementHistory;
+use PhpMyAdmin\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+#[CoversClass(StatementHistory::class)]
+final class StatementHistoryTest extends AbstractTestCase
+{
+    public function testStatementHistory(): void
+    {
+        Current::$database = 'test_db';
+        Current::$table = 'test_table';
+        $GLOBALS['sql_query'] = 'SELECT 1;';
+
+        $config = new Config();
+        $config->selectedServer['user'] = 'test_user';
+        $dbi = self::createStub(DatabaseInterface::class);
+        $dbi->method('isConnected')->willReturn(true);
+        $relation = self::createMock(Relation::class);
+        $relation->expects(self::once())->method('setHistory')->with(
+            self::identicalTo('test_db'),
+            self::identicalTo('test_table'),
+            self::identicalTo('test_user'),
+            self::identicalTo('SELECT 1;'),
+        );
+        $statementHistory = new StatementHistory($config, $dbi, $relation);
+
+        $response = self::createStub(ResponseInterface::class);
+        $handler = self::createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/');
+
+        self::assertSame($response, $statementHistory->process($request, $handler));
+    }
+
+    #[TestWith(['true', 'SELECT 1;', true])]
+    #[TestWith([null, '', true])]
+    #[TestWith([null, 'SELECT 1;', false])]
+    public function testSkipHistory(string|null $noHistoryParam, string $sqlQuery, bool $isConnected): void
+    {
+        $GLOBALS['sql_query'] = $sqlQuery;
+
+        $dbi = self::createStub(DatabaseInterface::class);
+        $dbi->method('isConnected')->willReturn($isConnected);
+        $relation = self::createMock(Relation::class);
+        $relation->expects(self::never())->method('setHistory');
+        $statementHistory = new StatementHistory(new Config(), $dbi, $relation);
+
+        $response = self::createStub(ResponseInterface::class);
+        $handler = self::createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $parsedBody = $noHistoryParam !== null ? ['no_history' => $noHistoryParam] : [];
+        $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/')
+            ->withParsedBody($parsedBody);
+
+        self::assertSame($response, $statementHistory->process($request, $handler));
+    }
+}


### PR DESCRIPTION
This is always done after a response, so is better to extract it into a middleware instead.


