### PR TITLE
Add support for statement messages in FlashMessenger class

### DIFF
--- a/app/services.php
+++ b/app/services.php
@@ -24,7 +24,7 @@ use PhpMyAdmin\Export\Export;
 use PhpMyAdmin\Export\Options;
 use PhpMyAdmin\Export\TemplateModel;
 use PhpMyAdmin\FileListing;
-use PhpMyAdmin\FlashMessages;
+use PhpMyAdmin\FlashMessenger;
 use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Import\Import;
 use PhpMyAdmin\Import\SimulateDml;
@@ -109,7 +109,7 @@ return [
         'export_template_model' => ['class' => TemplateModel::class, 'arguments' => ['@dbi']],
         'expression_language' => ['class' => ExpressionLanguage::class],
         'file_listing' => ['class' => FileListing::class],
-        'flash' => ['class' => FlashMessages::class],
+        FlashMessenger::class => ['class' => FlashMessenger::class],
         'http_request' => ['class' => HttpRequest::class],
         ResponseFactory::class => [
             'class' => ResponseFactory::class,
@@ -223,7 +223,6 @@ return [
         UserPrivilegesFactory::class => ['class' => UserPrivilegesFactory::class, 'arguments' => ['@dbi']],
         'version_information' => ['class' => VersionInformation::class],
         DatabaseInterface::class => 'dbi',
-        PhpMyAdmin\FlashMessages::class => 'flash',
         PhpMyAdmin\ResponseRenderer::class => 'response',
         'bookmarkRepository' => ['class' => BookmarkRepository::class, 'arguments' => ['@dbi', '@relation']],
         'console' => ['class' => Console::class, 'arguments' => [ '@relation', '@template', '@bookmarkRepository']],

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -321,7 +321,7 @@ return [
         ],
         Database\Structure\ReplacePrefixController::class => [
             'class' => Database\Structure\ReplacePrefixController::class,
-            'arguments' => ['$dbi' => '@dbi', '$structureController' => '@' . Database\StructureController::class],
+            'arguments' => ['@dbi', '@' . ResponseFactory::class, '@flash'],
         ],
         Database\Structure\ShowCreateController::class => [
             'class' => Database\Structure\ShowCreateController::class,

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -41,6 +41,7 @@ use PhpMyAdmin\Controllers\UserPasswordController;
 use PhpMyAdmin\Controllers\VersionCheckController;
 use PhpMyAdmin\Controllers\View;
 use PhpMyAdmin\DbTableExists;
+use PhpMyAdmin\FlashMessenger;
 use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Plugins\AuthenticationPluginFactory;
 use PhpMyAdmin\Theme\ThemeManager;
@@ -298,7 +299,7 @@ return [
                 '$dbi' => '@dbi',
                 '$relation' => '@relation',
                 '$relationCleanup' => '@relation_cleanup',
-                '$flash' => '@flash',
+                '$flashMessenger' => '@' . FlashMessenger::class,
                 '$structureController' => '@' . Database\StructureController::class,
             ],
         ],
@@ -321,7 +322,7 @@ return [
         ],
         Database\Structure\ReplacePrefixController::class => [
             'class' => Database\Structure\ReplacePrefixController::class,
-            'arguments' => ['@dbi', '@' . ResponseFactory::class, '@flash'],
+            'arguments' => ['@dbi', '@' . ResponseFactory::class, '@' . FlashMessenger::class],
         ],
         Database\Structure\ShowCreateController::class => [
             'class' => Database\Structure\ShowCreateController::class,
@@ -976,7 +977,7 @@ return [
             'arguments' => [
                 '$response' => '@response',
                 '$dbi' => '@dbi',
-                '$flash' => '@flash',
+                '$flashMessenger' => '@' . FlashMessenger::class,
                 '$relationCleanup' => '@relation_cleanup',
             ],
         ],

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1996,6 +1996,11 @@ parameters:
 			path: src/Controllers/Database/Structure/ReplacePrefixController.php
 
 		-
+			message: "#^Parameter \\#3 \\$statement of method PhpMyAdmin\\\\FlashMessages\\:\\:addMessage\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controllers/Database/Structure/ReplacePrefixController.php
+
+		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 4
 			path: src/Controllers/Database/StructureController.php
@@ -7471,7 +7476,7 @@ parameters:
 			path: src/FlashMessages.php
 
 		-
-			message: "#^Property PhpMyAdmin\\\\FlashMessages\\:\\:\\$previousMessages \\(array\\<string, array\\<string\\>\\>\\) does not accept mixed\\.$#"
+			message: "#^Property PhpMyAdmin\\\\FlashMessages\\:\\:\\$previousMessages \\(array\\<string, array\\<array\\<string\\>\\>\\>\\) does not accept mixed\\.$#"
 			count: 1
 			path: src/FlashMessages.php
 
@@ -15542,12 +15547,12 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$array of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
-			count: 1
+			count: 2
 			path: tests/unit/FlashMessagesTest.php
 
 		-
 			message: "#^Parameter \\#2 \\$array of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayNotHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
-			count: 1
+			count: 2
 			path: tests/unit/FlashMessagesTest.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1996,7 +1996,7 @@ parameters:
 			path: src/Controllers/Database/Structure/ReplacePrefixController.php
 
 		-
-			message: "#^Parameter \\#3 \\$statement of method PhpMyAdmin\\\\FlashMessages\\:\\:addMessage\\(\\) expects string, mixed given\\.$#"
+			message: "#^Parameter \\#3 \\$statement of method PhpMyAdmin\\\\FlashMessenger\\:\\:addMessage\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/Database/Structure/ReplacePrefixController.php
 
@@ -7468,17 +7468,17 @@ parameters:
 		-
 			message: "#^Cannot access an offset on mixed\\.$#"
 			count: 1
-			path: src/FlashMessages.php
+			path: src/FlashMessenger.php
 
 		-
 			message: "#^Cannot access offset string on mixed\\.$#"
 			count: 2
-			path: src/FlashMessages.php
+			path: src/FlashMessenger.php
 
 		-
-			message: "#^Property PhpMyAdmin\\\\FlashMessages\\:\\:\\$previousMessages \\(array\\<string, array\\<array\\<string\\>\\>\\>\\) does not accept mixed\\.$#"
+			message: "#^Property PhpMyAdmin\\\\FlashMessenger\\:\\:\\$previousMessages \\(array\\<string, array\\<array\\<string\\>\\>\\>\\) does not accept mixed\\.$#"
 			count: 1
-			path: src/FlashMessages.php
+			path: src/FlashMessenger.php
 
 		-
 			message: "#^Cannot access offset 'chars' on mixed\\.$#"
@@ -15548,12 +15548,12 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$array of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
 			count: 2
-			path: tests/unit/FlashMessagesTest.php
+			path: tests/unit/FlashMessengerTest.php
 
 		-
 			message: "#^Parameter \\#2 \\$array of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayNotHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
 			count: 2
-			path: tests/unit/FlashMessagesTest.php
+			path: tests/unit/FlashMessengerTest.php
 
 		-
 			message: "#^Cannot access offset 'queries' on mixed\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7471,12 +7471,12 @@ parameters:
 			path: src/FlashMessenger.php
 
 		-
-			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 2
+			message: "#^Method PhpMyAdmin\\\\FlashMessenger\\:\\:getCurrentMessages\\(\\) should return array\\<int, array\\{context\\: string, message\\: string, statement\\: string\\}\\> but returns mixed\\.$#"
+			count: 1
 			path: src/FlashMessenger.php
 
 		-
-			message: "#^Property PhpMyAdmin\\\\FlashMessenger\\:\\:\\$previousMessages \\(array\\<string, array\\<array\\<string\\>\\>\\>\\) does not accept mixed\\.$#"
+			message: "#^Property PhpMyAdmin\\\\FlashMessenger\\:\\:\\$previousMessages \\(array\\<int, array\\{context\\: string, message\\: string, statement\\: string\\}\\>\\) does not accept mixed\\.$#"
 			count: 1
 			path: src/FlashMessenger.php
 
@@ -15544,16 +15544,6 @@ parameters:
 			message: "#^Property PhpMyAdmin\\\\Config\\:\\:\\$settings \\(array\\{PmaAbsoluteUri\\: string, AuthLog\\: string, AuthLogSuccess\\: bool, PmaNoRelation_DisableWarning\\: bool, SuhosinDisableWarning\\: bool, LoginCookieValidityDisableWarning\\: bool, ReservedWordDisableWarning\\: bool, TranslationWarningThreshold\\: int, \\.\\.\\.\\}\\) does not accept array\\{PmaAbsoluteUri\\: string, AuthLog\\: string, AuthLogSuccess\\: bool, PmaNoRelation_DisableWarning\\: bool, SuhosinDisableWarning\\: bool, LoginCookieValidityDisableWarning\\: bool, ReservedWordDisableWarning\\: bool, TranslationWarningThreshold\\: int, \\.\\.\\.\\}\\.$#"
 			count: 1
 			path: tests/unit/Export/OptionsTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$array of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
-			count: 2
-			path: tests/unit/FlashMessengerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$array of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayNotHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
-			count: 2
-			path: tests/unit/FlashMessengerTest.php
 
 		-
 			message: "#^Cannot access offset 'queries' on mixed\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13646,10 +13646,14 @@
     <MixedArgument>
       <code><![CDATA[$_SESSION[self::STORAGE_KEY]]]></code>
       <code><![CDATA[$_SESSION[self::STORAGE_KEY]]]></code>
+      <code><![CDATA[$_SESSION[self::STORAGE_KEY]]]></code>
+      <code><![CDATA[$_SESSION[self::STORAGE_KEY]]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$_SESSION[self::STORAGE_KEY]['error']]]></code>
       <code><![CDATA[$_SESSION[self::STORAGE_KEY]['error']]]></code>
+      <code><![CDATA[$_SESSION[self::STORAGE_KEY]['success']]]></code>
+      <code><![CDATA[$_SESSION[self::STORAGE_KEY]['success']]]></code>
     </MixedArrayAccess>
   </file>
   <file src="tests/unit/FooterTest.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5944,12 +5944,17 @@
   </file>
   <file src="src/FlashMessenger.php">
     <MixedArrayAssignment>
-      <code><![CDATA[$this->storage[self::STORAGE_KEY][$key]]]></code>
-      <code><![CDATA[$this->storage[self::STORAGE_KEY][$key]]]></code>
+      <code><![CDATA[$this->storage[self::STORAGE_KEY][]]]></code>
     </MixedArrayAssignment>
     <MixedAssignment>
       <code><![CDATA[$this->previousMessages]]></code>
     </MixedAssignment>
+    <MixedInferredReturnType>
+      <code><![CDATA[list<array{context: string, message: string, statement: string}>]]></code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->storage[self::STORAGE_KEY]]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="src/Font.php">
     <MixedArgument>
@@ -13643,18 +13648,6 @@
     <InvalidScalarArgument>
       <code><![CDATA[$_SESSION]]></code>
     </InvalidScalarArgument>
-    <MixedArgument>
-      <code><![CDATA[$_SESSION[self::STORAGE_KEY]]]></code>
-      <code><![CDATA[$_SESSION[self::STORAGE_KEY]]]></code>
-      <code><![CDATA[$_SESSION[self::STORAGE_KEY]]]></code>
-      <code><![CDATA[$_SESSION[self::STORAGE_KEY]]]></code>
-    </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$_SESSION[self::STORAGE_KEY]['error']]]></code>
-      <code><![CDATA[$_SESSION[self::STORAGE_KEY]['error']]]></code>
-      <code><![CDATA[$_SESSION[self::STORAGE_KEY]['success']]]></code>
-      <code><![CDATA[$_SESSION[self::STORAGE_KEY]['success']]]></code>
-    </MixedArrayAccess>
   </file>
   <file src="tests/unit/FooterTest.php">
     <DeprecatedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5950,7 +5950,7 @@
       <code><![CDATA[$this->previousMessages]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code><![CDATA[list<array{context: string, message: string, statement: string}>]]></code>
+      <code><![CDATA[FlashMessageList]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
       <code><![CDATA[$this->storage[self::STORAGE_KEY]]]></code>
@@ -13643,11 +13643,6 @@
     <PossiblyUnusedMethod>
       <code><![CDATA[compressedFiles]]></code>
     </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/FlashMessengerTest.php">
-    <InvalidScalarArgument>
-      <code><![CDATA[$_SESSION]]></code>
-    </InvalidScalarArgument>
   </file>
   <file src="tests/unit/FooterTest.php">
     <DeprecatedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5942,7 +5942,7 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="src/FlashMessages.php">
+  <file src="src/FlashMessenger.php">
     <MixedArrayAssignment>
       <code><![CDATA[$this->storage[self::STORAGE_KEY][$key]]]></code>
       <code><![CDATA[$this->storage[self::STORAGE_KEY][$key]]]></code>
@@ -11657,9 +11657,9 @@
       <code><![CDATA[empty($_POST['item_timing'])]]></code>
     </RiskyTruthyFalsyComparison>
   </file>
-  <file src="src/Twig/FlashMessagesExtension.php">
+  <file src="src/Twig/FlashMessengerExtension.php">
     <InvalidArgument>
-      <code><![CDATA[[FlashMessages::class, 'getMessages']]]></code>
+      <code><![CDATA[[FlashMessenger::class, 'getMessages']]]></code>
     </InvalidArgument>
   </file>
   <file src="src/TwoFactor.php">
@@ -13639,7 +13639,7 @@
       <code><![CDATA[compressedFiles]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="tests/unit/FlashMessagesTest.php">
+  <file src="tests/unit/FlashMessengerTest.php">
     <InvalidScalarArgument>
       <code><![CDATA[$_SESSION]]></code>
     </InvalidScalarArgument>

--- a/resources/templates/components/flash_messages.twig
+++ b/resources/templates/components/flash_messages.twig
@@ -1,0 +1,9 @@
+{% for flash_message in flash_messages() %}
+  {% if flash_message.statement is empty %}
+    <div class="alert alert-{{ flash_message.context }}" role="alert">
+      {{ flash_message.message }}
+    </div>
+  {% else %}
+    {{ statement_message(flash_message.message, flash_message.statement, flash_message.context) }}
+  {% endif %}
+{% endfor %}

--- a/resources/templates/database/structure/change_prefix_form.twig
+++ b/resources/templates/database/structure/change_prefix_form.twig
@@ -1,4 +1,4 @@
-<form id="ajax_form" action="{{ url(route) }}" method="post">
+<form class="disableAjax" id="ajax_form" action="{{ url(route) }}" method="post">
   {{ get_hidden_inputs(url_params) }}
   <div class="mb-3">
     <label for="initialPrefixInput" class="form-label">{{ t('From') }}</label>

--- a/resources/templates/database/structure/index.twig
+++ b/resources/templates/database/structure/index.twig
@@ -1,13 +1,11 @@
-{% for flash_key, flash_messages in flash() %}
-  {% for flash_message in flash_messages %}
-    {% if flash_message.statement is empty %}
-      <div class="alert alert-{{ flash_key }}" role="alert">
-        {{ flash_message.message }}
-      </div>
-    {% else %}
-      {{ statement_message(flash_message.message, flash_message.statement, flash_key) }}
-    {% endif %}
-  {% endfor %}
+{% for flash_message in flash() %}
+  {% if flash_message.statement is empty %}
+    <div class="alert alert-{{ flash_message.context }}" role="alert">
+      {{ flash_message.message }}
+    </div>
+  {% else %}
+    {{ statement_message(flash_message.message, flash_message.statement, flash_message.context) }}
+  {% endif %}
 {% endfor %}
 
 {% if has_tables %}

--- a/resources/templates/database/structure/index.twig
+++ b/resources/templates/database/structure/index.twig
@@ -1,12 +1,4 @@
-{% for flash_message in flash() %}
-  {% if flash_message.statement is empty %}
-    <div class="alert alert-{{ flash_message.context }}" role="alert">
-      {{ flash_message.message }}
-    </div>
-  {% else %}
-    {{ statement_message(flash_message.message, flash_message.statement, flash_message.context) }}
-  {% endif %}
-{% endfor %}
+{{ include('components/flash_messages.twig', with_context = false) }}
 
 {% if has_tables %}
   <div id="tableslistcontainer">

--- a/resources/templates/database/structure/index.twig
+++ b/resources/templates/database/structure/index.twig
@@ -1,8 +1,12 @@
 {% for flash_key, flash_messages in flash() %}
   {% for flash_message in flash_messages %}
-    <div class="alert alert-{{ flash_key }}" role="alert">
-      {{ flash_message }}
-    </div>
+    {% if flash_message.statement is empty %}
+      <div class="alert alert-{{ flash_key }}" role="alert">
+        {{ flash_message.message }}
+      </div>
+    {% else %}
+      {{ statement_message(flash_message.message, flash_message.statement, flash_key) }}
+    {% endif %}
   {% endfor %}
 {% endfor %}
 

--- a/resources/templates/export.twig
+++ b/resources/templates/export.twig
@@ -9,9 +9,13 @@
 
   {% for flash_key, flash_messages in flash() %}
     {% for flash_message in flash_messages %}
-      <div class="alert alert-{{ flash_key }}" role="alert">
-        {{ flash_message }}
-      </div>
+      {% if flash_message.statement is empty %}
+        <div class="alert alert-{{ flash_key }}" role="alert">
+          {{ flash_message.message }}
+        </div>
+      {% else %}
+        {{ statement_message(flash_message.message, flash_message.statement, flash_key) }}
+      {% endif %}
     {% endfor %}
   {% endfor %}
 

--- a/resources/templates/export.twig
+++ b/resources/templates/export.twig
@@ -7,16 +7,14 @@
   {{ page_settings_error_html|raw }}
   {{ page_settings_html|raw }}
 
-  {% for flash_key, flash_messages in flash() %}
-    {% for flash_message in flash_messages %}
-      {% if flash_message.statement is empty %}
-        <div class="alert alert-{{ flash_key }}" role="alert">
-          {{ flash_message.message }}
-        </div>
-      {% else %}
-        {{ statement_message(flash_message.message, flash_message.statement, flash_key) }}
-      {% endif %}
-    {% endfor %}
+  {% for flash_message in flash() %}
+    {% if flash_message.statement is empty %}
+      <div class="alert alert-{{ flash_message.context }}" role="alert">
+        {{ flash_message.message }}
+      </div>
+    {% else %}
+      {{ statement_message(flash_message.message, flash_message.statement, flash_message.context) }}
+    {% endif %}
   {% endfor %}
 
   {% block message %}{% endblock %}

--- a/resources/templates/export.twig
+++ b/resources/templates/export.twig
@@ -7,15 +7,7 @@
   {{ page_settings_error_html|raw }}
   {{ page_settings_html|raw }}
 
-  {% for flash_message in flash() %}
-    {% if flash_message.statement is empty %}
-      <div class="alert alert-{{ flash_message.context }}" role="alert">
-        {{ flash_message.message }}
-      </div>
-    {% else %}
-      {{ statement_message(flash_message.message, flash_message.statement, flash_message.context) }}
-    {% endif %}
-  {% endfor %}
+  {{ include('components/flash_messages.twig', with_context = false) }}
 
   {% block message %}{% endblock %}
 

--- a/resources/templates/table/page_with_secondary_tabs.twig
+++ b/resources/templates/table/page_with_secondary_tabs.twig
@@ -14,16 +14,14 @@
   </ul>
 {% endif %}
 
-{% for flash_key, flash_messages in flash() %}
-  {% for flash_message in flash_messages %}
-    {% if flash_message.statement is empty %}
-      <div class="alert alert-{{ flash_key }}" role="alert">
-        {{ flash_message.message }}
-      </div>
-    {% else %}
-      {{ statement_message(flash_message.message, flash_message.statement, flash_key) }}
-    {% endif %}
-  {% endfor %}
+{% for flash_message in flash() %}
+  {% if flash_message.statement is empty %}
+    <div class="alert alert-{{ flash_message.context }}" role="alert">
+      {{ flash_message.message }}
+    </div>
+  {% else %}
+    {{ statement_message(flash_message.message, flash_message.statement, flash_message.context) }}
+  {% endif %}
 {% endfor %}
 
 <div id="structure_content">

--- a/resources/templates/table/page_with_secondary_tabs.twig
+++ b/resources/templates/table/page_with_secondary_tabs.twig
@@ -14,15 +14,7 @@
   </ul>
 {% endif %}
 
-{% for flash_message in flash() %}
-  {% if flash_message.statement is empty %}
-    <div class="alert alert-{{ flash_message.context }}" role="alert">
-      {{ flash_message.message }}
-    </div>
-  {% else %}
-    {{ statement_message(flash_message.message, flash_message.statement, flash_message.context) }}
-  {% endif %}
-{% endfor %}
+{{ include('components/flash_messages.twig', with_context = false) }}
 
 <div id="structure_content">
   {% block content %}{% endblock %}

--- a/resources/templates/table/page_with_secondary_tabs.twig
+++ b/resources/templates/table/page_with_secondary_tabs.twig
@@ -16,9 +16,13 @@
 
 {% for flash_key, flash_messages in flash() %}
   {% for flash_message in flash_messages %}
-    <div class="alert alert-{{ flash_key }}" role="alert">
-      {{ flash_message }}
-    </div>
+    {% if flash_message.statement is empty %}
+      <div class="alert alert-{{ flash_key }}" role="alert">
+        {{ flash_message.message }}
+      </div>
+    {% else %}
+      {{ statement_message(flash_message.message, flash_message.statement, flash_key) }}
+    {% endif %}
   {% endfor %}
 {% endfor %}
 

--- a/src/Controllers/Database/Structure/EmptyTableController.php
+++ b/src/Controllers/Database/Structure/EmptyTableController.php
@@ -12,7 +12,7 @@ use PhpMyAdmin\Controllers\Database\StructureController;
 use PhpMyAdmin\Controllers\InvocableController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\FlashMessages;
+use PhpMyAdmin\FlashMessenger;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Message;
@@ -34,7 +34,7 @@ final class EmptyTableController implements InvocableController
         private readonly DatabaseInterface $dbi,
         private readonly Relation $relation,
         private readonly RelationCleanup $relationCleanup,
-        private readonly FlashMessages $flash,
+        private readonly FlashMessenger $flashMessenger,
         private readonly StructureController $structureController,
     ) {
     }
@@ -46,7 +46,7 @@ final class EmptyTableController implements InvocableController
         $selected = $request->getParsedBodyParam('selected', []);
 
         if ($multBtn !== __('Yes')) {
-            $this->flash->addMessage('success', __('No change'));
+            $this->flashMessenger->addMessage('success', __('No change'));
             $this->response->redirectToRoute('/database/structure', ['db' => Current::$database]);
 
             return null;

--- a/src/Controllers/Database/Structure/ReplacePrefixController.php
+++ b/src/Controllers/Database/Structure/ReplacePrefixController.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Database\Structure;
 
-use PhpMyAdmin\Controllers\Database\StructureController;
+use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Controllers\InvocableController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\FlashMessages;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Message;
+use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
 
 use function mb_strlen;
@@ -20,11 +23,12 @@ final class ReplacePrefixController implements InvocableController
 {
     public function __construct(
         private readonly DatabaseInterface $dbi,
-        private readonly StructureController $structureController,
+        private readonly ResponseFactory $responseFactory,
+        private readonly FlashMessages $flashMessages,
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string[] $selected */
         $selected = $request->getParsedBodyParam('selected', []);
@@ -53,8 +57,9 @@ final class ReplacePrefixController implements InvocableController
 
         $GLOBALS['message'] = Message::success();
 
-        ($this->structureController)($request);
+        $this->flashMessages->addMessage('success', $GLOBALS['message']->getMessage(), $GLOBALS['sql_query']);
 
-        return null;
+        return $this->responseFactory->createResponse(StatusCodeInterface::STATUS_FOUND)
+            ->withHeader('Location', Url::getFromRoute('/database/structure', ['db' => Current::$database]));
     }
 }

--- a/src/Controllers/Database/Structure/ReplacePrefixController.php
+++ b/src/Controllers/Database/Structure/ReplacePrefixController.php
@@ -8,7 +8,7 @@ use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Controllers\InvocableController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\FlashMessages;
+use PhpMyAdmin\FlashMessenger;
 use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
@@ -24,7 +24,7 @@ final class ReplacePrefixController implements InvocableController
     public function __construct(
         private readonly DatabaseInterface $dbi,
         private readonly ResponseFactory $responseFactory,
-        private readonly FlashMessages $flashMessages,
+        private readonly FlashMessenger $flashMessenger,
     ) {
     }
 
@@ -57,7 +57,7 @@ final class ReplacePrefixController implements InvocableController
 
         $GLOBALS['message'] = Message::success();
 
-        $this->flashMessages->addMessage('success', $GLOBALS['message']->getMessage(), $GLOBALS['sql_query']);
+        $this->flashMessenger->addMessage('success', $GLOBALS['message']->getMessage(), $GLOBALS['sql_query']);
 
         return $this->responseFactory->createResponse(StatusCodeInterface::STATUS_FOUND)
             ->withHeader('Location', Url::getFromRoute('/database/structure', ['db' => Current::$database]));

--- a/src/Controllers/Table/DropColumnController.php
+++ b/src/Controllers/Table/DropColumnController.php
@@ -8,7 +8,7 @@ use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\Controllers\InvocableController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\FlashMessages;
+use PhpMyAdmin\FlashMessenger;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Message;
@@ -24,7 +24,7 @@ final class DropColumnController implements InvocableController
     public function __construct(
         private readonly ResponseRenderer $response,
         private readonly DatabaseInterface $dbi,
-        private readonly FlashMessages $flash,
+        private readonly FlashMessenger $flashMessenger,
         private readonly RelationCleanup $relationCleanup,
     ) {
     }
@@ -72,7 +72,7 @@ final class DropColumnController implements InvocableController
             $message->addParam($selectedCount);
         }
 
-        $this->flash->addMessage($message->isError() ? 'danger' : 'success', $message->getMessage());
+        $this->flashMessenger->addMessage($message->isError() ? 'danger' : 'success', $message->getMessage());
         $this->response->redirectToRoute('/table/structure', ['db' => Current::$database, 'table' => Current::$table]);
 
         return null;

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -12,7 +12,7 @@ use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Encoding;
 use PhpMyAdmin\Exceptions\ExportException;
-use PhpMyAdmin\FlashMessages;
+use PhpMyAdmin\FlashMessenger;
 use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\MessageType;
@@ -1045,7 +1045,7 @@ class Export
      */
     public function getPageLocationAndSaveMessage(string $exportType, Message $message): string
     {
-        (new FlashMessages())->addMessage($message->isError() ? 'danger' : 'success', $message->getMessage());
+        (new FlashMessenger())->addMessage($message->isError() ? 'danger' : 'success', $message->getMessage());
 
         if ($exportType === 'server') {
             return 'index.php?route=/server/export' . Url::getCommonRaw([], '&');

--- a/src/FlashMessages.php
+++ b/src/FlashMessages.php
@@ -15,7 +15,7 @@ final class FlashMessages
     /** @var mixed[] */
     private array $storage;
 
-    /** @var array<string, string[]> */
+    /** @var array<string, string[][]> */
     private array $previousMessages = [];
 
     public function __construct()
@@ -33,22 +33,22 @@ final class FlashMessages
         $this->storage[self::STORAGE_KEY] = [];
     }
 
-    public function addMessage(string $key, string $message): void
+    public function addMessage(string $key, string $message, string $statement = ''): void
     {
         if (! isset($this->storage[self::STORAGE_KEY][$key])) {
             $this->storage[self::STORAGE_KEY][$key] = [];
         }
 
-        $this->storage[self::STORAGE_KEY][$key][] = $message;
+        $this->storage[self::STORAGE_KEY][$key][] = ['message' => $message, 'statement' => $statement];
     }
 
-    /** @return string[]|null */
+    /** @return string[][]|null */
     public function getMessage(string $key): array|null
     {
         return $this->previousMessages[$key] ?? null;
     }
 
-    /** @return array<string, string[]> */
+    /** @return array<string, string[][]> */
     public function getMessages(): array
     {
         return $this->previousMessages;

--- a/src/FlashMessenger.php
+++ b/src/FlashMessenger.php
@@ -8,9 +8,9 @@ use RuntimeException;
 
 use function __;
 
-final class FlashMessages
+final class FlashMessenger
 {
-    private const STORAGE_KEY = 'flashMessages';
+    private const STORAGE_KEY = 'FlashMessenger';
 
     /** @var mixed[] */
     private array $storage;

--- a/src/FlashMessenger.php
+++ b/src/FlashMessenger.php
@@ -15,7 +15,7 @@ final class FlashMessenger
     /** @var mixed[] */
     private array $storage;
 
-    /** @var array<string, string[][]> */
+    /** @psalm-var list<array{context: string, message: string, statement: string}> */
     private array $previousMessages = [];
 
     public function __construct()
@@ -33,24 +33,20 @@ final class FlashMessenger
         $this->storage[self::STORAGE_KEY] = [];
     }
 
-    public function addMessage(string $key, string $message, string $statement = ''): void
+    public function addMessage(string $context, string $message, string $statement = ''): void
     {
-        if (! isset($this->storage[self::STORAGE_KEY][$key])) {
-            $this->storage[self::STORAGE_KEY][$key] = [];
-        }
-
-        $this->storage[self::STORAGE_KEY][$key][] = ['message' => $message, 'statement' => $statement];
+        $this->storage[self::STORAGE_KEY][] = ['context' => $context, 'message' => $message, 'statement' => $statement];
     }
 
-    /** @return string[][]|null */
-    public function getMessage(string $key): array|null
-    {
-        return $this->previousMessages[$key] ?? null;
-    }
-
-    /** @return array<string, string[][]> */
+    /** @psalm-return list<array{context: string, message: string, statement: string}> */
     public function getMessages(): array
     {
         return $this->previousMessages;
+    }
+
+    /** @psalm-return list<array{context: string, message: string, statement: string}> */
+    public function getCurrentMessages(): array
+    {
+        return $this->storage[self::STORAGE_KEY];
     }
 }

--- a/src/FlashMessenger.php
+++ b/src/FlashMessenger.php
@@ -8,18 +8,24 @@ use RuntimeException;
 
 use function __;
 
+/** @psalm-type FlashMessageList = list<array{context: string, message: string, statement: string}> */
 final class FlashMessenger
 {
     private const STORAGE_KEY = 'FlashMessenger';
 
     /** @var mixed[] */
-    private array $storage;
+    private array|null $storage = null;
 
-    /** @psalm-var list<array{context: string, message: string, statement: string}> */
+    /** @psalm-var FlashMessageList */
     private array $previousMessages = [];
 
-    public function __construct()
+    /** @psalm-assert !null $this->storage */
+    private function initSessionStorage(): void
     {
+        if ($this->storage !== null) {
+            return;
+        }
+
         if (! isset($_SESSION)) {
             throw new RuntimeException(__('Session not found.'));
         }
@@ -35,18 +41,24 @@ final class FlashMessenger
 
     public function addMessage(string $context, string $message, string $statement = ''): void
     {
+        $this->initSessionStorage();
+
         $this->storage[self::STORAGE_KEY][] = ['context' => $context, 'message' => $message, 'statement' => $statement];
     }
 
-    /** @psalm-return list<array{context: string, message: string, statement: string}> */
+    /** @psalm-return FlashMessageList */
     public function getMessages(): array
     {
+        $this->initSessionStorage();
+
         return $this->previousMessages;
     }
 
-    /** @psalm-return list<array{context: string, message: string, statement: string}> */
+    /** @psalm-return FlashMessageList */
     public function getCurrentMessages(): array
     {
+        $this->initSessionStorage();
+
         return $this->storage[self::STORAGE_KEY];
     }
 }

--- a/src/Html/Generator.php
+++ b/src/Html/Generator.php
@@ -390,7 +390,6 @@ class Generator
      *
      * @param Message|string $message  the message to display
      * @param string|null    $sqlQuery the query to display
-     * @param MessageType    $type     the type (level) of the message
      *
      * @throws Throwable
      * @throws LoaderError
@@ -400,7 +399,7 @@ class Generator
     public static function getMessage(
         Message|string $message,
         string|null $sqlQuery = null,
-        MessageType $type = MessageType::Notice,
+        MessageType|string $type = MessageType::Notice,
     ): string {
         $retval = '';
 
@@ -423,6 +422,14 @@ class Generator
         }
 
         if (is_string($message)) {
+            if (is_string($type)) {
+                $type = match ($type) {
+                    'success' => MessageType::Success,
+                    'error' => MessageType::Error,
+                    default => MessageType::Notice,
+                };
+            }
+
             $message = new Message($message, $type);
         }
 

--- a/src/Html/Generator.php
+++ b/src/Html/Generator.php
@@ -399,7 +399,7 @@ class Generator
     public static function getMessage(
         Message|string $message,
         string|null $sqlQuery = null,
-        MessageType|string $type = MessageType::Notice,
+        MessageType $type = MessageType::Notice,
     ): string {
         $retval = '';
 
@@ -422,14 +422,6 @@ class Generator
         }
 
         if (is_string($message)) {
-            if (is_string($type)) {
-                $type = match ($type) {
-                    'success' => MessageType::Success,
-                    'error' => MessageType::Error,
-                    default => MessageType::Notice,
-                };
-            }
-
             $message = new Message($message, $type);
         }
 

--- a/src/Template.php
+++ b/src/Template.php
@@ -7,7 +7,7 @@ namespace PhpMyAdmin;
 use PhpMyAdmin\Container\ContainerBuilder;
 use PhpMyAdmin\Twig\AssetExtension;
 use PhpMyAdmin\Twig\CoreExtension;
-use PhpMyAdmin\Twig\FlashMessagesExtension;
+use PhpMyAdmin\Twig\FlashMessengerExtension;
 use PhpMyAdmin\Twig\I18nExtension;
 use PhpMyAdmin\Twig\MessageExtension;
 use PhpMyAdmin\Twig\SanitizeExtension;
@@ -67,7 +67,7 @@ class Template
 
         $twig->addExtension(new AssetExtension());
         $twig->addExtension(new CoreExtension());
-        $twig->addExtension(new FlashMessagesExtension());
+        $twig->addExtension(new FlashMessengerExtension());
         $twig->addExtension(new I18nExtension());
         $twig->addExtension(new MessageExtension());
         $twig->addExtension(new SanitizeExtension());

--- a/src/Twig/FlashMessengerExtension.php
+++ b/src/Twig/FlashMessengerExtension.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Twig;
 
-use PhpMyAdmin\FlashMessages;
+use PhpMyAdmin\FlashMessenger;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
-final class FlashMessagesExtension extends AbstractExtension
+final class FlashMessengerExtension extends AbstractExtension
 {
     /** @return TwigFunction[] */
     public function getFunctions(): array
     {
-        return [new TwigFunction('flash', [FlashMessages::class, 'getMessages'])];
+        return [new TwigFunction('flash', [FlashMessenger::class, 'getMessages'])];
     }
 }

--- a/src/Twig/FlashMessengerExtension.php
+++ b/src/Twig/FlashMessengerExtension.php
@@ -13,6 +13,6 @@ final class FlashMessengerExtension extends AbstractExtension
     /** @return TwigFunction[] */
     public function getFunctions(): array
     {
-        return [new TwigFunction('flash', [FlashMessenger::class, 'getMessages'])];
+        return [new TwigFunction('flash_messages', [FlashMessenger::class, 'getMessages'])];
     }
 }

--- a/src/Twig/MessageExtension.php
+++ b/src/Twig/MessageExtension.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Twig;
 
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Message;
+use PhpMyAdmin\MessageType;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -41,6 +42,20 @@ class MessageExtension extends AbstractExtension
     /** @inheritDoc */
     public function getFunctions(): array
     {
-        return [new TwigFunction('statement_message', Generator::getMessage(...), ['is_safe' => ['html']])];
+        return [
+            new TwigFunction(
+                'statement_message',
+                static function (string $message, string $statement, string $context): string {
+                    $type = match ($context) {
+                        'success' => MessageType::Success,
+                        'error', 'danger' => MessageType::Error,
+                        default => MessageType::Notice,
+                    };
+
+                    return Generator::getMessage($message, $statement, $type);
+                },
+                ['is_safe' => ['html']],
+            ),
+        ];
     }
 }

--- a/src/Twig/MessageExtension.php
+++ b/src/Twig/MessageExtension.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Twig;
 
+use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Message;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 class MessageExtension extends AbstractExtension
 {
@@ -34,5 +36,11 @@ class MessageExtension extends AbstractExtension
                 ['is_safe' => ['html']],
             ),
         ];
+    }
+
+    /** @inheritDoc */
+    public function getFunctions(): array
+    {
+        return [new TwigFunction('statement_message', Generator::getMessage(...), ['is_safe' => ['html']])];
     }
 }

