### PR TITLE
`Query generator` support for `IN()` and `NOT IN()`

### DIFF
--- a/js/src/database/multi_table_query.js
+++ b/js/src/database/multi_table_query.js
@@ -25,6 +25,9 @@ AJAX.registerTeardown('database/multi_table_query.js', function () {
     $('.columnNameSelect').each(function () {
         $(this).off('change');
     });
+    $('.criteria_op').each(function () {
+        $(this).off('change');
+    });
     $('#update_query_button').off('click');
     $('#add_column_button').off('click');
 });
@@ -36,6 +39,13 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
 
     var columnCount = 3;
     addNewColumnCallbacks();
+
+    function theHints() {
+        return {
+            'IN (...)': 'Separate the values by commas',
+            'NOT IN (...)': 'Separate the values by commas',
+        };
+    }
 
     $('#update_query_button').on('click', function () {
         var columns = [];
@@ -176,16 +186,19 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
 
     $('.criteria_op').each(function () {
         $(this).on('change', function () {
-            const isIN = $(this).val() === 'IN (...)';
-            const criteriaInputCol = $(this).closest('table').find('.rhs_text_val').parent();
-
-            if (isIN) {
-                criteriaInputCol.append('<p class="rhs_hint">Separate the values by commas</p>');
-            } else {
-                criteriaInputCol.find(".rhs_hint").remove();
-            }
+            showHint($(this));
         });
     });
+
+    function showHint(opSelect) {
+        const hints = theHints();
+        const value = opSelect.val();
+        const criteriaInputCol = opSelect.closest('table').find('.rhs_text_val').parent();
+
+        Object.keys(hints).includes(value)
+            ? criteriaInputCol.append(`<p class="rhs_hint">${hints[value]}</p>`)
+            : criteriaInputCol.find(".rhs_hint").remove();
+    }
 
     function addNewColumnCallbacks () {
         $('.tableNameSelect').each(function () {

--- a/js/src/database/multi_table_query.js
+++ b/js/src/database/multi_table_query.js
@@ -174,6 +174,19 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
         });
     });
 
+    $('.criteria_op').each(function () {
+        $(this).on('change', function () {
+            const isIN = $(this).val() === 'IN (...)';
+            const criteriaInputCol = $(this).closest('table').find('.rhs_text_val').parent();
+
+            if (isIN) {
+                criteriaInputCol.append('<p class="rhs_hint">Separate the values by commas</p>');
+            } else {
+                criteriaInputCol.find(".rhs_hint").remove();
+            }
+        });
+    });
+
     function addNewColumnCallbacks () {
         $('.tableNameSelect').each(function () {
             $(this).on('change', function () {

--- a/js/src/database/multi_table_query.js
+++ b/js/src/database/multi_table_query.js
@@ -40,7 +40,7 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
     var columnCount = 3;
     addNewColumnCallbacks();
 
-    function theHints() {
+    function theHints () {
         return {
             'IN (...)': 'Separate the values by commas',
             'NOT IN (...)': 'Separate the values by commas',
@@ -190,12 +190,12 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
         });
     });
 
-    function showHint(opSelect) {
+    function showHint (opSelect) {
         const hints = theHints();
         const value = opSelect.val();
         const criteriaInputCol = opSelect.closest('table').find('.rhs_text_val').parent();
 
-        criteriaInputCol.find(".rhs_hint").remove();
+        criteriaInputCol.find('.rhs_hint').remove();
 
         Object.keys(hints).includes(value) && criteriaInputCol.append(`<p class="rhs_hint">${hints[value]}</p>`);
     }

--- a/js/src/database/multi_table_query.js
+++ b/js/src/database/multi_table_query.js
@@ -195,9 +195,9 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
         const value = opSelect.val();
         const criteriaInputCol = opSelect.closest('table').find('.rhs_text_val').parent();
 
-        Object.keys(hints).includes(value)
-            ? criteriaInputCol.append(`<p class="rhs_hint">${hints[value]}</p>`)
-            : criteriaInputCol.find(".rhs_hint").remove();
+        criteriaInputCol.find(".rhs_hint").remove();
+
+        Object.keys(hints).includes(value) && criteriaInputCol.append(`<p class="rhs_hint">${hints[value]}</p>`);
     }
 
     function addNewColumnCallbacks () {

--- a/js/src/database/query_generator.js
+++ b/js/src/database/query_generator.js
@@ -22,6 +22,7 @@ function getFormatsText () {
         'LIKE %...%': ' LIKE \'%%%s%%\'',
         'NOT LIKE': ' NOT LIKE \'%s\'',
         'NOT LIKE %...%': ' NOT LIKE \'%%%s%%\'',
+        'IN (...)': ' IN (%s)',
         'BETWEEN': ' BETWEEN \'%s\'',
         'NOT BETWEEN': ' NOT BETWEEN \'%s\'',
         'IS NULL': ' \'%s\' IS NULL',

--- a/js/src/database/query_generator.js
+++ b/js/src/database/query_generator.js
@@ -37,19 +37,21 @@ function getFormatsText () {
 function generateCondition (criteriaDiv, table) {
     const tableName = table.val();
     const tableAlias = table.siblings('.table_alias').val();
+    const criteriaOp = criteriaDiv.find('.criteria_op').first().val();
+    let criteriaText = criteriaDiv.find('.rhs_text_val').first().val();
 
-    var query = '`' + Functions.escapeBacktick(tableAlias === '' ? tableName : tableAlias) + '`.';
+    let query = '`' + Functions.escapeBacktick(tableAlias === '' ? tableName : tableAlias) + '`.';
     query += '`' + Functions.escapeBacktick(table.siblings('.columnNameSelect').first().val()) + '`';
     if (criteriaDiv.find('.criteria_rhs').first().val() === 'text') {
-        var formatsText = getFormatsText();
+        const formatsText = getFormatsText();
 
-        if (['IN (...)', 'NOT IN (...)'].includes(criteriaDiv.find('.criteria_op').first().val())) {
-            query += sprintf(formatsText[criteriaDiv.find('.criteria_op').first().val()], criteriaDiv.find('.rhs_text_val').first().val());
-        } else {
-            query += sprintf(formatsText[criteriaDiv.find('.criteria_op').first().val()], Functions.escapeSingleQuote(criteriaDiv.find('.rhs_text_val').first().val()));
+        if (!['IN (...)', 'NOT IN (...)'].includes(criteriaOp)) {
+            criteriaText = Functions.escapeSingleQuote(criteriaText);
         }
+
+        query += sprintf(formatsText[criteriaOp], criteriaText);
     } else {
-        query += ' ' + criteriaDiv.find('.criteria_op').first().val();
+        query += ' ' + criteriaOp;
         query += ' `' + Functions.escapeBacktick(criteriaDiv.find('.tableNameSelect').first().val()) + '`.';
         query += '`' + Functions.escapeBacktick(criteriaDiv.find('.columnNameSelect').first().val()) + '`';
     }

--- a/js/src/database/query_generator.js
+++ b/js/src/database/query_generator.js
@@ -42,7 +42,12 @@ function generateCondition (criteriaDiv, table) {
     query += '`' + Functions.escapeBacktick(table.siblings('.columnNameSelect').first().val()) + '`';
     if (criteriaDiv.find('.criteria_rhs').first().val() === 'text') {
         var formatsText = getFormatsText();
-        query += sprintf(formatsText[criteriaDiv.find('.criteria_op').first().val()], Functions.escapeSingleQuote(criteriaDiv.find('.rhs_text_val').first().val()));
+
+        if (['IN (...)', 'NOT IN (...)'].includes(criteriaDiv.find('.criteria_op').first().val())) {
+            query += sprintf(formatsText[criteriaDiv.find('.criteria_op').first().val()], criteriaDiv.find('.rhs_text_val').first().val());
+        } else {
+            query += sprintf(formatsText[criteriaDiv.find('.criteria_op').first().val()], Functions.escapeSingleQuote(criteriaDiv.find('.rhs_text_val').first().val()));
+        }
     } else {
         query += ' ' + criteriaDiv.find('.criteria_op').first().val();
         query += ' `' + Functions.escapeBacktick(criteriaDiv.find('.tableNameSelect').first().val()) + '`.';

--- a/js/src/database/query_generator.js
+++ b/js/src/database/query_generator.js
@@ -23,6 +23,7 @@ function getFormatsText () {
         'NOT LIKE': ' NOT LIKE \'%s\'',
         'NOT LIKE %...%': ' NOT LIKE \'%%%s%%\'',
         'IN (...)': ' IN (%s)',
+        'NOT IN (...)': ' NOT IN (%s)',
         'BETWEEN': ' BETWEEN \'%s\'',
         'NOT BETWEEN': ' NOT BETWEEN \'%s\'',
         'IS NULL': ' \'%s\' IS NULL',


### PR DESCRIPTION
Hellooo 👋🏻 

In this PR I have added `Query Generator` support to `IN()` and `NOT IN()`.

## Current

This is what it generates for now on both `IN()` and `NOT IN()`, which is not valid.

![Screenshot 2024-05-26 031847](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/5f295cd7-eb9f-4d4a-8b98-20edfe4be640)

## After

This how it will looks after merging this PR, generating a valid one.

> Separate the values by commas

As you can see I have added a hint that shows only when choosing `IN()` or `NOT INT()`.

![Screenshot 2024-05-26 033921](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/7c0e77dd-8e82-4ac0-8c26-bc5457a038e2)

### Server configuration

- phpMyAdmin version: 5.2.2-dev, 6.0.0-dev