### PR TITLE
Fix `Query Generator` single quotes and backslashes

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -438,7 +438,7 @@ Functions.escapeBacktick = function (s) {
  * @return {string}
  */
 Functions.escapeSingleQuote = function (s) {
-    return s.replace('\\', '\\\\').replace('\'', '\\\'');
+    return s.replaceAll('\\', '\\\\').replaceAll('\'', '\\\'');
 };
 
 Functions.sprintf = function () {


### PR DESCRIPTION
Hello :wave:

This PR fixes the generated query when the criteria text contains single quotes or backslashes.

### Current
For now it only escapes the first `single quote` and the first `backslash`, which generates an invalid query.

![Screenshot from 2024-06-19 18-49-43](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/264f2fc9-8d7c-47be-8114-153f6dfbda2f)

### After
After merging this PR it will escape all the `single quotes` and all the `backslashes`.

![Screenshot from 2024-06-19 18-44-15](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/b1050188-7750-4b9e-90a6-a57a6c1f90f6)

### Server configuration

- phpMyAdmin version: 5.2.2-dev, 6.0.0-dev