### PR TITLE
Show query stats for count(*) query

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -133,6 +133,7 @@ class Results
      *   unlim_num_rows: int|numeric-string|false,
      *   fields_meta: FieldMetadata[],
      *   is_count: bool|null,
+     *   is_group: bool|null,
      *   is_export: bool|null,
      *   is_func: bool|null,
      *   is_analyse: bool|null,
@@ -177,6 +178,8 @@ class Results
         'fields_meta' => [],
 
         'is_count' => null,
+
+        'is_group' => null,
 
         'is_export' => null,
 
@@ -394,6 +397,7 @@ class Results
      *                                                    any appended "LIMIT" clause programmatically
      * @param FieldMetadata[]           $fieldsMeta       meta information about fields
      * @param bool                      $isCount          statement is SELECT COUNT
+     * @param bool                      $isGroup          statement has GROUP BY
      * @param bool                      $isExport         statement contains INTO OUTFILE
      * @param bool                      $isFunction       statement contains a function like SUM()
      * @param bool                      $isAnalyse        statement contains PROCEDURE ANALYSE
@@ -415,6 +419,7 @@ class Results
         $unlimNumRows,
         array $fieldsMeta,
         $isCount,
+        $isGroup,
         $isExport,
         $isFunction,
         $isAnalyse,
@@ -433,6 +438,7 @@ class Results
         $this->properties['unlim_num_rows'] = $unlimNumRows;
         $this->properties['fields_meta'] = $fieldsMeta;
         $this->properties['is_count'] = $isCount;
+        $this->properties['is_group'] = $isGroup;
         $this->properties['is_export'] = $isExport;
         $this->properties['is_func'] = $isFunction;
         $this->properties['is_analyse'] = $isAnalyse;
@@ -466,6 +472,7 @@ class Results
         $displayParts['bkm_form'] = '0';
         $displayParts['text_btn'] = '0';
         $displayParts['pview_lnk'] = '0';
+        $displayParts['query_stats'] = '1';
 
         return $displayParts;
     }
@@ -510,6 +517,7 @@ class Results
         $displayParts['bkm_form'] = '1';
         $displayParts['text_btn'] = '1';
         $displayParts['pview_lnk'] = '1';
+        $displayParts['query_stats'] = '0';
 
         return $displayParts;
     }
@@ -531,6 +539,7 @@ class Results
         $displayParts['sort_lnk'] = '0';
         $displayParts['nav_bar'] = '0';
         $displayParts['bkm_form'] = '1';
