### PR TITLE
Remove ResponseRenderer::callExit() calls from auth plugins

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -2235,9 +2235,10 @@ logs. Currently there are two variables available:
     User name of currently active user (they do not have to be logged in).
 ``userStatus``
     Status of currently active user, one of ``ok`` (user is logged in),
-    ``mysql-denied`` (MySQL denied user login), ``allow-denied`` (user denied
+    ``server-denied`` (database server denied user login), ``allow-denied`` (user denied
     by allow/deny rules), ``root-denied`` (root is denied in configuration),
-    ``empty-denied`` (empty password is denied).
+    ``empty-denied`` (empty password is denied),
+    ``no-activity`` (automatically logged out due to inactivity).
 
 ``LogFormat`` directive for Apache can look like following:
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7679,6 +7679,7 @@
       <code><![CDATA[$password]]></code>
     </PossiblyInvalidPropertyAssignmentValue>
     <PossiblyUnusedReturnValue>
+      <code><![CDATA[Response]]></code>
       <code><![CDATA[bool]]></code>
     </PossiblyUnusedReturnValue>
     <RedundantCast>
@@ -7768,6 +7769,9 @@
       <code><![CDATA[$config->selectedServer]]></code>
       <code><![CDATA[array_merge($config->selectedServer, $singleSignonCfgUpdate)]]></code>
     </MixedPropertyTypeCoercion>
+    <PossiblyUnusedReturnValue>
+      <code><![CDATA[Response]]></code>
+    </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($config->selectedServer['SignonURL'])]]></code>
     </RiskyTruthyFalsyComparison>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14333,6 +14333,7 @@
       <code><![CDATA[$config->settings]]></code>
       <code><![CDATA[$config->settings]]></code>
       <code><![CDATA[$config->settings]]></code>
+      <code><![CDATA[$config->settings]]></code>
     </PropertyTypeCoercion>
     <TypeDoesNotContainType>
       <code><![CDATA[assertSame]]></code>