--- a/tests/unit/Controllers/Table/DropColumnControllerTest.php
+++ b/tests/unit/Controllers/Table/DropColumnControllerTest.php
@@ -42,20 +42,17 @@ class DropColumnControllerTest extends AbstractTestCase
         $dummyDbi->addResult('ALTER TABLE `test_table` DROP `name`, DROP `datetimefield`;', true);
         $dbi = $this->createDatabaseInterface($dummyDbi);
 
-        self::assertArrayNotHasKey('FlashMessenger', $_SESSION);
-
+        $flashMessenger = new FlashMessenger();
         (new DropColumnController(
             new ResponseRenderer(),
             $dbi,
-            new FlashMessenger(),
+            $flashMessenger,
             new RelationCleanup($dbi, new Relation($dbi)),
         ))(self::createStub(ServerRequest::class));
 
-        self::assertArrayHasKey('FlashMessenger', $_SESSION);
-        /** @psalm-suppress InvalidArrayOffset */
         self::assertSame(
-            ['success' => [['message' => '2 columns have been dropped successfully.', 'statement' => '']]],
-            $_SESSION['FlashMessenger'],
+            [['context' => 'success', 'message' => '2 columns have been dropped successfully.', 'statement' => '']],
+            $flashMessenger->getCurrentMessages(),
         );
     }
 }

