### PR TITLE
Change InvocableController to always return a Response object

### DIFF
--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -1165,10 +1165,7 @@ return [
         ],
         Table\Structure\AddKeyController::class => [
             'class' => Table\Structure\AddKeyController::class,
-            'arguments' => [
-                '$sqlController' => '@' . Sql\SqlController::class,
-                '$structureController' => '@' . Table\StructureController::class,
-            ],
+            'arguments' => ['@response', '@' . Table\StructureController::class, '@table_indexes'],
         ],
         Table\Structure\BrowseController::class => [
             'class' => Table\Structure\BrowseController::class,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4881,11 +4881,6 @@ parameters:
 			path: src/Controllers/Table/SqlController.php
 
 		-
-			message: "#^Parameter \\#3 \\$selectedColumns of static method PhpMyAdmin\\\\Query\\\\Generator\\:\\:getAddIndexSql\\(\\) expects array\\<string\\>, array given\\.$#"
-			count: 1
-			path: src/Controllers/Table/Structure/AbstractIndexController.php
-
-		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/Controllers/Table/Structure/BrowseController.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -808,7 +808,7 @@
   </file>
   <file src="src/Controllers/BrowseForeignersController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/CheckRelationsController.php">
@@ -816,17 +816,17 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/CollationConnectionController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/ColumnController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Console/Bookmark/AddController.php">
@@ -835,12 +835,12 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Console/Bookmark/RefreshController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Database/CentralColumns/PopulateColumnsController.php">
@@ -972,7 +972,7 @@
       <code><![CDATA[$page]]></code>
     </PossiblyNullArgument>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Database/EventsController.php">
@@ -1006,7 +1006,7 @@
       <code><![CDATA[isSuccess]]></code>
     </PossiblyNullReference>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($_GET['export_item'])]]></code>
@@ -1100,7 +1100,7 @@
   </file>
   <file src="src/Controllers/Database/MultiTableQuery/TablesController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Database/MultiTableQueryController.php">
@@ -1113,7 +1113,7 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Database/RoutinesController.php">
@@ -1212,7 +1212,7 @@
       <code><![CDATA[isSuccess]]></code>
     </PossiblyNullReference>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RedundantCondition>
       <code><![CDATA[! $GLOBALS['errors']]]></code>
@@ -1440,7 +1440,7 @@
       <code><![CDATA[$rowCount]]></code>
     </PossiblyNullArgument>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Database/Structure/ReplacePrefixController.php">
@@ -1587,7 +1587,7 @@
   </file>
   <file src="src/Controllers/DatabaseController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/ErrorReportController.php">
@@ -1857,7 +1857,7 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Export/Template/DeleteController.php">
@@ -1865,7 +1865,7 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Export/Template/LoadController.php">
@@ -1873,7 +1873,7 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Export/Template/UpdateController.php">
@@ -1881,7 +1881,7 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/GitInfoController.php">
@@ -1971,11 +1971,14 @@
       <code><![CDATA[$bookmarkVariables]]></code>
       <code><![CDATA[$consoleMessageId]]></code>
     </MixedAssignment>
+    <MixedInferredReturnType>
+      <code><![CDATA[Response]]></code>
+    </MixedInferredReturnType>
     <PossiblyInvalidPropertyAssignmentValue>
       <code><![CDATA[$memoryLimit / 8]]></code>
     </PossiblyInvalidPropertyAssignmentValue>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <PropertyTypeCoercion>
       <code><![CDATA[(string) $request->getParsedBodyParam('import_type')]]></code>
@@ -2020,12 +2023,12 @@
   </file>
   <file src="src/Controllers/LogoutController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Navigation/UpdateNavWidthConfigController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/NavigationController.php">
@@ -2044,17 +2047,17 @@
       <code><![CDATA[$itemType]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/AddNewPrimaryController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/CreateNewColumnController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/FirstNormalForm/FirstStepController.php">
@@ -2062,32 +2065,32 @@
       <code><![CDATA[$normalizeTo]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/FirstNormalForm/FourthStepController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/FirstNormalForm/SecondStepController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/FirstNormalForm/ThirdStepController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/GetColumnsController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/MainController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/MoveRepeatingGroup.php">
@@ -2104,12 +2107,12 @@
       <code><![CDATA[$repeatingColumns]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/PartialDependenciesController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/SecondNormalForm/CreateNewTablesController.php">
@@ -2124,12 +2127,12 @@
       <code><![CDATA[$tablesName]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/SecondNormalForm/FirstStepController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/SecondNormalForm/NewTablesController.php">
@@ -2141,7 +2144,7 @@
       <code><![CDATA[$partialDependencies]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/ThirdNormalForm/CreateNewTablesController.php">
@@ -2153,7 +2156,7 @@
       <code><![CDATA[$newtables]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/ThirdNormalForm/FirstStepController.php">
@@ -2164,7 +2167,7 @@
       <code><![CDATA[$tables]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Normalization/ThirdNormalForm/NewTablesController.php">
@@ -2179,7 +2182,7 @@
       <code><![CDATA[$tables]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Operations/Database/CollationController.php">
@@ -2258,7 +2261,7 @@
       <code><![CDATA[$GLOBALS['message_to_show']]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($GLOBALS['message_to_show'])]]></code>
@@ -2487,7 +2490,7 @@
       <code><![CDATA[$urlParams['log']]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/CollationsController.php">
@@ -2495,7 +2498,7 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Databases/CreateController.php">
@@ -2506,7 +2509,7 @@
       <code><![CDATA[$dbCollation]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Databases/DestroyController.php">
@@ -2526,7 +2529,7 @@
       <code><![CDATA[$database]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/DatabasesController.php">
@@ -2579,12 +2582,12 @@
       <code><![CDATA[$key]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/EnginesController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/ExportController.php">
@@ -2639,17 +2642,17 @@
   </file>
   <file src="src/Controllers/Server/PluginsController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Privileges/AccountLockController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Privileges/AccountUnlockController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/PrivilegesController.php">
@@ -2681,7 +2684,7 @@
       <code><![CDATA[$GLOBALS['sql_query']]]></code>
     </PossiblyInvalidArgument>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RedundantConditionGivenDocblockType>
       <code><![CDATA[! empty($GLOBALS['message']) && $GLOBALS['message'] instanceof Message]]></code>
@@ -2714,7 +2717,7 @@
   </file>
   <file src="src/Controllers/Server/ShowEngineController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/SqlController.php">
@@ -2730,7 +2733,7 @@
   </file>
   <file src="src/Controllers/Server/Status/AdvisorController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Status/Monitor/ChartingDataController.php">
@@ -2756,7 +2759,7 @@
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Status/Monitor/LogVarsController.php">
@@ -2771,7 +2774,7 @@
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Status/Monitor/QueryAnalyzerController.php">
@@ -2786,7 +2789,7 @@
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Status/Monitor/SlowLogController.php">
@@ -2797,12 +2800,12 @@
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Status/MonitorController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Status/Processes/KillController.php">
@@ -2812,12 +2815,12 @@
   </file>
   <file src="src/Controllers/Server/Status/Processes/RefreshController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Status/ProcessesController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Status/QueriesController.php">
@@ -2846,7 +2849,7 @@
       <code><![CDATA[str_replace(['Com_', '_'], ['', ' '], $key)]]></code>
     </PossiblyInvalidCast>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Status/StatusController.php">
@@ -2891,7 +2894,7 @@
       <code><![CDATA[$this->data->status['Uptime']]]></code>
     </MixedOperand>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Status/VariablesController.php">
@@ -2924,7 +2927,7 @@
       <code><![CDATA[$this->data->variables['thread_cache_size']]]></code>
     </MixedOperand>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <UnusedForeachValue>
       <code><![CDATA[$linkUrl]]></code>
@@ -2981,7 +2984,7 @@
       <code><![CDATA[$filterValue]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Setup/HomeController.php">
@@ -3028,7 +3031,7 @@
       <code><![CDATA[$currValue]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Sql/RelationalValuesController.php">
@@ -3057,7 +3060,7 @@
       <code><![CDATA[$whereClause]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Sql/SqlController.php">
@@ -3146,7 +3149,7 @@
       <code><![CDATA[$mimetype]]></code>
     </PossiblyInvalidCast>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/ChangeController.php">
@@ -3206,7 +3209,7 @@
       <code><![CDATA[$rowsToDelete]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/ChartController.php">
@@ -3238,7 +3241,7 @@
       <code><![CDATA[$statement->limit->rowCount]]></code>
     </PossiblyInvalidOperand>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/CreateController.php">
@@ -3276,7 +3279,7 @@
       <code><![CDATA[$mimetype]]></code>
     </PossiblyInvalidCast>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/DeleteConfirmController.php">
@@ -3290,7 +3293,7 @@
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/DeleteRowsController.php">
@@ -3320,7 +3323,7 @@
       <code><![CDATA[$selected]]></code>
     </PossiblyInvalidIterator>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($_REQUEST['pos'])]]></code>
@@ -3328,7 +3331,7 @@
   </file>
   <file src="src/Controllers/Table/DropColumnConfirmationController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/DropColumnController.php">
@@ -3350,7 +3353,7 @@
       <code><![CDATA[$selected]]></code>
     </PossiblyInvalidIterator>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$message->isError()]]></code>
@@ -3398,7 +3401,7 @@
       <code><![CDATA[$GLOBALS['where_clause']]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/FindReplaceController.php">
@@ -3440,7 +3443,7 @@
       <code><![CDATA[$row]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/GisVisualizationController.php">
@@ -3487,7 +3490,7 @@
       <code><![CDATA[$_SESSION[$GLOBALS['SESSION_KEY']]]]></code>
     </PossiblyInvalidArrayOffset>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/IndexRenameController.php">
@@ -3508,7 +3511,7 @@
       <code><![CDATA[$oldIndexName]]></code>
     </MixedAssignment>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/IndexesController.php">
@@ -3544,7 +3547,7 @@
   </file>
   <file src="src/Controllers/Table/Maintenance/AnalyzeController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$this->config->get('DisableMultiTableMaintenance')]]></code>
@@ -3552,7 +3555,7 @@
   </file>
   <file src="src/Controllers/Table/Maintenance/CheckController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$this->config->get('DisableMultiTableMaintenance')]]></code>
@@ -3560,7 +3563,7 @@
   </file>
   <file src="src/Controllers/Table/Maintenance/ChecksumController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$this->config->get('DisableMultiTableMaintenance')]]></code>
@@ -3568,7 +3571,7 @@
   </file>
   <file src="src/Controllers/Table/Maintenance/OptimizeController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$this->config->get('DisableMultiTableMaintenance')]]></code>
@@ -3576,7 +3579,7 @@
   </file>
   <file src="src/Controllers/Table/Maintenance/RepairController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$this->config->get('DisableMultiTableMaintenance')]]></code>
@@ -3587,7 +3590,7 @@
       <code><![CDATA[$query]]></code>
     </MixedArgument>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/Partition/CheckController.php">
@@ -3595,7 +3598,7 @@
       <code><![CDATA[$query]]></code>
     </MixedArgument>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/Partition/DropController.php">
@@ -3604,7 +3607,7 @@
       <code><![CDATA[$query]]></code>
     </MixedArgument>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/Partition/OptimizeController.php">
@@ -3612,12 +3615,12 @@
       <code><![CDATA[$query]]></code>
     </MixedArgument>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/Partition/RebuildController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/Partition/RepairController.php">
@@ -3625,12 +3628,12 @@
       <code><![CDATA[$query]]></code>
     </MixedArgument>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/Partition/TruncateController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/PrivilegesController.php">
@@ -3638,12 +3641,12 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/RecentFavoriteController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/RelationController.php">
@@ -3787,7 +3790,7 @@
       <code><![CDATA[$extraData]]></code>
     </PossiblyUndefinedVariable>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($GLOBALS['query'])]]></code>
@@ -3816,7 +3819,7 @@
       <code><![CDATA[$_POST['column']]]></code>
     </PossiblyInvalidCast>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(int) $config->settings['MaxRows']]]></code>
@@ -4029,7 +4032,7 @@
       <code><![CDATA[$_POST['field_virtuality'][$i]]]></code>
     </PossiblyInvalidOperand>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($_POST['field_adjust_privileges'][$i])]]></code>
@@ -4038,12 +4041,12 @@
   </file>
   <file src="src/Controllers/Table/Structure/SpatialController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/Structure/UniqueController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/StructureController.php">
@@ -4153,7 +4156,7 @@
       <code><![CDATA[$_POST['where_clause']]]></code>
     </PossiblyInvalidOperand>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(int) $config->settings['maxRowPlotLimit']]]></code>
@@ -4180,7 +4183,7 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/ThemesController.php">
@@ -4190,7 +4193,7 @@
   </file>
   <file src="src/Controllers/Transformation/OverviewController.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Transformation/WrapperController.php">
@@ -4235,7 +4238,7 @@
       <code><![CDATA[isSuccess]]></code>
     </PossiblyNullReference>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
+      <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($_POST['editor_process_add'])]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1059,9 +1059,6 @@
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($GLOBALS['table_select'])]]></code>
     </RiskyTruthyFalsyComparison>
@@ -1291,9 +1288,6 @@
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Database/SqlFormatController.php">
     <PossiblyUnusedMethod>
@@ -1565,9 +1559,6 @@
       <code><![CDATA[$currentTable['TABLE_NAME']]]></code>
       <code><![CDATA[$currentTable['TABLE_ROWS']]]></code>
     </MixedOperand>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$checkTime]]></code>
       <code><![CDATA[$createTime]]></code>
@@ -3113,9 +3104,6 @@
     <MixedOperand>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
     </MixedOperand>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($GLOBALS['back'])]]></code>
       <code><![CDATA[empty($GLOBALS['goto'])]]></code>
@@ -3201,9 +3189,6 @@
     <PossiblyNullArgument>
       <code><![CDATA[$isUpload]]></code>
     </PossiblyNullArgument>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$currentRow]]></code>
       <code><![CDATA[empty($GLOBALS['disp_message'])]]></code>
@@ -3398,9 +3383,6 @@
     <PossiblyNullArgument>
       <code><![CDATA[$parser->list]]></code>
     </PossiblyNullArgument>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($GLOBALS['sql_query'])]]></code>
       <code><![CDATA[empty($GLOBALS['where_clause'])]]></code>
@@ -3861,9 +3843,6 @@
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
       <code><![CDATA[$delimiter]]></code>
     </MixedAssignment>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/Structure/BrowseController.php">
     <MixedArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3865,16 +3865,6 @@
       <code><![CDATA[Response|null]]></code>
     </PossiblyUnusedReturnValue>
   </file>
-  <file src="src/Controllers/Table/Structure/AbstractIndexController.php">
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$selected]]></code>
-    </MixedArgumentTypeCoercion>
-  </file>
-  <file src="src/Controllers/Table/Structure/AddKeyController.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[__construct]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="src/Controllers/Table/Structure/BrowseController.php">
     <MixedArgument>
       <code><![CDATA[$sval]]></code>
@@ -4114,9 +4104,6 @@
     <PossiblyNullOperand>
       <code><![CDATA[$showTable['Rows']]]></code>
     </PossiblyNullOperand>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response|null]]></code>
-    </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($showTable['Data_length'])]]></code>
       <code><![CDATA[empty($showTable['Index_length'])]]></code>

--- a/resources/templates/table/structure/display_structure.twig
+++ b/resources/templates/table/structure/display_structure.twig
@@ -136,11 +136,9 @@
                           {% if type == 'text' or type == 'blob' or tbl_storage_engine == 'ARCHIVE' or (primary and primary.hasColumn(field_name)) %}
                             <span class="{{ hide_structure_actions ? 'dropdown-item-text' : 'nav-link px-1' }} disabled">{{ get_icon('bd_primary', t('Primary')) }}</span>
                           {% else %}
-                            <a rel="samepage" class="{{ hide_structure_actions ? 'dropdown-item' : 'nav-link px-1' }} ajax add_key d-print-none add_primary_key_anchor" href="{{ url('/table/structure/add-key') }}" data-post="{{ get_common({
-                              'db': db,
-                              'table': table,
-                              'sql_query': 'ALTER TABLE ' ~ backquote(table) ~ (primary ? ' DROP PRIMARY KEY,') ~ ' ADD PRIMARY KEY(' ~ backquote(row.field) ~ ');',
-                              'message_to_show': t('A primary key has been added on %s.')|format(row.field|e)
+                            <a rel="samepage" class="{{ hide_structure_actions ? 'dropdown-item' : 'nav-link px-1' }} ajax add_key d-print-none add_primary_key_anchor" href="{{ url('/table/structure/add-key', {'db': db, 'table': table}) }}" data-post="{{ get_common({
+                              'selected_fld': [row.field],
+                              'key_type': 'PRIMARY',
                             }, '', false) }}">
                               {{ get_icon('b_primary', t('Primary')) }}
                             </a>
@@ -151,11 +149,9 @@
                           {% if type == 'text' or type == 'blob' or tbl_storage_engine == 'ARCHIVE' %}
                             <span class="{{ hide_structure_actions ? 'dropdown-item-text' : 'nav-link px-1' }} disabled">{{ get_icon('bd_unique', t('Unique')) }}</span>
                           {% else %}
-                            <a rel="samepage" class="{{ hide_structure_actions ? 'dropdown-item' : 'nav-link px-1' }} ajax add_key d-print-none add_unique_anchor" href="{{ url('/table/structure/add-key') }}" data-post="{{ get_common({
-                              'db': db,
-                              'table': table,
-                              'sql_query': 'ALTER TABLE ' ~ backquote(table) ~ ' ADD UNIQUE(' ~ backquote(row.field) ~ ');',
-                              'message_to_show': t('An index has been added on %s.')|format(row.field|e)
+                            <a rel="samepage" class="{{ hide_structure_actions ? 'dropdown-item' : 'nav-link px-1' }} ajax add_key d-print-none add_unique_anchor" href="{{ url('/table/structure/add-key', {'db': db, 'table': table}) }}" data-post="{{ get_common({
+                              'selected_fld': [row.field],
+                              'key_type': 'UNIQUE',
                             }, '', false) }}">
                               {{ get_icon('b_unique', t('Unique')) }}
                             </a>
@@ -166,11 +162,9 @@
                           {% if type == 'text' or type == 'blob' or tbl_storage_engine == 'ARCHIVE' %}
                             <span class="{{ hide_structure_actions ? 'dropdown-item-text' : 'nav-link px-1' }} disabled">{{ get_icon('bd_index', t('Index')) }}</span>
                           {% else %}
-                            <a rel="samepage" class="{{ hide_structure_actions ? 'dropdown-item' : 'nav-link px-1' }} ajax add_key d-print-none add_index_anchor" href="{{ url('/table/structure/add-key') }}" data-post="{{ get_common({
-                              'db': db,
-                              'table': table,
-                              'sql_query': 'ALTER TABLE ' ~ backquote(table) ~ ' ADD INDEX(' ~ backquote(row.field) ~ ');',
-                              'message_to_show': t('An index has been added on %s.')|format(row.field|e)
+                            <a rel="samepage" class="{{ hide_structure_actions ? 'dropdown-item' : 'nav-link px-1' }} ajax add_key d-print-none add_index_anchor" href="{{ url('/table/structure/add-key', {'db': db, 'table': table}) }}" data-post="{{ get_common({
+                              'selected_fld': [row.field],
+                              'key_type': 'INDEX',
                             }, '', false) }}">
                               {{ get_icon('b_index', t('Index')) }}
                             </a>
@@ -191,11 +185,9 @@
                           {% if type == 'text' or type == 'blob' or tbl_storage_engine == 'ARCHIVE' or (type not in spatial_types and (tbl_storage_engine == 'MYISAM' or mysql_int_version >= 50705)) %}
                             <span class="{{ hide_structure_actions ? 'dropdown-item-text' : 'nav-link px-1' }} disabled">{{ get_icon('bd_spatial', t('Spatial')) }}</span>
                           {% else %}
-                            <a rel="samepage" class="{{ hide_structure_actions ? 'dropdown-item' : 'nav-link px-1' }} ajax add_key d-print-none add_spatial_anchor" href="{{ url('/table/structure/add-key') }}" data-post="{{ get_common({
-                              'db': db,
-                              'table': table,
-                              'sql_query': 'ALTER TABLE ' ~ backquote(table) ~ ' ADD SPATIAL(' ~ backquote(row.field) ~ ');',
-                              'message_to_show': t('An index has been added on %s.')|format(row.field|e)
+                            <a rel="samepage" class="{{ hide_structure_actions ? 'dropdown-item' : 'nav-link px-1' }} ajax add_key d-print-none add_spatial_anchor" href="{{ url('/table/structure/add-key', {'db': db, 'table': table}) }}" data-post="{{ get_common({
+                              'selected_fld': [row.field],
+                              'key_type': 'SPATIAL',
                             }, '', false) }}">
                               {{ get_icon('b_spatial', t('Spatial')) }}
                             </a>
@@ -210,11 +202,9 @@
                                 or tbl_storage_engine == 'MARIA'
                                 or (tbl_storage_engine == 'INNODB' and mysql_int_version >= 50604)
                             ) and ('text' in type or 'char' in type) %}
-                            <a rel="samepage" class="{{ hide_structure_actions ? 'dropdown-item' : 'nav-link px-1' }} ajax add_key add_fulltext_anchor" href="{{ url('/table/structure/add-key') }}" data-post="{{ get_common({
-                              'db': db,
-                              'table': table,
-                              'sql_query': 'ALTER TABLE ' ~ backquote(table) ~ ' ADD FULLTEXT(' ~ backquote(row.field) ~ ');',
-                              'message_to_show': t('An index has been added on %s.')|format(row.field|e)
+                            <a rel="samepage" class="{{ hide_structure_actions ? 'dropdown-item' : 'nav-link px-1' }} ajax add_key add_fulltext_anchor" href="{{ url('/table/structure/add-key', {'db': db, 'table': table}) }}" data-post="{{ get_common({
+                              'selected_fld': [row.field],
+                              'key_type': 'FULLTEXT',
                             }, '', false) }}">
                               {{ get_icon('b_ftext', t('Fulltext')) }}
                             </a>

--- a/src/Application.php
+++ b/src/Application.php
@@ -136,7 +136,7 @@ class Application
         $runner->run();
     }
 
-    public function handle(ServerRequest $request): Response|null
+    public function handle(ServerRequest $request): Response
     {
         return Routing::callControllerForRoute(
             $request,

--- a/src/Controllers/BrowseForeignersController.php
+++ b/src/Controllers/BrowseForeignersController.php
@@ -22,7 +22,7 @@ final class BrowseForeignersController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string|null $database */
         $database = $request->getParsedBodyParam('db');
@@ -40,7 +40,7 @@ final class BrowseForeignersController implements InvocableController
         $foreignFilter = $request->getParsedBodyParam('foreign_filter', '');
 
         if (! isset($database, $table, $field)) {
-            return null;
+            return $this->response->response();
         }
 
         $this->response->setMinimalFooter();
@@ -68,6 +68,6 @@ final class BrowseForeignersController implements InvocableController
             $data,
         ));
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/CheckRelationsController.php
+++ b/src/Controllers/CheckRelationsController.php
@@ -23,7 +23,7 @@ final class CheckRelationsController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $cfgStorageDbName = $this->relation->getConfigurationStorageDbName();
 