--- a/src/Exceptions/AuthenticationFailure.php
+++ b/src/Exceptions/AuthenticationFailure.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+use function __;
+
+final class AuthenticationFailure extends RuntimeException
+{
+    public const SERVER_DENIED = 'server-denied';
+    public const ALLOW_DENIED = 'allow-denied';
+    public const ROOT_DENIED = 'root-denied';
+    public const EMPTY_DENIED = 'empty-denied';
+    public const NO_ACTIVITY = 'no-activity';
+
+    /** @psalm-param self::* $failureType */
+    public function __construct(
+        public readonly string $failureType,
+        string $message = '',
+        int $code = 0,
+        Throwable|null $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * Database server denied user login
+     */
+    public static function serverDenied(): self
+    {
+        return new self(self::SERVER_DENIED, __('Cannot log in to the database server.'));
+    }
+
+    /**
+     * User denied by allow/deny rules
+     */
+    public static function allowDenied(): self
+    {
+        return new self(self::ALLOW_DENIED, __('Access denied!'));
+    }
+
+    /**
+     * User 'root' is denied in configuration
+     */
+    public static function rootDenied(): self
+    {
+        return new self(self::ROOT_DENIED, __('Access denied!'));
+    }
+
+    /**
+     * Empty password is denied
+     */
+    public static function emptyDenied(): self
+    {
+        return new self(
+            self::EMPTY_DENIED,
+            __('Login without a password is forbidden by configuration (see AllowNoPassword).'),
+        );
+    }
+
+    /**
+     * Automatically logged out due to inactivity
+     */
+    public static function noActivity(): self
+    {
+        return new self(
+            self::NO_ACTIVITY,
+            __(
+                'You have been automatically logged out due to inactivity of %s seconds.'
+                . ' Once you log in again, you should be able to resume the work where you left off.',
+            ),
+        );
+    }
+}

--- a/src/Exceptions/AuthenticationFailure.php
+++ b/src/Exceptions/AuthenticationFailure.php
@@ -30,7 +30,7 @@ final class AuthenticationFailure extends RuntimeException
     /**
      * Database server denied user login
      */
-    public static function serverDenied(): self
+    public static function deniedByDatabaseServer(): self
     {
         return new self(self::SERVER_DENIED, __('Cannot log in to the database server.'));
     }
@@ -38,7 +38,7 @@ final class AuthenticationFailure extends RuntimeException
     /**
      * User denied by allow/deny rules
      */
-    public static function allowDenied(): self
+    public static function deniedByAllowDenyRules(): self
     {
         return new self(self::ALLOW_DENIED, __('Access denied!'));
     }
@@ -46,7 +46,7 @@ final class AuthenticationFailure extends RuntimeException
     /**
      * User 'root' is denied in configuration
      */
-    public static function rootDenied(): self
+    public static function rootDeniedByConfiguration(): self
     {
         return new self(self::ROOT_DENIED, __('Access denied!'));
     }
@@ -54,7 +54,7 @@ final class AuthenticationFailure extends RuntimeException
     /**
      * Empty password is denied
      */
-    public static function emptyDenied(): self
+    public static function emptyPasswordDeniedByConfiguration(): self
     {
         return new self(
             self::EMPTY_DENIED,
@@ -65,7 +65,7 @@ final class AuthenticationFailure extends RuntimeException
     /**
      * Automatically logged out due to inactivity
      */
-    public static function noActivity(): self
+    public static function loggedOutDueToInactivity(): self
     {
         return new self(
             self::NO_ACTIVITY,

--- a/src/Http/Middleware/Authentication.php
+++ b/src/Http/Middleware/Authentication.php
@@ -63,7 +63,7 @@ final class Authentication implements MiddlewareInterface
             try {
                 $authPlugin->authenticate();
             } catch (AuthenticationFailure $exception) {
-                $authPlugin->showFailure($exception);
+                return $authPlugin->showFailure($exception);
             }
 
             $currentServer = new Server(Config::getInstance()->selectedServer);
@@ -79,7 +79,7 @@ final class Authentication implements MiddlewareInterface
             try {
                 $this->connectToDatabaseServer(DatabaseInterface::getInstance(), $currentServer);
             } catch (AuthenticationFailure $exception) {
-                $authPlugin->showFailure($exception);
+                return $authPlugin->showFailure($exception);
             }
 
             // Relation should only be initialized after the connection is successful

--- a/src/Http/Middleware/Authentication.php
+++ b/src/Http/Middleware/Authentication.php
@@ -93,7 +93,11 @@ final class Authentication implements MiddlewareInterface
             // Tracker can only be activated after the relation has been initialized
             Tracker::enable();
 
-            $authPlugin->rememberCredentials();
+            $response = $authPlugin->rememberCredentials();
+            if ($response !== null) {
+                return $response;
+            }
+
             assert($request instanceof ServerRequest);
             $authPlugin->checkTwoFactor($request);
         } catch (ExitException) {

--- a/src/Http/Middleware/Authentication.php
+++ b/src/Http/Middleware/Authentication.php
@@ -137,7 +137,7 @@ final class Authentication implements MiddlewareInterface
         // Connects to the server (validates user's login)
         $userConnection = $dbi->connect($currentServer, ConnectionType::User);
         if ($userConnection === null) {
-            throw AuthenticationFailure::serverDenied();
+            throw AuthenticationFailure::deniedByDatabaseServer();
         }
 
         if ($controlConnection !== null) {

--- a/src/Http/Middleware/Authentication.php
+++ b/src/Http/Middleware/Authentication.php
@@ -99,7 +99,10 @@ final class Authentication implements MiddlewareInterface
             }
 
             assert($request instanceof ServerRequest);
-            $authPlugin->checkTwoFactor($request);
+            $response = $authPlugin->checkTwoFactor($request);
+            if ($response !== null) {
+                return $response;
+            }
         } catch (ExitException) {
             return ResponseRenderer::getInstance()->response();
         }

--- a/src/Http/Middleware/Authentication.php
+++ b/src/Http/Middleware/Authentication.php
@@ -61,7 +61,10 @@ final class Authentication implements MiddlewareInterface
 
         try {
             try {
-                $authPlugin->authenticate();
+                $response = $authPlugin->authenticate();
+                if ($response !== null) {
+                    return $response;
+                }
             } catch (AuthenticationFailure $exception) {
                 return $authPlugin->showFailure($exception);
             }

--- a/src/Http/Middleware/Authentication.php
+++ b/src/Http/Middleware/Authentication.php
@@ -26,6 +26,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Throwable;
 
 use function assert;
 use function define;
@@ -67,6 +68,14 @@ final class Authentication implements MiddlewareInterface
                 }
             } catch (AuthenticationFailure $exception) {
                 return $authPlugin->showFailure($exception);
+            } catch (Throwable $exception) {
+                $response = $this->responseFactory->createResponse(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
+
+                return $response->write($this->template->render('error/generic', [
+                    'lang' => $GLOBALS['lang'] ?? 'en',
+                    'dir' => LanguageManager::$textDir,
+                    'error_message' => $exception->getMessage(),
+                ]));
             }
 
             $currentServer = new Server(Config::getInstance()->selectedServer);

--- a/src/Plugins/Auth/AuthenticationConfig.php
+++ b/src/Plugins/Auth/AuthenticationConfig.php
@@ -36,17 +36,18 @@ class AuthenticationConfig extends AuthenticationPlugin
     /**
      * Displays authentication form
      */
-    public function showLoginForm(): void
+    public function showLoginForm(): Response|null
     {
-        $response = ResponseRenderer::getInstance();
-        if (! $response->isAjax()) {
-            return;
+        $responseRenderer = ResponseRenderer::getInstance();
+        if (! $responseRenderer->isAjax()) {
+            return null;
         }
 
-        $response->setRequestStatus(false);
+        $responseRenderer->setRequestStatus(false);
         // reload_flag removes the token parameter from the URL and reloads
-        $response->addJSON('reload_flag', '1');
-        $response->callExit();
+        $responseRenderer->addJSON('reload_flag', '1');
+
+        return $responseRenderer->response();
     }
 
     /**

--- a/src/Plugins/Auth/AuthenticationCookie.php
+++ b/src/Plugins/Auth/AuthenticationCookie.php
@@ -13,6 +13,7 @@ use PhpMyAdmin\Current;
 use PhpMyAdmin\Error\ErrorHandler;
 use PhpMyAdmin\Exceptions\AuthenticationFailure;
 use PhpMyAdmin\Exceptions\SessionHandlerException;
+use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\LanguageManager;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Plugins\AuthenticationPlugin;
@@ -543,7 +544,7 @@ class AuthenticationCookie extends AuthenticationPlugin
      * prepares error message and switches to showLoginForm() which display the error
      * and the login form
      */
-    public function showFailure(AuthenticationFailure $failure): never
+    public function showFailure(AuthenticationFailure $failure): Response
     {
         $this->logFailure($failure);
 
@@ -552,11 +553,11 @@ class AuthenticationCookie extends AuthenticationPlugin
 
         $GLOBALS['conn_error'] = $this->getErrorMessage($failure);
 
-        $response = ResponseRenderer::getInstance();
+        $responseRenderer = ResponseRenderer::getInstance();
 
         // needed for PHP-CGI (not need for FastCGI or mod-php)
-        $response->addHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
-        $response->addHeader('Pragma', 'no-cache');
+        $responseRenderer->addHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+        $responseRenderer->addHeader('Pragma', 'no-cache');
 
         $this->showLoginForm();
     }

--- a/src/Plugins/Auth/AuthenticationCookie.php
+++ b/src/Plugins/Auth/AuthenticationCookie.php
@@ -65,11 +65,11 @@ class AuthenticationCookie extends AuthenticationPlugin
      *
      * @global string $conn_error the last connection error
      */
-    public function showLoginForm(): never
+    public function showLoginForm(): Response
     {
         $GLOBALS['conn_error'] ??= null;
 
-        $response = ResponseRenderer::getInstance();
+        $responseRenderer = ResponseRenderer::getInstance();
 
         /**
          * When sending login modal after session has expired, send the
@@ -77,8 +77,8 @@ class AuthenticationCookie extends AuthenticationPlugin
          * in all the forms having a hidden token.
          */
         $sessionExpired = isset($_REQUEST['check_timeout']) || isset($_REQUEST['session_timedout']);
-        if (! $sessionExpired && $response->loginPage()) {
-            $response->callExit();
+        if (! $sessionExpired && $responseRenderer->loginPage()) {
+            return $responseRenderer->response();
         }
 
         /**
@@ -87,8 +87,8 @@ class AuthenticationCookie extends AuthenticationPlugin
          * in all the forms having a hidden token.
          */
         if ($sessionExpired) {
-            $response->setRequestStatus(false);
-            $response->addJSON('new_token', $_SESSION[' PMA_token ']);
+            $responseRenderer->setRequestStatus(false);
+            $responseRenderer->addJSON('new_token', $_SESSION[' PMA_token ']);
         }
 
         /**
@@ -96,7 +96,7 @@ class AuthenticationCookie extends AuthenticationPlugin
          * using the modal was successful after session expiration.
          */
         if (isset($_REQUEST['session_timedout'])) {
-            $response->addJSON('logged_in', 0);
+            $responseRenderer->addJSON('logged_in', 0);
         }
 
         $config = Config::getInstance();
@@ -161,7 +161,7 @@ class AuthenticationCookie extends AuthenticationPlugin
 
         $configFooter = Config::renderFooter();
 
-        $response->addHTML($this->template->render('login/form', [
+        $responseRenderer->addHTML($this->template->render('login/form', [
             'login_header' => $loginHeader,
             'is_demo' => $config->config->debug->demo,
             'error_messages' => $errorMessages,
@@ -192,7 +192,7 @@ class AuthenticationCookie extends AuthenticationPlugin
             'config_footer' => $configFooter,
         ]));
 
-        $response->callExit();
+        return $responseRenderer->response();
     }
 
     /**
@@ -559,7 +559,7 @@ class AuthenticationCookie extends AuthenticationPlugin
         $responseRenderer->addHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
         $responseRenderer->addHeader('Pragma', 'no-cache');
 
-        $this->showLoginForm();
+        return $this->showLoginForm();
     }
 
     /**

--- a/src/Plugins/Auth/AuthenticationCookie.php
+++ b/src/Plugins/Auth/AuthenticationCookie.php
@@ -444,7 +444,7 @@ class AuthenticationCookie extends AuthenticationPlugin
     /**
      * Stores user credentials after successful login.
      */
-    public function rememberCredentials(): void
+    public function rememberCredentials(): Response|null
     {
         // Name and password cookies need to be refreshed each time
         // Duration = one month for username
@@ -469,18 +469,18 @@ class AuthenticationCookie extends AuthenticationPlugin
 
         // user logged in successfully after session expiration
         if (isset($_REQUEST['session_timedout'])) {
-            $response = ResponseRenderer::getInstance();
-            $response->addJSON('logged_in', 1);
-            $response->addJSON('success', 1);
-            $response->addJSON('new_token', $_SESSION[' PMA_token ']);
+            $responseRenderer = ResponseRenderer::getInstance();
+            $responseRenderer->addJSON('logged_in', 1);
+            $responseRenderer->addJSON('success', 1);
+            $responseRenderer->addJSON('new_token', $_SESSION[' PMA_token ']);
 
-            $response->callExit();
+            return $responseRenderer->response();
         }
 
         // Set server cookies if required (once per session) and, in this case,
         // force reload to ensure the client accepts cookies
         if ($GLOBALS['from_cookie']) {
-            return;
+            return null;
         }
 
         /**
@@ -488,11 +488,11 @@ class AuthenticationCookie extends AuthenticationPlugin
          */
         Util::clearUserCache();
 
-        $response = ResponseRenderer::getInstance();
-        $response->disable();
-        $response->redirect('./index.php?route=/' . Url::getCommonRaw($urlParams, '&'));
+        $responseRenderer = ResponseRenderer::getInstance();
+        $responseRenderer->disable();
+        $responseRenderer->redirect('./index.php?route=/' . Url::getCommonRaw($urlParams, '&'));
 
-        $response->callExit();
+        return $responseRenderer->response();
     }
 
     /**

--- a/src/Plugins/Auth/AuthenticationCookie.php
+++ b/src/Plugins/Auth/AuthenticationCookie.php
@@ -364,7 +364,7 @@ class AuthenticationCookie extends AuthenticationPlugin
             SessionCache::remove('table_priv');
             SessionCache::remove('proc_priv');
 
-            throw AuthenticationFailure::noActivity();
+            throw AuthenticationFailure::loggedOutDueToInactivity();
         }
 
         // check password cookie

--- a/src/Plugins/Auth/AuthenticationCookie.php
+++ b/src/Plugins/Auth/AuthenticationCookie.php
@@ -20,7 +20,6 @@ use PhpMyAdmin\Plugins\AuthenticationPlugin;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Server\Select;
 use PhpMyAdmin\Session;
-use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
 use PhpMyAdmin\Utils\SessionCache;
@@ -210,6 +209,7 @@ class AuthenticationCookie extends AuthenticationPlugin
      * it directly switches to showFailure() if user inactivity timeout is reached
      *
      * @throws AuthenticationFailure
+     * @throws SessionHandlerException
      */
     public function readCredentials(): bool
     {
@@ -313,19 +313,8 @@ class AuthenticationCookie extends AuthenticationPlugin
                 $GLOBALS['pma_auth_server'] = Core::sanitizeMySQLHost($_REQUEST['pma_servername']);
             }
 
-            try {
-                /* Secure current session on login to avoid session fixation */
-                Session::secure();
-            } catch (SessionHandlerException $exception) {
-                $responseRenderer = ResponseRenderer::getInstance();
-                $responseRenderer->addHTML((new Template())->render('error/generic', [
-                    'lang' => $GLOBALS['lang'] ?? 'en',
-                    'dir' => LanguageManager::$textDir,
-                    'error_message' => $exception->getMessage(),
-                ]));
-
-                $responseRenderer->callExit();
-            }
+            /* Secure current session on login to avoid session fixation */
+            Session::secure();
 
             return true;
         }

--- a/src/Plugins/Auth/AuthenticationHttp.php
+++ b/src/Plugins/Auth/AuthenticationHttp.php
@@ -12,6 +12,7 @@ use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Exceptions\AuthenticationFailure;
 use PhpMyAdmin\LanguageManager;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Plugins\AuthenticationPlugin;
@@ -178,12 +179,10 @@ class AuthenticationHttp extends AuthenticationPlugin
 
     /**
      * User is not allowed to login to MySQL -> authentication failed
-     *
-     * @param string $failure String describing why authentication has failed
      */
-    public function showFailure(string $failure): never
+    public function showFailure(AuthenticationFailure $failure): never
     {
-        parent::showFailure($failure);
+        $this->logFailure($failure);
 
         $error = DatabaseInterface::getInstance()->getError();
         if ($error && $GLOBALS['errno'] != 1045) {

--- a/src/Plugins/Auth/AuthenticationHttp.php
+++ b/src/Plugins/Auth/AuthenticationHttp.php
@@ -13,6 +13,7 @@ use PhpMyAdmin\Config;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Exceptions\AuthenticationFailure;
+use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\LanguageManager;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Plugins\AuthenticationPlugin;
@@ -180,19 +181,20 @@ class AuthenticationHttp extends AuthenticationPlugin
     /**
      * User is not allowed to login to MySQL -> authentication failed
      */
-    public function showFailure(AuthenticationFailure $failure): never
+    public function showFailure(AuthenticationFailure $failure): Response
     {
         $this->logFailure($failure);
 
         $error = DatabaseInterface::getInstance()->getError();
         if ($error && $GLOBALS['errno'] != 1045) {
-            echo $this->template->render('error/generic', [
+            $responseRenderer = ResponseRenderer::getInstance();
+            $responseRenderer->addHTML($this->template->render('error/generic', [
                 'lang' => $GLOBALS['lang'] ?? 'en',
                 'dir' => LanguageManager::$textDir,
                 'error_message' => $error,
-            ]);
+            ]));
 
-            ResponseRenderer::getInstance()->callExit();
+            return $responseRenderer->response();
         }
 
         $this->authForm();

--- a/src/Plugins/Auth/AuthenticationHttp.php
+++ b/src/Plugins/Auth/AuthenticationHttp.php
@@ -36,14 +36,15 @@ class AuthenticationHttp extends AuthenticationPlugin
     /**
      * Displays authentication form and redirect as necessary
      */
-    public function showLoginForm(): never
+    public function showLoginForm(): Response
     {
-        $response = ResponseRenderer::getInstance();
-        if ($response->isAjax()) {
-            $response->setRequestStatus(false);
+        $responseRenderer = ResponseRenderer::getInstance();
+        if ($responseRenderer->isAjax()) {
+            $responseRenderer->setRequestStatus(false);
             // reload_flag removes the token parameter from the URL and reloads
-            $response->addJSON('reload_flag', '1');
-            $response->callExit();
+            $responseRenderer->addJSON('reload_flag', '1');
+
+            return $responseRenderer->response();
         }
 
         $this->authForm();

--- a/src/Plugins/Auth/AuthenticationHttp.php
+++ b/src/Plugins/Auth/AuthenticationHttp.php
@@ -47,13 +47,13 @@ class AuthenticationHttp extends AuthenticationPlugin
             return $responseRenderer->response();
         }
 
-        $this->authForm();
+        return $this->authForm();
     }
 
     /**
      * Displays authentication form
      */
-    public function authForm(): never
+    public function authForm(): Response
     {
         $config = Config::getInstance();
         if (empty($config->selectedServer['auth_http_realm'])) {
@@ -95,7 +95,7 @@ class AuthenticationHttp extends AuthenticationPlugin
 
         $response->addHTML(Config::renderFooter());
 
-        $response->callExit();
+        return $response->response();
     }
 
     /**
@@ -198,7 +198,7 @@ class AuthenticationHttp extends AuthenticationPlugin
             return $responseRenderer->response();
         }
 
-        $this->authForm();
+        return $this->authForm();
     }
 
     /**

--- a/src/Plugins/Auth/AuthenticationSignon.php
+++ b/src/Plugins/Auth/AuthenticationSignon.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Plugins\Auth;
 
 use PhpMyAdmin\Config;
+use PhpMyAdmin\Exceptions\AuthenticationFailure;
 use PhpMyAdmin\LanguageManager;
 use PhpMyAdmin\Plugins\AuthenticationPlugin;
 use PhpMyAdmin\ResponseRenderer;
@@ -233,12 +234,10 @@ class AuthenticationSignon extends AuthenticationPlugin
 
     /**
      * User is not allowed to login to MySQL -> authentication failed
-     *
-     * @param string $failure String describing why authentication has failed
      */
-    public function showFailure(string $failure): never
+    public function showFailure(AuthenticationFailure $failure): never
     {
-        parent::showFailure($failure);
+        $this->logFailure($failure);
 
         /* Session name */
         $sessionName = Config::getInstance()->selectedServer['SignonSession'];

--- a/src/Plugins/Auth/AuthenticationSignon.php
+++ b/src/Plugins/Auth/AuthenticationSignon.php
@@ -35,25 +35,25 @@ class AuthenticationSignon extends AuthenticationPlugin
     /**
      * Displays authentication form
      */
-    public function showLoginForm(): never
+    public function showLoginForm(): Response
     {
-        $response = ResponseRenderer::getInstance();
-        $response->disable();
+        $responseRenderer = ResponseRenderer::getInstance();
+        $responseRenderer->disable();
         unset($_SESSION['LAST_SIGNON_URL']);
         $config = Config::getInstance();
         if (empty($config->selectedServer['SignonURL'])) {
-            echo $this->template->render('error/generic', [
+            $responseRenderer->addHTML($this->template->render('error/generic', [
                 'lang' => $GLOBALS['lang'] ?? 'en',
                 'dir' => LanguageManager::$textDir,
                 'error_message' => 'You must set SignonURL!',
-            ]);
+            ]));
 
-            $response->callExit();
-        } else {
-            $response->redirect($config->selectedServer['SignonURL']);
+            return $responseRenderer->response();
         }
 
-        $response->callExit();
+        $responseRenderer->redirect($config->selectedServer['SignonURL']);
+
+        return $responseRenderer->response();
     }
 
     /**
@@ -260,7 +260,7 @@ class AuthenticationSignon extends AuthenticationPlugin
             $_SESSION['PMA_single_signon_error_message'] = $this->getErrorMessage($failure);
         }
 
-        $this->showLoginForm();
+        return $this->showLoginForm();
     }
 
     /**

--- a/src/Plugins/Auth/AuthenticationSignon.php
+++ b/src/Plugins/Auth/AuthenticationSignon.php
@@ -14,6 +14,7 @@ use PhpMyAdmin\LanguageManager;
 use PhpMyAdmin\Plugins\AuthenticationPlugin;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Util;
+use RuntimeException;
 
 use function __;
 use function array_merge;
@@ -26,6 +27,7 @@ use function session_name;
 use function session_set_cookie_params;
 use function session_start;
 use function session_write_close;
+use function sprintf;
 
 /**
  * Handles the SignOn authentication method
@@ -92,6 +94,8 @@ class AuthenticationSignon extends AuthenticationPlugin
 
     /**
      * Gets authentication credentials
+     *
+     * @throws RuntimeException
      */
     public function readCredentials(): bool
     {
@@ -120,13 +124,10 @@ class AuthenticationSignon extends AuthenticationPlugin
         /* Handle script based auth */
         if ($scriptName !== '') {
             if (! @file_exists($scriptName)) {
-                echo $this->template->render('error/generic', [
-                    'lang' => $GLOBALS['lang'] ?? 'en',
-                    'dir' => LanguageManager::$textDir,
-                    'error_message' => __('Can not find signon authentication script:') . ' ' . $scriptName,
-                ]);
-
-                ResponseRenderer::getInstance()->callExit();
+                throw new RuntimeException(sprintf(
+                    __('Can not find signon authentication script: %s'),
+                    '$cfg[\'Servers\'][$i][\'SignonScript\']',
+                ));
             }
 
             include $scriptName;

--- a/src/Plugins/Auth/AuthenticationSignon.php
+++ b/src/Plugins/Auth/AuthenticationSignon.php
@@ -9,6 +9,7 @@ namespace PhpMyAdmin\Plugins\Auth;
 
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Exceptions\AuthenticationFailure;
+use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\LanguageManager;
 use PhpMyAdmin\Plugins\AuthenticationPlugin;
 use PhpMyAdmin\ResponseRenderer;
@@ -235,7 +236,7 @@ class AuthenticationSignon extends AuthenticationPlugin
     /**
      * User is not allowed to login to MySQL -> authentication failed
      */
-    public function showFailure(AuthenticationFailure $failure): never
+    public function showFailure(AuthenticationFailure $failure): Response
     {
         $this->logFailure($failure);
 

--- a/src/Plugins/AuthenticationPlugin.php
+++ b/src/Plugins/AuthenticationPlugin.php
@@ -1,20 +1,16 @@
 <?php
-/**
- * Abstract class for the authentication plugins
- */
 
 declare(strict_types=1);
 
 namespace PhpMyAdmin\Plugins;
 
+use Exception;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Exceptions\AuthenticationFailure;
-use PhpMyAdmin\Exceptions\SessionHandlerException;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\IpAllowDeny;
-use PhpMyAdmin\LanguageManager;
 use PhpMyAdmin\Logging;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
@@ -36,8 +32,7 @@ use function sprintf;
 use function time;
 
 /**
- * Provides a common interface that will have to be implemented by all of the
- * authentication plugins.
+ * Provides a common interface that will have to be implemented by all the authentication plugins.
  */
 abstract class AuthenticationPlugin
 {
@@ -70,6 +65,7 @@ abstract class AuthenticationPlugin
      * Gets authentication credentials
      *
      * @throws AuthenticationFailure
+     * @throws Exception
      */
     abstract public function readCredentials(): bool;
 
@@ -228,6 +224,7 @@ abstract class AuthenticationPlugin
      * Gets the credentials or shows login form if necessary
      *
      * @throws AuthenticationFailure
+     * @throws Exception
      */
     public function authenticate(): Response|null
     {
@@ -236,18 +233,7 @@ abstract class AuthenticationPlugin
         /* Show login form (this exits) */
         if (! $success) {
             /* Force generating of new session */
-            try {
-                Session::secure();
-            } catch (SessionHandlerException $exception) {
-                $responseRenderer = ResponseRenderer::getInstance();
-                $responseRenderer->addHTML((new Template())->render('error/generic', [
-                    'lang' => $GLOBALS['lang'] ?? 'en',
-                    'dir' => LanguageManager::$textDir,
-                    'error_message' => $exception->getMessage(),
-                ]));
-
-                return $responseRenderer->response();
-            }
+            Session::secure();
 
             $response = $this->showLoginForm();
             if ($response !== null) {

--- a/src/Plugins/AuthenticationPlugin.php
+++ b/src/Plugins/AuthenticationPlugin.php
@@ -65,7 +65,7 @@ abstract class AuthenticationPlugin
     /**
      * Displays authentication form
      */
-    abstract public function showLoginForm(): void;
+    abstract public function showLoginForm(): Response|null;
 
     /**
      * Gets authentication credentials
@@ -249,7 +249,10 @@ abstract class AuthenticationPlugin
                 return $responseRenderer->response();
             }
 
-            $this->showLoginForm();
+            $response = $this->showLoginForm();
+            if ($response !== null) {
+                return $response;
+            }
         }
 
         /* Store credentials (eg. in cookies) */

--- a/src/Plugins/AuthenticationPlugin.php
+++ b/src/Plugins/AuthenticationPlugin.php
@@ -273,13 +273,13 @@ abstract class AuthenticationPlugin
 
             // Ejects the user if banished
             if ($allowDenyForbidden) {
-                throw AuthenticationFailure::allowDenied();
+                throw AuthenticationFailure::deniedByAllowDenyRules();
             }
         }
 
         // is root allowed?
         if (! $config->selectedServer['AllowRoot'] && $config->selectedServer['user'] === 'root') {
-            throw AuthenticationFailure::rootDenied();
+            throw AuthenticationFailure::rootDeniedByConfiguration();
         }
 
         // is a login without password allowed?
@@ -287,7 +287,7 @@ abstract class AuthenticationPlugin
             return;
         }
 
-        throw AuthenticationFailure::emptyDenied();
+        throw AuthenticationFailure::emptyPasswordDeniedByConfiguration();
     }
 
     /**

--- a/src/Plugins/AuthenticationPlugin.php
+++ b/src/Plugins/AuthenticationPlugin.php
@@ -91,8 +91,9 @@ abstract class AuthenticationPlugin
     /**
      * Stores user credentials after successful login.
      */
-    public function rememberCredentials(): void
+    public function rememberCredentials(): Response|null
     {
+        return null;
     }
 
     /**

--- a/src/Plugins/AuthenticationPlugin.php
+++ b/src/Plugins/AuthenticationPlugin.php
@@ -229,7 +229,7 @@ abstract class AuthenticationPlugin
      *
      * @throws AuthenticationFailure
      */
-    public function authenticate(): void
+    public function authenticate(): Response|null
     {
         $success = $this->readCredentials();
 
@@ -246,7 +246,7 @@ abstract class AuthenticationPlugin
                     'error_message' => $exception->getMessage(),
                 ]));
 
-                $responseRenderer->callExit();
+                return $responseRenderer->response();
             }
 
             $this->showLoginForm();
@@ -258,6 +258,8 @@ abstract class AuthenticationPlugin
         $this->checkRules();
         /* clear user cache */
         Util::clearUserCache();
+
+        return null;
     }
 
     /**

--- a/src/Plugins/AuthenticationPlugin.php
+++ b/src/Plugins/AuthenticationPlugin.php
@@ -12,6 +12,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Exceptions\AuthenticationFailure;
 use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Exceptions\SessionHandlerException;
+use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\IpAllowDeny;
 use PhpMyAdmin\LanguageManager;
@@ -97,7 +98,7 @@ abstract class AuthenticationPlugin
     /**
      * User is not allowed to login to MySQL -> authentication failed
      */
-    abstract public function showFailure(AuthenticationFailure $failure): never;
+    abstract public function showFailure(AuthenticationFailure $failure): Response;
 
     protected function logFailure(AuthenticationFailure $failure): void
     {

--- a/tests/unit/Exceptions/AuthenticationFailureTest.php
+++ b/tests/unit/Exceptions/AuthenticationFailureTest.php
@@ -13,14 +13,14 @@ final class AuthenticationFailureTest extends TestCase
 {
     public function testAllowDenied(): void
     {
-        $exception = AuthenticationFailure::allowDenied();
+        $exception = AuthenticationFailure::deniedByAllowDenyRules();
         self::assertSame('allow-denied', $exception->failureType);
         self::assertSame('Access denied!', $exception->getMessage());
     }
 
     public function testEmptyDenied(): void
     {
-        $exception = AuthenticationFailure::emptyDenied();
+        $exception = AuthenticationFailure::emptyPasswordDeniedByConfiguration();
         self::assertSame('empty-denied', $exception->failureType);
         self::assertSame(
             'Login without a password is forbidden by configuration (see AllowNoPassword).',
@@ -30,7 +30,7 @@ final class AuthenticationFailureTest extends TestCase
 
     public function testNoActivity(): void
     {
-        $exception = AuthenticationFailure::noActivity();
+        $exception = AuthenticationFailure::loggedOutDueToInactivity();
         self::assertSame('no-activity', $exception->failureType);
         self::assertSame(
             'You have been automatically logged out due to inactivity of %s seconds.'
@@ -41,14 +41,14 @@ final class AuthenticationFailureTest extends TestCase
 
     public function testRootDenied(): void
     {
-        $exception = AuthenticationFailure::rootDenied();
+        $exception = AuthenticationFailure::rootDeniedByConfiguration();
         self::assertSame('root-denied', $exception->failureType);
         self::assertSame('Access denied!', $exception->getMessage());
     }
 
     public function testServerDenied(): void
     {
-        $exception = AuthenticationFailure::serverDenied();
+        $exception = AuthenticationFailure::deniedByDatabaseServer();
         self::assertSame('server-denied', $exception->failureType);
         self::assertSame('Cannot log in to the database server.', $exception->getMessage());
     }

--- a/tests/unit/Exceptions/AuthenticationFailureTest.php
+++ b/tests/unit/Exceptions/AuthenticationFailureTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Exceptions;
+
+use PhpMyAdmin\Exceptions\AuthenticationFailure;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AuthenticationFailure::class)]
+final class AuthenticationFailureTest extends TestCase
+{
+    public function testAllowDenied(): void
+    {
+        $exception = AuthenticationFailure::allowDenied();
+        self::assertSame('allow-denied', $exception->failureType);
+        self::assertSame('Access denied!', $exception->getMessage());
+    }
+
+    public function testEmptyDenied(): void
+    {
+        $exception = AuthenticationFailure::emptyDenied();
+        self::assertSame('empty-denied', $exception->failureType);
+        self::assertSame(
+            'Login without a password is forbidden by configuration (see AllowNoPassword).',
+            $exception->getMessage(),
+        );
+    }
+
+    public function testNoActivity(): void
+    {
+        $exception = AuthenticationFailure::noActivity();
+        self::assertSame('no-activity', $exception->failureType);
+        self::assertSame(
+            'You have been automatically logged out due to inactivity of %s seconds.'
+            . ' Once you log in again, you should be able to resume the work where you left off.',
+            $exception->getMessage(),
+        );
+    }
+
+    public function testRootDenied(): void
+    {
+        $exception = AuthenticationFailure::rootDenied();
+        self::assertSame('root-denied', $exception->failureType);
+        self::assertSame('Access denied!', $exception->getMessage());
+    }
+
+    public function testServerDenied(): void
+    {
+        $exception = AuthenticationFailure::serverDenied();
+        self::assertSame('server-denied', $exception->failureType);
+        self::assertSame('Cannot log in to the database server.', $exception->getMessage());
+    }
+}

--- a/tests/unit/Plugins/Auth/AuthenticationConfigTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationConfigTest.php
@@ -15,10 +15,6 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Medium;
 use ReflectionProperty;
-use Throwable;
-
-use function ob_get_clean;
-use function ob_start;
 
 #[CoversClass(AuthenticationConfig::class)]
 #[Medium]
@@ -90,17 +86,9 @@ class AuthenticationConfigTest extends AbstractTestCase
 
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
 
-        ob_start();
-        try {
-            $this->object->showFailure(AuthenticationFailure::serverDenied());
-        } catch (Throwable $throwable) {
-        }
+        $response = $this->object->showFailure(AuthenticationFailure::serverDenied());
 
-        $html = ob_get_clean();
-
-        self::assertInstanceOf(ExitException::class, $throwable);
-
-        self::assertIsString($html);
+        $html = (string) $response->getBody();
 
         self::assertStringContainsString(
             'You probably did not create a configuration file. You might want ' .

--- a/tests/unit/Plugins/Auth/AuthenticationConfigTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationConfigTest.php
@@ -100,7 +100,7 @@ class AuthenticationConfigTest extends AbstractTestCase
 
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
 
-        $response = $this->object->showFailure(AuthenticationFailure::serverDenied());
+        $response = $this->object->showFailure(AuthenticationFailure::deniedByDatabaseServer());
 
         $html = (string) $response->getBody();
 

--- a/tests/unit/Plugins/Auth/AuthenticationConfigTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationConfigTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\Tests\Plugins\Auth;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Exceptions\AuthenticationFailure;
 use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Plugins\Auth\AuthenticationConfig;
 use PhpMyAdmin\ResponseRenderer;
@@ -91,7 +92,7 @@ class AuthenticationConfigTest extends AbstractTestCase
 
         ob_start();
         try {
-            $this->object->showFailure('');
+            $this->object->showFailure(AuthenticationFailure::serverDenied());
         } catch (Throwable $throwable) {
         }
 

--- a/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
@@ -546,7 +546,7 @@ class AuthenticationCookieTest extends AbstractTestCase
             ->method('cookieDecrypt')
             ->willReturn('testBF');
 
-        $this->expectExceptionObject(AuthenticationFailure::noActivity());
+        $this->expectExceptionObject(AuthenticationFailure::loggedOutDueToInactivity());
         $this->object->readCredentials();
     }
 
@@ -628,7 +628,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, $responseStub);
 
         try {
-            $this->object->showFailure(AuthenticationFailure::emptyDenied());
+            $this->object->showFailure(AuthenticationFailure::emptyPasswordDeniedByConfiguration());
         } catch (Throwable $throwable) {
         }
 
@@ -696,7 +696,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, $responseStub);
 
         try {
-            $this->object->showFailure(AuthenticationFailure::allowDenied());
+            $this->object->showFailure(AuthenticationFailure::deniedByAllowDenyRules());
         } catch (Throwable $throwable) {
         }
 
@@ -728,7 +728,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, $responseStub);
 
         try {
-            $this->object->showFailure(AuthenticationFailure::noActivity());
+            $this->object->showFailure(AuthenticationFailure::loggedOutDueToInactivity());
         } catch (Throwable $throwable) {
         }
 
@@ -773,7 +773,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, $responseStub);
 
         try {
-            $this->object->showFailure(AuthenticationFailure::serverDenied());
+            $this->object->showFailure(AuthenticationFailure::deniedByDatabaseServer());
         } catch (Throwable $throwable) {
         }
 
@@ -814,7 +814,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, $responseStub);
 
         try {
-            $this->object->showFailure(AuthenticationFailure::serverDenied());
+            $this->object->showFailure(AuthenticationFailure::deniedByDatabaseServer());
         } catch (Throwable $throwable) {
         }
 

--- a/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
@@ -552,7 +552,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         // mock for blowfish function
         $this->object = $this->getMockBuilder(AuthenticationCookie::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['showFailure', 'cookieDecrypt'])
+            ->onlyMethods(['cookieDecrypt'])
             ->getMock();
 
         $this->object->expects(self::once())
@@ -639,7 +639,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         } catch (Throwable $throwable) {
         }
 
-        self::assertInstanceOf(ExitException::class, $throwable);
+        self::assertInstanceOf(ExitException::class, $throwable ?? null);
         $response = $responseStub->getResponse();
         self::assertSame(['no-store, no-cache, must-revalidate'], $response->getHeader('Cache-Control'));
         self::assertSame(['no-cache'], $response->getHeader('Pragma'));
@@ -707,7 +707,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         } catch (Throwable $throwable) {
         }
 
-        self::assertInstanceOf(ExitException::class, $throwable);
+        self::assertInstanceOf(ExitException::class, $throwable ?? null);
         $response = $responseStub->getResponse();
         self::assertSame(['no-store, no-cache, must-revalidate'], $response->getHeader('Cache-Control'));
         self::assertSame(['no-cache'], $response->getHeader('Pragma'));
@@ -739,7 +739,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         } catch (Throwable $throwable) {
         }
 
-        self::assertInstanceOf(ExitException::class, $throwable);
+        self::assertInstanceOf(ExitException::class, $throwable ?? null);
         $response = $responseStub->getResponse();
         self::assertSame(['no-store, no-cache, must-revalidate'], $response->getHeader('Cache-Control'));
         self::assertSame(['no-cache'], $response->getHeader('Pragma'));
@@ -784,7 +784,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         } catch (Throwable $throwable) {
         }
 
-        self::assertInstanceOf(ExitException::class, $throwable);
+        self::assertInstanceOf(ExitException::class, $throwable ?? null);
         $response = $responseStub->getResponse();
         self::assertSame(['no-store, no-cache, must-revalidate'], $response->getHeader('Cache-Control'));
         self::assertSame(['no-cache'], $response->getHeader('Pragma'));
@@ -825,7 +825,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         } catch (Throwable $throwable) {
         }
 
-        self::assertInstanceOf(ExitException::class, $throwable);
+        self::assertInstanceOf(ExitException::class, $throwable ?? null);
         $response = $responseStub->getResponse();
         self::assertSame(['no-store, no-cache, must-revalidate'], $response->getHeader('Cache-Control'));
         self::assertSame(['no-cache'], $response->getHeader('Pragma'));

--- a/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
@@ -590,6 +590,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         $config->selectedServer['user'] = 'pmaUser';
         $config->settings['Servers'][1] = $arr;
         $config->settings['AllowArbitraryServer'] = true;
+        $config->settings['PmaAbsoluteUri'] = 'http://localhost/phpmyadmin';
         $GLOBALS['pma_auth_server'] = 'b 2';
         $this->object->password = 'testPW';
         $config->settings['LoginCookieStore'] = 100;
@@ -599,8 +600,13 @@ class AuthenticationCookieTest extends AbstractTestCase
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, $responseStub);
 
         $this->object->storeCredentials();
-        $this->expectException(ExitException::class);
-        $this->object->rememberCredentials();
+        $response = $this->object->rememberCredentials();
+        self::assertNotNull($response);
+        self::assertSame(StatusCodeInterface::STATUS_FOUND, $response->getStatusCode());
+        self::assertStringEndsWith(
+            '/phpmyadmin/index.php?route=/&db=db&table=table&lang=en',
+            $response->getHeaderLine('Location'),
+        );
     }
 
     public function testAuthFailsNoPass(): void

--- a/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
@@ -118,6 +118,8 @@ class AuthenticationCookieTest extends AbstractTestCase
         Current::$table = 'testTable';
         $config->settings['Servers'] = [1, 2];
 
+        (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
+
         $response = $this->object->showLoginForm();
 
         $result = (string) $response->getBody();

--- a/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
@@ -933,9 +933,10 @@ class AuthenticationCookieTest extends AbstractTestCase
         $_POST['pma_password'] = 'testPassword';
 
         ob_start();
-        $this->object->authenticate();
+        $response = $this->object->authenticate();
         $result = ob_get_clean();
 
+        self::assertNull($response);
         /* Nothing should be printed */
         self::assertSame('', $result);
 

--- a/tests/unit/Plugins/Auth/AuthenticationHttpTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationHttpTest.php
@@ -20,8 +20,6 @@ use ReflectionProperty;
 use Throwable;
 
 use function base64_encode;
-use function ob_get_clean;
-use function ob_start;
 
 #[CoversClass(AuthenticationHttp::class)]
 #[Medium]
@@ -285,17 +283,9 @@ class AuthenticationHttpTest extends AbstractTestCase
         DatabaseInterface::$instance = $dbi;
         $GLOBALS['errno'] = 31;
 
-        ob_start();
-        try {
-            $this->object->showFailure(AuthenticationFailure::serverDenied());
-        } catch (Throwable $throwable) {
-        }
+        $response = $this->object->showFailure(AuthenticationFailure::serverDenied());
 
-        $result = ob_get_clean();
-
-        self::assertInstanceOf(ExitException::class, $throwable);
-
-        self::assertIsString($result);
+        $result = (string) $response->getBody();
 
         self::assertStringContainsString('<p>error 123</p>', $result);
 

--- a/tests/unit/Plugins/Auth/AuthenticationHttpTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationHttpTest.php
@@ -8,7 +8,6 @@ use PhpMyAdmin\Config;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Exceptions\AuthenticationFailure;
-use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Plugins\Auth\AuthenticationHttp;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -17,7 +16,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Medium;
 use ReflectionProperty;
-use Throwable;
 
 use function base64_encode;
 use function json_decode;
@@ -82,13 +80,8 @@ class AuthenticationHttpTest extends AbstractTestCase
         $responseStub = new ResponseRendererStub();
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, $responseStub);
 
-        try {
-            $this->object->showLoginForm();
-        } catch (Throwable $throwable) {
-        }
+        $response = $this->object->showLoginForm();
 
-        self::assertInstanceOf(ExitException::class, $throwable ?? null);
-        $response = $responseStub->getResponse();
         self::assertSame(['Basic realm="phpMyAdmin verboseMessag"'], $response->getHeader('WWW-Authenticate'));
         self::assertSame(401, $response->getStatusCode());
     }
@@ -103,13 +96,8 @@ class AuthenticationHttpTest extends AbstractTestCase
         $responseStub = new ResponseRendererStub();
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, $responseStub);
 
-        try {
-            $this->object->showLoginForm();
-        } catch (Throwable $throwable) {
-        }
+        $response = $this->object->showLoginForm();
 
-        self::assertInstanceOf(ExitException::class, $throwable ?? null);
-        $response = $responseStub->getResponse();
         self::assertSame(['Basic realm="phpMyAdmin hst"'], $response->getHeader('WWW-Authenticate'));
         self::assertSame(401, $response->getStatusCode());
     }
@@ -124,13 +112,8 @@ class AuthenticationHttpTest extends AbstractTestCase
         $responseStub = new ResponseRendererStub();
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, $responseStub);
 
-        try {
-            $this->object->showLoginForm();
-        } catch (Throwable $throwable) {
-        }
+        $response = $this->object->showLoginForm();
 
-        self::assertInstanceOf(ExitException::class, $throwable ?? null);
-        $response = $responseStub->getResponse();
         self::assertSame(['Basic realm="realmmessage"'], $response->getHeader('WWW-Authenticate'));
         self::assertSame(401, $response->getStatusCode());
     }