--- a/tests/unit/Controllers/Table/DropColumnControllerTest.php
+++ b/tests/unit/Controllers/Table/DropColumnControllerTest.php
@@ -9,7 +9,7 @@ use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\Controllers\Table\DropColumnController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\FlashMessages;
+use PhpMyAdmin\FlashMessenger;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
@@ -42,20 +42,20 @@ class DropColumnControllerTest extends AbstractTestCase
         $dummyDbi->addResult('ALTER TABLE `test_table` DROP `name`, DROP `datetimefield`;', true);
         $dbi = $this->createDatabaseInterface($dummyDbi);
 
-        self::assertArrayNotHasKey('flashMessages', $_SESSION);
+        self::assertArrayNotHasKey('FlashMessenger', $_SESSION);
 
         (new DropColumnController(
             new ResponseRenderer(),
             $dbi,
-            new FlashMessages(),
+            new FlashMessenger(),
             new RelationCleanup($dbi, new Relation($dbi)),
         ))(self::createStub(ServerRequest::class));
 
-        self::assertArrayHasKey('flashMessages', $_SESSION);
+        self::assertArrayHasKey('FlashMessenger', $_SESSION);
         /** @psalm-suppress InvalidArrayOffset */
         self::assertSame(
             ['success' => [['message' => '2 columns have been dropped successfully.', 'statement' => '']]],
-            $_SESSION['flashMessages'],
+            $_SESSION['FlashMessenger'],
         );
     }
 }

