### PR TITLE
Remove unneeded var assignment

### DIFF
--- a/examples/signon.php
+++ b/examples/signon.php
@@ -32,7 +32,6 @@ if (isset($_POST['user'])) {
     /* Update another field of server configuration */
     $_SESSION['PMA_single_signon_cfgupdate'] = ['verbose' => 'Signon test'];
     $_SESSION['PMA_single_signon_HMAC_secret'] = hash('sha1', uniqid(strval(random_int(0, mt_getrandmax())), true));
-    $id = session_id();
     /* Close that session */
     @session_write_close();
     /* Redirect to phpMyAdmin (should use absolute URL here!) */


### PR DESCRIPTION
The $id variable is assigned, but never used in the script. This may confuse readers, so remove the assignment.

### Description

Update documentation to remove an assignment that may confuse readers.

Fixes #

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [X] Any new functionality is covered by tests.