@@ -57,6 +57,6 @@ final class CheckRelationsController implements InvocableController
             'are_config_storage_tables_defined' => $this->relation->arePmadbTablesDefined(),
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/CollationConnectionController.php
+++ b/src/Controllers/CollationConnectionController.php
@@ -16,7 +16,7 @@ final class CollationConnectionController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $this->config->setUserValue(
             null,
@@ -27,6 +27,6 @@ final class CollationConnectionController implements InvocableController
 
         $this->response->redirect('index.php?route=/' . Url::getCommonRaw([], '&'));
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/ColumnController.php
+++ b/src/Controllers/ColumnController.php
@@ -16,7 +16,7 @@ final class ColumnController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string|null $db */
         $db = $request->getParsedBodyParam('db');
@@ -27,11 +27,11 @@ final class ColumnController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON(['message' => Message::error()]);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addJSON(['columns' => $this->dbi->getColumnNames($db, $table)]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Console/Bookmark/AddController.php
+++ b/src/Controllers/Console/Bookmark/AddController.php
@@ -22,7 +22,7 @@ final class AddController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $db = $request->getParsedBodyParam('db');
         $label = $request->getParsedBodyParam('label');
@@ -32,7 +32,7 @@ final class AddController implements InvocableController
         if (! is_string($label) || ! is_string($db) || ! is_string($bookmarkQuery) || ! is_string($shared)) {
             $this->response->addJSON('message', __('Incomplete params'));
 
-            return null;
+            return $this->response->response();
         }
 
         $bookmark = $this->bookmarkRepository->createBookmark(
@@ -45,7 +45,7 @@ final class AddController implements InvocableController
         if ($bookmark === false || ! $bookmark->save()) {
             $this->response->addJSON('message', __('Failed'));
 
-            return null;
+            return $this->response->response();
         }
 
         $bookmarkFields = [
@@ -59,6 +59,6 @@ final class AddController implements InvocableController
         $this->response->addJSON('data', $bookmarkFields);
         $this->response->addJSON('isShared', $shared === 'true');
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Console/Bookmark/RefreshController.php
+++ b/src/Controllers/Console/Bookmark/RefreshController.php
@@ -16,10 +16,10 @@ final class RefreshController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $this->response->addJSON('console_message_bookmark', $this->console->getBookmarkContent());
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/CentralColumns/PopulateColumnsController.php
+++ b/src/Controllers/Database/CentralColumns/PopulateColumnsController.php
@@ -19,7 +19,7 @@ final class PopulateColumnsController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $columns = $this->centralColumns->getColumnsNotInCentralList(
             Current::$database,
@@ -27,6 +27,6 @@ final class PopulateColumnsController implements InvocableController
         );
         $this->response->render('database/central_columns/populate_columns', ['columns' => $columns]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/CentralColumnsController.php
+++ b/src/Controllers/Database/CentralColumnsController.php
@@ -32,7 +32,7 @@ final class CentralColumnsController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['message'] ??= null;
         $db = DatabaseName::from($request->getParam('db'));
@@ -52,7 +52,7 @@ final class CentralColumnsController implements InvocableController
                 $db,
             ));
 
-            return null;
+            return $this->response->response();
         }
 
         if ($request->hasBodyParam('add_new_column')) {
@@ -76,7 +76,7 @@ final class CentralColumnsController implements InvocableController
                 $request->getParsedBodyParam('cur_table', ''),
             ));
 
-            return null;
+            return $this->response->response();
         }
 
         if ($request->hasBodyParam('add_column')) {
@@ -100,7 +100,7 @@ final class CentralColumnsController implements InvocableController
                 'db' => $request->getParsedBodyParam('db'),
             ]);
 
-            return null;
+            return $this->response->response();
         }
 
         if ($request->hasBodyParam('multi_edit_central_column_save')) {
@@ -150,12 +150,12 @@ final class CentralColumnsController implements InvocableController
             sprintf(__('Showing rows %1$s - %2$s.'), $pos + 1, $pos + $numberOfColumns),
         );
         if (! isset($tmpMsg) || $tmpMsg === true) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['message'] = $tmpMsg;
 
-        return null;
+        return $this->response->response();
     }
 
     public function main(string $totalRows, string $position, DatabaseName $db): void

--- a/src/Controllers/Database/DataDictionaryController.php
+++ b/src/Controllers/Database/DataDictionaryController.php
@@ -28,10 +28,10 @@ final class DataDictionaryController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $this->response->checkParameters(['db'], true)) {
-            return null;
+            return $this->response->response();
         }
 
         $relationParameters = $this->relation->getRelationParameters();
@@ -110,6 +110,6 @@ final class DataDictionaryController implements InvocableController
             'tables' => $tables,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/DesignerController.php
+++ b/src/Controllers/Database/DesignerController.php
@@ -37,7 +37,7 @@ final class DesignerController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['message'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
@@ -83,7 +83,7 @@ final class DesignerController implements InvocableController
                 $this->response->addHTML($html);
             }
 
-            return null;
+            return $this->response->response();
         }
 
         if ($request->hasBodyParam('operation')) {
@@ -105,7 +105,7 @@ final class DesignerController implements InvocableController
                     );
                     $this->response->setRequestStatus(false);
 
-                    return null;
+                    return $this->response->response();
                 } else {
                     $page = $this->designerCommon->createNewPage($request->getParsedBodyParam('selected_value'), $db);
                     $this->response->addJSON('id', $page);
@@ -150,11 +150,11 @@ final class DesignerController implements InvocableController
                 $this->response->setRequestStatus($success);
             }
 
-            return null;
+            return $this->response->response();
         }
 
         if (! $this->response->checkParameters(['db'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['errorUrl'] = Util::getScriptNameForOption(
@@ -169,12 +169,12 @@ final class DesignerController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $scriptDisplayField = $this->designerCommon->getTablesInfo();
@@ -257,6 +257,6 @@ final class DesignerController implements InvocableController
 
         $this->response->addHTML('<div id="PMA_disable_floating_menubar"></div>');
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/EventsController.php
+++ b/src/Controllers/Database/EventsController.php
@@ -38,7 +38,7 @@ final class EventsController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errors'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
@@ -47,7 +47,7 @@ final class EventsController implements InvocableController
 
         if (! $request->isAjax()) {
             if (! $this->response->checkParameters(['db'])) {
-                return null;
+                return $this->response->response();
             }
 
             $GLOBALS['errorUrl'] = Util::getScriptNameForOption(
@@ -60,7 +60,7 @@ final class EventsController implements InvocableController
             if ($databaseName === null || ! $this->dbTableExists->selectDatabase($databaseName)) {
                 $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-                return null;
+                return $this->response->response();
             }
         } elseif (Current::$database !== '') {
             $this->dbi->selectDb(Current::$database);
@@ -111,7 +111,7 @@ final class EventsController implements InvocableController
 
                 $this->response->addJSON('tableType', 'events');
 
-                return null;
+                return $this->response->response();
             }
         }
 
@@ -184,12 +184,12 @@ final class EventsController implements InvocableController
                     $this->response->addJSON('message', $editor);
                     $this->response->addJSON('title', $title);
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->addHTML("\n\n<h2>" . $title . "</h2>\n\n" . $editor);
 
-                return null;
+                return $this->response->response();
             }
 
             $message = __('Error in processing request:') . ' ';
@@ -203,7 +203,7 @@ final class EventsController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', $message);
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->addHTML($message->getDisplay());
@@ -226,7 +226,7 @@ final class EventsController implements InvocableController
                     $this->response->addJSON('message', $exportData);
                     $this->response->addJSON('title', $title);
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $output = '<div class="container">';
@@ -248,7 +248,7 @@ final class EventsController implements InvocableController
                     $this->response->setRequestStatus(false);
                     $this->response->addJSON('message', $message);
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->addHTML($message->getDisplay());
@@ -266,6 +266,6 @@ final class EventsController implements InvocableController
             'is_ajax' => $request->isAjax() && empty($_REQUEST['ajax_page_request']),
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/ExportController.php
+++ b/src/Controllers/Database/ExportController.php
@@ -36,7 +36,7 @@ final class ExportController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['table_select'] ??= null;
@@ -50,7 +50,7 @@ final class ExportController implements InvocableController
         $this->response->addScriptFiles(['export.js']);
 
         if (! $this->response->checkParameters(['db'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['errorUrl'] = Util::getScriptNameForOption(
@@ -65,12 +65,12 @@ final class ExportController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/database/export');
@@ -84,7 +84,7 @@ final class ExportController implements InvocableController
                 Message::error(__('No tables found in database.'))->getDisplay(),
             );
 
-            return null;
+            return $this->response->response();
         }
 
         $selectedTable = $request->getParsedBodyParam('selected_tbl');
@@ -150,7 +150,7 @@ final class ExportController implements InvocableController
                 __('Could not load export plugins, please check your installation!'),
             )->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         $options = $this->exportOptions->getOptions(
@@ -170,6 +170,6 @@ final class ExportController implements InvocableController
             'tables' => $tablesForMultiValues,
         ]));
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/ImportController.php
+++ b/src/Controllers/Database/ImportController.php
@@ -38,7 +38,7 @@ final class ImportController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['SESSION_KEY'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
@@ -50,7 +50,7 @@ final class ImportController implements InvocableController
         $this->response->addScriptFiles(['import.js']);
 
         if (! $this->response->checkParameters(['db'])) {
-            return null;
+            return $this->response->response();
         }
 
         $config = Config::getInstance();
@@ -63,12 +63,12 @@ final class ImportController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         [$GLOBALS['SESSION_KEY'], $uploadId] = Ajax::uploadProgressSetup();
@@ -81,7 +81,7 @@ final class ImportController implements InvocableController
                 'Could not load import plugins, please check your installation!',
             ))->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         $offset = null;
@@ -138,6 +138,6 @@ final class ImportController implements InvocableController
             'local_files' => Import::getLocalFiles($importList),
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/MultiTableQuery/QueryController.php
+++ b/src/Controllers/Database/MultiTableQuery/QueryController.php
@@ -16,13 +16,13 @@ final class QueryController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $this->response->addHTML(MultiTableQuery::displayResults(
             $request->getParsedBodyParam('sql_query'),
             $request->getParam('db'),
         ));
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/MultiTableQuery/TablesController.php
+++ b/src/Controllers/Database/MultiTableQuery/TablesController.php
@@ -20,7 +20,7 @@ final class TablesController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string[] $tables */
         $tables = $request->getQueryParam('tables', []);
@@ -37,6 +37,6 @@ final class TablesController implements InvocableController
         );
         $this->response->addJSON(['foreignKeyConstrains' => $constrains]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/MultiTableQueryController.php
+++ b/src/Controllers/Database/MultiTableQueryController.php
@@ -25,7 +25,7 @@ final class MultiTableQueryController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $this->response->addScriptFiles(['database/multi_table_query.js', 'database/query_generator.js']);
 
@@ -33,6 +33,6 @@ final class MultiTableQueryController implements InvocableController
 
         $this->response->addHTML($queryInstance->getFormHtml());
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/PrivilegesController.php
+++ b/src/Controllers/Database/PrivilegesController.php
@@ -35,7 +35,7 @@ final class PrivilegesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         try {
             $db = DatabaseName::from($request->getParam('db'));
@@ -45,7 +45,7 @@ final class PrivilegesController implements InvocableController
         } catch (InvalidDatabaseName $exception) {
             $this->response->addHTML(Message::error($exception->getMessage())->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addScriptFiles(['server/privileges.js', 'vendor/zxcvbn-ts.js']);
@@ -63,7 +63,7 @@ final class PrivilegesController implements InvocableController
                     ->getDisplay(),
             );
 
-            return null;
+            return $this->response->response();
         }
 
         if (! $isGrantUser && ! $isCreateUser) {
@@ -90,6 +90,6 @@ final class PrivilegesController implements InvocableController
         ]);
         $this->response->render('export_modal', []);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/RoutinesController.php
+++ b/src/Controllers/Database/RoutinesController.php
@@ -47,7 +47,7 @@ final class RoutinesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errors'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
@@ -66,7 +66,7 @@ final class RoutinesController implements InvocableController
              */
             if (Current::$table !== '' && in_array(Current::$table, $this->dbi->getTables(Current::$database), true)) {
                 if (! $this->response->checkParameters(['db', 'table'])) {
-                    return null;
+                    return $this->response->response();
                 }
 
                 $GLOBALS['urlParams'] = ['db' => Current::$database, 'table' => Current::$table];
@@ -80,20 +80,20 @@ final class RoutinesController implements InvocableController
                         ['reload' => true, 'message' => __('No databases selected.')],
                     );
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $tableName = TableName::tryFrom($request->getParam('table'));
                 if ($tableName === null || ! $this->dbTableExists->hasTable($databaseName, $tableName)) {
                     $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-                    return null;
+                    return $this->response->response();
                 }
             } else {
                 Current::$table = '';
 
                 if (! $this->response->checkParameters(['db'])) {
-                    return null;
+                    return $this->response->response();
                 }
 
                 $GLOBALS['errorUrl'] = Util::getScriptNameForOption(
@@ -109,7 +109,7 @@ final class RoutinesController implements InvocableController
                         ['reload' => true, 'message' => __('No databases selected.')],
                     );
 
-                    return null;
+                    return $this->response->response();
                 }
             }
         } elseif (Current::$database !== '') {
@@ -130,7 +130,7 @@ final class RoutinesController implements InvocableController
                     $this->response->setRequestStatus(false);
                     $this->response->addJSON('message', $output);
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $routines = Routines::getDetails(
@@ -154,7 +154,7 @@ final class RoutinesController implements InvocableController
                 $this->response->addJSON('message', $output);
                 $this->response->addJSON('tableType', 'routines');
 
-                return null;
+                return $this->response->response();
             }
         }
 
@@ -282,12 +282,12 @@ final class RoutinesController implements InvocableController
                     );
                     $this->response->addJSON('type', $routine['item_type']);
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->addHTML("\n\n<h2>" . $title . "</h2>\n\n" . $editor);
 
-                return null;
+                return $this->response->response();
             }
 
             $message = __('Error in processing request:') . ' ';
@@ -307,7 +307,7 @@ final class RoutinesController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', $message);
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->addHTML($message->getDisplay());
@@ -331,12 +331,12 @@ final class RoutinesController implements InvocableController
                     $this->response->setRequestStatus(false);
                     $this->response->addJSON('message', $message);
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->addHTML($message->getDisplay());
 
-                return null;
+                return $this->response->response();
             }
 
             [$output, $message] = $this->routines->handleExecuteRoutine($routine);
@@ -347,14 +347,14 @@ final class RoutinesController implements InvocableController
                 $this->response->addJSON('message', $message->getDisplay() . $output);
                 $this->response->addJSON('dialog', false);
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->addHTML($message->getDisplay() . $output);
             if ($message->isError()) {
                 // At least one query has failed, so shouldn't
                 // execute any more queries, so we quit.
-                return null;
+                return $this->response->response();
             }
         } elseif (! empty($_GET['execute_dialog']) && ! empty($_GET['item_name'])) {
             /**
@@ -378,13 +378,13 @@ final class RoutinesController implements InvocableController
                     $this->response->addJSON('title', $title);
                     $this->response->addJSON('dialog', true);
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->addHTML("\n\n<h2>" . __('Execute routine') . "</h2>\n\n");
                 $this->response->addHTML($form);
 
-                return null;
+                return $this->response->response();
             }
 
             if ($request->isAjax()) {
@@ -399,7 +399,7 @@ final class RoutinesController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', $message);
 
-                return null;
+                return $this->response->response();
             }
         }
 
@@ -439,7 +439,7 @@ final class RoutinesController implements InvocableController
                     $this->response->addJSON('message', $exportData);
                     $this->response->addJSON('title', $title);
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $output = '<div class="container">';
@@ -464,7 +464,7 @@ final class RoutinesController implements InvocableController
                     $this->response->setRequestStatus(false);
                     $this->response->addJSON('message', $message);
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->addHTML($message->getDisplay());
@@ -494,6 +494,6 @@ final class RoutinesController implements InvocableController
             'has_privilege' => Util::currentUserHasPrivilege('CREATE ROUTINE', Current::$database, Current::$table),
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/SearchController.php
+++ b/src/Controllers/Database/SearchController.php
@@ -32,7 +32,7 @@ final class SearchController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
         $GLOBALS['urlParams'] ??= null;
@@ -40,7 +40,7 @@ final class SearchController implements InvocableController
         $this->response->addScriptFiles(['database/search.js', 'sql.js', 'makegrid.js']);
 
         if (! $this->response->checkParameters(['db'])) {
-            return null;
+            return $this->response->response();
         }
 
         $config = Config::getInstance();
@@ -53,12 +53,12 @@ final class SearchController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         if (! $config->settings['UseDbSearch']) {
@@ -70,7 +70,7 @@ final class SearchController implements InvocableController
             if ($request->isAjax()) {
                 $this->response->addJSON('message', Message::error($errorMessage)->getDisplay());
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->render('error/simple', [
@@ -78,7 +78,7 @@ final class SearchController implements InvocableController
                 'back_url' => $GLOBALS['errorUrl'],
             ]);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/database/search');
@@ -93,12 +93,12 @@ final class SearchController implements InvocableController
 
         // If we are in an Ajax request, we need to exit after displaying all the HTML
         if ($request->isAjax() && empty($_REQUEST['ajax_page_request'])) {
-            return null;
+            return $this->response->response();
         }
 
         // Display the search form
         $this->response->addHTML($databaseSearch->getMainHtml());
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/SqlAutoCompleteController.php
+++ b/src/Controllers/Database/SqlAutoCompleteController.php
@@ -26,7 +26,7 @@ final class SqlAutoCompleteController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $sqlAutocomplete = [];
         if ($this->config->settings['EnableAutocompleteForTablesAndColumns']) {
@@ -38,7 +38,7 @@ final class SqlAutoCompleteController implements InvocableController
 
         $this->response->addJSON(['tables' => $sqlAutocomplete]);
 
-        return null;
+        return $this->response->response();
     }
 
     /** @return string[][][] */

--- a/src/Controllers/Database/SqlController.php
+++ b/src/Controllers/Database/SqlController.php
@@ -34,7 +34,7 @@ class SqlController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['goto'] ??= null;
         $GLOBALS['back'] ??= null;
@@ -47,7 +47,7 @@ class SqlController implements InvocableController
         $this->response->addHTML($this->pageSettings->getHTML());
 
         if (! $this->response->checkParameters(['db'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['errorUrl'] = Util::getScriptNameForOption(
@@ -62,12 +62,12 @@ class SqlController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         /**
@@ -86,6 +86,6 @@ class SqlController implements InvocableController
             htmlspecialchars($delimiter),
         ));
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/SqlFormatController.php
+++ b/src/Controllers/Database/SqlFormatController.php
@@ -19,12 +19,12 @@ final class SqlFormatController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string $query */
         $query = $request->getParsedBodyParam('sql', '');
         $this->response->addJSON(['sql' => Formatter::format($query)]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/Structure/AddPrefixController.php
+++ b/src/Controllers/Database/Structure/AddPrefixController.php
@@ -23,7 +23,7 @@ final class AddPrefixController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string[] $selected */
         $selected = $request->getParsedBodyParam('selected_tbl', []);
@@ -32,7 +32,7 @@ final class AddPrefixController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         $params = ['db' => Current::$database];

--- a/src/Controllers/Database/Structure/AddPrefixTableController.php
+++ b/src/Controllers/Database/Structure/AddPrefixTableController.php
@@ -40,8 +40,6 @@ final class AddPrefixTableController implements InvocableController
 
         $GLOBALS['message'] = Message::success();
 
-        ($this->structureController)($request);
-
-        return null;
+        return ($this->structureController)($request);
     }
 }

--- a/src/Controllers/Database/Structure/AddPrefixTableController.php
+++ b/src/Controllers/Database/Structure/AddPrefixTableController.php
@@ -21,7 +21,7 @@ final class AddPrefixTableController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string[] $selected */
         $selected = $request->getParsedBodyParam('selected', []);

--- a/src/Controllers/Database/Structure/CentralColumns/AddController.php
+++ b/src/Controllers/Database/Structure/CentralColumns/AddController.php
@@ -49,8 +49,6 @@ final class AddController implements InvocableController
 
         unset($_POST['submit_mult']);
 
-        ($this->structureController)($request);
-
-        return null;
+        return ($this->structureController)($request);
     }
 }

--- a/src/Controllers/Database/Structure/CentralColumns/AddController.php
+++ b/src/Controllers/Database/Structure/CentralColumns/AddController.php
@@ -27,7 +27,7 @@ final class AddController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['message'] ??= null;
 
@@ -37,7 +37,7 @@ final class AddController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         Assert::allString($selected);

--- a/src/Controllers/Database/Structure/CentralColumns/MakeConsistentController.php
+++ b/src/Controllers/Database/Structure/CentralColumns/MakeConsistentController.php
@@ -49,8 +49,6 @@ final class MakeConsistentController implements InvocableController
 
         unset($_POST['submit_mult']);
 
-        ($this->structureController)($request);
-
-        return null;
+        return ($this->structureController)($request);
     }
 }

--- a/src/Controllers/Database/Structure/CentralColumns/MakeConsistentController.php
+++ b/src/Controllers/Database/Structure/CentralColumns/MakeConsistentController.php
@@ -27,7 +27,7 @@ final class MakeConsistentController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['message'] ??= null;
 
@@ -37,7 +37,7 @@ final class MakeConsistentController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         Assert::allString($selected);

--- a/src/Controllers/Database/Structure/CentralColumns/RemoveController.php
+++ b/src/Controllers/Database/Structure/CentralColumns/RemoveController.php
@@ -26,7 +26,7 @@ final class RemoveController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['message'] ??= null;
 
@@ -36,7 +36,7 @@ final class RemoveController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         Assert::allString($selected);

--- a/src/Controllers/Database/Structure/CentralColumns/RemoveController.php
+++ b/src/Controllers/Database/Structure/CentralColumns/RemoveController.php
@@ -48,8 +48,6 @@ final class RemoveController implements InvocableController
 
         unset($_POST['submit_mult']);
 
-        ($this->structureController)($request);
-
-        return null;
+        return ($this->structureController)($request);
     }
 }

--- a/src/Controllers/Database/Structure/ChangePrefixFormController.php
+++ b/src/Controllers/Database/Structure/ChangePrefixFormController.php
@@ -23,7 +23,7 @@ final class ChangePrefixFormController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string[] $selected */
         $selected = $request->getParsedBodyParam('selected_tbl', []);
@@ -32,7 +32,7 @@ final class ChangePrefixFormController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         $route = '/database/structure/replace-prefix';

--- a/src/Controllers/Database/Structure/CopyFormController.php
+++ b/src/Controllers/Database/Structure/CopyFormController.php
@@ -24,7 +24,7 @@ final class CopyFormController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string[] $selected */
         $selected = $request->getParsedBodyParam('selected_tbl', []);
@@ -33,7 +33,7 @@ final class CopyFormController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         $urlParams = ['db' => Current::$database];

--- a/src/Controllers/Database/Structure/CopyTableController.php
+++ b/src/Controllers/Database/Structure/CopyTableController.php
@@ -61,8 +61,6 @@ final class CopyTableController implements InvocableController
 
         $GLOBALS['message'] = Message::success();
 
-        ($this->structureController)($request);
-
-        return null;
+        return ($this->structureController)($request);
     }
 }

--- a/src/Controllers/Database/Structure/CopyTableController.php
+++ b/src/Controllers/Database/Structure/CopyTableController.php
@@ -26,7 +26,7 @@ final class CopyTableController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string[] $selected */
         $selected = $request->getParsedBodyParam('selected', []);

--- a/src/Controllers/Database/Structure/CopyTableWithPrefixController.php
+++ b/src/Controllers/Database/Structure/CopyTableWithPrefixController.php
@@ -25,7 +25,7 @@ final class CopyTableWithPrefixController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string[] $selected */
         $selected = $request->getParsedBodyParam('selected', []);

--- a/src/Controllers/Database/Structure/CopyTableWithPrefixController.php
+++ b/src/Controllers/Database/Structure/CopyTableWithPrefixController.php
@@ -50,8 +50,6 @@ final class CopyTableWithPrefixController implements InvocableController
 
         $GLOBALS['message'] = Message::success();
 
-        ($this->structureController)($request);
-
-        return null;
+        return ($this->structureController)($request);
     }
 }

--- a/src/Controllers/Database/Structure/DropFormController.php
+++ b/src/Controllers/Database/Structure/DropFormController.php
@@ -22,7 +22,7 @@ final class DropFormController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string[] $selected */
         $selected = $request->getParsedBodyParam('selected_tbl', []);
@@ -31,7 +31,7 @@ final class DropFormController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         $fullQueryViews = '';
@@ -66,6 +66,6 @@ final class DropFormController implements InvocableController
             'is_foreign_key_check' => ForeignKey::isCheckEnabled(),
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/Structure/DropTableController.php
+++ b/src/Controllers/Database/Structure/DropTableController.php
@@ -38,9 +38,7 @@ final class DropTableController implements InvocableController
 
             unset($_POST['mult_btn']);
 
-            ($this->structureController)($request);
-
-            return null;
+            return ($this->structureController)($request);
         }
 
         $defaultFkCheckValue = ForeignKey::handleDisableCheckInit();
@@ -101,8 +99,6 @@ final class DropTableController implements InvocableController
 
         unset($_POST['mult_btn']);
 
-        ($this->structureController)($request);
-
-        return null;
+        return ($this->structureController)($request);
     }
 }

--- a/src/Controllers/Database/Structure/DropTableController.php
+++ b/src/Controllers/Database/Structure/DropTableController.php
@@ -26,7 +26,7 @@ final class DropTableController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['reload'] = $_POST['reload'] ?? $GLOBALS['reload'] ?? null;
         $multBtn = $_POST['mult_btn'] ?? '';

--- a/src/Controllers/Database/Structure/EmptyFormController.php
+++ b/src/Controllers/Database/Structure/EmptyFormController.php
@@ -21,7 +21,7 @@ final class EmptyFormController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string[] $selected */
         $selected = $request->getParsedBodyParam('selected_tbl', []);
@@ -30,7 +30,7 @@ final class EmptyFormController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         $fullQuery = '';
@@ -48,6 +48,6 @@ final class EmptyFormController implements InvocableController
             'is_foreign_key_check' => ForeignKey::isCheckEnabled(),
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/Structure/EmptyTableController.php
+++ b/src/Controllers/Database/Structure/EmptyTableController.php
@@ -39,7 +39,7 @@ final class EmptyTableController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $multBtn = $_POST['mult_btn'] ?? '';
         /** @var string[] $selected */
