### PR TITLE
Fix `Query Generator` criteria on column `*`

### DIFF
--- a/js/src/database/multi_table_query.js
+++ b/js/src/database/multi_table_query.js
@@ -177,15 +177,18 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
     function addNewColumnCallbacks () {
         $('.tableNameSelect').each(function () {
             $(this).on('change', function () {
-                var $sibs = $(this).siblings('.columnNameSelect');
-                const $alias = $(this).siblings('.col_alias');
+                const $table = $(this);
+                const $alias = $table.siblings('.col_alias');
+                const $colsSelect = $table.parent().find('.columnNameSelect');
 
-                if ($sibs.length === 0) {
-                    $sibs = $(this).parent().parent().find('.columnNameSelect');
-                }
-
-                $sibs.first().html($('#' + $(this).find(':selected').data('hash')).html());
                 $alias.prop('disabled', true);
+                $colsSelect.each(function () {
+                    $(this).show();
+                    $(this).first().html($('#' + $table.find(':selected').data('hash')).html());
+                    if ($(this).hasClass('opColumn')) {
+                        $(this).find('option[value="*"]').remove();
+                    }
+                });
             });
         });
 

--- a/js/src/database/multi_table_query.js
+++ b/js/src/database/multi_table_query.js
@@ -182,6 +182,7 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
                 const $colsSelect = $table.parent().find('.columnNameSelect');
 
                 $alias.prop('disabled', true);
+
                 $colsSelect.each(function () {
                     $(this).show();
                     $(this).first().html($('#' + $table.find(':selected').data('hash')).html());

--- a/js/src/database/query_generator.js
+++ b/js/src/database/query_generator.js
@@ -37,14 +37,14 @@ function generateCondition (criteriaDiv, table) {
     const tableAlias = table.siblings('.table_alias').val();
 
     var query = '`' + Functions.escapeBacktick(tableAlias === '' ? tableName : tableAlias) + '`.';
-    query += '`' + Functions.escapeBacktick(table.siblings('.columnNameSelect').first().val()) + '`';
+    query += '`' + Functions.escapeBacktick(table.parent().find('.opColumn').first().val()) + '`';
     if (criteriaDiv.find('.criteria_rhs').first().val() === 'text') {
         var formatsText = getFormatsText();
         query += sprintf(formatsText[criteriaDiv.find('.criteria_op').first().val()], Functions.escapeSingleQuote(criteriaDiv.find('.rhs_text_val').first().val()));
     } else {
         query += ' ' + criteriaDiv.find('.criteria_op').first().val();
         query += ' `' + Functions.escapeBacktick(criteriaDiv.find('.tableNameSelect').first().val()) + '`.';
-        query += '`' + Functions.escapeBacktick(criteriaDiv.find('.columnNameSelect').first().val()) + '`';
+        query += '`' + Functions.escapeBacktick(criteriaDiv.find('.opColumn').first().val()) + '`';
     }
     return query;
 }

--- a/templates/database/multi_table_query/form.twig
+++ b/templates/database/multi_table_query/form.twig
@@ -88,6 +88,15 @@
                             </td>
                         </tr>
 
+                        <tr>
+                            <td>Column</td>
+                            <td colspan="2">
+                                <select class="columnNameSelect query-form__select--inline opColumn">
+                                    <option value="">{% trans 'select column' %}</option>
+                                </select>
+                            </td>
+                        </tr>
+
                         <tr class="query-form__tr--bg-none">
                             <td>Op </td>
                             <td>


### PR DESCRIPTION
### Before
When choosing `*` in the column we can't use it in condition. This generates a non-valid query.

![Screenshot from 2024-05-15 16-45-48](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/b6d28c2f-cb23-44c2-bf03-6b26c4c6f1fa)

To fix this issue I have added another select in the criteria area where we can choose the column (* not included) that we want the criteria to be applied on

### After

![Screenshot from 2024-05-15 16-50-52](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/ac8bf739-436a-4f37-a50b-afd8b4823cfe)
