### PR TITLE
Fix `Query Generator` IS NULL / IS NOT NULL

### DIFF
--- a/js/src/database/query_generator.js
+++ b/js/src/database/query_generator.js
@@ -10,6 +10,13 @@
 
 /* global sprintf */ // js/vendor/sprintf.js
 
+$(document).on('change', '.criteria_op', function () {
+    const op = $(this).val();
+    const criteria = $(this).closest('.table').find('.rhs_text_val');
+
+    isOpWithoutArg(op) ? criteria.hide() : criteria.show();
+});
+
 function getFormatsText () {
     return {
         '=': ' = \'%s\'',

--- a/js/src/database/query_generator.js
+++ b/js/src/database/query_generator.js
@@ -14,7 +14,7 @@ $(document).on('change', '.criteria_op', function () {
     const op = $(this).val();
     const criteria = $(this).closest('.table').find('.rhs_text_val');
 
-    isOpWithoutArg(op) ? criteria.hide() : criteria.show();
+    isOpWithoutArg(op) ? criteria.hide().val('') : criteria.show();
 });
 
 function getFormatsText () {

--- a/js/src/database/query_generator.js
+++ b/js/src/database/query_generator.js
@@ -24,25 +24,36 @@ function getFormatsText () {
         'NOT LIKE %...%': ' NOT LIKE \'%%%s%%\'',
         'BETWEEN': ' BETWEEN \'%s\'',
         'NOT BETWEEN': ' NOT BETWEEN \'%s\'',
-        'IS NULL': ' \'%s\' IS NULL',
-        'IS NOT NULL': ' \'%s\' IS NOT NULL',
         'REGEXP': ' REGEXP \'%s\'',
         'REGEXP ^...$': ' REGEXP \'^%s$\'',
         'NOT REGEXP': ' NOT REGEXP \'%s\''
     };
 }
 
+function opsWithoutArg () {
+    return ['IS NULL', 'IS NOT NULL'];
+}
+
+function isOpWithoutArg (op) {
+    return opsWithoutArg().includes(op);
+}
+
 function generateCondition (criteriaDiv, table) {
     const tableName = table.val();
     const tableAlias = table.siblings('.table_alias').val();
+    const op = criteriaDiv.find('.criteria_op').first().val();
 
     var query = '`' + Functions.escapeBacktick(tableAlias === '' ? tableName : tableAlias) + '`.';
     query += '`' + Functions.escapeBacktick(table.siblings('.columnNameSelect').first().val()) + '`';
     if (criteriaDiv.find('.criteria_rhs').first().val() === 'text') {
-        var formatsText = getFormatsText();
-        query += sprintf(formatsText[criteriaDiv.find('.criteria_op').first().val()], Functions.escapeSingleQuote(criteriaDiv.find('.rhs_text_val').first().val()));
+        if (isOpWithoutArg(op)) {
+            query += ' ' + op;
+        } else {
+            const formatsText = getFormatsText();
+            query += sprintf(formatsText[op], Functions.escapeSingleQuote(criteriaDiv.find('.rhs_text_val').first().val()));
+        }
     } else {
-        query += ' ' + criteriaDiv.find('.criteria_op').first().val();
+        query += ' ' + op;
         query += ' `' + Functions.escapeBacktick(criteriaDiv.find('.tableNameSelect').first().val()) + '`.';
         query += '`' + Functions.escapeBacktick(criteriaDiv.find('.columnNameSelect').first().val()) + '`';
     }


### PR DESCRIPTION
Hellooo 👋🏻 

In this PR I fixed the bug in the `Query Generator`  that generates a non-valid query when using `IS NULL` and `IS NOT NULL`.

### Before
As you can see it adds the criteria string before `IS NULL`  which is empty in this case (Same thing for `IS NOT NULL`).
Which is not a valid query. ❌ 

![Screenshot from 2024-05-14 21-07-52](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/16be3b2c-d7e7-4ffd-a37b-04e1793f87fa)

### After
Valid ✅ 
![Screenshot from 2024-05-14 21-10-06](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/882cd744-577d-49b3-8106-bc3f651a9f85)

### Hide criteria when the op doesn't need it.
[Screencast from 14-05-24 21:53:10.webm](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/2c6b308f-9f26-40fe-a0ea-2c0e09dacc0f)


### Server configuration

- phpMyAdmin version: 5.2.2-dev, 6.0.0-dev