@@ -49,7 +49,7 @@ final class EmptyTableController implements InvocableController
             $this->flashMessenger->addMessage('success', __('No change'));
             $this->response->redirectToRoute('/database/structure', ['db' => Current::$database]);
 
-            return null;
+            return $this->response->response();
         }
 
         $defaultFkCheckValue = ForeignKey::handleDisableCheckInit();

--- a/src/Controllers/Database/Structure/EmptyTableController.php
+++ b/src/Controllers/Database/Structure/EmptyTableController.php
@@ -90,8 +90,6 @@ final class EmptyTableController implements InvocableController
 
         unset($_POST['mult_btn']);
 
-        ($this->structureController)($request);
-
-        return null;
+        return ($this->structureController)($request);
     }
 }

--- a/src/Controllers/Database/Structure/FavoriteTableController.php
+++ b/src/Controllers/Database/Structure/FavoriteTableController.php
@@ -39,12 +39,12 @@ final class FavoriteTableController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
 
         if (Current::$database === '') {
-            return null;
+            return $this->response->response();
         }
 
         $config = Config::getInstance();
@@ -52,7 +52,7 @@ final class FavoriteTableController implements InvocableController
         $GLOBALS['errorUrl'] .= Url::getCommon(['db' => Current::$database], '&');
 
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         $favoriteInstance = RecentFavoriteTables::getInstance(TableType::Favorite);
@@ -74,7 +74,7 @@ final class FavoriteTableController implements InvocableController
                 ));
             }
 
-            return null;
+            return $this->response->response();
         }
 
         $databaseName = DatabaseName::tryFrom($request->getParam('db'));
@@ -82,7 +82,7 @@ final class FavoriteTableController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-            return null;
+            return $this->response->response();
         }
 
         $changes = true;
@@ -120,7 +120,7 @@ final class FavoriteTableController implements InvocableController
             ]);
             $this->response->addJSON($json);
 
-            return null;
+            return $this->response->response();
         }
 
         // Check if current table is already in favorite list.
@@ -143,7 +143,7 @@ final class FavoriteTableController implements InvocableController
 
         $this->response->addJSON($json);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Database/Structure/RealRowCountController.php
+++ b/src/Controllers/Database/Structure/RealRowCountController.php
@@ -31,7 +31,7 @@ final class RealRowCountController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
 
@@ -41,7 +41,7 @@ final class RealRowCountController implements InvocableController
         ];
 
         if (! $this->response->checkParameters(['db'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['errorUrl'] = Util::getScriptNameForOption(
@@ -51,7 +51,7 @@ final class RealRowCountController implements InvocableController
         $GLOBALS['errorUrl'] .= Url::getCommon(['db' => Current::$database], '&');
 
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         $databaseName = DatabaseName::tryFrom($request->getParam('db'));
@@ -59,7 +59,7 @@ final class RealRowCountController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-            return null;
+            return $this->response->response();
         }
 
         // If there is a request to update all table's row count.
@@ -73,7 +73,7 @@ final class RealRowCountController implements InvocableController
 
             $this->response->addJSON(['real_row_count' => $realRowCount]);
 
-            return null;
+            return $this->response->response();
         }
 
         // Array to store the results.
@@ -88,6 +88,6 @@ final class RealRowCountController implements InvocableController
 
         $this->response->addJSON(['real_row_count_all' => $realRowCountAll]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Database/Structure/ShowCreateController.php
+++ b/src/Controllers/Database/Structure/ShowCreateController.php
@@ -24,7 +24,7 @@ final class ShowCreateController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string[] $selected */
         $selected = $request->getParsedBodyParam('selected_tbl', []);
@@ -33,7 +33,7 @@ final class ShowCreateController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         $tables = $this->getShowCreateTables($selected);
@@ -42,7 +42,7 @@ final class ShowCreateController implements InvocableController
 
         $this->response->addJSON('message', $showCreate);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Database/StructureController.php
+++ b/src/Controllers/Database/StructureController.php
@@ -121,14 +121,14 @@ final class StructureController implements InvocableController
         $this->dbIsSystemSchema = true;
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
 
         $parameters = ['sort' => $_REQUEST['sort'] ?? null, 'sort_order' => $_REQUEST['sort_order'] ?? null];
 
         if (! $this->response->checkParameters(['db'])) {
-            return null;
+            return $this->response->response();
         }
 
         $config = Config::getInstance();
@@ -141,12 +141,12 @@ final class StructureController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addScriptFiles(['database/structure.js', 'table/change.js']);
@@ -208,7 +208,7 @@ final class StructureController implements InvocableController
             'create_table_html' => $createTable,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 
     /** @param mixed[] $replicaInfo */

--- a/src/Controllers/Database/TrackingController.php
+++ b/src/Controllers/Database/TrackingController.php
@@ -38,7 +38,7 @@ final class TrackingController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
@@ -46,7 +46,7 @@ final class TrackingController implements InvocableController
         $this->response->addScriptFiles(['vendor/jquery/jquery.tablesorter.js', 'database/tracking.js']);
 
         if (! $this->response->checkParameters(['db'])) {
-            return null;
+            return $this->response->response();
         }
 
         $config = Config::getInstance();
@@ -59,12 +59,12 @@ final class TrackingController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/table/tracking');
@@ -114,7 +114,7 @@ final class TrackingController implements InvocableController
                         'default_statements' => $config->selectedServer['tracking_default_statements'],
                     ]);
 
-                    return null;
+                    return $this->response->response();
                 }
             } else {
                 $this->response->addHTML(Message::notice(
@@ -134,7 +134,7 @@ final class TrackingController implements InvocableController
                 $this->response->render('database/create_table', ['db' => Current::$database]);
             }
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addHTML($this->tracking->getHtmlForDbTrackingTables(
@@ -145,7 +145,7 @@ final class TrackingController implements InvocableController
 
         // If available print out database log
         if ($trackedData->ddlog === []) {
-            return null;
+            return $this->response->response();
         }
 
         $log = '';
@@ -156,6 +156,6 @@ final class TrackingController implements InvocableController
 
         $this->response->addHTML(Generator::getMessage(__('Database Log'), $log));
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/DatabaseController.php
+++ b/src/Controllers/DatabaseController.php
@@ -15,10 +15,10 @@ final class DatabaseController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $this->response->addJSON(['databases' => $this->dbi->getDatabaseList()]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/ErrorReportController.php
+++ b/src/Controllers/ErrorReportController.php
@@ -39,7 +39,7 @@ final class ErrorReportController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string $exceptionType */
         $exceptionType = $request->getParsedBodyParam('exception_type', '');
@@ -49,7 +49,7 @@ final class ErrorReportController implements InvocableController
         $alwaysSend = $request->getParsedBodyParam('always_send');
 
         if (! in_array($exceptionType, ['js', 'php'], true)) {
-            return null;
+            return $this->response->response();
         }
 
         $config = Config::getInstance();
@@ -146,6 +146,6 @@ final class ErrorReportController implements InvocableController
             $this->errorHandler->savePreviousErrors();
         }
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Export/CheckTimeOutController.php
+++ b/src/Controllers/Export/CheckTimeOutController.php
@@ -15,21 +15,21 @@ final class CheckTimeOutController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         if (isset($_SESSION['pma_export_error'])) {
             unset($_SESSION['pma_export_error']);
             $this->response->addJSON('message', 'timeout');
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addJSON('message', 'success');
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Export/ExportController.php
+++ b/src/Controllers/Export/ExportController.php
@@ -47,7 +47,7 @@ final class ExportController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['export_type'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
@@ -100,7 +100,7 @@ final class ExportController implements InvocableController
         $GLOBALS['what'] = Core::securePath($whatParam);
 
         if (! $this->response->checkParameters(['what', 'export_type'])) {
-            return null;
+            return $this->response->response();
         }
 
         // export class instance, not array of properties, as before
@@ -114,7 +114,7 @@ final class ExportController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addHTML(Message::error(__('Bad type!'))->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         if ($request->hasBodyParam('sql_backquotes') && $exportPlugin instanceof ExportSql) {
@@ -189,7 +189,7 @@ final class ExportController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addHTML(Message::error(__('Bad parameters!'))->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         // Merge SQL Query aliases with Export aliases from
@@ -276,7 +276,7 @@ final class ExportController implements InvocableController
                 $location = $this->export->getPageLocationAndSaveMessage($GLOBALS['export_type'], $message);
                 $this->response->redirect($location);
 
-                return null;
+                return $this->response->response();
             }
         } elseif ($GLOBALS['asfile']) {
             /**
@@ -486,7 +486,7 @@ final class ExportController implements InvocableController
             $location = $this->export->getPageLocationAndSaveMessage($GLOBALS['export_type'], $GLOBALS['message']);
             $this->response->redirect($location);
 
-            return null;
+            return $this->response->response();
         }
 
         /**
@@ -499,7 +499,7 @@ final class ExportController implements InvocableController
                 Current::$table,
             );
 
-            return null;
+            return $this->response->response();
         }
 
         // Convert the charset if required.
@@ -538,7 +538,7 @@ final class ExportController implements InvocableController
             $location = $this->export->getPageLocationAndSaveMessage($GLOBALS['export_type'], $message);
             $this->response->redirect($location);
 
-            return null;
+            return $this->response->response();
         }
 
         return $this->responseFactory->createResponse()->write($this->export->dumpBuffer);

--- a/src/Controllers/Export/ExportController.php
+++ b/src/Controllers/Export/ExportController.php
@@ -299,9 +299,8 @@ final class ExportController implements InvocableController
                     );
                     /** @var DatabaseExportController $controller */
                     $controller = ContainerBuilder::getContainer()->get(DatabaseExportController::class);
-                    $controller($request);
 
-                    return null;
+                    return $controller($request);
                 }
             }
 

--- a/src/Controllers/Export/TablesController.php
+++ b/src/Controllers/Export/TablesController.php
@@ -29,8 +29,6 @@ final class TablesController implements InvocableController
             return null;
         }
 
-        ($this->exportController)($request);
-
-        return null;
+        return ($this->exportController)($request);
     }
 }

--- a/src/Controllers/Export/TablesController.php
+++ b/src/Controllers/Export/TablesController.php
@@ -20,13 +20,13 @@ final class TablesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $request->hasBodyParam('selected_tbl')) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         return ($this->exportController)($request);

--- a/src/Controllers/Export/Template/CreateController.php
+++ b/src/Controllers/Export/Template/CreateController.php
@@ -26,7 +26,7 @@ final class CreateController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string $exportType */
         $exportType = $request->getParsedBodyParam('exportType', '');
@@ -39,7 +39,7 @@ final class CreateController implements InvocableController
 
         $exportTemplatesFeature = $this->relation->getRelationParameters()->exportTemplatesFeature;
         if ($exportTemplatesFeature === null) {
-            return null;
+            return $this->response->response();
         }
 
         $template = ExportTemplate::fromArray([
@@ -58,7 +58,7 @@ final class CreateController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $result);
 
-            return null;
+            return $this->response->response();
         }
 
         $templates = $this->model->getAll(
@@ -77,6 +77,6 @@ final class CreateController implements InvocableController
             ]),
         );
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Export/Template/DeleteController.php
+++ b/src/Controllers/Export/Template/DeleteController.php
@@ -21,13 +21,13 @@ final class DeleteController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $templateId = (int) $request->getParsedBodyParam('templateId');
 
         $exportTemplatesFeature = $this->relation->getRelationParameters()->exportTemplatesFeature;
         if ($exportTemplatesFeature === null) {
-            return null;
+            return $this->response->response();
         }
 
         $result = $this->model->delete(
@@ -41,11 +41,11 @@ final class DeleteController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $result);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->setRequestStatus(true);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Export/Template/LoadController.php
+++ b/src/Controllers/Export/Template/LoadController.php
@@ -22,13 +22,13 @@ final class LoadController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $templateId = (int) $request->getParsedBodyParam('templateId');
 
         $exportTemplatesFeature = $this->relation->getRelationParameters()->exportTemplatesFeature;
         if ($exportTemplatesFeature === null) {
-            return null;
+            return $this->response->response();
         }
 
         $template = $this->model->load(
@@ -42,12 +42,12 @@ final class LoadController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $template);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->setRequestStatus(true);
         $this->response->addJSON('data', $template->getData());
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Export/Template/UpdateController.php
+++ b/src/Controllers/Export/Template/UpdateController.php
@@ -22,7 +22,7 @@ final class UpdateController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $templateId = (int) $request->getParsedBodyParam('templateId');
         /** @var string $templateData */
@@ -30,7 +30,7 @@ final class UpdateController implements InvocableController
 
         $exportTemplatesFeature = $this->relation->getRelationParameters()->exportTemplatesFeature;
         if ($exportTemplatesFeature === null) {
-            return null;
+            return $this->response->response();
         }
 
         $template = ExportTemplate::fromArray([
@@ -48,11 +48,11 @@ final class UpdateController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $result);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->setRequestStatus(true);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/GisDataEditorController.php
+++ b/src/Controllers/GisDataEditorController.php
@@ -40,7 +40,7 @@ final class GisDataEditorController implements InvocableController
         'GEOMETRYCOLLECTION',
     ];
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         /** @var string|null $field */
         $field = $request->getParsedBodyParam('field');
@@ -54,7 +54,7 @@ final class GisDataEditorController implements InvocableController
         $inputName = $request->getParsedBodyParam('input_name');
 
         if (! isset($field)) {
-            return null;
+            return $this->response->response();
         }
 
         // Get data if any posted
@@ -66,7 +66,7 @@ final class GisDataEditorController implements InvocableController
         // Generate parameters from value passed.
         $gisObj = GisFactory::fromType($geomType);
         if ($gisObj === null) {
-            return null;
+            return $this->response->response();
         }
 
         if (isset($value)) {
@@ -91,7 +91,7 @@ final class GisDataEditorController implements InvocableController
         if ($request->hasBodyParam('generate')) {
             $this->response->addJSON(['result' => $result, 'visualization' => $svg, 'openLayers' => $openLayers]);
 
-            return null;
+            return $this->response->response();
         }
 
         $templateOutput = $this->template->render('gis_data_editor_form', [
@@ -111,7 +111,7 @@ final class GisDataEditorController implements InvocableController
 
         $this->response->addJSON(['gis_editor' => $templateOutput]);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/GitInfoController.php
+++ b/src/Controllers/GitInfoController.php
@@ -19,16 +19,16 @@ final class GitInfoController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         $git = new Git($this->config->get('ShowGitRevision') ?? true);
 
         if (! $git->isGitRevision()) {
-            return null;
+            return $this->response->response();
         }
 
         $commit = $git->checkGitRevision();
@@ -36,7 +36,7 @@ final class GitInfoController implements InvocableController
         if (! $git->hasGitInformation() || $commit === null) {
             $this->response->setRequestStatus(false);
 
-            return null;
+            return $this->response->response();
         }
 
         $commit['author']['date'] = Util::localisedDate(strtotime($commit['author']['date']));
@@ -44,6 +44,6 @@ final class GitInfoController implements InvocableController
 
         $this->response->render('home/git_info', $commit);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/HomeController.php
+++ b/src/Controllers/HomeController.php
@@ -59,7 +59,7 @@ final class HomeController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if ($this->shouldRedirectToDatabaseOrTablePage($request)) {
             return $this->redirectToDatabaseOrTablePage($request);
@@ -70,7 +70,7 @@ final class HomeController implements InvocableController
         $GLOBALS['errorUrl'] ??= null;
 
         if ($request->isAjax() && ! empty($_REQUEST['access_time'])) {
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addScriptFiles(['home.js']);
@@ -250,7 +250,7 @@ final class HomeController implements InvocableController
             'errors' => $this->errors,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 
     private function checkRequirements(): void

--- a/src/Controllers/Import/ImportController.php
+++ b/src/Controllers/Import/ImportController.php
@@ -59,7 +59,7 @@ final class ImportController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['goto'] ??= null;
         $GLOBALS['display_query'] ??= null;
@@ -176,7 +176,7 @@ final class ImportController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $GLOBALS['message']);
 
-            return null; // the footer is displayed automatically
+            return $this->response->response();
         }
 
         // Add console message id to response output
@@ -191,7 +191,7 @@ final class ImportController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addHTML(Message::error(__('Incorrect format parameter'))->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         if (Current::$table !== '' && Current::$database !== '') {
@@ -304,7 +304,7 @@ final class ImportController implements InvocableController
                         $this->response->addJSON('sql_query', $GLOBALS['import_text']);
                         $this->response->addJSON('action_bookmark', $actionBookmark);
 
-                        return null;
+                        return $this->response->response();
                     }
 
                     ImportSettings::$runQuery = false;
@@ -325,7 +325,7 @@ final class ImportController implements InvocableController
                         $this->response->addJSON('action_bookmark', $actionBookmark);
                         $this->response->addJSON('id_bookmark', $idBookmark);
 
-                        return null;
+                        return $this->response->response();
                     }
 
                     ImportSettings::$runQuery = false;
@@ -408,7 +408,7 @@ final class ImportController implements InvocableController
                 $this->response->addJSON('message', $errorMessage->getDisplay());
                 $this->response->addHTML($errorMessage->getDisplay());
 
-                return null;
+                return $this->response->response();
             }
 
             $importHandle->setDecompressContent(true);
@@ -425,7 +425,7 @@ final class ImportController implements InvocableController
                 $this->response->addJSON('message', $errorMessage->getDisplay());
                 $this->response->addHTML($errorMessage->getDisplay());
 
-                return null;
+                return $this->response->response();
             }
         } elseif (! $GLOBALS['error'] && empty($GLOBALS['import_text'])) {
             $GLOBALS['message'] = Message::error(
@@ -442,7 +442,7 @@ final class ImportController implements InvocableController
             $this->response->addJSON('message', $GLOBALS['message']->getDisplay());
             $this->response->addHTML($GLOBALS['message']->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         // Convert the file's charset if necessary
@@ -635,7 +635,7 @@ final class ImportController implements InvocableController
                         $_SESSION['Import_message']['go_back_url'],
                     );
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 if (Current::$table != $tableFromSql && $tableFromSql !== '') {
@@ -677,7 +677,7 @@ final class ImportController implements InvocableController
             $this->response->addJSON('ajax_reload', $GLOBALS['ajax_reload']);
             $this->response->addHTML($htmlOutput);
 
-            return null;
+            return $this->response->response();
         }
 
         if ($request->hasBodyParam('rollback_query')) {
@@ -716,6 +716,6 @@ final class ImportController implements InvocableController
             include ROOT_PATH . $GLOBALS['goto'];
         }
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Import/SimulateDmlController.php
+++ b/src/Controllers/Import/SimulateDmlController.php
@@ -25,7 +25,7 @@ final class SimulateDmlController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $error = '';
         $errorMsg = __('Only single-table UPDATE and DELETE queries can be simulated.');
@@ -77,11 +77,11 @@ final class SimulateDmlController implements InvocableController
             $this->response->addJSON('message', $message);
             $this->response->addJSON('sql_data', false);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addJSON('sql_data', $sqlData);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Import/StatusController.php
+++ b/src/Controllers/Import/StatusController.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Import\Ajax;
 use PhpMyAdmin\Message;
+use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 
 use function __;
@@ -30,7 +31,7 @@ class StatusController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['SESSION_KEY'] ??= null;
 
@@ -78,6 +79,6 @@ class StatusController implements InvocableController
             Ajax::status($request->getQueryParam('id'));
         }
 
-        return null;
+        return ResponseRenderer::getInstance()->response();
     }
 }

--- a/src/Controllers/InvocableController.php
+++ b/src/Controllers/InvocableController.php
@@ -9,5 +9,5 @@ use PhpMyAdmin\Http\ServerRequest;
 
 interface InvocableController
 {
-    public function __invoke(ServerRequest $request): Response|null;
+    public function __invoke(ServerRequest $request): Response;
 }

--- a/src/Controllers/LintController.php
+++ b/src/Controllers/LintController.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Linter;
+use PhpMyAdmin\ResponseRenderer;
 
 use function is_array;
 use function is_string;
