### PR TITLE
Fix textarea resize horizontally - Bootstrap theme

### DIFF
--- a/themes/bootstrap/scss/_common.scss
+++ b/themes/bootstrap/scss/_common.scss
@@ -1714,6 +1714,7 @@ input#auto_increment_opt {
     overflow-y: scroll;
     padding: 0;
     margin: 0;
+    resize: both;
   }
 
   .edit_box_posting {
@@ -1862,10 +1863,6 @@ table.show_create {
   bottom: 0;
   left: 0;
   z-index: 100;
-}
-
-textarea {
-  resize: both;
 }
 
 #pma_console {

--- a/themes/bootstrap/scss/_common.scss
+++ b/themes/bootstrap/scss/_common.scss
@@ -1864,6 +1864,10 @@ table.show_create {
   z-index: 100;
 }
 
+textarea {
+  resize: both;
+}
+
 #pma_console {
   position: relative;
   margin-left: $navigation-width;


### PR DESCRIPTION
### Description

Fix textarea resize horizontally on Bootstrap theme.

Before:

https://github.com/phpmyadmin/phpmyadmin/assets/25424343/114f89a6-8a36-45de-8df6-05fa7115da4c

After:

https://github.com/phpmyadmin/phpmyadmin/assets/25424343/a4fd056b-cae5-4442-8f4d-0b9602007d14

Fixes #

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