@@ -286,33 +269,33 @@ class AuthenticationHttpTest extends AbstractTestCase
         DatabaseInterface::$instance = $dbi;
         $GLOBALS['errno'] = 31;
 
+        (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
+        ResponseRenderer::getInstance()->setAjax(false);
+
         $response = $this->object->showFailure(AuthenticationFailure::serverDenied());
 
         $result = (string) $response->getBody();
-
         self::assertStringContainsString('<p>error 123</p>', $result);
 
-        $this->object = $this->getMockBuilder(AuthenticationHttp::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['authForm'])
-            ->getMock();
-
-        $this->object->expects(self::exactly(2))
-            ->method('authForm')
-            ->willThrowException(new ExitException());
         // case 2
         $config->selectedServer['host'] = 'host';
         $GLOBALS['errno'] = 1045;
 
-        try {
-            $this->object->showFailure(AuthenticationFailure::serverDenied());
-        } catch (ExitException) {
-        }
+        (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
+        ResponseRenderer::getInstance()->setAjax(false);
+
+        $response = $this->object->showFailure(AuthenticationFailure::serverDenied());
+        $result = (string) $response->getBody();
+        self::assertStringContainsString('Wrong username/password. Access denied.', $result);
+
+        (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
+        ResponseRenderer::getInstance()->setAjax(false);
 
         // case 3
         $GLOBALS['errno'] = 1043;
-        $this->expectException(ExitException::class);
-        $this->object->showFailure(AuthenticationFailure::serverDenied());
+        $response = $this->object->showFailure(AuthenticationFailure::serverDenied());
+        $result = (string) $response->getBody();
+        self::assertStringContainsString('Wrong username/password. Access denied.', $result);
     }
 
     public function testShowLoginFormWithAjax(): void

--- a/tests/unit/Plugins/Auth/AuthenticationHttpTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationHttpTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\Tests\Plugins\Auth;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Exceptions\AuthenticationFailure;
 use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Plugins\Auth\AuthenticationHttp;
 use PhpMyAdmin\ResponseRenderer;
@@ -286,7 +287,7 @@ class AuthenticationHttpTest extends AbstractTestCase
 
         ob_start();
         try {
-            $this->object->showFailure('');
+            $this->object->showFailure(AuthenticationFailure::serverDenied());
         } catch (Throwable $throwable) {
         }
 
@@ -311,13 +312,13 @@ class AuthenticationHttpTest extends AbstractTestCase
         $GLOBALS['errno'] = 1045;
 
         try {
-            $this->object->showFailure('');
+            $this->object->showFailure(AuthenticationFailure::serverDenied());
         } catch (ExitException) {
         }
 
         // case 3
         $GLOBALS['errno'] = 1043;
         $this->expectException(ExitException::class);
-        $this->object->showFailure('');
+        $this->object->showFailure(AuthenticationFailure::serverDenied());
     }
 }