@@ -29,10 +30,10 @@ final class LintController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $request->isAjax()) {
-            return null;
+            return ResponseRenderer::getInstance()->response();
         }
 
         /**

--- a/src/Controllers/LogoutController.php
+++ b/src/Controllers/LogoutController.php
@@ -15,17 +15,18 @@ final class LogoutController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
+        $responseRenderer = ResponseRenderer::getInstance();
         if (! $request->isPost() || $GLOBALS['token_mismatch']) {
-            ResponseRenderer::getInstance()->redirect('./index.php?route=/');
+            $responseRenderer->redirect('./index.php?route=/');
 
-            return null;
+            return $responseRenderer->response();
         }
 
         $authPlugin = $this->authPluginFactory->create();
         $authPlugin->logOut();
 
-        return null;
+        return $responseRenderer->response();
     }
 }

--- a/src/Controllers/Navigation/UpdateNavWidthConfigController.php
+++ b/src/Controllers/Navigation/UpdateNavWidthConfigController.php
@@ -20,24 +20,24 @@ final class UpdateNavWidthConfigController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $value = $request->getParsedBodyParam('value');
         if (! is_numeric($value) || $value < 0) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON(['message' => Message::error(__('Unexpected parameter value.'))]);
 
-            return null;
+            return $this->response->response();
         }
 
         $result = $this->config->setUserValue(null, 'NavigationWidth', (int) $value);
         if ($result === true) {
-            return null;
+            return $this->response->response();
         }
 
         $this->response->setRequestStatus(false);
         $this->response->addJSON(['message' => $result]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/NavigationController.php
+++ b/src/Controllers/NavigationController.php
@@ -30,7 +30,7 @@ final class NavigationController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $request->isAjax()) {
             $this->response->addHTML(
@@ -39,7 +39,7 @@ final class NavigationController implements InvocableController
                 )->getDisplay(),
             );
 
-            return null;
+            return $this->response->response();
         }
 
         if ($request->hasBodyParam('getNaviSettings')) {
@@ -47,7 +47,7 @@ final class NavigationController implements InvocableController
             $this->response->addHTML($this->pageSettings->getErrorHTML());
             $this->response->addJSON('message', $this->pageSettings->getHTML());
 
-            return null;
+            return $this->response->response();
         }
 
         if ($request->hasBodyParam('reload')) {
@@ -65,7 +65,7 @@ final class NavigationController implements InvocableController
                     $this->navigation->hideNavigationItem($itemName, $itemType, $dbName);
                 }
 
-                return null;
+                return $this->response->response();
             }
 
             if ($request->hasBodyParam('unhideNavItem')) {
@@ -73,7 +73,7 @@ final class NavigationController implements InvocableController
                     $this->navigation->unhideNavigationItem($itemName, $itemType, $dbName);
                 }
 
-                return null;
+                return $this->response->response();
             }
 
             if ($request->hasBodyParam('showUnhideDialog')) {
@@ -84,12 +84,12 @@ final class NavigationController implements InvocableController
                     );
                 }
 
-                return null;
+                return $this->response->response();
             }
         }
 
         $this->response->addJSON('message', $this->navigation->getDisplay());
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/AddNewPrimaryController.php
+++ b/src/Controllers/Normalization/AddNewPrimaryController.php
@@ -24,7 +24,7 @@ final class AddNewPrimaryController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
@@ -46,6 +46,6 @@ final class AddNewPrimaryController implements InvocableController
         $html .= Url::getHiddenInputs($dbName, $tableName);
         $this->response->addHTML($html);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/CreateNewColumnController.php
+++ b/src/Controllers/Normalization/CreateNewColumnController.php
@@ -24,7 +24,7 @@ final class CreateNewColumnController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
@@ -38,6 +38,6 @@ final class CreateNewColumnController implements InvocableController
         $html .= Url::getHiddenInputs(Current::$database, Current::$table);
         $this->response->addHTML($html);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/FirstNormalForm/FirstStepController.php
+++ b/src/Controllers/Normalization/FirstNormalForm/FirstStepController.php
@@ -21,7 +21,7 @@ final class FirstStepController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $this->response->addScriptFiles(['normalization.js', 'vendor/jquery/jquery.uitablefilter.js']);
 
@@ -34,6 +34,6 @@ final class FirstStepController implements InvocableController
         $html = $this->normalization->getHtmlFor1NFStep1(Current::$database, Current::$table, $normalForm);
         $this->response->addHTML($html);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/FirstNormalForm/FourthStepController.php
+++ b/src/Controllers/Normalization/FirstNormalForm/FourthStepController.php
@@ -19,11 +19,11 @@ final class FourthStepController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $res = $this->normalization->getHtmlContentsFor1NFStep4(Current::$database, Current::$table);
         $this->response->addJSON($res);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/FirstNormalForm/SecondStepController.php
+++ b/src/Controllers/Normalization/FirstNormalForm/SecondStepController.php
@@ -19,11 +19,11 @@ final class SecondStepController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $res = $this->normalization->getHtmlContentsFor1NFStep2(Current::$database, Current::$table);
         $this->response->addJSON($res);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/FirstNormalForm/ThirdStepController.php
+++ b/src/Controllers/Normalization/FirstNormalForm/ThirdStepController.php
@@ -19,11 +19,11 @@ final class ThirdStepController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $res = $this->normalization->getHtmlContentsFor1NFStep3(Current::$database, Current::$table);
         $this->response->addJSON($res);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/GetColumnsController.php
+++ b/src/Controllers/Normalization/GetColumnsController.php
@@ -22,7 +22,7 @@ final class GetColumnsController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $html = '<option selected disabled>' . __('Select one…') . '</option>'
             . '<option value="no_such_col">' . __('No such column') . '</option>';
@@ -34,6 +34,6 @@ final class GetColumnsController implements InvocableController
         );
         $this->response->addHTML($html);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/MainController.php
+++ b/src/Controllers/Normalization/MainController.php
@@ -19,7 +19,7 @@ final class MainController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $this->response->addScriptFiles(['normalization.js', 'vendor/jquery/jquery.uitablefilter.js']);
         $this->response->render('table/normalization/normalization', [
@@ -27,6 +27,6 @@ final class MainController implements InvocableController
             'table' => Current::$table,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/MoveRepeatingGroup.php
+++ b/src/Controllers/Normalization/MoveRepeatingGroup.php
@@ -19,7 +19,7 @@ final class MoveRepeatingGroup implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $repeatingColumns = $request->getParsedBodyParam('repeatingColumns');
         $newTable = $request->getParsedBodyParam('newTable');
@@ -35,6 +35,6 @@ final class MoveRepeatingGroup implements InvocableController
         );
         $this->response->addJSON($res);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/PartialDependenciesController.php
+++ b/src/Controllers/Normalization/PartialDependenciesController.php
@@ -19,11 +19,11 @@ final class PartialDependenciesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $html = $this->normalization->findPartialDependencies(Current::$table, Current::$database);
         $this->response->addHTML($html);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/SecondNormalForm/CreateNewTablesController.php
+++ b/src/Controllers/Normalization/SecondNormalForm/CreateNewTablesController.php
@@ -21,7 +21,7 @@ final class CreateNewTablesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $partialDependencies = json_decode($request->getParsedBodyParam('pd'), true);
         $tablesName = json_decode($request->getParsedBodyParam('newTablesName'));
@@ -33,6 +33,6 @@ final class CreateNewTablesController implements InvocableController
         );
         $this->response->addJSON($res);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/SecondNormalForm/FirstStepController.php
+++ b/src/Controllers/Normalization/SecondNormalForm/FirstStepController.php
@@ -19,11 +19,11 @@ final class FirstStepController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $res = $this->normalization->getHtmlFor2NFstep1(Current::$database, Current::$table);
         $this->response->addJSON($res);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/SecondNormalForm/NewTablesController.php
+++ b/src/Controllers/Normalization/SecondNormalForm/NewTablesController.php
@@ -21,12 +21,12 @@ final class NewTablesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $partialDependencies = json_decode($request->getParsedBodyParam('pd'), true);
         $html = $this->normalization->getHtmlForNewTables2NF($partialDependencies, Current::$table);
         $this->response->addHTML($html);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/ThirdNormalForm/CreateNewTablesController.php
+++ b/src/Controllers/Normalization/ThirdNormalForm/CreateNewTablesController.php
@@ -21,12 +21,12 @@ final class CreateNewTablesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $newtables = json_decode($request->getParsedBodyParam('newTables'), true);
         $res = $this->normalization->createNewTablesFor3NF($newtables, Current::$database);
         $this->response->addJSON($res);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/ThirdNormalForm/FirstStepController.php
+++ b/src/Controllers/Normalization/ThirdNormalForm/FirstStepController.php
@@ -19,12 +19,12 @@ final class FirstStepController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $tables = $request->getParsedBodyParam('tables');
         $res = $this->normalization->getHtmlFor3NFstep1(Current::$database, $tables);
         $this->response->addJSON($res);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Normalization/ThirdNormalForm/NewTablesController.php
+++ b/src/Controllers/Normalization/ThirdNormalForm/NewTablesController.php
@@ -21,13 +21,13 @@ final class NewTablesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $dependencies = json_decode($request->getParsedBodyParam('pd'));
         $tables = json_decode($request->getParsedBodyParam('tables'), true);
         $newTables = $this->normalization->getHtmlForNewTables3NF($dependencies, $tables, Current::$database);
         $this->response->addJSON($newTables);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Operations/Database/CollationController.php
+++ b/src/Controllers/Operations/Database/CollationController.php
@@ -30,12 +30,12 @@ final class CollationController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
 
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         $dbCollation = $request->getParsedBodyParam('db_collation') ?? '';
@@ -43,11 +43,11 @@ final class CollationController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', Message::error(__('No collation provided.')));
 
-            return null;
+            return $this->response->response();
         }
 
         if (! $this->response->checkParameters(['db'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['errorUrl'] = Util::getScriptNameForOption(
@@ -61,7 +61,7 @@ final class CollationController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-            return null;
+            return $this->response->response();
         }
 
         $sqlQuery = 'ALTER DATABASE ' . Util::backquote(Current::$database)
@@ -102,6 +102,6 @@ final class CollationController implements InvocableController
         $this->response->setRequestStatus($message->isSuccess());
         $this->response->addJSON('message', $message);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Operations/DatabaseController.php
+++ b/src/Controllers/Operations/DatabaseController.php
@@ -46,7 +46,7 @@ final class DatabaseController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['message'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
@@ -211,7 +211,7 @@ final class DatabaseController implements InvocableController
                 );
                 $this->response->addJSON('db', Current::$database);
 
-                return null;
+                return $this->response->response();
             }
         }
 
@@ -226,7 +226,7 @@ final class DatabaseController implements InvocableController
         }
 
         if (! $this->response->checkParameters(['db'])) {
-            return null;
+            return $this->response->response();
         }
 
         $config = Config::getInstance();
@@ -239,12 +239,12 @@ final class DatabaseController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/database/operations');
@@ -258,7 +258,7 @@ final class DatabaseController implements InvocableController
         $dbCollation = $this->dbi->getDbCollation(Current::$database);
 
         if (Utilities::isSystemSchema(Current::$database)) {
-            return null;
+            return $this->response->response();
         }
 
         $databaseComment = '';
@@ -307,6 +307,6 @@ final class DatabaseController implements InvocableController
             'collations' => $collations,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Operations/TableController.php
+++ b/src/Controllers/Operations/TableController.php
@@ -52,7 +52,7 @@ final class TableController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['auto_increment'] ??= null;
@@ -70,7 +70,7 @@ final class TableController implements InvocableController
         $this->response->addScriptFiles(['table/operations.js']);
 
         if (! $this->response->checkParameters(['db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         $isSystemSchema = Utilities::isSystemSchema(Current::$database);
@@ -85,12 +85,12 @@ final class TableController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $tableName = TableName::tryFrom($request->getParam('table'));
@@ -99,12 +99,12 @@ final class TableController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams']['goto'] = $GLOBALS['urlParams']['back'] = Url::getFromRoute('/table/operations');
@@ -154,7 +154,7 @@ final class TableController implements InvocableController
             $message = $this->operations->moveOrCopyTable($userPrivileges, Current::$database, Current::$table);
 
             if (! $request->isAjax()) {
-                return null;
+                return $this->response->response();
             }
 
             $this->response->addJSON('message', $message);
@@ -168,12 +168,12 @@ final class TableController implements InvocableController
 
                 $this->response->addJSON('db', Current::$database);
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->setRequestStatus(false);
 
-            return null;
+            return $this->response->response();
         }
 
         $newMessage = '';
@@ -277,7 +277,7 @@ final class TableController implements InvocableController
                         Message::error(__('No collation provided.')),
                     );
 
-                    return null;
+                    return $this->response->response();
                 }
             }
         }
@@ -361,7 +361,7 @@ final class TableController implements InvocableController
                         );
                     }
 
-                    return null;
+                    return $this->response->response();
                 }
             } else {
                 $newMessage = $result
@@ -383,7 +383,7 @@ final class TableController implements InvocableController
                         );
                     }
 
-                    return null;
+                    return $this->response->response();
                 }
             }
 
@@ -521,6 +521,6 @@ final class TableController implements InvocableController
             'foreigners' => $foreigners,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Operations/ViewController.php
+++ b/src/Controllers/Operations/ViewController.php
@@ -37,7 +37,7 @@ final class ViewController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['urlParams'] ??= null;
         $tableObject = $this->dbi->getTable(Current::$database, Current::$table);
@@ -46,7 +46,7 @@ final class ViewController implements InvocableController
         $this->response->addScriptFiles(['table/operations.js']);
 
         if (! $this->response->checkParameters(['db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams'] = ['db' => Current::$database, 'table' => Current::$table];
@@ -62,12 +62,12 @@ final class ViewController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $tableName = TableName::tryFrom($request->getParam('table'));
@@ -76,12 +76,12 @@ final class ViewController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams']['goto'] = $GLOBALS['urlParams']['back'] = Url::getFromRoute('/view/operations');
@@ -140,6 +140,6 @@ final class ViewController implements InvocableController
             'url_params' => $GLOBALS['urlParams'],
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Preferences/ExportController.php
+++ b/src/Controllers/Preferences/ExportController.php
@@ -33,7 +33,7 @@ final class ExportController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['error'] ??= null;
         $GLOBALS['tabHash'] ??= null;
@@ -49,7 +49,7 @@ final class ExportController implements InvocableController
             $formDisplay->fixErrors();
             $this->response->redirectToRoute('/preferences/export', []);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['error'] = null;
@@ -67,7 +67,7 @@ final class ExportController implements InvocableController
                 $GLOBALS['hash'] = ltrim($GLOBALS['tabHash'], '#');
                 $this->userPreferences->redirect('index.php?route=/preferences/export', null, $GLOBALS['hash']);
 
-                return null;
+                return $this->response->response();
             }
 
             $GLOBALS['error'] = $result;
@@ -100,6 +100,6 @@ final class ExportController implements InvocableController
             define('PMA_DISABLE_NAVI_SETTINGS', true);
         }
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Preferences/FeaturesController.php
+++ b/src/Controllers/Preferences/FeaturesController.php
@@ -33,7 +33,7 @@ final class FeaturesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['error'] ??= null;
         $GLOBALS['tabHash'] ??= null;
@@ -49,7 +49,7 @@ final class FeaturesController implements InvocableController
             $formDisplay->fixErrors();
             $this->response->redirectToRoute('/preferences/features', []);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['error'] = null;
@@ -67,7 +67,7 @@ final class FeaturesController implements InvocableController
                 $GLOBALS['hash'] = ltrim($GLOBALS['tabHash'], '#');
                 $this->userPreferences->redirect('index.php?route=/preferences/features', null, $GLOBALS['hash']);
 
-                return null;
+                return $this->response->response();
             }
 
             $GLOBALS['error'] = $result;
@@ -100,6 +100,6 @@ final class FeaturesController implements InvocableController
             define('PMA_DISABLE_NAVI_SETTINGS', true);
         }
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Preferences/ImportController.php
+++ b/src/Controllers/Preferences/ImportController.php
@@ -33,7 +33,7 @@ final class ImportController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['error'] ??= null;
         $GLOBALS['tabHash'] ??= null;
@@ -49,7 +49,7 @@ final class ImportController implements InvocableController
             $formDisplay->fixErrors();
             $this->response->redirectToRoute('/preferences/import', []);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['error'] = null;
@@ -67,7 +67,7 @@ final class ImportController implements InvocableController
                 $GLOBALS['hash'] = ltrim($GLOBALS['tabHash'], '#');
                 $this->userPreferences->redirect('index.php?route=/preferences/import', null, $GLOBALS['hash']);
 
-                return null;
+                return $this->response->response();
             }
 
             $GLOBALS['error'] = $result;
@@ -100,6 +100,6 @@ final class ImportController implements InvocableController
             define('PMA_DISABLE_NAVI_SETTINGS', true);
         }
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Preferences/MainPanelController.php
+++ b/src/Controllers/Preferences/MainPanelController.php
@@ -33,7 +33,7 @@ final class MainPanelController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['error'] ??= null;
         $GLOBALS['tabHash'] ??= null;
@@ -49,7 +49,7 @@ final class MainPanelController implements InvocableController
             $formDisplay->fixErrors();
             $this->response->redirectToRoute('/preferences/main-panel', []);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['error'] = null;
@@ -67,7 +67,7 @@ final class MainPanelController implements InvocableController
                 $GLOBALS['hash'] = ltrim($GLOBALS['tabHash'], '#');
                 $this->userPreferences->redirect('index.php?route=/preferences/main-panel', null, $GLOBALS['hash']);
 
-                return null;
+                return $this->response->response();
             }
 
             $GLOBALS['error'] = $result;
@@ -100,6 +100,6 @@ final class MainPanelController implements InvocableController
             define('PMA_DISABLE_NAVI_SETTINGS', true);
         }
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Preferences/ManageController.php
+++ b/src/Controllers/Preferences/ManageController.php
@@ -56,7 +56,7 @@ final class ManageController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['error'] ??= null;
         $GLOBALS['lang'] ??= null;
@@ -100,7 +100,7 @@ final class ManageController implements InvocableController
             $this->response->addJSON('prefs', json_encode($settings['config_data']));
             $this->response->addJSON('mtime', $settings['mtime']);
 
-            return null;
+            return $this->response->response();
         }
 
         if ($request->hasBodyParam('submit_import')) {
@@ -180,7 +180,7 @@ final class ManageController implements InvocableController
                         'return_url' => $returnUrl,
                     ]);
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 // check for ThemeDefault
@@ -222,7 +222,7 @@ final class ManageController implements InvocableController
                     $this->config->loadUserPreferences($this->themeManager);
                     $this->userPreferences->redirect($returnUrl ?? '', $redirectParams);
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $GLOBALS['error'] = $result;
@@ -233,12 +233,12 @@ final class ManageController implements InvocableController
                 $this->config->removeCookie('pma_lang');
                 $this->userPreferences->redirect('index.php?route=/preferences/manage');
 
-                return null;
+                return $this->response->response();
             }
 
             $GLOBALS['error'] = $result;
 
-            return null;
+            return $this->response->response();
         }
 
         $relationParameters = $this->relation->getRelationParameters();
@@ -270,6 +270,6 @@ final class ManageController implements InvocableController
             define('PMA_DISABLE_NAVI_SETTINGS', true);
         }
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Preferences/NavigationController.php
+++ b/src/Controllers/Preferences/NavigationController.php
@@ -33,7 +33,7 @@ final class NavigationController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['error'] ??= null;
         $GLOBALS['tabHash'] ??= null;
@@ -49,7 +49,7 @@ final class NavigationController implements InvocableController
             $formDisplay->fixErrors();
             $this->response->redirectToRoute('/preferences/navigation', []);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['error'] = null;
@@ -67,7 +67,7 @@ final class NavigationController implements InvocableController
                 $GLOBALS['hash'] = ltrim($GLOBALS['tabHash'], '#');
                 $this->userPreferences->redirect('index.php?route=/preferences/navigation', null, $GLOBALS['hash']);
 
-                return null;
+                return $this->response->response();
             }
 
             $GLOBALS['error'] = $result;
@@ -97,11 +97,11 @@ final class NavigationController implements InvocableController
         if ($request->isAjax()) {
             $this->response->addJSON('disableNaviSettings', true);
 
-            return null;
+            return $this->response->response();
         }
 
         define('PMA_DISABLE_NAVI_SETTINGS', true);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Preferences/SqlController.php
+++ b/src/Controllers/Preferences/SqlController.php
@@ -33,7 +33,7 @@ final class SqlController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['error'] ??= null;
         $GLOBALS['tabHash'] ??= null;
@@ -49,7 +49,7 @@ final class SqlController implements InvocableController
             $formDisplay->fixErrors();
             $this->response->redirectToRoute('/preferences/sql', []);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['error'] = null;
@@ -67,7 +67,7 @@ final class SqlController implements InvocableController
                 $GLOBALS['hash'] = ltrim($GLOBALS['tabHash'], '#');
                 $this->userPreferences->redirect('index.php?route=/preferences/sql', null, $GLOBALS['hash']);
 
-                return null;
+                return $this->response->response();
             }
 
             $GLOBALS['error'] = $result;
@@ -100,6 +100,6 @@ final class SqlController implements InvocableController
             define('PMA_DISABLE_NAVI_SETTINGS', true);
         }
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Preferences/TwoFactorController.php
+++ b/src/Controllers/Preferences/TwoFactorController.php
@@ -23,7 +23,7 @@ final class TwoFactorController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $relationParameters = $this->relation->getRelationParameters();
 
@@ -39,7 +39,7 @@ final class TwoFactorController implements InvocableController
             if (! $twoFactor->check($request, true)) {
                 $this->response->render('preferences/two_factor/confirm', ['form' => $twoFactor->render($request)]);
 
-                return null;
+                return $this->response->response();
             }
 
             $twoFactor->configure($request, '');
@@ -53,7 +53,7 @@ final class TwoFactorController implements InvocableController
                     'configure' => $request->getParsedBodyParam('2fa_configure'),
                 ]);
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->addHTML(
@@ -78,6 +78,6 @@ final class TwoFactorController implements InvocableController
             define('PMA_DISABLE_NAVI_SETTINGS', true);
         }
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/SchemaExportController.php
+++ b/src/Controllers/SchemaExportController.php
@@ -31,7 +31,7 @@ final class SchemaExportController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $db = DatabaseName::tryFrom($request->getParsedBodyParam('db'));
         /** @var mixed $exportType */
@@ -43,7 +43,7 @@ final class SchemaExportController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addHTML(Message::error($errorMessage)->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         /**
@@ -55,7 +55,7 @@ final class SchemaExportController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addHTML(Message::error($exception->getMessage())->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         $response = $this->responseFactory->createResponse();

--- a/src/Controllers/Server/BinlogController.php
+++ b/src/Controllers/Server/BinlogController.php
@@ -34,7 +34,7 @@ final class BinlogController implements InvocableController
         $this->binaryLogs = $this->dbi->fetchResult('SHOW MASTER LOGS', 'Log_name');
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $log = $request->getParsedBodyParam('log');
         $position = (int) $request->getParsedBodyParam('pos', 0);
@@ -98,7 +98,7 @@ final class BinlogController implements InvocableController
             'is_full_query' => $isFullQuery,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Server/CollationsController.php
+++ b/src/Controllers/Server/CollationsController.php
@@ -41,7 +41,7 @@ final class CollationsController implements InvocableController
         $this->collations = $collations ?? Charsets::getCollations($this->dbi, $config->selectedServer['DisableIS']);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] = Url::getFromRoute('/');
 
@@ -69,6 +69,6 @@ final class CollationsController implements InvocableController
 
         $this->response->render('server/collations/index', ['charsets' => $charsets]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Databases/CreateController.php
+++ b/src/Controllers/Server/Databases/CreateController.php
@@ -31,7 +31,7 @@ final class CreateController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $newDb = $request->getParsedBodyParam('new_db');
         $dbCollation = $request->getParsedBodyParam('db_collation');
@@ -39,7 +39,7 @@ final class CreateController implements InvocableController
         if (! is_string($newDb) || $newDb === '' || ! $request->isAjax()) {
             $this->response->addJSON(['message' => Message::error()]);
 
-            return null;
+            return $this->response->response();
         }
 
         if ($this->dbi->getLowerCaseNames() === 1) {
@@ -96,6 +96,6 @@ final class CreateController implements InvocableController
 
         $this->response->addJSON($json);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Databases/DestroyController.php
+++ b/src/Controllers/Server/Databases/DestroyController.php
@@ -33,7 +33,7 @@ final class DestroyController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['selected'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
@@ -51,7 +51,7 @@ final class DestroyController implements InvocableController
             $this->response->setRequestStatus($message->isSuccess());
             $this->response->addJSON($json);
 
-            return null;
+            return $this->response->response();
         }
 
         if (
@@ -63,7 +63,7 @@ final class DestroyController implements InvocableController
             $this->response->setRequestStatus($message->isSuccess());
             $this->response->addJSON($json);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['errorUrl'] = Url::getFromRoute('/server/databases');
@@ -93,6 +93,6 @@ final class DestroyController implements InvocableController
         $this->response->setRequestStatus($message->isSuccess());
         $this->response->addJSON($json);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/DatabasesController.php
+++ b/src/Controllers/Server/DatabasesController.php
@@ -66,7 +66,7 @@ final class DatabasesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
 
@@ -166,7 +166,7 @@ final class DatabasesController implements InvocableController
             'text_dir' => LanguageManager::$textDir,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Server/EnginesController.php
+++ b/src/Controllers/Server/EnginesController.php
@@ -21,7 +21,7 @@ final class EnginesController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] = Url::getFromRoute('/');
 
@@ -31,6 +31,6 @@ final class EnginesController implements InvocableController
 
         $this->response->render('server/engines/index', ['engines' => StorageEngine::getStorageEngines()]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/ExportController.php
+++ b/src/Controllers/Server/ExportController.php
@@ -29,7 +29,7 @@ final class ExportController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['unlim_num_rows'] ??= null;
         $GLOBALS['errorUrl'] = Url::getFromRoute('/');
@@ -70,7 +70,7 @@ final class ExportController implements InvocableController
                 __('Could not load export plugins, please check your installation!'),
             )->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         $options = $this->export->getOptions(
@@ -89,6 +89,6 @@ final class ExportController implements InvocableController
             'databases' => $databases,
         ]));
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/ImportController.php
+++ b/src/Controllers/Server/ImportController.php
@@ -35,7 +35,7 @@ final class ImportController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['SESSION_KEY'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
@@ -61,7 +61,7 @@ final class ImportController implements InvocableController
                 'Could not load import plugins, please check your installation!',
             ))->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         $offset = null;
@@ -119,6 +119,6 @@ final class ImportController implements InvocableController
             'local_files' => Import::getLocalFiles($importList),
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/PluginsController.php
+++ b/src/Controllers/Server/PluginsController.php
@@ -29,7 +29,7 @@ final class PluginsController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] = Url::getFromRoute('/');
 
@@ -58,6 +58,6 @@ final class PluginsController implements InvocableController
 
         $this->response->render('server/plugins/index', ['plugins' => $plugins, 'clean_types' => $cleanTypes]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Privileges/AccountLockController.php
+++ b/src/Controllers/Server/Privileges/AccountLockController.php
@@ -23,10 +23,10 @@ final class AccountLockController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         /** @var string $userName */
@@ -41,7 +41,7 @@ final class AccountLockController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON(['message' => Message::error($exception->getMessage())]);
 
-            return null;
+            return $this->response->response();
         }
 
         $message = Message::success(__('The account %s@%s has been successfully locked.'));
@@ -49,6 +49,6 @@ final class AccountLockController implements InvocableController
         $message->addParam($hostName);
         $this->response->addJSON(['message' => $message]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Privileges/AccountUnlockController.php
+++ b/src/Controllers/Server/Privileges/AccountUnlockController.php
@@ -23,10 +23,10 @@ final class AccountUnlockController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         /** @var string $userName */
@@ -41,7 +41,7 @@ final class AccountUnlockController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON(['message' => Message::error($exception->getMessage())]);
 
-            return null;
+            return $this->response->response();
         }
 
         $message = Message::success(__('The account %s@%s has been successfully unlocked.'));
@@ -49,6 +49,6 @@ final class AccountUnlockController implements InvocableController
         $message->addParam($hostName);
         $this->response->addJSON(['message' => $message]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/PrivilegesController.php
+++ b/src/Controllers/Server/PrivilegesController.php
@@ -42,7 +42,7 @@ final class PrivilegesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
         $GLOBALS['message'] ??= null;
@@ -106,7 +106,7 @@ final class PrivilegesController implements InvocableController
                     ->getDisplay(),
             );
 
-            return null;
+            return $this->response->response();
         }
 
         if (! $isGrantUser && ! $isCreateUser) {
@@ -135,7 +135,7 @@ final class PrivilegesController implements InvocableController
             );
             $this->response->setRequestStatus(false);
 
