### PR TITLE
Allow opening table create form without table name

### DIFF
--- a/resources/templates/database/create_table.twig
+++ b/resources/templates/database/create_table.twig
@@ -4,7 +4,7 @@
   <div class="card-body row row-cols-lg-auto g-3">
     <div class="col-12">
       <label for="createTableNameInput" class="form-label">{{ t('Table name') }}</label>
-      <input type="text" class="form-control" name="table" id="createTableNameInput" maxlength="64" required>
+      <input type="text" class="form-control" name="table" id="createTableNameInput" maxlength="64">
     </div>
     <div class="col-12">
       <label for="createTableNumFieldsInput" class="form-label">{{ t('Number of columns') }}</label>

--- a/resources/templates/database/operations/index.twig
+++ b/resources/templates/database/operations/index.twig
@@ -29,7 +29,7 @@
     <div class="card-body row row-cols-lg-auto g-3">
       <div class="col-md-6">
         <label for="createTableNameInput" class="form-label">{{ t('Table name') }}</label>
-        <input type="text" class="form-control" name="table" id="createTableNameInput" maxlength="64" required>
+        <input type="text" class="form-control" name="table" id="createTableNameInput" maxlength="64">
       </div>
       <div class="col-md-6">
         <label for="createTableNumFieldsInput" class="form-label">{{ t('Number of columns') }}</label>


### PR DESCRIPTION
### Description

Allow opening the full table create form without entering a table name.
The name will still be required in the full form.

Remove this check:
![image](https://github.com/phpmyadmin/phpmyadmin/assets/4426597/a1d2d97c-f78d-4f19-b1de-61469ef21bd6)