--- a/tests/unit/Plugins/Auth/AuthenticationHttpTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationHttpTest.php
@@ -272,7 +272,7 @@ class AuthenticationHttpTest extends AbstractTestCase
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
         ResponseRenderer::getInstance()->setAjax(false);
 
-        $response = $this->object->showFailure(AuthenticationFailure::serverDenied());
+        $response = $this->object->showFailure(AuthenticationFailure::deniedByDatabaseServer());
 
         $result = (string) $response->getBody();
         self::assertStringContainsString('<p>error 123</p>', $result);
@@ -284,7 +284,7 @@ class AuthenticationHttpTest extends AbstractTestCase
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
         ResponseRenderer::getInstance()->setAjax(false);
 
-        $response = $this->object->showFailure(AuthenticationFailure::serverDenied());
+        $response = $this->object->showFailure(AuthenticationFailure::deniedByDatabaseServer());
         $result = (string) $response->getBody();
         self::assertStringContainsString('Wrong username/password. Access denied.', $result);
 
@@ -293,7 +293,7 @@ class AuthenticationHttpTest extends AbstractTestCase
 
         // case 3
         $GLOBALS['errno'] = 1043;
-        $response = $this->object->showFailure(AuthenticationFailure::serverDenied());
+        $response = $this->object->showFailure(AuthenticationFailure::deniedByDatabaseServer());
         $result = (string) $response->getBody();
         self::assertStringContainsString('Wrong username/password. Access denied.', $result);
     }