--- a/tests/unit/Controllers/Table/DropColumnControllerTest.php
+++ b/tests/unit/Controllers/Table/DropColumnControllerTest.php
@@ -53,6 +53,9 @@ class DropColumnControllerTest extends AbstractTestCase
 
         self::assertArrayHasKey('flashMessages', $_SESSION);
         /** @psalm-suppress InvalidArrayOffset */
-        self::assertSame(['success' => ['2 columns have been dropped successfully.']], $_SESSION['flashMessages']);
+        self::assertSame(
+            ['success' => [['message' => '2 columns have been dropped successfully.', 'statement' => '']]],
+            $_SESSION['flashMessages'],
+        );
     }
 }

--- a/tests/unit/Export/ExportTest.php
+++ b/tests/unit/Export/ExportTest.php
@@ -242,7 +242,10 @@ SQL;
         $export = new Export($dbi);
         $location = $export->getPageLocationAndSaveMessage('server', Message::error('Error message!'));
         self::assertSame('index.php?route=/server/export&server=2&lang=en', $location);
-        self::assertSame(['danger' => ['Error message!']], (new FlashMessages())->getMessages());
+        self::assertSame(
+            ['danger' => [['message' => 'Error message!', 'statement' => '']]],
+            (new FlashMessages())->getMessages(),
+        );
     }
 
     public function testGetPageLocationAndSaveMessageForServerExportWithSuccess(): void