+        $displayParts['query_stats'] = '0';
 
         if ($this->properties['is_maint']) {
             $displayParts['text_btn'] = '1';
@@ -628,14 +637,13 @@ class Results
         $db = $this->properties['db'];
         $table = $this->properties['table'];
         $unlimNumRows = $this->properties['unlim_num_rows'];
-        $numRows = $this->properties['num_rows'];
         $printView = $this->properties['printview'];
 
         // 2. Updates the display parts
         if ($printView == '1') {
             $displayParts = $this->setDisplayPartsForPrintView($displayParts);
         } elseif (
-            $this->properties['is_count'] || $this->properties['is_analyse']
+            $this->properties['is_analyse']
             || $this->properties['is_maint'] || $this->properties['is_explain']
         ) {
             $displayParts = $this->setDisplayPartsForNonData($displayParts);
@@ -658,9 +666,9 @@ class Results
 
         // if for COUNT query, number of rows returned more than 1
         // (may be being used GROUP BY)
-        if ($this->properties['is_count'] && $numRows > 1) {
-            $displayParts['nav_bar'] = '1';
-            $displayParts['sort_lnk'] = '1';
+        if ($this->properties['is_count'] && ! $this->properties['is_group']) {
+            $displayParts['nav_bar'] = '0';
+            $displayParts['sort_lnk'] = '0';
         }
 
         // 4. If navigation bar or sorting fields names URLs should be
@@ -3642,7 +3650,7 @@ class Results
         // 1.2 Defines offsets for the next and previous pages
         $posNext = 0;
         $posPrev = 0;
-        if ($displayParts['nav_bar'] == '1') {
+        if ($displayParts['nav_bar'] == '1' || $displayParts['query_stats'] === '1') {
             [$posNext, $posPrev] = $this->getOffsets();
         }
 
@@ -3675,7 +3683,7 @@ class Results
 
         // 2.1 Prepares a messages with position information
         $sqlQueryMessage = '';
-        if ($displayParts['nav_bar'] == '1') {
+        if ($displayParts['query_stats'] == '1') {
             $message = $this->setMessageInformation(
                 $sortedColumnMessage,
                 $analyzedSqlResults,

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -1078,6 +1078,7 @@ class Sql
             'bkm_form' => '1',
             'text_btn' => '1',
             'pview_lnk' => '1',
+            'query_stats' => '1',
         ];
 
         $sqlQueryResultsTable = $this->getHtmlForSqlQueryResultsTable(
@@ -1222,6 +1223,7 @@ class Sql
                         $numRows,
                         $fieldsMeta,
                         $analyzedSqlResults['is_count'],
+                        $analyzedSqlResults['is_group'],
                         $analyzedSqlResults['is_export'],
                         $analyzedSqlResults['is_func'],
                         $analyzedSqlResults['is_analyse'],
@@ -1246,6 +1248,7 @@ class Sql
                         'bkm_form' => '1',
                         'text_btn' => '1',
                         'pview_lnk' => '1',
+                        'query_stats' => '1',
                     ];
 
                     $tableHtml .= $displayResultsObject->getTable(
@@ -1270,6 +1273,7 @@ class Sql
                 $unlimNumRows,
                 $fieldsMeta,
                 $analyzedSqlResults['is_count'],
+                $analyzedSqlResults['is_group'],
                 $analyzedSqlResults['is_export'],
                 $analyzedSqlResults['is_func'],
                 $analyzedSqlResults['is_analyse'],
@@ -1477,6 +1481,7 @@ class Sql
             'bkm_form' => '1',
             'text_btn' => '0',
             'pview_lnk' => '1',
+            'query_stats' => '1',
         ];
 
         if (! $editable) {
@@ -1488,6 +1493,7 @@ class Sql
                 'bkm_form' => '1',
                 'text_btn' => '1',
                 'pview_lnk' => '1',
+                'query_stats' => '1',
             ];
         }
 
@@ -1500,6 +1506,7 @@ class Sql
                 'bkm_form' => '0',
                 'text_btn' => '0',
                 'pview_lnk' => '0',
+                'query_stats' => '0',
             ];
         }
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6066,7 +6066,7 @@
       <code>$sortExpression</code>
       <code>$urlParams</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="68">
+    <MixedArrayAccess occurrences="69">
       <code>$_SESSION['tmpval']['display_binary']</code>
       <code>$_SESSION['tmpval']['display_binary']</code>
       <code>$_SESSION['tmpval']['display_binary']</code>
@@ -6112,7 +6112,8 @@
       <code>$displayParams['data'][$rowNumber]</code>
       <code>$displayParts['nav_bar']</code>
       <code>$displayParts['nav_bar']</code>
-      <code>$displayParts['nav_bar']</code>
+      <code>$displayParts['query_stats']</code>
+      <code>$displayParts['query_stats']</code>
       <code>$displayParts['sort_lnk']</code>
       <code>$oneKey['index_list']</code>
       <code>$oneKey['ref_db_name']</code>
@@ -13141,7 +13142,7 @@
     <LessSpecificReturnStatement occurrences="1">
       <code>$unlimNumRows</code>
     </LessSpecificReturnStatement>
-    <MixedArgument occurrences="41">
+    <MixedArgument occurrences="43">
       <code>$analyzedSqlResults</code>
       <code>$analyzedSqlResults['is_affected']</code>
       <code>$analyzedSqlResults['is_analyse']</code>
@@ -13154,6 +13155,8 @@
       <code>$analyzedSqlResults['is_export']</code>
       <code>$analyzedSqlResults['is_func']</code>
       <code>$analyzedSqlResults['is_func']</code>
+      <code>$analyzedSqlResults['is_group']</code>
+      <code>$analyzedSqlResults['is_group']</code>
       <code>$analyzedSqlResults['is_maint']</code>
       <code>$analyzedSqlResults['is_maint']</code>
       <code>$analyzedSqlResults['is_show']</code>
@@ -15276,7 +15279,7 @@
     <DocblockTypeContradiction occurrences="1">
       <code>assertSame</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="16">
+    <MixedArgument occurrences="17">
       <code>$actual</code>
       <code>$analyzedSqlResults</code>
       <code>$analyzedSqlResults</code>
@@ -15287,18 +15290,20 @@
       <code>$analyzedSqlResults['is_explain']</code>
       <code>$analyzedSqlResults['is_export']</code>
       <code>$analyzedSqlResults['is_func']</code>
+      <code>$analyzedSqlResults['is_group']</code>
       <code>$analyzedSqlResults['is_maint']</code>
       <code>$analyzedSqlResults['is_show']</code>
       <code>$output</code>
       <code>$output</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="8">
+    <MixedArrayAccess occurrences="9">
       <code>$_SESSION['tmpval']['pftext']</code>
       <code>$analyzedSqlResults['is_analyse']</code>
       <code>$analyzedSqlResults['is_count']</code>
       <code>$analyzedSqlResults['is_explain']</code>
       <code>$analyzedSqlResults['is_export']</code>
       <code>$analyzedSqlResults['is_func']</code>
+      <code>$analyzedSqlResults['is_group']</code>
       <code>$analyzedSqlResults['is_maint']</code>
       <code>$analyzedSqlResults['is_show']</code>
     </MixedArrayAccess>

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -1416,6 +1416,7 @@ class ResultsTest extends AbstractTestCase
             3,
             $fieldsMeta,
             $analyzedSqlResults['is_count'],
+            $analyzedSqlResults['is_group'],
             $analyzedSqlResults['is_export'],
             $analyzedSqlResults['is_func'],
             $analyzedSqlResults['is_analyse'],
@@ -1454,6 +1455,7 @@ class ResultsTest extends AbstractTestCase
             'bkm_form' => '1',
             'text_btn' => '0',
             'pview_lnk' => '1',
+            'query_stats' => '1',
         ];
         $this->assertNotFalse($dtResult);
         $actual = $object->getTable($dtResult, $displayParts, $analyzedSqlResults);


### PR DESCRIPTION
Fixes #16869

Treat `SELECT COUNT(*) ...` query more like a normal select query.

If no group by is included (always only one row) then, like before, no navigation is shown. Otherwise it shows with navigation like any other select.
Before this PR the `nav_bar` property controlled the navigation and the query duration, now the new `query_stats` property allows to show the stats without navigation.