--- a/tests/unit/Plugins/Auth/AuthenticationSignonTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationSignonTest.php
@@ -16,10 +16,7 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseRendererStub;
 use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionProperty;
-use Throwable;
 
-use function ob_get_clean;
-use function ob_start;
 use function session_get_cookie_params;
 use function session_id;
 use function session_name;
@@ -62,20 +59,8 @@ class AuthenticationSignonTest extends AbstractTestCase
         Config::getInstance()->selectedServer['SignonURL'] = '';
         $_REQUEST = [];
         ResponseRenderer::getInstance()->setAjax(false);
-
-        ob_start();
-        try {
-            $this->object->showLoginForm();
-        } catch (Throwable $throwable) {
-        }
-
-        $result = ob_get_clean();
-
-        self::assertInstanceOf(ExitException::class, $throwable);
-
-        self::assertIsString($result);
-
-        self::assertStringContainsString('You must set SignonURL!', $result);
+        $response = $this->object->showLoginForm();
+        self::assertStringContainsString('You must set SignonURL!', (string) $response->getBody());
     }
 
     public function testAuthLogoutURL(): void

--- a/tests/unit/Plugins/Auth/AuthenticationSignonTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationSignonTest.php
@@ -246,7 +246,7 @@ class AuthenticationSignonTest extends AbstractTestCase
             ->willThrowException(new ExitException());
 
         try {
-            $this->object->showFailure(AuthenticationFailure::emptyDenied());
+            $this->object->showFailure(AuthenticationFailure::emptyPasswordDeniedByConfiguration());
         } catch (ExitException) {
         }
 