@@ -254,7 +257,10 @@ SQL;
         $export = new Export($dbi);
         $location = $export->getPageLocationAndSaveMessage('server', Message::success('Success message!'));
         self::assertSame('index.php?route=/server/export&server=2&lang=en', $location);
-        self::assertSame(['success' => ['Success message!']], (new FlashMessages())->getMessages());
+        self::assertSame(
+            ['success' => [['message' => 'Success message!', 'statement' => '']]],
+            (new FlashMessages())->getMessages(),
+        );
     }
 
     public function testGetPageLocationAndSaveMessageForDatabaseExportWithError(): void
@@ -267,7 +273,10 @@ SQL;
         $export = new Export($dbi);
         $location = $export->getPageLocationAndSaveMessage('database', Message::error('Error message!'));
         self::assertSame('index.php?route=/database/export&db=test_db&server=2&lang=en', $location);
-        self::assertSame(['danger' => ['Error message!']], (new FlashMessages())->getMessages());
+        self::assertSame(
+            ['danger' => [['message' => 'Error message!', 'statement' => '']]],
+            (new FlashMessages())->getMessages(),
+        );
     }
 
     public function testGetPageLocationAndSaveMessageForDatabaseExportWithSuccess(): void
@@ -280,7 +289,10 @@ SQL;
         $export = new Export($dbi);
         $location = $export->getPageLocationAndSaveMessage('database', Message::success('Success message!'));
         self::assertSame('index.php?route=/database/export&db=test_db&server=2&lang=en', $location);
