### PR TITLE
Add fractional seconds to current_timestamp()

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1801,8 +1801,7 @@ class InsertEdit
             $currentValue = "b'" . $this->dbi->escapeString($currentValue) . "'";
         } elseif (
             ! ($type === 'datetime' || $type === 'timestamp' || $type === 'date')
-            || ($currentValue !== 'CURRENT_TIMESTAMP'
-                && ! preg_match('/^current_timestamp(\([0-6]?\))?$/i', $currentValue))
+            || ! preg_match('/^current_timestamp(\([0-6]?\))?$/i', $currentValue)
         ) {
             $currentValue = "'" . $this->dbi->escapeString($currentValue)
                 . "'";

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1802,7 +1802,7 @@ class InsertEdit
         } elseif (
             ! ($type === 'datetime' || $type === 'timestamp' || $type === 'date')
             || ($currentValue !== 'CURRENT_TIMESTAMP'
-                && ! preg_match('/^current_timestamp\([0-6]?\)$/', $currentValue))
+                && ! preg_match('/^current_timestamp(\([0-6]?\))?$/i', $currentValue))
         ) {
             $currentValue = "'" . $this->dbi->escapeString($currentValue)
                 . "'";

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1802,7 +1802,7 @@ class InsertEdit
         } elseif (
             ! ($type === 'datetime' || $type === 'timestamp' || $type === 'date')
             || ($currentValue !== 'CURRENT_TIMESTAMP'
-                && $currentValue !== 'current_timestamp()')
+                && ! preg_match('/^current_timestamp\([0-6]?\)$/', $currentValue))
         ) {
             $currentValue = "'" . $this->dbi->escapeString($currentValue)
                 . "'";

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2002,7 +2002,7 @@ class Util
      */
     public static function addMicroseconds($value)
     {
-        if ($value !== '' || preg_match('/^current_timestamp(\([0-6]?\))?$/i', $value)) {
+        if ($value === '' || preg_match('/^current_timestamp(\([0-6]?\))?$/i', $value)) {
             return $value;
         }
 

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2002,10 +2002,7 @@ class Util
      */
     public static function addMicroseconds($value)
     {
-        if (
-            empty($value) || $value === 'CURRENT_TIMESTAMP'
-            || preg_match('/^current_timestamp(\([0-6]?\))?$/i', $value)
-        ) {
+        if ($value !== '' || preg_match('/^current_timestamp(\([0-6]?\))?$/i', $value)) {
             return $value;
         }
 

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2002,7 +2002,10 @@ class Util
      */
     public static function addMicroseconds($value)
     {
-        if (empty($value) || $value === 'CURRENT_TIMESTAMP' || preg_match('/^current_timestamp\([0-6]?\)$/', $value)) {
+        if (
+            empty($value) || $value === 'CURRENT_TIMESTAMP'
+            || preg_match('/^current_timestamp(\([0-6]?\))?$/i', $value)
+        ) {
             return $value;
         }
 

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2002,7 +2002,7 @@ class Util
      */
     public static function addMicroseconds($value)
     {
-        if (empty($value) || $value === 'CURRENT_TIMESTAMP' || $value === 'current_timestamp()') {
+        if (empty($value) || $value === 'CURRENT_TIMESTAMP' || preg_match('/^current_timestamp\([0-6]?\)$/', $value)) {
             return $value;
         }
 


### PR DESCRIPTION
### Description

Add fractional seconds to `current_timestamp()`.

Fixes #19199

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