@@ -271,7 +271,7 @@ class AuthenticationSignonTest extends AbstractTestCase
             ->willThrowException(new ExitException());
 
         try {
-            $this->object->showFailure(AuthenticationFailure::allowDenied());
+            $this->object->showFailure(AuthenticationFailure::deniedByAllowDenyRules());
         } catch (ExitException) {
         }
 
@@ -296,7 +296,7 @@ class AuthenticationSignonTest extends AbstractTestCase
         $config->settings['LoginCookieValidity'] = '1440';
 
         try {
-            $this->object->showFailure(AuthenticationFailure::noActivity());
+            $this->object->showFailure(AuthenticationFailure::loggedOutDueToInactivity());
         } catch (ExitException) {
         }
 
@@ -333,7 +333,7 @@ class AuthenticationSignonTest extends AbstractTestCase
         DatabaseInterface::$instance = $dbi;
 
         try {
-            $this->object->showFailure(AuthenticationFailure::serverDenied());
+            $this->object->showFailure(AuthenticationFailure::deniedByDatabaseServer());
         } catch (ExitException) {
         }
 
@@ -366,7 +366,7 @@ class AuthenticationSignonTest extends AbstractTestCase
         DatabaseInterface::$instance = $dbi;
 
         try {
-            $this->object->showFailure(AuthenticationFailure::serverDenied());
+            $this->object->showFailure(AuthenticationFailure::deniedByDatabaseServer());
         } catch (ExitException) {
         }
 