-        self::assertSame(['success' => ['Success message!']], (new FlashMessages())->getMessages());
+        self::assertSame(
+            ['success' => [['message' => 'Success message!', 'statement' => '']]],
+            (new FlashMessages())->getMessages(),
+        );
     }
 
     public function testGetPageLocationAndSaveMessageForTableExportWithError(): void
@@ -297,7 +309,10 @@ SQL;
             'index.php?route=/table/export&db=test_db&table=test_table&single_table=true&server=2&lang=en',
             $location,
         );
-        self::assertSame(['danger' => ['Error message!']], (new FlashMessages())->getMessages());
+        self::assertSame(
+            ['danger' => [['message' => 'Error message!', 'statement' => '']]],
+            (new FlashMessages())->getMessages(),
+        );
     }
 
     public function testGetPageLocationAndSaveMessageForTableExportWithSuccess(): void
@@ -314,6 +329,9 @@ SQL;
             'index.php?route=/table/export&db=test_db&table=test_table&single_table=true&server=2&lang=en',
             $location,
         );
-        self::assertSame(['success' => ['Success message!']], (new FlashMessages())->getMessages());
+        self::assertSame(
+            ['success' => [['message' => 'Success message!', 'statement' => '']]],
+            (new FlashMessages())->getMessages(),
+        );
     }
 }