-            return null;
+            return $this->response->response();
         }
 
         /**
@@ -300,7 +300,7 @@ final class PrivilegesController implements InvocableController
                 $this->response->addJSON('message', $GLOBALS['message']);
                 $this->response->addJSON($extraData);
 
-                return null;
+                return $this->response->response();
             }
         }
 
@@ -331,7 +331,7 @@ final class PrivilegesController implements InvocableController
                 $this->response->addJSON('message', $export);
                 $this->response->addJSON('title', $title);
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->addHTML('<h2>' . $title . '</h2>' . $export);
@@ -395,12 +395,12 @@ final class PrivilegesController implements InvocableController
         }
 
         if ($relationParameters->configurableMenusFeature === null) {
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addHTML('</div>');
 
-        return null;
+        return $this->response->response();
     }
 
     private function getExportPageTitle(string $username, string $hostname, array|null $selectedUsers): string

--- a/src/Controllers/Server/ReplicationController.php
+++ b/src/Controllers/Server/ReplicationController.php
@@ -30,7 +30,7 @@ final class ReplicationController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
@@ -133,6 +133,6 @@ final class ReplicationController implements InvocableController
             'change_primary_html' => $changePrimaryHtml ?? '',
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/ShowEngineController.php
+++ b/src/Controllers/Server/ShowEngineController.php
@@ -27,7 +27,7 @@ final class ShowEngineController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $this->setEngineAndPageProperties($request->getAttribute('routeVars'));
 
@@ -54,7 +54,7 @@ final class ShowEngineController implements InvocableController
 
         $this->response->render('server/engines/show', ['engine' => $engine, 'page' => $this->page]);
 
-        return null;
+        return $this->response->response();
     }
 
     private function setEngineAndPageProperties(mixed $routeVars): void

--- a/src/Controllers/Server/SqlController.php
+++ b/src/Controllers/Server/SqlController.php
@@ -26,7 +26,7 @@ final class SqlController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
 
@@ -43,6 +43,6 @@ final class SqlController implements InvocableController
 
         $this->response->addHTML($this->sqlQueryForm->getHtml('', ''));
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Status/AdvisorController.php
+++ b/src/Controllers/Server/Status/AdvisorController.php
@@ -26,7 +26,7 @@ final class AdvisorController extends AbstractController implements InvocableCon
         parent::__construct($response, $template, $data);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $data = [];
         if ($this->data->dataLoaded) {
@@ -35,6 +35,6 @@ final class AdvisorController extends AbstractController implements InvocableCon
 
         $this->response->render('server/status/advisor/index', ['data' => $data]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Status/Monitor/ChartingDataController.php
+++ b/src/Controllers/Server/Status/Monitor/ChartingDataController.php
@@ -27,7 +27,7 @@ final class ChartingDataController extends AbstractController implements Invocab
         parent::__construct($response, $template, $data);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
 
@@ -39,11 +39,11 @@ final class ChartingDataController extends AbstractController implements Invocab
         }
 
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addJSON(['message' => $this->monitor->getJsonForChartingData($requiredData)]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Status/Monitor/GeneralLogController.php
+++ b/src/Controllers/Server/Status/Monitor/GeneralLogController.php
@@ -27,7 +27,7 @@ final class GeneralLogController extends AbstractController implements Invocable
         parent::__construct($response, $template, $data);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
 
@@ -38,7 +38,7 @@ final class GeneralLogController extends AbstractController implements Invocable
         }
 
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         $data = $this->monitor->getJsonForLogDataTypeGeneral(
@@ -50,11 +50,11 @@ final class GeneralLogController extends AbstractController implements Invocable
         if ($data === null) {
             $this->response->setRequestStatus(false);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addJSON(['message' => $data]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Status/Monitor/LogVarsController.php
+++ b/src/Controllers/Server/Status/Monitor/LogVarsController.php
@@ -27,7 +27,7 @@ final class LogVarsController extends AbstractController implements InvocableCon
         parent::__construct($response, $template, $data);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
 
@@ -38,7 +38,7 @@ final class LogVarsController extends AbstractController implements InvocableCon
         }
 
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addJSON([
@@ -48,6 +48,6 @@ final class LogVarsController extends AbstractController implements InvocableCon
             ),
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Status/Monitor/QueryAnalyzerController.php
+++ b/src/Controllers/Server/Status/Monitor/QueryAnalyzerController.php
@@ -27,7 +27,7 @@ final class QueryAnalyzerController extends AbstractController implements Invoca
         parent::__construct($response, $template, $data);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
 
@@ -38,7 +38,7 @@ final class QueryAnalyzerController extends AbstractController implements Invoca
         }
 
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addJSON([
@@ -48,6 +48,6 @@ final class QueryAnalyzerController extends AbstractController implements Invoca
             ),
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Status/Monitor/SlowLogController.php
+++ b/src/Controllers/Server/Status/Monitor/SlowLogController.php
@@ -27,7 +27,7 @@ final class SlowLogController extends AbstractController implements InvocableCon
         parent::__construct($response, $template, $data);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
 
@@ -38,7 +38,7 @@ final class SlowLogController extends AbstractController implements InvocableCon
         }
 
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         $data = $this->monitor->getJsonForLogDataTypeSlow(
@@ -48,11 +48,11 @@ final class SlowLogController extends AbstractController implements InvocableCon
         if ($data === null) {
             $this->response->setRequestStatus(false);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addJSON(['message' => $data]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Status/MonitorController.php
+++ b/src/Controllers/Server/Status/MonitorController.php
@@ -28,7 +28,7 @@ final class MonitorController extends AbstractController implements InvocableCon
         parent::__construct($response, $template, $data);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] = Url::getFromRoute('/');
 
@@ -73,6 +73,6 @@ final class MonitorController extends AbstractController implements InvocableCon
             'form' => $form,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Status/Processes/KillController.php
+++ b/src/Controllers/Server/Status/Processes/KillController.php
@@ -29,10 +29,10 @@ final class KillController extends AbstractController implements InvocableContro
         parent::__construct($response, $template, $data);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         $processId = $this->getProcessId($request->getAttribute('routeVars'));
@@ -56,7 +56,7 @@ final class KillController extends AbstractController implements InvocableContro
 
         $this->response->addJSON(['message' => $message]);
 
-        return null;
+        return $this->response->response();
     }
 
     private function getProcessId(mixed $routeVars): int

--- a/src/Controllers/Server/Status/Processes/RefreshController.php
+++ b/src/Controllers/Server/Status/Processes/RefreshController.php
@@ -24,10 +24,10 @@ final class RefreshController extends AbstractController implements InvocableCon
         parent::__construct($response, $template, $data);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         $this->response->render('server/status/processes/list', $this->processes->getList(
@@ -37,6 +37,6 @@ final class RefreshController extends AbstractController implements InvocableCon
             (string) $request->getParsedBodyParam('sort_order', ''),
         ));
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Status/ProcessesController.php
+++ b/src/Controllers/Server/Status/ProcessesController.php
@@ -26,7 +26,7 @@ final class ProcessesController extends AbstractController implements InvocableC
         parent::__construct($response, $template, $data);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] = Url::getFromRoute('/');
 
@@ -62,6 +62,6 @@ final class ProcessesController extends AbstractController implements InvocableC
             'server_process_list' => $listHtml,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Status/QueriesController.php
+++ b/src/Controllers/Server/Status/QueriesController.php
@@ -38,7 +38,7 @@ final class QueriesController extends AbstractController implements InvocableCon
         parent::__construct($response, $template, $data);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] = Url::getFromRoute('/');
 
@@ -102,6 +102,6 @@ final class QueriesController extends AbstractController implements InvocableCon
             'chart_data' => $chartData,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/Status/StatusController.php
+++ b/src/Controllers/Server/Status/StatusController.php
@@ -33,7 +33,7 @@ final class StatusController extends AbstractController implements InvocableCont
         parent::__construct($response, $template, $data);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] = Url::getFromRoute('/');
 
@@ -92,7 +92,7 @@ final class StatusController extends AbstractController implements InvocableCont
             'replication' => $replication,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 
     private function getStartTime(): int

--- a/src/Controllers/Server/Status/VariablesController.php
+++ b/src/Controllers/Server/Status/VariablesController.php
@@ -33,7 +33,7 @@ final class VariablesController extends AbstractController implements InvocableC
         parent::__construct($response, $template, $data);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
 
@@ -130,7 +130,7 @@ final class VariablesController extends AbstractController implements InvocableC
             'variables' => $variables ?? [],
         ]);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Server/UserGroupsController.php
+++ b/src/Controllers/Server/UserGroupsController.php
@@ -28,11 +28,11 @@ final class UserGroupsController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $configurableMenusFeature = $this->relation->getRelationParameters()->configurableMenusFeature;
         if ($configurableMenusFeature === null) {
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addScriptFiles(['server/user_groups.js']);
@@ -45,7 +45,7 @@ final class UserGroupsController implements InvocableController
                 Message::error(__('No Privileges'))->getDisplay(),
             );
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addHTML('<div class="container-fluid">');
@@ -98,6 +98,6 @@ final class UserGroupsController implements InvocableController
 
         $this->response->addHTML('</div>');
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Server/UserGroupsFormController.php
+++ b/src/Controllers/Server/UserGroupsFormController.php
@@ -29,10 +29,10 @@ final class UserGroupsFormController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         /** @var string $username */
@@ -43,7 +43,7 @@ final class UserGroupsFormController implements InvocableController
             $this->response->setStatusCode(StatusCodeInterface::STATUS_BAD_REQUEST);
             $this->response->addJSON('message', __('Missing parameter:') . ' username');
 
-            return null;
+            return $this->response->response();
         }
 
         $configurableMenusFeature = $this->relation->getRelationParameters()->configurableMenusFeature;
@@ -52,14 +52,14 @@ final class UserGroupsFormController implements InvocableController
             $this->response->setStatusCode(StatusCodeInterface::STATUS_BAD_REQUEST);
             $this->response->addJSON('message', __('User groups management is not enabled.'));
 
-            return null;
+            return $this->response->response();
         }
 
         $form = $this->getHtmlToChooseUserGroup($username, $configurableMenusFeature);
 
         $this->response->addJSON('message', $form);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Server/Variables/GetVariableController.php
+++ b/src/Controllers/Server/Variables/GetVariableController.php
@@ -22,10 +22,10 @@ final class GetVariableController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         $name = $this->getName($request->getAttribute('routeVars'));
@@ -50,7 +50,7 @@ final class GetVariableController implements InvocableController
 
         $this->response->addJSON($json);
 
-        return null;
+        return $this->response->response();
     }
 
     private function getName(mixed $routeVars): string

--- a/src/Controllers/Server/Variables/SetVariableController.php
+++ b/src/Controllers/Server/Variables/SetVariableController.php
@@ -35,10 +35,10 @@ final class SetVariableController implements InvocableController
     /**
      * Handle the AJAX request for setting value for a single variable
      */
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $request->isAjax()) {
-            return null;
+            return $this->response->response();
         }
 
         $value = (string) $request->getParsedBodyParam('varValue');
@@ -83,7 +83,7 @@ final class SetVariableController implements InvocableController
 
         $this->response->addJSON($json);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Server/VariablesController.php
+++ b/src/Controllers/Server/VariablesController.php
@@ -34,7 +34,7 @@ final class VariablesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] = Url::getFromRoute('/');
 
@@ -93,7 +93,7 @@ final class VariablesController implements InvocableController
             'is_mariadb' => $this->dbi->isMariaDB(),
         ]);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Sql/ColumnPreferencesController.php
+++ b/src/Controllers/Sql/ColumnPreferencesController.php
@@ -24,7 +24,7 @@ final class ColumnPreferencesController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $tableObject = $this->dbi->getTable(Current::$database, Current::$table);
         $status = false;
@@ -50,11 +50,11 @@ final class ColumnPreferencesController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $status->getString());
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->setRequestStatus($status);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Sql/DefaultForeignKeyCheckValueController.php
+++ b/src/Controllers/Sql/DefaultForeignKeyCheckValueController.php
@@ -16,10 +16,10 @@ final class DefaultForeignKeyCheckValueController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $this->response->addJSON('default_fk_check_value', ForeignKey::isCheckEnabled());
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Sql/EnumValuesController.php
+++ b/src/Controllers/Sql/EnumValuesController.php
@@ -26,7 +26,7 @@ final class EnumValuesController implements InvocableController
     /**
      * Get possible values for enum fields during grid edit.
      */
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $column = $request->getParsedBodyParam('column');
         $currValue = $request->getParsedBodyParam('curr_value');
@@ -36,7 +36,7 @@ final class EnumValuesController implements InvocableController
             $this->response->addJSON('message', __('Error in processing request'));
             $this->response->setRequestStatus(false);
 
-            return null;
+            return $this->response->response();
         }
 
         $dropdown = $this->template->render('sql/enum_column_dropdown', [
@@ -46,6 +46,6 @@ final class EnumValuesController implements InvocableController
 
         $this->response->addJSON('dropdown', $dropdown);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Sql/RelationalValuesController.php
+++ b/src/Controllers/Sql/RelationalValuesController.php
@@ -22,7 +22,7 @@ final class RelationalValuesController implements InvocableController
      *
      * During grid edit, if we have a relational field, show the dropdown for it.
      */
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $column = $request->getParsedBodyParam('column');
         $relationKeyOrDisplayColumn = $request->getParsedBodyParam('relation_key_or_display_column');
@@ -41,6 +41,6 @@ final class RelationalValuesController implements InvocableController
         );
         $this->response->addJSON('dropdown', $dropdown);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Sql/SetValuesController.php
+++ b/src/Controllers/Sql/SetValuesController.php
@@ -27,7 +27,7 @@ final class SetValuesController implements InvocableController
     /**
      * Get possible values for SET fields during grid edit.
      */
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $column = $request->getParsedBodyParam('column');
         $currentValue = $request->getParsedBodyParam('curr_value');
@@ -39,7 +39,7 @@ final class SetValuesController implements InvocableController
             $this->response->addJSON('message', __('Error in processing request'));
             $this->response->setRequestStatus(false);
 
-            return null;
+            return $this->response->response();
         }
 
         // If the $currentValue was truncated, we should fetch the correct full values from the table.
@@ -59,6 +59,6 @@ final class SetValuesController implements InvocableController
 
         $this->response->addJSON('select', $select);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Sql/SqlController.php
+++ b/src/Controllers/Sql/SqlController.php
@@ -37,7 +37,7 @@ class SqlController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['display_query'] ??= null;
         $GLOBALS['ajax_reload'] ??= null;
@@ -126,7 +126,7 @@ class SqlController implements InvocableController
             // set $goto to what will be displayed if query returns 0 rows
             $GLOBALS['goto'] = '';
         } elseif (! $this->response->checkParameters(['sql_query'])) {
-            return null;
+            return $this->response->response();
         }
 
         /**
@@ -171,7 +171,7 @@ class SqlController implements InvocableController
         if ($storeBkm && $bkmFields !== null) {
             $this->addBookmark($GLOBALS['goto'], $bkmFields, (bool) $bkmAllUsers);
 
-            return null;
+            return $this->response->response();
         }
 
         /**
@@ -201,7 +201,7 @@ class SqlController implements InvocableController
             $GLOBALS['complete_query'] ?? null,
         ));
 
-        return null;
+        return $this->response->response();
     }
 
     /** @param array<string> $bkmFields */

--- a/src/Controllers/Table/AddFieldController.php
+++ b/src/Controllers/Table/AddFieldController.php
@@ -47,7 +47,7 @@ final class AddFieldController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
         $GLOBALS['message'] ??= null;
@@ -58,7 +58,7 @@ final class AddFieldController implements InvocableController
         $this->response->addScriptFiles(['table/structure.js']);
 
         if (! $this->response->checkParameters(['db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
@@ -93,7 +93,7 @@ final class AddFieldController implements InvocableController
             if (isset($_POST['preview_sql'])) {
                 Core::previewSQL($GLOBALS['sql_query']);
 
-                return null;
+                return $this->response->response();
             }
 
             $result = $createAddField->tryColumnCreationQuery(
@@ -107,7 +107,7 @@ final class AddFieldController implements InvocableController
                 $this->response->addHTML($errorMessageHtml ?? '');
                 $this->response->setRequestStatus(false);
 
-                return null;
+                return $this->response->response();
             }
 
             // Update comment table for mime types [MIME]
@@ -150,7 +150,7 @@ final class AddFieldController implements InvocableController
                 ]),
             );
 
-            return null;
+            return $this->response->response();
         }
 
         $urlParams = ['db' => Current::$database, 'table' => Current::$table];
@@ -163,12 +163,12 @@ final class AddFieldController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $tableName = TableName::tryFrom($request->getParam('table'));
@@ -177,24 +177,24 @@ final class AddFieldController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addScriptFiles(['vendor/jquery/jquery.uitablefilter.js']);
 
         if (! $this->response->checkParameters(['server', 'db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         $templateData = $this->columnsDefinition->displayForm($userPrivileges, '/table/add-field', $numFields);
 
         $this->response->render('columns_definitions/column_definitions_form', $templateData);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/ChangeController.php
+++ b/src/Controllers/Table/ChangeController.php
@@ -49,7 +49,7 @@ class ChangeController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['disp_message'] ??= null;
         $GLOBALS['urlParams'] ??= null;
@@ -68,12 +68,12 @@ class ChangeController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $tableName = TableName::tryFrom($request->getParam('table'));
@@ -82,12 +82,12 @@ class ChangeController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->setInsertRowsParam($request->getParsedBodyParam('insert_rows'));
@@ -291,7 +291,7 @@ class ChangeController implements InvocableController
 
         $this->response->addHTML($htmlOutput);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Table/ChangeRowsController.php
+++ b/src/Controllers/Table/ChangeRowsController.php
@@ -46,8 +46,6 @@ final class ChangeRowsController implements InvocableController
             $GLOBALS['where_clause'] = array_values($rowsToDelete);
         }
 
-        ($this->changeController)($request);
-
-        return null;
+        return ($this->changeController)($request);
     }
 }

--- a/src/Controllers/Table/ChangeRowsController.php
+++ b/src/Controllers/Table/ChangeRowsController.php
@@ -21,7 +21,7 @@ final class ChangeRowsController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['where_clause'] ??= null;
 
@@ -34,7 +34,7 @@ final class ChangeRowsController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No row selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         // As we got the rows to be edited from the

--- a/src/Controllers/Table/ChartController.php
+++ b/src/Controllers/Table/ChartController.php
@@ -41,7 +41,7 @@ final class ChartController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
 
@@ -50,12 +50,12 @@ final class ChartController implements InvocableController
                 Current::$table !== '' && Current::$database !== ''
                 && ! $this->response->checkParameters(['db', 'table'])
             ) {
-                return null;
+                return $this->response->response();
             }
 
             $this->ajax($request);
 
-            return null;
+            return $this->response->response();
         }
 
         // Throw error if no sql query is set
@@ -65,7 +65,7 @@ final class ChartController implements InvocableController
                 Message::error(__('No SQL query was set to fetch data.'))->getDisplay(),
             );
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addScriptFiles([
@@ -91,7 +91,7 @@ final class ChartController implements InvocableController
          */
         if (Current::$table !== '') {
             if (! $this->response->checkParameters(['db', 'table'])) {
-                return null;
+                return $this->response->response();
             }
 
             $urlParams = ['db' => Current::$database, 'table' => Current::$table];
@@ -104,12 +104,12 @@ final class ChartController implements InvocableController
                     $this->response->setRequestStatus(false);
                     $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-                return null;
+                return $this->response->response();
             }
 
             $tableName = TableName::tryFrom($request->getParam('table'));
@@ -118,12 +118,12 @@ final class ChartController implements InvocableController
                     $this->response->setRequestStatus(false);
                     $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-                return null;
+                return $this->response->response();
             }
 
             $urlParams['goto'] = Util::getScriptNameForOption($config->settings['DefaultTabTable'], 'table');
@@ -134,7 +134,7 @@ final class ChartController implements InvocableController
             $urlParams['back'] = Url::getFromRoute('/sql');
 
             if (! $this->response->checkParameters(['db'])) {
-                return null;
+                return $this->response->response();
             }
 
             $GLOBALS['errorUrl'] = Util::getScriptNameForOption($config->settings['DefaultTabDatabase'], 'database');
@@ -146,12 +146,12 @@ final class ChartController implements InvocableController
                     $this->response->setRequestStatus(false);
                     $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-                return null;
+                return $this->response->response();
             }
         } else {
             $urlParams['goto'] = Util::getScriptNameForOption($config->settings['DefaultTabServer'], 'server');
@@ -191,7 +191,7 @@ final class ChartController implements InvocableController
                 __('No numeric columns present in the table to plot.'),
             );
 
-            return null;
+            return $this->response->response();
         }
 
         $urlParams['db'] = Current::$database;
@@ -210,7 +210,7 @@ final class ChartController implements InvocableController
             'start_and_number_of_rows_fieldset' => $startAndNumberOfRowsFieldset,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Table/CreateController.php
+++ b/src/Controllers/Table/CreateController.php
@@ -42,10 +42,10 @@ final class CreateController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $this->response->checkParameters(['db'])) {
-            return null;
+            return $this->response->response();
         }
 
         $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
@@ -103,7 +103,7 @@ final class CreateController implements InvocableController
             if (isset($_POST['preview_sql'])) {
                 Core::previewSQL($GLOBALS['sql_query']);
 
-                return null;
+                return $this->response->response();
             }
 
             // Executes the query
@@ -137,7 +137,7 @@ final class CreateController implements InvocableController
                 $this->response->addJSON('message', $this->dbi->getError());
             }
 
-            return null;
+            return $this->response->response();
         }
 
         // Do not display the table in the header since it hasn't been created yet
@@ -146,14 +146,14 @@ final class CreateController implements InvocableController
         $this->response->addScriptFiles(['vendor/jquery/jquery.uitablefilter.js']);
 
         if (! $this->response->checkParameters(['server', 'db'])) {
-            return null;
+            return $this->response->response();
         }
 
         $templateData = $this->columnsDefinition->displayForm($userPrivileges, '/table/create', $numFields);
 
         $this->response->render('columns_definitions/column_definitions_form', $templateData);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Table/DeleteConfirmController.php
