### PR TITLE
Fix `Query Generator` backticks

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -430,7 +430,7 @@ Functions.escapeJsString = function (unsafe) {
  * @return {string}
  */
 Functions.escapeBacktick = function (s) {
-    return s.replace('`', '``');
+    return s.replaceAll('`', '``');
 };
 
 /**


### PR DESCRIPTION
Hellooo 👋🏻 

In this PR I have fixed the issue with `Query Generator` that doesn't escape all the backticks when we have more than one.
It only escapes one backtick (The first one), so the issue appears if we have multiple backticks.

Like you can see in the example I'm showing you 3 different columns which contain different number of backticks:

- **\`col_one**: contains one *backtick* which is escaped as expected.
- **\`col_two\`**: contains two *backticks* which only the first was escaped.
- **\`col_\`three\`**: contains three *backticks* which only the first was escaped.

This generates a non-valid query.

## Before
![Screenshot 2024-05-12 145321](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/cdf0e17f-afbd-4ac0-b843-216073859389)


## After
All backticks escaped as expected.

![Screenshot 2024-05-12 145140](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/3159fb2e-0c17-400e-9371-90e5b4ba6d0e)

### Server configuration

- phpMyAdmin version: 5.2.2-dev, 6.0.0-dev

