### PR TITLE
Simulate query fixes

### DIFF
--- a/libraries/classes/Controllers/Import/SimulateDmlController.php
+++ b/libraries/classes/Controllers/Import/SimulateDmlController.php
@@ -12,16 +12,32 @@ use PhpMyAdmin\SqlParser\Lexer;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statements\DeleteStatement;
 use PhpMyAdmin\SqlParser\Statements\UpdateStatement;
+use PhpMyAdmin\SqlParser\Token;
+use PhpMyAdmin\SqlParser\TokensList;
 use PhpMyAdmin\SqlParser\Utils\Query;
 use PhpMyAdmin\Template;
 
 use function __;
+use function array_filter;
+use function array_values;
 use function count;
 
 final class SimulateDmlController extends AbstractController
 {
     /** @var SimulateDml */
     private $simulateDml;
+
+    /** @var string */
+    private $error = '';
+    /**
+     * @var list<array<mixed>>
+     * @psalm-var list<array{
+     *   sql_query: string,
+     *   matched_rows: int,
+     *   matched_rows_url: string,
+     * }>
+     */
+    private $data = [];
 
     public function __construct(
         ResponseRenderer $response,
@@ -34,42 +50,56 @@ final class SimulateDmlController extends AbstractController
 
     public function __invoke(): void
     {
-        $error = '';
         /** @var string $sqlDelimiter */
         $sqlDelimiter = $_POST['sql_delimiter'];
-        $sqlData = [];
-        $lexer = new Lexer($GLOBALS['sql_query'], false, $sqlDelimiter);
-        $parser = new Parser($lexer->list);
 
+        $parser = $this->createParser($GLOBALS['sql_query'], $sqlDelimiter);
+        $this->process($parser);
+
+        if ($this->error) {
+            $this->response->addJSON('message', Message::rawError($this->error));
+            $this->response->addJSON('sql_data', false);
+
+            return;
+        }
+
+        $this->response->addJSON('sql_data', $this->data);
+    }
+
+    private function createParser(string $query, string $delimiter): Parser
+    {
+        $lexer = new Lexer($query, false, $delimiter);
+        $list = new TokensList(array_values(array_filter(
+            $lexer->list->tokens,
+            static function ($token): bool {
+                return $token->type !== Token::TYPE_COMMENT;
+            }
+        )));
+
+        return new Parser($list);
+    }
+
+    private function process(Parser $parser): void
+    {
         foreach ($parser->statements as $statement) {
             if (
                 ! $statement instanceof UpdateStatement && ! $statement instanceof DeleteStatement
                 || ! empty($statement->join)
                 || count(Query::getTables($statement)) > 1
             ) {
-                $error = __('Only single-table UPDATE and DELETE queries can be simulated.');
+                $this->error = __('Only single-table UPDATE and DELETE queries can be simulated.');
                 break;
             }
 
             // Get the matched rows for the query.
             $result = $this->simulateDml->getMatchedRows($parser, $statement);
-            $error = $this->simulateDml->getError();
+            $this->error = $this->simulateDml->getError();
 
-            if ($error !== '') {
+            if ($this->error !== '') {
                 break;
             }
 
-            $sqlData[] = $result;
+            $this->data[] = $result;
         }
-
-        if ($error) {
-            $message = Message::rawError($error);
-            $this->response->addJSON('message', $message);
-            $this->response->addJSON('sql_data', false);
-
-            return;
-        }
-
-        $this->response->addJSON('sql_data', $sqlData);
     }
 }

--- a/libraries/classes/Import/SimulateDml.php
+++ b/libraries/classes/Import/SimulateDml.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Html;
 use PhpMyAdmin\SqlParser\Parser;
+use PhpMyAdmin\SqlParser\Statement;
 use PhpMyAdmin\SqlParser\Statements\DeleteStatement;
 use PhpMyAdmin\SqlParser\Statements\UpdateStatement;
 use PhpMyAdmin\SqlParser\Utils\Query;
@@ -46,7 +47,7 @@ final class SimulateDml
      *   matched_rows_url: string
      * }
      */
-    public function getMatchedRows(string $query, Parser $parser, $statement): array
+    public function getMatchedRows(Parser $parser, Statement $statement): array
     {
         if ($statement instanceof DeleteStatement) {
             $matchedRowsQuery = $this->getSimulatedDeleteQuery($parser, $statement);
@@ -63,7 +64,7 @@ final class SimulateDml
         ]);
 
         return [
-            'sql_query' => Html\Generator::formatSql($query),
+            'sql_query' => Html\Generator::formatSql($statement->build()),
             'matched_rows' => $matchedRows,
             'matched_rows_url' => $matchedRowsUrl,
         ];

--- a/test/classes/AbstractTestCase.php
+++ b/test/classes/AbstractTestCase.php
@@ -309,4 +309,23 @@ abstract class AbstractTestCase extends TestCase
 
         return $method->invokeArgs($object, $params);
     }
+
+    /**
+     * Get a private or protected property via reflection.
+     *
+     * @param object $object       The object to inspect, pass null for static objects()
+     * @param string $className    The class name
+     * @param string $propertyName The method name
+     * @phpstan-param class-string $className
+     *
+     * @return mixed
+     */
+    protected function getProperty(object $object, string $className, string $propertyName)
+    {
+        $class = new ReflectionClass($className);
+        $property = $class->getProperty($propertyName);
+        $property->setAccessible(true);
+
+        return $property->getValue($object);
+    }
 }


### PR DESCRIPTION
Fixes #19187

Depends on https://github.com/phpmyadmin/sql-parser/pull/560 to work without regression in the case of a condition `0` because now the query is parsed and built again to remove comments.