+++ b/src/Controllers/Table/DeleteConfirmController.php
@@ -29,7 +29,7 @@ final class DeleteConfirmController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
@@ -40,11 +40,11 @@ final class DeleteConfirmController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No row selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         if (! $this->response->checkParameters(['db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams'] = ['db' => Current::$database, 'table' => Current::$table];
@@ -60,12 +60,12 @@ final class DeleteConfirmController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $tableName = TableName::tryFrom($request->getParam('table'));
@@ -74,12 +74,12 @@ final class DeleteConfirmController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->render('table/delete/confirm', [
@@ -90,6 +90,6 @@ final class DeleteConfirmController implements InvocableController
             'is_foreign_key_check' => ForeignKey::isCheckEnabled(),
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/DeleteRowsController.php
+++ b/src/Controllers/Table/DeleteRowsController.php
@@ -32,7 +32,7 @@ final class DeleteRowsController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['goto'] ??= null;
         $GLOBALS['disp_message'] ??= null;
@@ -97,6 +97,6 @@ final class DeleteRowsController implements InvocableController
             null,
         ));
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/DropColumnConfirmationController.php
+++ b/src/Controllers/Table/DropColumnConfirmationController.php
@@ -27,7 +27,7 @@ final class DropColumnConfirmationController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $fields = $request->getParsedBodyParam('selected_fld');
         try {
@@ -37,11 +37,11 @@ final class DropColumnConfirmationController implements InvocableController
         } catch (InvalidIdentifier $exception) {
             $this->sendErrorResponse($exception->getMessage());
 
-            return null;
+            return $this->response->response();
         } catch (InvalidArgumentException) {
             $this->sendErrorResponse(__('No column selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         if (! $this->dbTableExists->selectDatabase($db)) {
@@ -49,12 +49,12 @@ final class DropColumnConfirmationController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         if (! $this->dbTableExists->hasTable($db, $table)) {
@@ -62,12 +62,12 @@ final class DropColumnConfirmationController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->render('table/structure/drop_confirm', [
@@ -76,7 +76,7 @@ final class DropColumnConfirmationController implements InvocableController
             'fields' => $fields,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 
     private function sendErrorResponse(string $message): void

--- a/src/Controllers/Table/DropColumnController.php
+++ b/src/Controllers/Table/DropColumnController.php
@@ -29,7 +29,7 @@ final class DropColumnController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $selected = $_POST['selected'] ?? [];
 
@@ -37,7 +37,7 @@ final class DropColumnController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No column selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         $selectedCount = count($selected);
@@ -75,6 +75,6 @@ final class DropColumnController implements InvocableController
         $this->flashMessenger->addMessage($message->isError() ? 'danger' : 'success', $message->getMessage());
         $this->response->redirectToRoute('/table/structure', ['db' => Current::$database, 'table' => Current::$table]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/ExportController.php
+++ b/src/Controllers/Table/ExportController.php
@@ -34,7 +34,7 @@ class ExportController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
@@ -48,7 +48,7 @@ class ExportController implements InvocableController
         $this->response->addScriptFiles(['export.js']);
 
         if (! $this->response->checkParameters(['db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams'] = ['db' => Current::$database, 'table' => Current::$table];
@@ -103,7 +103,7 @@ class ExportController implements InvocableController
                 __('Could not load export plugins, please check your installation!'),
             )->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         $exportType = 'table';
@@ -128,6 +128,6 @@ class ExportController implements InvocableController
             'page_settings_html' => $pageSettingsHtml,
         ]));
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/ExportRowsController.php
+++ b/src/Controllers/Table/ExportRowsController.php
@@ -21,7 +21,7 @@ final class ExportRowsController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['single_table'] ??= null;
         $GLOBALS['where_clause'] ??= null;
@@ -30,7 +30,7 @@ final class ExportRowsController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No row selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         // Needed to allow SQL export

--- a/src/Controllers/Table/ExportRowsController.php
+++ b/src/Controllers/Table/ExportRowsController.php
@@ -45,8 +45,6 @@ final class ExportRowsController implements InvocableController
             $GLOBALS['where_clause'] = array_values($_POST['rows_to_delete']);
         }
 
-        ($this->exportController)($request);
-
-        return null;
+        return ($this->exportController)($request);
     }
 }

--- a/src/Controllers/Table/FindReplaceController.php
+++ b/src/Controllers/Table/FindReplaceController.php
@@ -52,12 +52,12 @@ final class FindReplaceController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
         if (! $this->response->checkParameters(['db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams'] = ['db' => Current::$database, 'table' => Current::$table];
@@ -73,12 +73,12 @@ final class FindReplaceController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $tableName = TableName::tryFrom($request->getParam('table'));
@@ -87,12 +87,12 @@ final class FindReplaceController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->loadTableInfo();
@@ -107,7 +107,7 @@ final class FindReplaceController implements InvocableController
             $preview = $this->getReplacePreview($columnIndex, $find, $replaceWith, $useRegex, $connectionCharSet);
             $this->response->addJSON('preview', $preview);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addScriptFiles(['table/find_replace.js']);
@@ -127,7 +127,7 @@ final class FindReplaceController implements InvocableController
         // Displays the find and replace form
         $this->displaySelectionFormAction();
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Table/GetFieldController.php
+++ b/src/Controllers/Table/GetFieldController.php
@@ -35,10 +35,10 @@ final class GetFieldController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $this->response->checkParameters(['db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         /* Select database */
@@ -65,7 +65,7 @@ final class GetFieldController implements InvocableController
             /* l10n: In case a SQL query did not pass a security check  */
             $this->response->addHTML(Message::error(__('There is an issue with your request.'))->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         $transformKey = (string) $request->getQueryParam('transform_key', '');
@@ -82,7 +82,7 @@ final class GetFieldController implements InvocableController
                 $sql,
             );
 
-            return null;
+            return $this->response->response();
         }
 
         $result ??= '';

--- a/src/Controllers/Table/GisVisualizationController.php
+++ b/src/Controllers/Table/GisVisualizationController.php
@@ -44,10 +44,10 @@ final class GisVisualizationController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $this->response->checkParameters(['db'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['errorUrl'] = Util::getScriptNameForOption(
@@ -62,12 +62,12 @@ final class GisVisualizationController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         // SQL query for retrieving GIS data
@@ -80,7 +80,7 @@ final class GisVisualizationController implements InvocableController
                 Message::error(__('No SQL query was set to fetch data.'))->getDisplay(),
             );
 
-            return null;
+            return $this->response->response();
         }
 
         $meta = $this->getColumnMeta($sqlQuery);
@@ -102,7 +102,7 @@ final class GisVisualizationController implements InvocableController
                 Message::error(__('No spatial column found for this SQL query.'))->getDisplay(),
             );
 
-            return null;
+            return $this->response->response();
         }
 
         // Get settings if any posted
@@ -169,7 +169,7 @@ final class GisVisualizationController implements InvocableController
 
         $this->response->addHTML($html);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Table/ImportController.php
+++ b/src/Controllers/Table/ImportController.php
@@ -39,7 +39,7 @@ final class ImportController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['SESSION_KEY'] ??= null;
@@ -52,7 +52,7 @@ final class ImportController implements InvocableController
         $this->response->addScriptFiles(['import.js']);
 
         if (! $this->response->checkParameters(['db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams'] = ['db' => Current::$database, 'table' => Current::$table];
@@ -66,12 +66,12 @@ final class ImportController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $tableName = TableName::tryFrom($request->getParam('table'));
@@ -80,12 +80,12 @@ final class ImportController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/table/import');
@@ -101,7 +101,7 @@ final class ImportController implements InvocableController
                 'Could not load import plugins, please check your installation!',
             ))->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         $offset = null;
@@ -163,6 +163,6 @@ final class ImportController implements InvocableController
             'local_files' => Import::getLocalFiles($importList),
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/IndexRenameController.php
+++ b/src/Controllers/Table/IndexRenameController.php
@@ -36,13 +36,13 @@ final class IndexRenameController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
 
         if (! $this->response->checkParameters(['db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams'] = ['db' => Current::$database, 'table' => Current::$table];
@@ -58,12 +58,12 @@ final class IndexRenameController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $tableName = TableName::tryFrom($request->getParam('table'));
@@ -72,12 +72,12 @@ final class IndexRenameController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $oldIndexName = $request->getParsedBodyParam('old_index');
@@ -93,7 +93,7 @@ final class IndexRenameController implements InvocableController
 
             $this->response->render('table/index_rename_form', ['index' => $index, 'form_params' => $formParams]);
 
-            return null;
+            return $this->response->response();
         }
 
         // coming already from form
@@ -115,7 +115,7 @@ final class IndexRenameController implements InvocableController
                 $this->template->render('preview_sql', ['query_data' => $sqlQuery]),
             );
 
-            return null;
+            return $this->response->response();
         }
 
         $logicError = $this->indexes->getError();
@@ -123,7 +123,7 @@ final class IndexRenameController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $logicError);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->dbi->query($sqlQuery);
@@ -147,6 +147,6 @@ final class IndexRenameController implements InvocableController
             ]),
         );
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/IndexesController.php
+++ b/src/Controllers/Table/IndexesController.php
@@ -164,9 +164,8 @@ final class IndexesController implements InvocableController
 
             /** @var StructureController $controller */
             $controller = ContainerBuilder::getContainer()->get(StructureController::class);
-            $controller($request);
 
-            return null;
+            return $controller($request);
         }
 
         $this->displayForm($index);

--- a/src/Controllers/Table/IndexesController.php
+++ b/src/Controllers/Table/IndexesController.php
@@ -45,14 +45,14 @@ final class IndexesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
 
         if (! isset($_POST['create_edit_table'])) {
             if (! $this->response->checkParameters(['db', 'table'])) {
-                return null;
+                return $this->response->response();
             }
 
             $GLOBALS['urlParams'] = ['db' => Current::$database, 'table' => Current::$table];
@@ -68,12 +68,12 @@ final class IndexesController implements InvocableController
                     $this->response->setRequestStatus(false);
                     $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-                return null;
+                return $this->response->response();
             }
 
             $tableName = TableName::tryFrom($request->getParam('table'));
@@ -82,12 +82,12 @@ final class IndexesController implements InvocableController
                     $this->response->setRequestStatus(false);
                     $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-                return null;
+                return $this->response->response();
             }
         }
 
@@ -124,7 +124,7 @@ final class IndexesController implements InvocableController
                     $this->template->render('preview_sql', ['query_data' => $sqlQuery]),
                 );
 
-                return null;
+                return $this->response->response();
             }
 
             $logicError = $this->indexes->getError();
@@ -132,7 +132,7 @@ final class IndexesController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', $logicError);
 
-                return null;
+                return $this->response->response();
             }
 
             $this->dbi->query($sqlQuery);
@@ -159,7 +159,7 @@ final class IndexesController implements InvocableController
                     ]),
                 );
 
-                return null;
+                return $this->response->response();
             }
 
             /** @var StructureController $controller */
@@ -170,7 +170,7 @@ final class IndexesController implements InvocableController
 
         $this->displayForm($index);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Table/Maintenance/AnalyzeController.php
+++ b/src/Controllers/Table/Maintenance/AnalyzeController.php
@@ -31,7 +31,7 @@ final class AnalyzeController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $selectedTablesParam = $request->getParsedBodyParam('selected_tbl');
 
@@ -43,7 +43,7 @@ final class AnalyzeController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         try {
@@ -57,14 +57,14 @@ final class AnalyzeController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $message->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         if ($this->config->get('DisableMultiTableMaintenance') && count($selectedTables) > 1) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('Maintenance operations on multiple tables are disabled.'));
 
-            return null;
+            return $this->response->response();
         }
 
         [$rows, $query] = $this->model->getAnalyzeTableRows($database, $selectedTables);
@@ -77,6 +77,6 @@ final class AnalyzeController implements InvocableController
 
         $this->response->render('table/maintenance/analyze', ['message' => $message, 'rows' => $rows]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/Maintenance/CheckController.php
+++ b/src/Controllers/Table/Maintenance/CheckController.php
@@ -31,7 +31,7 @@ final class CheckController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $selectedTablesParam = $request->getParsedBodyParam('selected_tbl');
 
@@ -43,7 +43,7 @@ final class CheckController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         try {
@@ -57,14 +57,14 @@ final class CheckController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $message->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         if ($this->config->get('DisableMultiTableMaintenance') && count($selectedTables) > 1) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('Maintenance operations on multiple tables are disabled.'));
 
-            return null;
+            return $this->response->response();
         }
 
         [$rows, $query] = $this->model->getCheckTableRows($database, $selectedTables);
@@ -83,6 +83,6 @@ final class CheckController implements InvocableController
             'indexes_problems' => $indexesProblems,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/Maintenance/ChecksumController.php
+++ b/src/Controllers/Table/Maintenance/ChecksumController.php
@@ -31,7 +31,7 @@ final class ChecksumController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $selectedTablesParam = $request->getParsedBodyParam('selected_tbl');
 
@@ -43,7 +43,7 @@ final class ChecksumController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         try {
@@ -57,14 +57,14 @@ final class ChecksumController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $message->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         if ($this->config->get('DisableMultiTableMaintenance') && count($selectedTables) > 1) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('Maintenance operations on multiple tables are disabled.'));
 
-            return null;
+            return $this->response->response();
         }
 
         [$rows, $query, $warnings] = $this->model->getChecksumTableRows($database, $selectedTables);
@@ -81,6 +81,6 @@ final class ChecksumController implements InvocableController
             'warnings' => $warnings,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/Maintenance/OptimizeController.php
+++ b/src/Controllers/Table/Maintenance/OptimizeController.php
@@ -31,7 +31,7 @@ final class OptimizeController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $selectedTablesParam = $request->getParsedBodyParam('selected_tbl');
 
@@ -43,7 +43,7 @@ final class OptimizeController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         try {
@@ -57,14 +57,14 @@ final class OptimizeController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $message->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         if ($this->config->get('DisableMultiTableMaintenance') && count($selectedTables) > 1) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('Maintenance operations on multiple tables are disabled.'));
 
-            return null;
+            return $this->response->response();
         }
 
         [$rows, $query] = $this->model->getOptimizeTableRows($database, $selectedTables);
@@ -77,6 +77,6 @@ final class OptimizeController implements InvocableController
 
         $this->response->render('table/maintenance/optimize', ['message' => $message, 'rows' => $rows]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/Maintenance/RepairController.php
+++ b/src/Controllers/Table/Maintenance/RepairController.php
@@ -31,7 +31,7 @@ final class RepairController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $selectedTablesParam = $request->getParsedBodyParam('selected_tbl');
 
@@ -43,7 +43,7 @@ final class RepairController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No table selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         try {
@@ -57,14 +57,14 @@ final class RepairController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $message->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         if ($this->config->get('DisableMultiTableMaintenance') && count($selectedTables) > 1) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('Maintenance operations on multiple tables are disabled.'));
 
-            return null;
+            return $this->response->response();
         }
 
         [$rows, $query] = $this->model->getRepairTableRows($database, $selectedTables);