--- a/tests/unit/Plugins/Auth/AuthenticationSignonTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationSignonTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\Settings\Server;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Exceptions\AuthenticationFailure;
 use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Plugins\Auth\AuthenticationSignon;
 use PhpMyAdmin\ResponseRenderer;
@@ -260,12 +261,12 @@ class AuthenticationSignonTest extends AbstractTestCase
             ->willThrowException(new ExitException());
 
         try {
-            $this->object->showFailure('empty-denied');
+            $this->object->showFailure(AuthenticationFailure::emptyDenied());
         } catch (ExitException) {
         }
 
         self::assertSame(
-            'Login without a password is forbidden by configuration (see AllowNoPassword)',
+            'Login without a password is forbidden by configuration (see AllowNoPassword).',
             $_SESSION['PMA_single_signon_error_message'],
         );
     }
@@ -285,7 +286,7 @@ class AuthenticationSignonTest extends AbstractTestCase
             ->willThrowException(new ExitException());
 
         try {
-            $this->object->showFailure('allow-denied');
+            $this->object->showFailure(AuthenticationFailure::allowDenied());
         } catch (ExitException) {
         }
 
@@ -310,7 +311,7 @@ class AuthenticationSignonTest extends AbstractTestCase
         $config->settings['LoginCookieValidity'] = '1440';
 
         try {
-            $this->object->showFailure('no-activity');
+            $this->object->showFailure(AuthenticationFailure::noActivity());
         } catch (ExitException) {
         }
 
