### PR TITLE
Fix `Query Generator` column alias with asterisk

### DIFF
--- a/js/src/database/multi_table_query.js
+++ b/js/src/database/multi_table_query.js
@@ -22,6 +22,9 @@ AJAX.registerTeardown('database/multi_table_query.js', function () {
     $('.tableNameSelect').each(function () {
         $(this).off('change');
     });
+    $('.columnNameSelect').each(function () {
+        $(this).off('change');
+    });
     $('#update_query_button').off('click');
     $('#add_column_button').off('click');
 });
@@ -162,14 +165,27 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
         addNewColumnCallbacks();
     });
 
+    $('.columnNameSelect').each(function () {
+        $(this).on('change', function () {
+            const colIsStar = $(this).val() === '*';
+
+            colIsStar && $(this).siblings('.col_alias').val('');
+            $(this).siblings('.col_alias').prop('disabled', colIsStar);
+        });
+    });
+
     function addNewColumnCallbacks () {
         $('.tableNameSelect').each(function () {
             $(this).on('change', function () {
                 var $sibs = $(this).siblings('.columnNameSelect');
+                const $alias = $(this).siblings('.col_alias');
+
                 if ($sibs.length === 0) {
                     $sibs = $(this).parent().parent().find('.columnNameSelect');
                 }
+
                 $sibs.first().html($('#' + $(this).find(':selected').data('hash')).html());
+                $alias.prop('disabled', true);
             });
         });
 


### PR DESCRIPTION
## Before
We can't use `*`  for column with alias. This generates a non-valid query.

![Screenshot from 2024-05-20 17-32-41](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/79097550-17f1-4c7f-b832-a240e3410411)

To fix this I disable the `column alias` input when `*` selected.

## After

[Screencast from 20-05-24 17:37:44.webm](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/ff73811a-cb66-41f1-8151-7e8b9f9c9838)

### Server configuration

- phpMyAdmin version: 5.2.2-dev, 6.0.0-dev