--- a/tests/unit/Export/ExportTest.php
+++ b/tests/unit/Export/ExportTest.php
@@ -243,7 +243,7 @@ SQL;
         $location = $export->getPageLocationAndSaveMessage('server', Message::error('Error message!'));
         self::assertSame('index.php?route=/server/export&server=2&lang=en', $location);
         self::assertSame(
-            ['danger' => [['message' => 'Error message!', 'statement' => '']]],
+            [['context' => 'danger', 'message' => 'Error message!', 'statement' => '']],
             (new FlashMessenger())->getMessages(),
         );
     }
@@ -258,7 +258,7 @@ SQL;
         $location = $export->getPageLocationAndSaveMessage('server', Message::success('Success message!'));
         self::assertSame('index.php?route=/server/export&server=2&lang=en', $location);
         self::assertSame(
-            ['success' => [['message' => 'Success message!', 'statement' => '']]],
+            [['context' => 'success', 'message' => 'Success message!', 'statement' => '']],
             (new FlashMessenger())->getMessages(),
         );
     }
@@ -274,7 +274,7 @@ SQL;
         $location = $export->getPageLocationAndSaveMessage('database', Message::error('Error message!'));
         self::assertSame('index.php?route=/database/export&db=test_db&server=2&lang=en', $location);
         self::assertSame(
-            ['danger' => [['message' => 'Error message!', 'statement' => '']]],
+            [['context' => 'danger', 'message' => 'Error message!', 'statement' => '']],
             (new FlashMessenger())->getMessages(),
         );
     }
@@ -290,7 +290,7 @@ SQL;
         $location = $export->getPageLocationAndSaveMessage('database', Message::success('Success message!'));
         self::assertSame('index.php?route=/database/export&db=test_db&server=2&lang=en', $location);
         self::assertSame(
-            ['success' => [['message' => 'Success message!', 'statement' => '']]],
+            [['context' => 'success', 'message' => 'Success message!', 'statement' => '']],
             (new FlashMessenger())->getMessages(),
         );
     }
@@ -310,7 +310,7 @@ SQL;
             $location,
         );
         self::assertSame(
-            ['danger' => [['message' => 'Error message!', 'statement' => '']]],
+            [['context' => 'danger', 'message' => 'Error message!', 'statement' => '']],
             (new FlashMessenger())->getMessages(),
         );
     }
@@ -330,7 +330,7 @@ SQL;
             $location,
         );
         self::assertSame(
-            ['success' => [['message' => 'Success message!', 'statement' => '']]],
+            [['context' => 'success', 'message' => 'Success message!', 'statement' => '']],
             (new FlashMessenger())->getMessages(),
         );
     }

--- a/tests/unit/Export/ExportTest.php
+++ b/tests/unit/Export/ExportTest.php
@@ -9,7 +9,7 @@ use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Export\Export;
-use PhpMyAdmin\FlashMessages;
+use PhpMyAdmin\FlashMessenger;
 use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Plugins\Export\ExportPhparray;
@@ -244,7 +244,7 @@ SQL;
         self::assertSame('index.php?route=/server/export&server=2&lang=en', $location);
         self::assertSame(
             ['danger' => [['message' => 'Error message!', 'statement' => '']]],
-            (new FlashMessages())->getMessages(),
+            (new FlashMessenger())->getMessages(),
         );
     }
 
@@ -259,7 +259,7 @@ SQL;
         self::assertSame('index.php?route=/server/export&server=2&lang=en', $location);
         self::assertSame(
             ['success' => [['message' => 'Success message!', 'statement' => '']]],
-            (new FlashMessages())->getMessages(),
+            (new FlashMessenger())->getMessages(),
         );
     }
 
@@ -275,7 +275,7 @@ SQL;
         self::assertSame('index.php?route=/database/export&db=test_db&server=2&lang=en', $location);
         self::assertSame(
             ['danger' => [['message' => 'Error message!', 'statement' => '']]],
-            (new FlashMessages())->getMessages(),
+            (new FlashMessenger())->getMessages(),
         );
     }
 
@@ -291,7 +291,7 @@ SQL;
         self::assertSame('index.php?route=/database/export&db=test_db&server=2&lang=en', $location);
         self::assertSame(
             ['success' => [['message' => 'Success message!', 'statement' => '']]],
-            (new FlashMessages())->getMessages(),
+            (new FlashMessenger())->getMessages(),
         );
     }
 
@@ -311,7 +311,7 @@ SQL;
         );
         self::assertSame(
             ['danger' => [['message' => 'Error message!', 'statement' => '']]],
-            (new FlashMessages())->getMessages(),
+            (new FlashMessenger())->getMessages(),
         );
     }
 
@@ -331,7 +331,7 @@ SQL;
         );
         self::assertSame(
             ['success' => [['message' => 'Success message!', 'statement' => '']]],
-            (new FlashMessages())->getMessages(),
+            (new FlashMessenger())->getMessages(),
         );
     }
 }

--- a/tests/unit/FlashMessagesTest.php
+++ b/tests/unit/FlashMessagesTest.php
@@ -36,27 +36,52 @@ class FlashMessagesTest extends AbstractTestCase
         $flash->addMessage('error', 'Error');
         self::assertArrayHasKey('error', $_SESSION[self::STORAGE_KEY]);
         self::assertIsArray($_SESSION[self::STORAGE_KEY]['error']);
-        self::assertSame(['Error'], $_SESSION[self::STORAGE_KEY]['error']);
+        self::assertSame([['message' => 'Error', 'statement' => '']], $_SESSION[self::STORAGE_KEY]['error']);
+    }
+
+    public function testAddMessageWithStatement(): void
+    {
+        $flash = new FlashMessages();
+        self::assertArrayNotHasKey('success', $_SESSION[self::STORAGE_KEY]);
+        $flash->addMessage('success', 'Your SQL query has been executed successfully.', 'SELECT 1;');
+        self::assertArrayHasKey('success', $_SESSION[self::STORAGE_KEY]);
+        self::assertIsArray($_SESSION[self::STORAGE_KEY]['success']);
+        self::assertSame(
+            [['message' => 'Your SQL query has been executed successfully.', 'statement' => 'SELECT 1;']],
+            $_SESSION[self::STORAGE_KEY]['success'],
+        );
     }
 
     public function testGetMessage(): void
     {
-        $_SESSION[self::STORAGE_KEY] = ['warning' => ['Warning']];
+        $_SESSION[self::STORAGE_KEY] = ['warning' => [['message' => 'Warning', 'statement' => '']]];
         $flash = new FlashMessages();
         $message = $flash->getMessage('error');
         self::assertNull($message);
         $message = $flash->getMessage('warning');
-        self::assertSame(['Warning'], $message);
+        self::assertSame([['message' => 'Warning', 'statement' => '']], $message);
     }
 
     public function testGetMessages(): void
     {
-        $_SESSION[self::STORAGE_KEY] = ['error' => ['Error1', 'Error2'], 'warning' => ['Warning']];
+        $_SESSION[self::STORAGE_KEY] = [
+            'error' => [
+                ['message' => 'Error1', 'statement' => ''],
+                ['message' => 'Error2', 'statement' => ''],
+            ],
+            'warning' => [['message' => 'Warning', 'statement' => '']],
+        ];
         $flash = new FlashMessages();
         $flash->addMessage('notice', 'Notice');
         $messages = $flash->getMessages();
         self::assertSame(
-            ['error' => ['Error1', 'Error2'], 'warning' => ['Warning']],
+            [
+                'error' => [
+                    ['message' => 'Error1', 'statement' => ''],
+                    ['message' => 'Error2', 'statement' => ''],
+                ],
+                'warning' => [['message' => 'Warning', 'statement' => '']],
+            ],
             $messages,
         );
     }

