### PR TITLE
Fix #19216 - SyntaxError thrown when updating existing NULL JSON cell in grid

### DIFF
--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -1522,7 +1522,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                     isValueUpdated = thisFieldParams[fieldName] !== Functions.getCellValue(g.currentEditCell);
                 } else {
                     const JSONString = Functions.stringifyJSON(thisFieldParams[fieldName]);
-                    isValueUpdated = JSONString !== JSON.stringify(JSON.parse(Functions.getCellValue(g.currentEditCell)));
+                    isValueUpdated = JSONString !== Functions.stringifyJSON(Functions.getCellValue(g.currentEditCell));
                 }
 
                 if (g.wasEditedCellNull || isValueUpdated) {


### PR DESCRIPTION
### Description
Resolves a thrown `SyntaxError` when attempting to update a JSON cell that currently has a `NULL` value.

Originally introduced in #17976 by cb6012cf2aa8752b6eb188cb4f727ad7f4b2b88d which saw the addition of the `Functions.stringifyJSON` helper used to safely validate if the new JSON value being input in the cell is different from the current value in order to determine whether or not we need to post the change:
https://github.com/phpmyadmin/phpmyadmin/blob/f8dd8d3475b3e0ad31dd14539f7e45062b3458b4/js/src/makegrid.js#L1524-L1525

Whilst this does ensure we only `POST` when the cell is actually changed, it didn't take into consideration that the edited cell could have been `NULL` in which case it evaluates to `JSON.parse("")` and throws the error.

This fix changes the right-hand side of the `isValueUpdated` conditional to also safely validate the JSON value of the current edited cell.

Fixes #19216

https://github.com/phpmyadmin/phpmyadmin/assets/27928708/1718d530-f197-4601-8878-5da6e50bc704