@@ -77,6 +77,6 @@ final class RepairController implements InvocableController
 
         $this->response->render('table/maintenance/repair', ['message' => $message, 'rows' => $rows]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/Partition/AnalyzeController.php
+++ b/src/Controllers/Table/Partition/AnalyzeController.php
@@ -26,7 +26,7 @@ final class AnalyzeController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $partitionName = $request->getParsedBodyParam('partition_name');
 
@@ -38,7 +38,7 @@ final class AnalyzeController implements InvocableController
             $message = Message::error($exception->getMessage());
             $this->response->addHTML($message->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         [$rows, $query] = $this->model->analyze($database, $table, $partitionName);
@@ -55,6 +55,6 @@ final class AnalyzeController implements InvocableController
             'rows' => $rows,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/Partition/CheckController.php
+++ b/src/Controllers/Table/Partition/CheckController.php
@@ -26,7 +26,7 @@ final class CheckController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $partitionName = $request->getParsedBodyParam('partition_name');
 
@@ -38,7 +38,7 @@ final class CheckController implements InvocableController
             $message = Message::error($exception->getMessage());
             $this->response->addHTML($message->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         [$rows, $query] = $this->model->check($database, $table, $partitionName);
@@ -55,6 +55,6 @@ final class CheckController implements InvocableController
             'rows' => $rows,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/Partition/DropController.php
+++ b/src/Controllers/Table/Partition/DropController.php
@@ -26,7 +26,7 @@ final class DropController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $partitionName = $request->getParsedBodyParam('partition_name');
 
@@ -38,7 +38,7 @@ final class DropController implements InvocableController
             $message = Message::error($exception->getMessage());
             $this->response->addHTML($message->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         [$result, $query] = $this->model->drop($database, $table, $partitionName);
@@ -59,6 +59,6 @@ final class DropController implements InvocableController
 
         $this->response->render('table/partition/drop', ['partition_name' => $partitionName, 'message' => $message]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/Partition/OptimizeController.php
+++ b/src/Controllers/Table/Partition/OptimizeController.php
@@ -26,7 +26,7 @@ final class OptimizeController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $partitionName = $request->getParsedBodyParam('partition_name');
 
@@ -38,7 +38,7 @@ final class OptimizeController implements InvocableController
             $message = Message::error($exception->getMessage());
             $this->response->addHTML($message->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         [$rows, $query] = $this->model->optimize($database, $table, $partitionName);
@@ -55,6 +55,6 @@ final class OptimizeController implements InvocableController
             'rows' => $rows,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/Partition/RebuildController.php
+++ b/src/Controllers/Table/Partition/RebuildController.php
@@ -26,7 +26,7 @@ final class RebuildController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $partitionName = $request->getParsedBodyParam('partition_name');
 
@@ -38,7 +38,7 @@ final class RebuildController implements InvocableController
             $message = Message::error($exception->getMessage());
             $this->response->addHTML($message->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         [$result, $query] = $this->model->rebuild($database, $table, $partitionName);
@@ -59,6 +59,6 @@ final class RebuildController implements InvocableController
 
         $this->response->render('table/partition/rebuild', ['partition_name' => $partitionName, 'message' => $message]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/Partition/RepairController.php
+++ b/src/Controllers/Table/Partition/RepairController.php
@@ -26,7 +26,7 @@ final class RepairController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $partitionName = $request->getParsedBodyParam('partition_name');
 
@@ -38,7 +38,7 @@ final class RepairController implements InvocableController
             $message = Message::error($exception->getMessage());
             $this->response->addHTML($message->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         [$rows, $query] = $this->model->repair($database, $table, $partitionName);
@@ -55,6 +55,6 @@ final class RepairController implements InvocableController
             'rows' => $rows,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/Partition/TruncateController.php
+++ b/src/Controllers/Table/Partition/TruncateController.php
@@ -26,7 +26,7 @@ final class TruncateController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $partitionName = $request->getParsedBodyParam('partition_name');
 
@@ -38,7 +38,7 @@ final class TruncateController implements InvocableController
             $message = Message::error($exception->getMessage());
             $this->response->addHTML($message->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         [$result, $query] = $this->model->truncate($database, $table, $partitionName);
@@ -62,6 +62,6 @@ final class TruncateController implements InvocableController
             'message' => $message,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/PrivilegesController.php
+++ b/src/Controllers/Table/PrivilegesController.php
@@ -36,7 +36,7 @@ final class PrivilegesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         try {
             $db = DatabaseName::from($request->getParam('db'));
@@ -48,7 +48,7 @@ final class PrivilegesController implements InvocableController
         } catch (InvalidIdentifier $exception) {
             $this->response->addHTML(Message::error($exception->getMessage())->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addScriptFiles(['server/privileges.js', 'vendor/zxcvbn-ts.js']);
@@ -66,7 +66,7 @@ final class PrivilegesController implements InvocableController
                     ->getDisplay(),
             );
 
-            return null;
+            return $this->response->response();
         }
 
         if (! $isGrantUser && ! $isCreateUser) {
@@ -94,6 +94,6 @@ final class PrivilegesController implements InvocableController
         ]);
         $this->response->render('export_modal', []);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/RecentFavoriteController.php
+++ b/src/Controllers/Table/RecentFavoriteController.php
@@ -26,7 +26,7 @@ final class RecentFavoriteController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         try {
             $db = DatabaseName::from($request->getParam('db'));
@@ -34,7 +34,7 @@ final class RecentFavoriteController implements InvocableController
         } catch (InvalidIdentifier) {
             $this->response->redirectToRoute('/', ['message' => __('Invalid database or table name.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $favoriteTable = new RecentFavoriteTable($db, $table);
@@ -43,6 +43,6 @@ final class RecentFavoriteController implements InvocableController
 
         $this->response->redirectToRoute('/sql', ['db' => $db->getName(), 'table' => $table->getName()]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/RelationController.php
+++ b/src/Controllers/Table/RelationController.php
@@ -51,7 +51,7 @@ final class RelationController implements InvocableController
     /**
      * Index
      */
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $options = [
             'CASCADE' => 'CASCADE',
@@ -85,7 +85,7 @@ final class RelationController implements InvocableController
                 $this->getDropdownValueForDatabase($storageEngine);
             }
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addScriptFiles(['table/relation.js']);
@@ -131,7 +131,7 @@ final class RelationController implements InvocableController
         if (isset($_POST['preview_sql'])) {
             Core::previewSQL($previewSqlData);
 
-            return null;
+            return $this->response->response();
         }
 
         if ($displayQuery !== '' && ! $seenError) {
@@ -311,7 +311,7 @@ final class RelationController implements InvocableController
             'foreign_key_row' => $foreignKeyRow,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Table/ReplaceController.php
+++ b/src/Controllers/Table/ReplaceController.php
@@ -286,9 +286,7 @@ final class ReplaceController implements InvocableController
                 $gotoInclude = '/table/change';
             }
 
-            $this->moveBackToCallingScript($gotoInclude, $request);
-
-            return null;
+            return $this->moveBackToCallingScript($gotoInclude, $request);
         }
 
         // If there is a request for SQL previewing.
@@ -375,9 +373,7 @@ final class ReplaceController implements InvocableController
             unset($_POST['where_clause']);
         }
 
-        $this->moveBackToCallingScript($gotoInclude, $request);
-
-        return null;
+        return $this->moveBackToCallingScript($gotoInclude, $request);
     }
 
     /** @param string[][] $mimeMap */
@@ -465,27 +461,21 @@ final class ReplaceController implements InvocableController
         $this->response->addJSON($extraData);
     }
 
-    private function moveBackToCallingScript(string $gotoInclude, ServerRequest $request): void
+    private function moveBackToCallingScript(string $gotoInclude, ServerRequest $request): Response|null
     {
         if ($gotoInclude === '/sql') {
-            ($this->sqlController)($request);
-
-            return;
+            return ($this->sqlController)($request);
         }
 
         if ($gotoInclude === '/database/sql') {
-            ($this->databaseSqlController)($request);
-
-            return;
+            return ($this->databaseSqlController)($request);
         }
 
         if ($gotoInclude === '/table/sql') {
-            ($this->tableSqlController)($request);
-
-            return;
+            return ($this->tableSqlController)($request);
         }
 
-        ($this->changeController)($request);
+        return ($this->changeController)($request);
     }
 
     /**

--- a/src/Controllers/Table/ReplaceController.php
+++ b/src/Controllers/Table/ReplaceController.php
@@ -54,12 +54,12 @@ final class ReplaceController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['message'] ??= null;
         if (! $this->response->checkParameters(['db', 'table', 'goto'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['errorUrl'] ??= null;
@@ -293,7 +293,7 @@ final class ReplaceController implements InvocableController
         if ($request->hasBodyParam('preview_sql')) {
             Core::previewSQL($GLOBALS['query']);
 
-            return null;
+            return $this->response->response();
         }
 
         $returnToSqlQuery = '';
@@ -352,7 +352,7 @@ final class ReplaceController implements InvocableController
              */
             $this->doTransformations($mimeMap, $request);
 
-            return null;
+            return $this->response->response();
         }
 
         if (! empty($returnToSqlQuery)) {
@@ -461,7 +461,7 @@ final class ReplaceController implements InvocableController
         $this->response->addJSON($extraData);
     }
 
-    private function moveBackToCallingScript(string $gotoInclude, ServerRequest $request): Response|null
+    private function moveBackToCallingScript(string $gotoInclude, ServerRequest $request): Response
     {
         if ($gotoInclude === '/sql') {
             return ($this->sqlController)($request);

--- a/src/Controllers/Table/SearchController.php
+++ b/src/Controllers/Table/SearchController.php
@@ -153,10 +153,10 @@ final class SearchController implements InvocableController
     /**
      * Index action
      */
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $this->response->checkParameters(['db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams'] = ['db' => Current::$database, 'table' => Current::$table];
@@ -172,12 +172,12 @@ final class SearchController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $tableName = TableName::tryFrom($request->getParam('table'));
@@ -186,12 +186,12 @@ final class SearchController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->loadTableInfo();
@@ -208,7 +208,7 @@ final class SearchController implements InvocableController
         if (isset($_POST['range_search'])) {
             $this->rangeSearchAction();
 
-            return null;
+            return $this->response->response();
         }
 
         /**
@@ -220,7 +220,7 @@ final class SearchController implements InvocableController
             $this->doSelectionAction();
         }
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Table/SqlController.php
+++ b/src/Controllers/Table/SqlController.php
@@ -35,7 +35,7 @@ class SqlController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
         $GLOBALS['goto'] ??= null;
@@ -48,7 +48,7 @@ class SqlController implements InvocableController
         $this->response->addHTML($this->pageSettings->getHTML());
 
         if (! $this->response->checkParameters(['db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         $urlParams = ['db' => Current::$database, 'table' => Current::$table];
@@ -64,12 +64,12 @@ class SqlController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $tableName = TableName::tryFrom($request->getParam('table'));
@@ -78,12 +78,12 @@ class SqlController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         /**
@@ -102,6 +102,6 @@ class SqlController implements InvocableController
             htmlspecialchars($delimiter),
         ));
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/Structure/AbstractIndexController.php
+++ b/src/Controllers/Table/Structure/AbstractIndexController.php
@@ -26,14 +26,14 @@ abstract class AbstractIndexController
     }
 
     /** @psalm-param 'FULLTEXT'|'INDEX'|'PRIMARY'|'SPATIAL'|'UNIQUE' $indexType */
-    public function handleIndexCreation(ServerRequest $request, string $indexType): Response|null
+    public function handleIndexCreation(ServerRequest $request, string $indexType): Response
     {
         $selected = $request->getParsedBodyParam('selected_fld', []);
         if (! is_array($selected) || $selected === []) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No column selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         Assert::allString($selected);

--- a/src/Controllers/Table/Structure/AbstractIndexController.php
+++ b/src/Controllers/Table/Structure/AbstractIndexController.php
@@ -6,10 +6,12 @@ namespace PhpMyAdmin\Controllers\Table\Structure;
 
 use PhpMyAdmin\Controllers\Table\StructureController;
 use PhpMyAdmin\Current;
+use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Query\Generator;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Table\Indexes;
+use Webmozart\Assert\Assert;
 
 use function __;
 use function is_array;
@@ -23,23 +25,31 @@ abstract class AbstractIndexController
     ) {
     }
 
-    public function handleIndexCreation(ServerRequest $request, string $indexType): void
+    /** @psalm-param 'FULLTEXT'|'INDEX'|'PRIMARY'|'SPATIAL'|'UNIQUE' $indexType */
+    public function handleIndexCreation(ServerRequest $request, string $indexType): Response|null
     {
-        $GLOBALS['message'] ??= null;
-
         $selected = $request->getParsedBodyParam('selected_fld', []);
-
         if (! is_array($selected) || $selected === []) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No column selected.'));
 
-            return;
+            return null;
         }
 
-        $GLOBALS['sql_query'] = Generator::getAddIndexSql($indexType, Current::$table, $selected);
+        Assert::allString($selected);
 
-        $GLOBALS['message'] = $this->indexes->executeAddIndexSql(Current::$database, $GLOBALS['sql_query']);
+        if ($indexType === 'PRIMARY') {
+            $hasPrimaryKey = $this->indexes->hasPrimaryKey(Current::$table);
+            $statement = Generator::getAddPrimaryKeyStatement(Current::$table, $selected[0], $hasPrimaryKey);
+        } else {
+            $statement = Generator::getAddIndexSql($indexType, Current::$table, $selected);
+        }
 
-        ($this->structureController)($request);
+        $message = $this->indexes->executeAddIndexSql(Current::$database, $statement);
+
+        $GLOBALS['sql_query'] = $statement;
+        $GLOBALS['message'] = $message;
+
+        return ($this->structureController)($request);
     }
 }

--- a/src/Controllers/Table/Structure/AddIndexController.php
+++ b/src/Controllers/Table/Structure/AddIndexController.php
@@ -12,8 +12,6 @@ final class AddIndexController extends AbstractIndexController implements Invoca
 {
     public function __invoke(ServerRequest $request): Response|null
     {
-        $this->handleIndexCreation($request, 'INDEX');
-
-        return null;
+        return $this->handleIndexCreation($request, 'INDEX');
     }
 }

--- a/src/Controllers/Table/Structure/AddIndexController.php
+++ b/src/Controllers/Table/Structure/AddIndexController.php
@@ -10,7 +10,7 @@ use PhpMyAdmin\Http\ServerRequest;
 
 final class AddIndexController extends AbstractIndexController implements InvocableController
 {
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         return $this->handleIndexCreation($request, 'INDEX');
     }

--- a/src/Controllers/Table/Structure/AddKeyController.php
+++ b/src/Controllers/Table/Structure/AddKeyController.php
@@ -5,27 +5,32 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers\Table\Structure;
 
 use PhpMyAdmin\Controllers\InvocableController;
-use PhpMyAdmin\Controllers\Sql\SqlController;
-use PhpMyAdmin\Controllers\Table\StructureController;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 
-final class AddKeyController implements InvocableController
-{
-    public function __construct(
-        private readonly SqlController $sqlController,
-        private readonly StructureController $structureController,
-    ) {
-    }
+use function __;
+use function in_array;
 
+final class AddKeyController extends AbstractIndexController implements InvocableController
+{
     public function __invoke(ServerRequest $request): Response|null
     {
-        ($this->sqlController)($request);
-
         $GLOBALS['reload'] = true;
 
-        ($this->structureController)($request);
+        $keyType = $this->getKeyType($request->getParsedBodyParam('key_type'));
+        if ($keyType === '') {
+            $this->response->setRequestStatus(false);
+            $this->response->addJSON('message', __('Invalid request parameter.'));
 
-        return null;
+            return null;
+        }
+
+        return $this->handleIndexCreation($request, $keyType);
+    }
+
+    /** @psalm-return  'FULLTEXT'|'INDEX'|'PRIMARY'|'SPATIAL'|'UNIQUE'|'' */
+    private function getKeyType(mixed $keyType): string
+    {
+        return in_array($keyType, ['FULLTEXT', 'INDEX', 'PRIMARY', 'SPATIAL', 'UNIQUE'], true) ? $keyType : '';
     }
 }

--- a/src/Controllers/Table/Structure/AddKeyController.php
+++ b/src/Controllers/Table/Structure/AddKeyController.php
@@ -13,7 +13,7 @@ use function in_array;
 
 final class AddKeyController extends AbstractIndexController implements InvocableController
 {
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['reload'] = true;
 
@@ -22,7 +22,7 @@ final class AddKeyController extends AbstractIndexController implements Invocabl
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('Invalid request parameter.'));
 
-            return null;
+            return $this->response->response();
         }
 
         return $this->handleIndexCreation($request, $keyType);

--- a/src/Controllers/Table/Structure/BrowseController.php
+++ b/src/Controllers/Table/Structure/BrowseController.php
@@ -23,18 +23,18 @@ final class BrowseController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (empty($_POST['selected_fld'])) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No column selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         $this->displayTableBrowseForSelectedColumns($GLOBALS['goto']);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Table/Structure/CentralColumnsAddController.php
+++ b/src/Controllers/Table/Structure/CentralColumnsAddController.php
@@ -26,7 +26,7 @@ final class CentralColumnsAddController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['message'] ??= null;
 
@@ -36,7 +36,7 @@ final class CentralColumnsAddController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No column selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         Assert::allString($selected);

--- a/src/Controllers/Table/Structure/CentralColumnsAddController.php
+++ b/src/Controllers/Table/Structure/CentralColumnsAddController.php
@@ -56,8 +56,6 @@ final class CentralColumnsAddController implements InvocableController
             $GLOBALS['message'] = Message::success();
         }
 
-        ($this->structureController)($request);
-
-        return null;
+        return ($this->structureController)($request);
     }
 }

--- a/src/Controllers/Table/Structure/CentralColumnsRemoveController.php
+++ b/src/Controllers/Table/Structure/CentralColumnsRemoveController.php
@@ -51,8 +51,6 @@ final class CentralColumnsRemoveController implements InvocableController
             $GLOBALS['message'] = Message::success();
         }
 
-        ($this->structureController)($request);
-
-        return null;
+        return ($this->structureController)($request);
     }
 }

--- a/src/Controllers/Table/Structure/CentralColumnsRemoveController.php
+++ b/src/Controllers/Table/Structure/CentralColumnsRemoveController.php
@@ -26,7 +26,7 @@ final class CentralColumnsRemoveController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['message'] ??= null;
 
@@ -36,7 +36,7 @@ final class CentralColumnsRemoveController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No column selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         Assert::allString($selected);

--- a/src/Controllers/Table/Structure/ChangeController.php
+++ b/src/Controllers/Table/Structure/ChangeController.php
@@ -32,16 +32,16 @@ final class ChangeController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $this->response->checkParameters(['server', 'db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         if ($request->getParam('change_column') !== null) {
             $this->displayHtmlForColumnChange([$request->getParam('field')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $selected = $request->getParsedBodyParam('selected_fld', []);
@@ -50,12 +50,12 @@ final class ChangeController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No column selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         $this->displayHtmlForColumnChange($selected);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Table/Structure/FulltextController.php
+++ b/src/Controllers/Table/Structure/FulltextController.php
@@ -12,8 +12,6 @@ final class FulltextController extends AbstractIndexController implements Invoca
 {
     public function __invoke(ServerRequest $request): Response|null
     {
-        $this->handleIndexCreation($request, 'FULLTEXT');
-
-        return null;
+        return $this->handleIndexCreation($request, 'FULLTEXT');
     }
 }

--- a/src/Controllers/Table/Structure/FulltextController.php
+++ b/src/Controllers/Table/Structure/FulltextController.php
@@ -10,7 +10,7 @@ use PhpMyAdmin\Http\ServerRequest;
 
 final class FulltextController extends AbstractIndexController implements InvocableController
 {
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         return $this->handleIndexCreation($request, 'FULLTEXT');
     }

--- a/src/Controllers/Table/Structure/MoveColumnsController.php
+++ b/src/Controllers/Table/Structure/MoveColumnsController.php
@@ -37,14 +37,14 @@ final class MoveColumnsController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $moveColumns = $request->getParsedBodyParam('move_columns');
         $previewSql = $request->getParsedBodyParam('preview_sql') === '1';
         if (! is_array($moveColumns) || ! array_is_list($moveColumns) || ! $this->response->isAjax()) {
             $this->response->setRequestStatus(false);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->dbi->selectDb(Current::$database);
@@ -55,7 +55,7 @@ final class MoveColumnsController implements InvocableController
         if ($sqlQuery === null) {
             $this->response->setRequestStatus(false);
 
-            return null;
+            return $this->response->response();
         }
 
         if ($previewSql) {
@@ -64,7 +64,7 @@ final class MoveColumnsController implements InvocableController
                 $this->template->render('preview_sql', ['query_data' => $sqlQuery]),
             );
 
-            return null;
+            return $this->response->response();
         }
 
         $this->dbi->tryQuery($sqlQuery);
@@ -73,7 +73,7 @@ final class MoveColumnsController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', Message::error($tmpError));
 
-            return null;
+            return $this->response->response();
         }
 
         $message = Message::success(
@@ -82,7 +82,7 @@ final class MoveColumnsController implements InvocableController
         $this->response->addJSON('message', $message);
         $this->response->addJSON('columns', $moveColumns);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Table/Structure/PartitioningController.php
+++ b/src/Controllers/Table/Structure/PartitioningController.php
@@ -41,7 +41,7 @@ final class PartitioningController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (isset($_POST['save_partitioning'])) {
             $this->dbi->selectDb(Current::$database);
@@ -74,7 +74,7 @@ final class PartitioningController implements InvocableController
             'storage_engines' => $storageEngines,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Table/Structure/PartitioningController.php
+++ b/src/Controllers/Table/Structure/PartitioningController.php
@@ -46,9 +46,8 @@ final class PartitioningController implements InvocableController
         if (isset($_POST['save_partitioning'])) {
             $this->dbi->selectDb(Current::$database);
             $this->updatePartitioning();
-            ($this->structureController)($request);
 
-            return null;
+            return ($this->structureController)($request);
         }
 
         $this->pageSettings->init('TableStructure');

--- a/src/Controllers/Table/Structure/PrimaryController.php
+++ b/src/Controllers/Table/Structure/PrimaryController.php
@@ -131,9 +131,7 @@ final class PrimaryController implements InvocableController
             $GLOBALS['message'] = Message::success();
         }
 
-        ($this->structureController)($request);
-
-        return null;
+        return ($this->structureController)($request);
     }
 
     private function hasPrimaryKey(): bool

--- a/src/Controllers/Table/Structure/PrimaryController.php
+++ b/src/Controllers/Table/Structure/PrimaryController.php
@@ -33,7 +33,7 @@ final class PrimaryController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['message'] ??= null;
         $GLOBALS['urlParams'] ??= null;
@@ -46,7 +46,7 @@ final class PrimaryController implements InvocableController
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No column selected.'));
 
-            return null;
+            return $this->response->response();
         }
 
         $this->dbi->selectDb(Current::$database);
@@ -57,7 +57,7 @@ final class PrimaryController implements InvocableController
 
         if ($hasPrimary && $deletionConfirmed === null) {
             if (! $this->response->checkParameters(['db', 'table'])) {
-                return null;
+                return $this->response->response();
             }
 
             $GLOBALS['urlParams'] = ['db' => Current::$database, 'table' => Current::$table];
@@ -73,12 +73,12 @@ final class PrimaryController implements InvocableController
                     $this->response->setRequestStatus(false);
                     $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-                return null;
+                return $this->response->response();
             }
 
             $tableName = TableName::tryFrom($request->getParam('table'));
@@ -87,12 +87,12 @@ final class PrimaryController implements InvocableController
                     $this->response->setRequestStatus(false);
                     $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->render('table/structure/primary', [
@@ -101,7 +101,7 @@ final class PrimaryController implements InvocableController
                 'selected' => $selected,
             ]);
 
-            return null;
+            return $this->response->response();
         }
 
         if ($deletionConfirmed === __('Yes') || ! $hasPrimary) {

--- a/src/Controllers/Table/Structure/ReservedWordCheckController.php
+++ b/src/Controllers/Table/Structure/ReservedWordCheckController.php
@@ -24,12 +24,12 @@ final class ReservedWordCheckController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (Config::getInstance()->settings['ReservedWordDisableWarning'] !== false) {
             $this->response->setRequestStatus(false);
 
-            return null;
+            return $this->response->response();
         }
 
         $columnsNames = $request->getParsedBodyParam('field_name');
@@ -62,6 +62,6 @@ final class ReservedWordCheckController implements InvocableController
             ),
         );
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Table/Structure/SaveController.php
+++ b/src/Controllers/Table/Structure/SaveController.php
@@ -60,9 +60,7 @@ final class SaveController implements InvocableController
             unset($_POST['selected']);
         }
 
-        ($this->structureController)($request);
-
-        return null;
+        return ($this->structureController)($request);
     }
 
     /**

--- a/src/Controllers/Table/Structure/SaveController.php
+++ b/src/Controllers/Table/Structure/SaveController.php
@@ -50,7 +50,7 @@ final class SaveController implements InvocableController
         $this->tableObj = $this->dbi->getTable(Current::$database, Current::$table);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 

--- a/src/Controllers/Table/Structure/SpatialController.php
+++ b/src/Controllers/Table/Structure/SpatialController.php
@@ -12,8 +12,6 @@ final class SpatialController extends AbstractIndexController implements Invocab
 {
     public function __invoke(ServerRequest $request): Response|null
     {
-        $this->handleIndexCreation($request, 'SPATIAL');
-
-        return null;
+        return $this->handleIndexCreation($request, 'SPATIAL');
     }
 }

--- a/src/Controllers/Table/Structure/SpatialController.php
+++ b/src/Controllers/Table/Structure/SpatialController.php
@@ -10,7 +10,7 @@ use PhpMyAdmin\Http\ServerRequest;
 
 final class SpatialController extends AbstractIndexController implements InvocableController
 {
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         return $this->handleIndexCreation($request, 'SPATIAL');
     }

--- a/src/Controllers/Table/Structure/UniqueController.php
+++ b/src/Controllers/Table/Structure/UniqueController.php
@@ -12,8 +12,6 @@ final class UniqueController extends AbstractIndexController implements Invocabl
 {
     public function __invoke(ServerRequest $request): Response|null
     {
-        $this->handleIndexCreation($request, 'UNIQUE');
-
-        return null;
+        return $this->handleIndexCreation($request, 'UNIQUE');
     }
 }

--- a/src/Controllers/Table/Structure/UniqueController.php
+++ b/src/Controllers/Table/Structure/UniqueController.php
@@ -10,7 +10,7 @@ use PhpMyAdmin\Http\ServerRequest;
 
 final class UniqueController extends AbstractIndexController implements InvocableController
 {
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         return $this->handleIndexCreation($request, 'UNIQUE');
     }

--- a/src/Controllers/Table/StructureController.php
+++ b/src/Controllers/Table/StructureController.php
@@ -62,7 +62,7 @@ class StructureController implements InvocableController
         $this->tableObj = $this->dbi->getTable(Current::$database, Current::$table);
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errorUrl'] ??= null;
 
@@ -77,7 +77,7 @@ class StructureController implements InvocableController
         $relationParameters = $this->relation->getRelationParameters();
 
         if (! $this->response->checkParameters(['db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         $isSystemSchema = Utilities::isSystemSchema(Current::$database);
@@ -94,12 +94,12 @@ class StructureController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $tableName = TableName::tryFrom($request->getParam('table'));
@@ -108,12 +108,12 @@ class StructureController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $primary = Index::getPrimary($this->dbi, Current::$table, Current::$database);
@@ -132,7 +132,7 @@ class StructureController implements InvocableController
             $request->getRoute(),
         ));
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/Table/TrackingController.php
+++ b/src/Controllers/Table/TrackingController.php
@@ -47,7 +47,7 @@ final class TrackingController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
@@ -55,7 +55,7 @@ final class TrackingController implements InvocableController
         $this->response->addScriptFiles(['vendor/jquery/jquery.tablesorter.js', 'table/tracking.js']);
 
         if (! $this->response->checkParameters(['db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams'] = ['db' => Current::$database, 'table' => Current::$table];
@@ -71,12 +71,12 @@ final class TrackingController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $activeMessage = '';
@@ -270,7 +270,7 @@ final class TrackingController implements InvocableController
             'main' => $main,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 
     private function validateDateTimeParam(mixed $param): DateTimeImmutable

--- a/src/Controllers/Table/ZoomSearchController.php
+++ b/src/Controllers/Table/ZoomSearchController.php
@@ -78,13 +78,13 @@ final class ZoomSearchController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['goto'] ??= null;
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
         if (! $this->response->checkParameters(['db', 'table'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams'] = ['db' => Current::$database, 'table' => Current::$table];
@@ -98,12 +98,12 @@ final class ZoomSearchController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $tableName = TableName::tryFrom($request->getParam('table'));
@@ -112,12 +112,12 @@ final class ZoomSearchController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No table selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->loadTableInfo();
@@ -143,7 +143,7 @@ final class ZoomSearchController implements InvocableController
         if (isset($_POST['get_data_row']) && $_POST['get_data_row'] == true) {
             $this->getDataRowAction();
 
-            return null;
+            return $this->response->response();
         }
 
         /**
@@ -153,7 +153,7 @@ final class ZoomSearchController implements InvocableController
         if ($request->hasBodyParam('change_tbl_info')) {
             $this->changeTableInfoAction();
 
-            return null;
+            return $this->response->response();
         }
 
         //Set default datalabel if not selected
@@ -176,7 +176,7 @@ final class ZoomSearchController implements InvocableController
             || $_POST['criteriaColumnNames'][1] === 'pma_null'
             || $_POST['criteriaColumnNames'][0] == $_POST['criteriaColumnNames'][1]
         ) {
-            return null;
+            return $this->response->response();
         }
 
         if (! isset($GLOBALS['goto'])) {
@@ -185,7 +185,7 @@ final class ZoomSearchController implements InvocableController
 
         $this->zoomSubmitAction($dataLabel, $GLOBALS['goto']);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/TableController.php
+++ b/src/Controllers/TableController.php
@@ -16,17 +16,17 @@ final class TableController implements InvocableController
     {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $request->hasBodyParam('db')) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON(['message' => Message::error()]);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addJSON(['tables' => $this->dbi->getTables($request->getParsedBodyParam('db'))]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/ThemeSetController.php
+++ b/src/Controllers/ThemeSetController.php
@@ -23,19 +23,19 @@ final class ThemeSetController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $theme = $request->getParsedBodyParam('set_theme');
         if (! Config::getInstance()->settings['ThemeManager'] || ! is_string($theme) || $theme === '') {
             if ($request->isAjax()) {
                 $this->response->addJSON('themeColorMode', '');
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirect('index.php?route=/' . Url::getCommonRaw([], '&'));
 
-            return null;
+            return $this->response->response();
         }
 
         $this->themeManager->setActiveTheme($theme);
@@ -55,11 +55,11 @@ final class ThemeSetController implements InvocableController
         if ($request->isAjax()) {
             $this->response->addJSON('themeColorMode', $this->themeManager->theme->getColorMode());
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->redirect('index.php?route=/' . Url::getCommonRaw([], '&'));
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/ThemesController.php
+++ b/src/Controllers/ThemesController.php
@@ -19,18 +19,18 @@ final class ThemesController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $themes = $this->themeManager->getThemesArray();
         $themesList = $this->template->render('home/themes', ['themes' => $themes]);
         if ($request->isAjax()) {
             $this->response->addJSON('themes', $themesList);
 
-            return null;
+            return $this->response->response();
         }
 
         $this->response->addHTML($themesList);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Transformation/OverviewController.php
+++ b/src/Controllers/Transformation/OverviewController.php
@@ -23,7 +23,7 @@ final class OverviewController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $header = $this->response->getHeader();
         $header->disableMenuAndConsole();
@@ -51,6 +51,6 @@ final class OverviewController implements InvocableController
             'transformations' => $transformations,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/Transformation/WrapperController.php
+++ b/src/Controllers/Transformation/WrapperController.php
@@ -49,7 +49,7 @@ final class WrapperController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $this->response->getHeader()->setIsTransformationWrapper(true);
 
@@ -57,15 +57,15 @@ final class WrapperController implements InvocableController
             $db = DatabaseName::from($request->getParam('db'));
             $table = TableName::from($request->getParam('table'));
         } catch (InvalidIdentifier) {
-            return null;
+            return $this->response->response();
         }
 
         if (! $this->dbi->selectDb($db)) {
-            return null;
+            return $this->response->response();
         }
 
         if (! $this->dbTableExists->hasTable($db, $table)) {
-            return null;
+            return $this->response->response();
         }
 
         $query = $this->getQuery($table, $request->getParam('where_clause'), $request->getParam('where_clause_sign'));
@@ -74,12 +74,12 @@ final class WrapperController implements InvocableController
             /* l10n: In case a SQL query did not pass a security check  */
             $this->response->addHTML(Message::error(__('There is an issue with your request.'))->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         $row = $this->dbi->query($query)->fetchAssoc();
         if ($row === []) {
-            return null;
+            return $this->response->response();
         }
 
         $transformKey = $request->getParam('transform_key');
@@ -87,7 +87,7 @@ final class WrapperController implements InvocableController
             ! is_string($transformKey) || $transformKey === ''
             || ! isset($row[$transformKey]) || $row[$transformKey] === ''
         ) {
-            return null;
+            return $this->response->response();
         }
 
         $mediaTypeMap = [];

--- a/src/Controllers/Triggers/IndexController.php
+++ b/src/Controllers/Triggers/IndexController.php
@@ -44,7 +44,7 @@ final class IndexController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['errors'] ??= null;
         $GLOBALS['urlParams'] ??= null;
@@ -59,7 +59,7 @@ final class IndexController implements InvocableController
              */
             if (Current::$table !== '' && in_array(Current::$table, $this->dbi->getTables(Current::$database), true)) {
                 if (! $this->response->checkParameters(['db', 'table'])) {
-                    return null;
+                    return $this->response->response();
                 }
 
                 $GLOBALS['urlParams'] = ['db' => Current::$database, 'table' => Current::$table];
@@ -73,20 +73,20 @@ final class IndexController implements InvocableController
                         ['reload' => true, 'message' => __('No databases selected.')],
                     );
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $tableName = TableName::tryFrom($request->getParam('table'));
                 if ($tableName === null || ! $this->dbTableExists->hasTable($databaseName, $tableName)) {
                     $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No table selected.')]);
 
-                    return null;
+                    return $this->response->response();
                 }
             } else {
                 Current::$table = '';
 
                 if (! $this->response->checkParameters(['db'])) {
-                    return null;
+                    return $this->response->response();
                 }
 
                 $GLOBALS['errorUrl'] = Util::getScriptNameForOption(
@@ -102,7 +102,7 @@ final class IndexController implements InvocableController
                         ['reload' => true, 'message' => __('No databases selected.')],
                     );
 
-                    return null;
+                    return $this->response->response();
                 }
             }
         } elseif (Current::$database !== '') {
@@ -168,7 +168,7 @@ final class IndexController implements InvocableController
 
                 $this->response->addJSON('tableType', 'triggers');
 
-                return null;
+                return $this->response->response();
             }
         }
 
@@ -222,12 +222,12 @@ final class IndexController implements InvocableController
                     $this->response->addJSON('message', $editor);
                     $this->response->addJSON('title', $title);
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->addHTML("\n\n<h2>" . $title . "</h2>\n\n" . $editor);
 
-                return null;
+                return $this->response->response();
             }
 
             $message = __('Error in processing request:') . ' ';
@@ -241,7 +241,7 @@ final class IndexController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', $message);
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->addHTML($message->getDisplay());
@@ -260,7 +260,7 @@ final class IndexController implements InvocableController
                 $this->response->addJSON('title', $title);
                 $this->response->addJSON('message', htmlspecialchars(trim($exportData)));
 
-                return null;
+                return $this->response->response();
             }
 
             if ($exportData !== null) {
@@ -269,7 +269,7 @@ final class IndexController implements InvocableController
                     'item_name' => $triggerName->getName(),
                 ]);
 
-                return null;
+                return $this->response->response();
             }
 
             $message = Message::error(sprintf(
@@ -281,7 +281,7 @@ final class IndexController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', $message);
 
-                return null;
+                return $this->response->response();
             }
         }
 
@@ -298,7 +298,7 @@ final class IndexController implements InvocableController
             'error_message' => $message?->getDisplay() ?? '',
         ]);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/UserPasswordController.php
+++ b/src/Controllers/UserPasswordController.php
@@ -28,7 +28,7 @@ final class UserPasswordController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         $GLOBALS['hostname'] ??= null;
         $GLOBALS['username'] ??= null;
@@ -50,7 +50,7 @@ final class UserPasswordController implements InvocableController
                 __('You don\'t have sufficient privileges to be here right now!'),
             )->getDisplay());
 
-            return null;
+            return $this->response->response();
         }
 
         $noPass = $request->getParsedBodyParam('nopass');
@@ -84,21 +84,21 @@ final class UserPasswordController implements InvocableController
                     );
                     $this->response->addJSON('message', $sqlQuery);
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->addHTML('<h1>' . __('Change password') . '</h1>' . "\n\n");
                 $this->response->addHTML(Generator::getMessage($message, $sqlQuery, MessageType::Success));
                 $this->response->render('user_password', []);
 
-                return null;
+                return $this->response->response();
             }
 
             if ($request->isAjax()) {
                 $this->response->addJSON('message', $GLOBALS['change_password_message']['msg']);
                 $this->response->setRequestStatus(false);
 
-                return null;
+                return $this->response->response();
             }
         }
 
@@ -118,6 +118,6 @@ final class UserPasswordController implements InvocableController
             $request->getRoute(),
         ));
 
-        return null;
+        return $this->response->response();
     }
 }

--- a/src/Controllers/View/CreateController.php
+++ b/src/Controllers/View/CreateController.php
@@ -53,10 +53,10 @@ final class CreateController implements InvocableController
     ) {
     }
 
-    public function __invoke(ServerRequest $request): Response|null
+    public function __invoke(ServerRequest $request): Response
     {
         if (! $this->response->checkParameters(['db'])) {
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams'] ??= null;
@@ -74,12 +74,12 @@ final class CreateController implements InvocableController
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', Message::error(__('No databases selected.')));
 
-                return null;
+                return $this->response->response();
             }
 
             $this->response->redirectToRoute('/', ['reload' => true, 'message' => __('No databases selected.')]);
 
-            return null;
+            return $this->response->response();
         }
 
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/table/structure');
@@ -94,7 +94,7 @@ final class CreateController implements InvocableController
             $this->response->addJSON('message', $GLOBALS['message']);
             $this->response->setRequestStatus(false);
 
-            return null;
+            return $this->response->response();
         }
 
         $createview = $request->hasBodyParam('createview');