--- a/tests/unit/FlashMessengerTest.php
+++ b/tests/unit/FlashMessengerTest.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests;
 
-use PhpMyAdmin\FlashMessages;
+use PhpMyAdmin\FlashMessenger;
 use PHPUnit\Framework\Attributes\CoversClass;
 use RuntimeException;
 
-#[CoversClass(FlashMessages::class)]
-class FlashMessagesTest extends AbstractTestCase
+#[CoversClass(FlashMessenger::class)]
+final class FlashMessengerTest extends AbstractTestCase
 {
-    private const STORAGE_KEY = 'flashMessages';
+    private const STORAGE_KEY = 'FlashMessenger';
 
     public function testConstructor(): void
     {
         self::assertArrayNotHasKey(self::STORAGE_KEY, $_SESSION);
-        $flash = new FlashMessages();
+        $flashMessenger = new FlashMessenger();
         self::assertIsArray($_SESSION[self::STORAGE_KEY]);
-        self::assertSame([], $flash->getMessages());
+        self::assertSame([], $flashMessenger->getMessages());
     }
 
     public function testConstructorSessionNotFound(): void
@@ -26,14 +26,14 @@ class FlashMessagesTest extends AbstractTestCase
         $_SESSION = null;
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Session not found.');
-        new FlashMessages();
+        new FlashMessenger();
     }
 
     public function testAddMessage(): void
     {
-        $flash = new FlashMessages();
+        $flashMessenger = new FlashMessenger();
         self::assertArrayNotHasKey('error', $_SESSION[self::STORAGE_KEY]);
-        $flash->addMessage('error', 'Error');
+        $flashMessenger->addMessage('error', 'Error');
         self::assertArrayHasKey('error', $_SESSION[self::STORAGE_KEY]);
         self::assertIsArray($_SESSION[self::STORAGE_KEY]['error']);
         self::assertSame([['message' => 'Error', 'statement' => '']], $_SESSION[self::STORAGE_KEY]['error']);
@@ -41,9 +41,9 @@ class FlashMessagesTest extends AbstractTestCase
 
     public function testAddMessageWithStatement(): void
     {
-        $flash = new FlashMessages();
+        $flashMessenger = new FlashMessenger();
         self::assertArrayNotHasKey('success', $_SESSION[self::STORAGE_KEY]);
-        $flash->addMessage('success', 'Your SQL query has been executed successfully.', 'SELECT 1;');
+        $flashMessenger->addMessage('success', 'Your SQL query has been executed successfully.', 'SELECT 1;');
         self::assertArrayHasKey('success', $_SESSION[self::STORAGE_KEY]);
         self::assertIsArray($_SESSION[self::STORAGE_KEY]['success']);
         self::assertSame(
@@ -55,10 +55,10 @@ class FlashMessagesTest extends AbstractTestCase
     public function testGetMessage(): void
     {
         $_SESSION[self::STORAGE_KEY] = ['warning' => [['message' => 'Warning', 'statement' => '']]];
-        $flash = new FlashMessages();
-        $message = $flash->getMessage('error');
+        $flashMessenger = new FlashMessenger();
+        $message = $flashMessenger->getMessage('error');
         self::assertNull($message);
-        $message = $flash->getMessage('warning');
+        $message = $flashMessenger->getMessage('warning');
         self::assertSame([['message' => 'Warning', 'statement' => '']], $message);
     }
 
@@ -71,9 +71,9 @@ class FlashMessagesTest extends AbstractTestCase
             ],
             'warning' => [['message' => 'Warning', 'statement' => '']],
         ];
-        $flash = new FlashMessages();
-        $flash->addMessage('notice', 'Notice');
-        $messages = $flash->getMessages();
+        $flashMessenger = new FlashMessenger();
+        $flashMessenger->addMessage('notice', 'Notice');
+        $messages = $flashMessenger->getMessages();
         self::assertSame(
             [
                 'error' => [

--- a/tests/unit/FlashMessengerTest.php
+++ b/tests/unit/FlashMessengerTest.php
@@ -13,28 +13,21 @@ final class FlashMessengerTest extends AbstractTestCase
 {
     private const STORAGE_KEY = 'FlashMessenger';
 
-    public function testConstructor(): void
-    {
-        self::assertArrayNotHasKey(self::STORAGE_KEY, $_SESSION);
-        $flashMessenger = new FlashMessenger();
-        self::assertIsArray($_SESSION[self::STORAGE_KEY]);
-        self::assertSame([], $flashMessenger->getMessages());
-    }
-
-    public function testConstructorSessionNotFound(): void
+    public function testSessionNotFoundException(): void
     {
         $_SESSION = null;
+        $flashMessenger = new FlashMessenger();
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Session not found.');
-        new FlashMessenger();
+        $flashMessenger->getCurrentMessages();
     }
 
     public function testAddMessage(): void
     {
+        unset($_SESSION[self::STORAGE_KEY]);
         $flashMessenger = new FlashMessenger();
-        self::assertSame([], $_SESSION[self::STORAGE_KEY]);
+        self::assertArrayNotHasKey(self::STORAGE_KEY, $_SESSION);
         $flashMessenger->addMessage('error', 'Error');
-        /** @psalm-suppress DocblockTypeContradiction addMessage() mutates $_SESSION[self::STORAGE_KEY] */
         self::assertSame(
             [['context' => 'error', 'message' => 'Error', 'statement' => '']],
             $_SESSION[self::STORAGE_KEY],
@@ -43,10 +36,10 @@ final class FlashMessengerTest extends AbstractTestCase
 
     public function testAddMessageWithStatement(): void
     {
+        unset($_SESSION[self::STORAGE_KEY]);
         $flashMessenger = new FlashMessenger();
-        self::assertSame([], $_SESSION[self::STORAGE_KEY]);
+        self::assertArrayNotHasKey(self::STORAGE_KEY, $_SESSION);
         $flashMessenger->addMessage('success', 'Success!', 'SELECT 1;');
-        /** @psalm-suppress DocblockTypeContradiction addMessage() mutates $_SESSION[self::STORAGE_KEY] */
         self::assertSame(
             [['context' => 'success', 'message' => 'Success!', 'statement' => 'SELECT 1;']],
             $_SESSION[self::STORAGE_KEY],
@@ -55,7 +48,7 @@ final class FlashMessengerTest extends AbstractTestCase
 
     public function testGetMessages(): void
     {
-        $_SESSION[self::STORAGE_KEY] = [];
+        unset($_SESSION[self::STORAGE_KEY]);
         $flashMessengerOne = new FlashMessenger();
         self::assertSame([], $flashMessengerOne->getCurrentMessages());
         $flashMessengerOne->addMessage('error', 'Error1');


### PR DESCRIPTION
Besides standard feedback messages, is also common to have a feedback message with the executed statement after an action is executed. This allows to use HTTP redirection in those cases.