### PR TITLE
Fix Table/CreateTest e2e test

### DIFF
--- a/.github/workflows/test-selenium.yml
+++ b/.github/workflows/test-selenium.yml
@@ -121,6 +121,8 @@ jobs:
           FPM_PATH: php-fpm${{ env.php-version }}
           SKIP_STANDALONE: 1
         run: |
+          sudo chown -R runner:docker /var/lib/nginx/
+          sudo chown -R runner:docker /var/log/nginx/
           ./tests/start-local-server
           echo "SELENIUM_TEMPDIR=$(cat /tmp/last_temp_dir_phpMyAdminTests)" >> $GITHUB_OUTPUT
         id: start-local-server


### PR DESCRIPTION
Changes owner of `/var/lib/nginx/` and `/var/log/nginx/` directory to `runner:docker` to fix some permission denied errors.

```
+ nginx -c /tmp/tmp.FGUCPeFmlv-phpMyAdminTest/nginx.conf
nginx: [alert] could not open error log file: open() "/var/log/nginx/error.log" failed (13: Permission denied)
```
```
2024/07/09 03:25:43 [crit] 5452#5452: *1 open() "/var/lib/nginx/fastcgi/1/00/0000000001" failed (13: Permission denied) while reading upstream, client: 172.18.0.4, server: _, request: "POST /index.php?route=/table/create HTTP/1.1", upstream: "fastcgi://unix:/tmp/tmp.FGUCPeFmlv-phpMyAdminTest/php-fpm.sock:", host: "docker-host-bridge:8000", referrer: "http://docker-host-bridge:8000/index.php?route=/database/structure&db=selenium55d498d1"
```

https://github.com/phpmyadmin/phpmyadmin/actions/runs/9844362774/job/27177575242#step:14:15