@@ -108,7 +108,7 @@ final class CreateController implements InvocableController
                 if (! $ajaxdialog) {
                     $GLOBALS['message'] = Message::rawError($this->dbi->getError());
 
-                    return null;
+                    return $this->response->response();
                 }
 
                 $this->response->addJSON(
@@ -120,7 +120,7 @@ final class CreateController implements InvocableController
                 );
                 $this->response->setRequestStatus(false);
 
-                return null;
+                return $this->response->response();
             }
 
             return $this->setSuccessResponse($view, $ajaxdialog, $request);
@@ -197,11 +197,11 @@ final class CreateController implements InvocableController
             'view_security_options' => self::VIEW_SECURITY_OPTIONS,
         ]);
 
-        return null;
+        return $this->response->response();
     }
 
     /** @param mixed[] $view */
-    private function setSuccessResponse(array $view, bool $ajaxdialog, ServerRequest $request): Response|null
+    private function setSuccessResponse(array $view, bool $ajaxdialog, ServerRequest $request): Response
     {
         // If different column names defined for VIEW
         $viewColumns = [];
@@ -245,7 +245,7 @@ final class CreateController implements InvocableController
         );
         $this->response->setRequestStatus(true);
 
-        return null;
+        return $this->response->response();
     }
 
     /**

--- a/src/Controllers/View/CreateController.php
+++ b/src/Controllers/View/CreateController.php
@@ -123,9 +123,7 @@ final class CreateController implements InvocableController
                 return null;
             }
 
-            $this->setSuccessResponse($view, $ajaxdialog, $request);
-
-            return null;
+            return $this->setSuccessResponse($view, $ajaxdialog, $request);
         }
 
         $GLOBALS['sql_query'] = $request->getParsedBodyParam('sql_query', '');
@@ -203,7 +201,7 @@ final class CreateController implements InvocableController
     }
 
     /** @param mixed[] $view */
-    private function setSuccessResponse(array $view, bool $ajaxdialog, ServerRequest $request): void
+    private function setSuccessResponse(array $view, bool $ajaxdialog, ServerRequest $request): Response|null
     {
         // If different column names defined for VIEW
         $viewColumns = [];
@@ -234,17 +232,20 @@ final class CreateController implements InvocableController
             $GLOBALS['message'] = Message::success();
             /** @var StructureController $controller */
             $controller = ContainerBuilder::getContainer()->get(StructureController::class);
-            $controller($request);
-        } else {
-            $this->response->addJSON(
-                'message',
-                Generator::getMessage(
-                    Message::success(),
-                    $GLOBALS['sql_query'],
-                ),
-            );
-            $this->response->setRequestStatus(true);
+
+            return $controller($request);
         }
+
+        $this->response->addJSON(
+            'message',
+            Generator::getMessage(
+                Message::success(),
+                $GLOBALS['sql_query'],
+            ),
+        );
+        $this->response->setRequestStatus(true);
+
+        return null;
     }
 
     /**

--- a/src/Http/Handler/ApplicationHandler.php
+++ b/src/Http/Handler/ApplicationHandler.php
@@ -24,14 +24,9 @@ final class ApplicationHandler implements RequestHandlerInterface
     {
         assert($request instanceof ServerRequest);
         try {
-            $response = $this->application->handle($request);
-            if ($response === null) {
-                throw new ExitException();
-            }
+            return $this->application->handle($request);
         } catch (ExitException) {
-            $response = ResponseRenderer::getInstance()->response();
+            return ResponseRenderer::getInstance()->response();
         }
-
-        return $response;
     }
 }

--- a/src/Http/Middleware/MinimumCommonRedirection.php
+++ b/src/Http/Middleware/MinimumCommonRedirection.php
@@ -38,20 +38,15 @@ final class MinimumCommonRedirection implements MiddlewareInterface
         assert($request instanceof ServerRequest);
 
         try {
-            $response = Routing::callControllerForRoute(
+            return Routing::callControllerForRoute(
                 $request,
                 Routing::getDispatcher(),
                 $container,
                 $this->responseFactory,
             );
-            if ($response === null) {
-                throw new ExitException();
-            }
         } catch (ExitException) {
-            $response = ResponseRenderer::getInstance()->response();
+            return ResponseRenderer::getInstance()->response();
         }
-
-        return $response;
     }
 
     private function isMinimumCommon(mixed $route): bool

--- a/src/Query/Generator.php
+++ b/src/Query/Generator.php
@@ -447,12 +447,28 @@ class Generator
         return $sqlQuery . implode(', ', $partitionNames) . ';';
     }
 
-    /** @param string[] $selectedColumns */
+    /**
+     * @param string[] $selectedColumns
+     * @psalm-param 'FULLTEXT'|'INDEX'|'SPATIAL'|'UNIQUE' $indexType
+     */
     public static function getAddIndexSql(string $indexType, string $table, array $selectedColumns): string
     {
         $columnsSql = implode(', ', array_map(Util::backquote(...), $selectedColumns));
 
         return 'ALTER TABLE ' . Util::backquote($table) . ' ADD ' . $indexType . '(' . $columnsSql . ');';
+    }
+
+    public static function getAddPrimaryKeyStatement(string $table, string $column, bool $hasDropPrimaryKey): string
+    {
+        if ($hasDropPrimaryKey) {
+            return sprintf(
+                'ALTER TABLE %s DROP PRIMARY KEY, ADD PRIMARY KEY(%s);',
+                Util::backquote($table),
+                Util::backquote($column),
+            );
+        }
+
+        return sprintf('ALTER TABLE %s ADD PRIMARY KEY(%s);', Util::backquote($table), Util::backquote($column));
     }
 
     /**

--- a/src/Routing/Routing.php
+++ b/src/Routing/Routing.php
@@ -142,7 +142,7 @@ class Routing
         Dispatcher $dispatcher,
         ContainerInterface $container,
         ResponseFactory $responseFactory,
-    ): Response|null {
+    ): Response {
         $route = $request->getRoute();
         $routeInfo = $dispatcher->dispatch($request->getMethod(), rawurldecode($route));
 
@@ -211,7 +211,7 @@ class Routing
         }
 
         $controller = $container->get($controllerName);
-        assert($controller instanceof $controllerName);
+        assert($controller instanceof InvocableController);
 
         return $controller($request);
     }

--- a/src/Table/Indexes.php
+++ b/src/Table/Indexes.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Table;
 
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Identifiers\DatabaseName;
+use PhpMyAdmin\Identifiers\TableName;
 use PhpMyAdmin\Index;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Query\Compatibility;
@@ -186,5 +187,17 @@ final class Indexes
         }
 
         return Message::success();
+    }
+
+    public function hasPrimaryKey(string|TableName $table): bool
+    {
+        $result = $this->dbi->query('SHOW KEYS FROM ' . Util::backquote($table));
+        foreach ($result as $row) {
+            if ($row['Key_name'] === 'PRIMARY') {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/unit/Controllers/CollationConnectionControllerTest.php
+++ b/tests/unit/Controllers/CollationConnectionControllerTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Tests\Controllers;
 
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\CollationConnectionController;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -23,6 +24,7 @@ class CollationConnectionControllerTest extends AbstractTestCase
         $response = self::createMock(ResponseRenderer::class);
         $response->expects(self::once())->method('redirect')
             ->with('index.php?route=/' . Url::getCommonRaw([], '&'));
+        $response->expects(self::once())->method('response')->willReturn(ResponseFactory::create()->createResponse());
 
         $config = self::createMock(Config::class);
         $config->expects(self::once())->method('setUserValue')

--- a/tests/unit/Controllers/Database/Structure/AddPrefixControllerTest.php
+++ b/tests/unit/Controllers/Database/Structure/AddPrefixControllerTest.php
@@ -34,7 +34,6 @@ final class AddPrefixControllerTest extends AbstractTestCase
             ['url_params' => ['db' => 'test_db', 'selected' => ['test_table']]],
         );
 
-        self::assertNotNull($response);
         self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
         self::assertSame(['text/html; charset=utf-8'], $response->getHeader('Content-Type'));
         self::assertSame($expected, (string) $response->getBody());

--- a/tests/unit/Controllers/Database/Structure/ChangePrefixFormControllerTest.php
+++ b/tests/unit/Controllers/Database/Structure/ChangePrefixFormControllerTest.php
@@ -34,7 +34,6 @@ final class ChangePrefixFormControllerTest extends AbstractTestCase
             'url_params' => ['db' => 'test_db', 'selected' => ['test_table']],
         ]);
 
-        self::assertNotNull($response);
         self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
         self::assertSame(['text/html; charset=utf-8'], $response->getHeader('Content-Type'));
         self::assertSame($expected, (string) $response->getBody());

--- a/tests/unit/Controllers/Database/Structure/CopyFormControllerTest.php
+++ b/tests/unit/Controllers/Database/Structure/CopyFormControllerTest.php
@@ -46,7 +46,6 @@ final class CopyFormControllerTest extends AbstractTestCase
             ],
         ]);
 
-        self::assertNotNull($response);
         self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
         self::assertSame(['text/html; charset=utf-8'], $response->getHeader('Content-Type'));
         self::assertSame($expected, (string) $response->getBody());

--- a/tests/unit/Controllers/Export/ExportControllerTest.php
+++ b/tests/unit/Controllers/Export/ExportControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Export;
 
+use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Container\ContainerBuilder;
 use PhpMyAdmin\Controllers\Export\ExportController;
@@ -194,7 +195,7 @@ final class ExportControllerTest extends AbstractTestCase
         $response = $exportController($request);
         $output = $this->getActualOutputForAssertion();
 
-        self::assertNull($response);
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
         self::assertStringNotContainsString('Missing parameter: what', $output);
         self::assertStringNotContainsString('Missing parameter: export_type', $output);
         self::assertStringContainsString(htmlspecialchars($expectedOutput, ENT_COMPAT), $output);
@@ -347,7 +348,6 @@ final class ExportControllerTest extends AbstractTestCase
 
         $output = $this->getActualOutputForAssertion();
 
-        self::assertNotNull($response);
         self::assertSame('', (string) $response->getBody());
         self::assertStringStartsWith('-- phpMyAdmin SQL Dump', $output);
         self::assertStringEndsWith($expected, $output);
@@ -512,7 +512,6 @@ final class ExportControllerTest extends AbstractTestCase
         $exportController = new ExportController(new ResponseRenderer(), $export, ResponseFactory::create());
         $response = $exportController($request);
 
-        self::assertNotNull($response);
         $output = (string) $response->getBody();
 
         $tmpFile = tempnam('./', 'exportFileTest');

--- a/tests/unit/Controllers/HomeControllerTest.php
+++ b/tests/unit/Controllers/HomeControllerTest.php
@@ -30,7 +30,7 @@ final class HomeControllerTest extends AbstractTestCase
             ResponseFactory::create(),
         );
         $response = $controller($request);
-        self::assertNotNull($response);
+
         self::assertSame(StatusCodeInterface::STATUS_FOUND, $response->getStatusCode());
         self::assertSame('./index.php?route=/database/structure&db=test_db', $response->getHeaderLine('Location'));
         self::assertSame('', (string) $response->getBody());
@@ -48,7 +48,7 @@ final class HomeControllerTest extends AbstractTestCase
             ResponseFactory::create(),
         );
         $response = $controller($request);
-        self::assertNotNull($response);
+
         self::assertSame(StatusCodeInterface::STATUS_FOUND, $response->getStatusCode());
         self::assertSame('./index.php?route=/sql&db=test_db&table=test_table', $response->getHeaderLine('Location'));
         self::assertSame('', (string) $response->getBody());

--- a/tests/unit/Controllers/LintControllerTest.php
+++ b/tests/unit/Controllers/LintControllerTest.php
@@ -32,7 +32,6 @@ final class LintControllerTest extends AbstractTestCase
 
         $response = $this->getLintController()($request);
 
-        self::assertNotNull($response);
         self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
         self::assertSame(['application/json; charset=UTF-8'], $response->getHeader('Content-Type'));
         $output = (string) $response->getBody();
@@ -51,7 +50,6 @@ final class LintControllerTest extends AbstractTestCase
 
         $response = $this->getLintController()($request);
 
-        self::assertNotNull($response);
         self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
         self::assertSame(['application/json; charset=UTF-8'], $response->getHeader('Content-Type'));
         $output = (string) $response->getBody();
@@ -106,7 +104,6 @@ final class LintControllerTest extends AbstractTestCase
 
         $response = $this->getLintController()($request);
 
-        self::assertNotNull($response);
         self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
         self::assertSame(['application/json; charset=UTF-8'], $response->getHeader('Content-Type'));
         $output = (string) $response->getBody();

--- a/tests/unit/Controllers/LogoutControllerTest.php
+++ b/tests/unit/Controllers/LogoutControllerTest.php
@@ -8,14 +8,20 @@ use PhpMyAdmin\Controllers\LogoutController;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Plugins\AuthenticationPlugin;
 use PhpMyAdmin\Plugins\AuthenticationPluginFactory;
+use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseRendererStub;
 use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionProperty;
 
 #[CoversClass(LogoutController::class)]
 class LogoutControllerTest extends AbstractTestCase
 {
     public function testValidLogout(): void
     {
+        $responseStub = new ResponseRendererStub();
+        (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, $responseStub);
+
         $GLOBALS['token_mismatch'] = false;
 
         $request = self::createStub(ServerRequest::class);
@@ -30,5 +36,7 @@ class LogoutControllerTest extends AbstractTestCase
         (new LogoutController($factory))($request);
 
         unset($GLOBALS['token_mismatch']);
+
+        (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
     }
 }

--- a/tests/unit/Controllers/SchemaExportControllerTest.php
+++ b/tests/unit/Controllers/SchemaExportControllerTest.php
@@ -38,7 +38,6 @@ final class SchemaExportControllerTest extends AbstractTestCase
         $controller = new SchemaExportController($export, new ResponseRenderer(), ResponseFactory::create());
         $response = $controller($request);
 
-        self::assertNotNull($response);
         self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
         self::assertSame('file data', (string) $response->getBody());
 

--- a/tests/unit/Controllers/Table/ChangeRowsControllerTest.php
+++ b/tests/unit/Controllers/Table/ChangeRowsControllerTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\Controllers\Table\ChangeController;
 use PhpMyAdmin\Controllers\Table\ChangeRowsController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Factory\ServerRequestFactory;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
@@ -32,7 +33,8 @@ class ChangeRowsControllerTest extends AbstractTestCase
             ->withParsedBody(['rows_to_delete' => 'row']);
 
         $mock = self::createMock(ChangeController::class);
-        $mock->expects(self::once())->method('__invoke')->with($request);
+        $mock->expects(self::once())->method('__invoke')->with($request)
+            ->willReturn(ResponseFactory::create()->createResponse());
 
         (new ChangeRowsController(new ResponseRenderer(), $mock))($request);
 
@@ -46,7 +48,8 @@ class ChangeRowsControllerTest extends AbstractTestCase
             ->withParsedBody(['goto' => 'goto']);
 
         $mock = self::createMock(ChangeController::class);
-        $mock->expects(self::never())->method('__invoke')->with($request);
+        $mock->expects(self::never())->method('__invoke')->with($request)
+            ->willReturn(ResponseFactory::create()->createResponse());
 
         $response = new ResponseRenderer();
         (new ChangeRowsController($response, $mock))($request);
@@ -63,7 +66,8 @@ class ChangeRowsControllerTest extends AbstractTestCase
             ->withParsedBody(['goto' => 'goto', 'rows_to_delete' => ['key1' => 'row1', 'key2' => 'row2']]);
 
         $mock = self::createMock(ChangeController::class);
-        $mock->expects(self::once())->method('__invoke')->with($request);
+        $mock->expects(self::once())->method('__invoke')->with($request)
+            ->willReturn(ResponseFactory::create()->createResponse());
 
         (new ChangeRowsController(new ResponseRenderer(), $mock))($request);
 

--- a/tests/unit/Controllers/Table/ExportRowsControllerTest.php
+++ b/tests/unit/Controllers/Table/ExportRowsControllerTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\Controllers\Table\ExportController;
 use PhpMyAdmin\Controllers\Table\ExportRowsController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
@@ -32,7 +33,8 @@ class ExportRowsControllerTest extends AbstractTestCase
         $_POST['rows_to_delete'] = 'row';
 
         $controller = $this->createMock(ExportController::class);
-        $controller->expects(self::once())->method('__invoke');
+        $controller->expects(self::once())->method('__invoke')
+            ->willReturn(ResponseFactory::create()->createResponse());
 
         (new ExportRowsController(
             new ResponseRenderer(),
@@ -69,7 +71,8 @@ class ExportRowsControllerTest extends AbstractTestCase
         $_POST['rows_to_delete'] = ['key1' => 'row1', 'key2' => 'row2'];
 
         $controller = $this->createMock(ExportController::class);
-        $controller->expects(self::once())->method('__invoke');
+        $controller->expects(self::once())->method('__invoke')
+            ->willReturn(ResponseFactory::create()->createResponse());
 
         (new ExportRowsController(
             new ResponseRenderer(),

--- a/tests/unit/Controllers/Table/GetFieldControllerTest.php
+++ b/tests/unit/Controllers/Table/GetFieldControllerTest.php
@@ -55,7 +55,6 @@ class GetFieldControllerTest extends AbstractTestCase
 
         $response = (new GetFieldController(new ResponseRenderer(), $dbi, ResponseFactory::create()))($request);
 
-        self::assertNotNull($response);
         self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
         self::assertSame('46494c45', (string) $response->getBody());
     }

--- a/tests/unit/Controllers/Table/GisVisualizationControllerTest.php
+++ b/tests/unit/Controllers/Table/GisVisualizationControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Table;
 
+use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Controllers\Table\GisVisualizationController;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\Current;
@@ -122,7 +123,7 @@ class GisVisualizationControllerTest extends AbstractTestCase
         );
         $response = $controller($request);
 
-        self::assertNull($response);
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
         self::assertSame($expected, $responseRenderer->getHTMLResult());
     }
 }

--- a/tests/unit/Controllers/Table/Structure/SaveControllerTest.php
+++ b/tests/unit/Controllers/Table/Structure/SaveControllerTest.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\Controllers\Table\Structure\SaveController;
 use PhpMyAdmin\Controllers\Table\StructureController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
@@ -89,7 +90,8 @@ class SaveControllerTest extends AbstractTestCase
         $request = self::createStub(ServerRequest::class);
 
         $mock = self::createMock(StructureController::class);
-        $mock->expects(self::once())->method('__invoke')->with($request);
+        $mock->expects(self::once())->method('__invoke')->with($request)
+            ->willReturn(ResponseFactory::create()->createResponse());
 
         (new SaveController(
             new ResponseRenderer(),

--- a/tests/unit/Controllers/Table/Structure/SpatialControllerTest.php
+++ b/tests/unit/Controllers/Table/Structure/SpatialControllerTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\Controllers\Table\Structure\SpatialController;
 use PhpMyAdmin\Controllers\Table\StructureController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Table\Indexes;
@@ -33,7 +34,8 @@ class SpatialControllerTest extends AbstractTestCase
         $request = self::createStub(ServerRequest::class);
         $request->method('getParsedBodyParam')->willReturnMap([['selected_fld', [], ['test_field']]]);
         $controllerStub = self::createMock(StructureController::class);
-        $controllerStub->expects(self::once())->method('__invoke')->with($request);
+        $controllerStub->expects(self::once())->method('__invoke')->with($request)
+            ->willReturn(ResponseFactory::create()->createResponse());
 
         $indexes = new Indexes(DatabaseInterface::getInstance());
         $controller = new SpatialController(new ResponseRenderer(), $controllerStub, $indexes);
@@ -61,7 +63,8 @@ class SpatialControllerTest extends AbstractTestCase
         $request = self::createStub(ServerRequest::class);
         $request->method('getParsedBodyParam')->willReturnMap([['selected_fld', [], ['test_field1', 'test_field2']]]);
         $controllerStub = self::createMock(StructureController::class);
-        $controllerStub->expects(self::once())->method('__invoke')->with($request);
+        $controllerStub->expects(self::once())->method('__invoke')->with($request)
+            ->willReturn(ResponseFactory::create()->createResponse());
 
         $indexes = new Indexes(DatabaseInterface::getInstance());
         $controller = new SpatialController(new ResponseRenderer(), $controllerStub, $indexes);
@@ -117,7 +120,8 @@ class SpatialControllerTest extends AbstractTestCase
         $request = self::createStub(ServerRequest::class);
         $request->method('getParsedBodyParam')->willReturnMap([['selected_fld', [], ['test_field']]]);
         $controllerStub = self::createMock(StructureController::class);
-        $controllerStub->expects(self::once())->method('__invoke')->with($request);
+        $controllerStub->expects(self::once())->method('__invoke')->with($request)
+            ->willReturn(ResponseFactory::create()->createResponse());
 
         $indexes = new Indexes(DatabaseInterface::getInstance());
         $controller = new SpatialController(new ResponseRenderer(), $controllerStub, $indexes);

--- a/tests/unit/Controllers/Table/Structure/UniqueControllerTest.php
+++ b/tests/unit/Controllers/Table/Structure/UniqueControllerTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\Controllers\Table\Structure\UniqueController;
 use PhpMyAdmin\Controllers\Table\StructureController;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Table\Indexes;
@@ -33,7 +34,8 @@ class UniqueControllerTest extends AbstractTestCase
         $request = self::createStub(ServerRequest::class);
         $request->method('getParsedBodyParam')->willReturnMap([['selected_fld', [], ['test_field']]]);
         $controllerStub = self::createMock(StructureController::class);
-        $controllerStub->expects(self::once())->method('__invoke')->with($request);
+        $controllerStub->expects(self::once())->method('__invoke')->with($request)
+            ->willReturn(ResponseFactory::create()->createResponse());
 
         $indexes = new Indexes(DatabaseInterface::getInstance());
         $controller = new UniqueController(new ResponseRenderer(), $controllerStub, $indexes);
@@ -61,7 +63,8 @@ class UniqueControllerTest extends AbstractTestCase
         $request = self::createStub(ServerRequest::class);
         $request->method('getParsedBodyParam')->willReturnMap([['selected_fld', [], ['test_field1', 'test_field2']]]);
         $controllerStub = self::createMock(StructureController::class);
-        $controllerStub->expects(self::once())->method('__invoke')->with($request);
+        $controllerStub->expects(self::once())->method('__invoke')->with($request)
+            ->willReturn(ResponseFactory::create()->createResponse());
 
         $indexes = new Indexes(DatabaseInterface::getInstance());
         $controller = new UniqueController(new ResponseRenderer(), $controllerStub, $indexes);
@@ -117,7 +120,8 @@ class UniqueControllerTest extends AbstractTestCase
         $request = self::createStub(ServerRequest::class);
         $request->method('getParsedBodyParam')->willReturnMap([['selected_fld', [], ['test_field']]]);
         $controllerStub = self::createMock(StructureController::class);
-        $controllerStub->expects(self::once())->method('__invoke')->with($request);
+        $controllerStub->expects(self::once())->method('__invoke')->with($request)
+            ->willReturn(ResponseFactory::create()->createResponse());
 
         $indexes = new Indexes(DatabaseInterface::getInstance());
         $controller = new UniqueController(new ResponseRenderer(), $controllerStub, $indexes);

--- a/tests/unit/Controllers/Table/TrackingControllerTest.php
+++ b/tests/unit/Controllers/Table/TrackingControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Table;
 
+use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Bookmarks\BookmarkRepository;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
@@ -71,7 +72,7 @@ class TrackingControllerTest extends AbstractTestCase
             ResponseFactory::create(),
         ))($request);
 
-        self::assertNull($response);
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
 
         $main = $template->render('table/tracking/main', [
             'url_params' => [

--- a/tests/unit/Http/Handler/ApplicationHandlerTest.php
+++ b/tests/unit/Http/Handler/ApplicationHandlerTest.php
@@ -49,20 +49,4 @@ final class ApplicationHandlerTest extends TestCase
         self::assertSame($response, $responseStub);
         $reflectionProperty->setValue(null, null);
     }
-
-    public function testHandleReturnsNull(): void
-    {
-        $responseStub = new Response(self::createStub(ResponseInterface::class));
-        $responseRendererMock = self::createMock(ResponseRenderer::class);
-        $responseRendererMock->expects(self::once())->method('response')->willReturn($responseStub);
-        $reflectionProperty = new ReflectionProperty(ResponseRenderer::class, 'instance');
-        $reflectionProperty->setValue(null, $responseRendererMock);
-        $request = self::createStub(ServerRequest::class);
-        $appMock = self::createMock(Application::class);
-        $appMock->expects(self::once())->method('handle')->with($request)->willReturn(null);
-        $handler = new ApplicationHandler($appMock);
-        $response = $handler->handle($request);
-        self::assertSame($response, $responseStub);
-        $reflectionProperty->setValue(null, null);
-    }
 }


### PR DESCRIPTION
When `null` is returned by an `InvocableController`, `ResponseRenderer::response()` is called by the `ApplicationHandler`, so call it early to always return a `Response` object.