@@ -347,7 +348,7 @@ class AuthenticationSignonTest extends AbstractTestCase
         DatabaseInterface::$instance = $dbi;
 
         try {
-            $this->object->showFailure('');
+            $this->object->showFailure(AuthenticationFailure::serverDenied());
         } catch (ExitException) {
         }
 
@@ -380,11 +381,11 @@ class AuthenticationSignonTest extends AbstractTestCase
         DatabaseInterface::$instance = $dbi;
 
         try {
-            $this->object->showFailure('');
+            $this->object->showFailure(AuthenticationFailure::serverDenied());
         } catch (ExitException) {
         }
 
-        self::assertSame('Cannot log in to the MySQL server', $_SESSION['PMA_single_signon_error_message']);
+        self::assertSame('Cannot log in to the database server.', $_SESSION['PMA_single_signon_error_message']);
     }
 
     public function testSetCookieParamsDefaults(): void

--- a/tests/unit/Plugins/AuthenticationPluginTest.php
+++ b/tests/unit/Plugins/AuthenticationPluginTest.php
@@ -28,8 +28,9 @@ final class AuthenticationPluginTest extends AbstractTestCase
         DatabaseInterface::$instance = $dbi;
 
         $object = new class extends AuthenticationPlugin {
-            public function showLoginForm(): void
+            public function showLoginForm(): Response|null
             {
+                return null;
             }
 
             public function readCredentials(): bool

--- a/tests/unit/Plugins/AuthenticationPluginTest.php
+++ b/tests/unit/Plugins/AuthenticationPluginTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Exceptions\AuthenticationFailure;
 use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Http\Factory\ServerRequestFactory;
+use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Plugins\AuthenticationPlugin;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -36,7 +37,7 @@ final class AuthenticationPluginTest extends AbstractTestCase
                 return false;
             }
 
-            public function showFailure(AuthenticationFailure $failure): never
+            public function showFailure(AuthenticationFailure $failure): Response
             {
                 throw new ExitException();
             }

--- a/tests/unit/Plugins/AuthenticationPluginTest.php
+++ b/tests/unit/Plugins/AuthenticationPluginTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Plugins;
 
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Exceptions\AuthenticationFailure;
 use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Http\Factory\ServerRequestFactory;
 use PhpMyAdmin\Plugins\AuthenticationPlugin;
@@ -33,6 +34,11 @@ final class AuthenticationPluginTest extends AbstractTestCase
             public function readCredentials(): bool
             {
                 return false;
+            }
+
+            public function showFailure(AuthenticationFailure $failure): never
+            {
+                throw new ExitException();
             }
         };
 

--- a/tests/unit/Plugins/AuthenticationPluginTest.php
+++ b/tests/unit/Plugins/AuthenticationPluginTest.php
@@ -53,12 +53,9 @@ final class AuthenticationPluginTest extends AbstractTestCase
         $request = ServerRequestFactory::create()->createServerRequest('GET', 'http://example.com/');
 
         $object->user = 'test_user';
-        try {
-            $object->checkTwoFactor($request);
-        } catch (ExitException) {
-        }
+        $response = $object->checkTwoFactor($request);
 
-        $response = $responseRenderer->response();
+        self::assertNotNull($response);
         self::assertStringContainsString(
             'You have enabled two factor authentication, please confirm your login.',
             (string) $response->getBody(),


### PR DESCRIPTION
Refactors authentication plugins to return a response object instead of throwing `ExitException`.