### PR TITLE
Fix boolean usage of the return value of preg_match()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -236,11 +236,6 @@ parameters:
 			path: src/Command/TwigLintCommand.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 1
-			path: src/Command/TwigLintCommand.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
 			count: 2
 			path: src/Command/TwigLintCommand.php
@@ -336,16 +331,6 @@ parameters:
 			path: src/Config.php
 
 		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the left side\\.$#"
-			count: 3
-			path: src/Config.php
-
-		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
-			count: 4
-			path: src/Config.php
-
-		-
 			message: "#^Only booleans are allowed in &&, string\\|null given on the right side\\.$#"
 			count: 1
 			path: src/Config.php
@@ -363,16 +348,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
 			count: 2
-			path: src/Config.php
-
-		-
-			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
-			count: 6
-			path: src/Config.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 1
 			path: src/Config.php
 
 		-
@@ -633,11 +608,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a ternary operator condition, mixed given\\.$#"
 			count: 1
-			path: src/Config/FormDisplay.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 2
 			path: src/Config/FormDisplay.php
 
 		-
@@ -931,11 +901,6 @@ parameters:
 			path: src/Config/Validator.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/Config/Validator.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, mysqli\\|false given\\.$#"
 			count: 1
 			path: src/Config/Validator.php
@@ -943,11 +908,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a ternary operator condition, int\\<0, max\\>\\|false given\\.$#"
 			count: 1
-			path: src/Config/Validator.php
-
-		-
-			message: "#^Only booleans are allowed in a ternary operator condition, int\\|false given\\.$#"
-			count: 2
 			path: src/Config/Validator.php
 
 		-
@@ -1278,11 +1238,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in &&, string given on the left side\\.$#"
 			count: 1
-			path: src/ConfigStorage/Relation.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 3
 			path: src/ConfigStorage/Relation.php
 
 		-
@@ -2051,11 +2006,6 @@ parameters:
 			path: src/Controllers/Database/StructureController.php
 
 		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
-			count: 1
-			path: src/Controllers/Database/StructureController.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/Database/StructureController.php
@@ -2426,11 +2376,6 @@ parameters:
 			path: src/Controllers/GisDataEditorController.php
 
 		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
-			count: 1
-			path: src/Controllers/GisDataEditorController.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$gisDataParam has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Controllers/GisDataEditorController.php
@@ -2452,11 +2397,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in &&, string\\|false given on the right side\\.$#"
-			count: 1
-			path: src/Controllers/HomeController.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
 			count: 1
 			path: src/Controllers/HomeController.php
 
@@ -2558,16 +2498,6 @@ parameters:
 		-
 			message: "#^Negated boolean expression is always true\\.$#"
 			count: 1
-			path: src/Controllers/Import/ImportController.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/Controllers/Import/ImportController.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 5
 			path: src/Controllers/Import/ImportController.php
 
 		-
@@ -3556,16 +3486,6 @@ parameters:
 			path: src/Controllers/Server/Variables/SetVariableController.php
 
 		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
-			count: 1
-			path: src/Controllers/Server/Variables/SetVariableController.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/Controllers/Server/Variables/SetVariableController.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, int\\|string given\\.$#"
 			count: 1
 			path: src/Controllers/Server/Variables/SetVariableController.php
@@ -4161,11 +4081,6 @@ parameters:
 			path: src/Controllers/Table/FindReplaceController.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/Controllers/Table/FindReplaceController.php
-
-		-
 			message: "#^Parameter \\#1 \\$identifier of static method PhpMyAdmin\\\\Util\\:\\:backquote\\(\\) expects string\\|Stringable\\|null, mixed given\\.$#"
 			count: 16
 			path: src/Controllers/Table/FindReplaceController.php
@@ -4736,11 +4651,6 @@ parameters:
 			path: src/Controllers/Table/SearchController.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/Controllers/Table/SearchController.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/Table/SearchController.php
@@ -5211,11 +5121,6 @@ parameters:
 			path: src/Controllers/Table/ZoomSearchController.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/Controllers/Table/ZoomSearchController.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/Table/ZoomSearchController.php
@@ -5486,17 +5391,7 @@ parameters:
 			path: src/Core.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/Core.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\|string given\\.$#"
-			count: 1
-			path: src/Core.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
 			count: 1
 			path: src/Core.php
 
@@ -6101,18 +5996,8 @@ parameters:
 			path: src/Database/Routines.php
 
 		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
-			count: 2
-			path: src/Database/Routines.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
 			count: 4
-			path: src/Database/Routines.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 2
 			path: src/Database/Routines.php
 
 		-
@@ -6671,11 +6556,6 @@ parameters:
 			path: src/Display/Results.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/Display/Results.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Display/Results.php
@@ -6693,11 +6573,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a ternary operator condition, mixed given\\.$#"
 			count: 1
-			path: src/Display/Results.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 2
 			path: src/Display/Results.php
 
 		-
@@ -6906,11 +6781,6 @@ parameters:
 			path: src/Engines/Innodb.php
 
 		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
-			count: 1
-			path: src/Engines/Pbxt.php
-
-		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
 			count: 3
 			path: src/Error/Error.php
@@ -7036,11 +6906,6 @@ parameters:
 			path: src/Error/ErrorReport.php
 
 		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
-			count: 1
-			path: src/Error/ErrorReport.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
 			count: 1
 			path: src/Error/ErrorReport.php
@@ -7117,11 +6982,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Export\\\\Export\\:\\:compress\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Export/Export.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
 			count: 1
 			path: src/Export/Export.php
 
@@ -7361,11 +7221,6 @@ parameters:
 			path: src/File.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/FileListing.php
-
-		-
 			message: "#^Cannot access an offset on mixed\\.$#"
 			count: 1
 			path: src/FlashMessenger.php
@@ -7414,16 +7269,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$params of static method PhpMyAdmin\\\\Url\\:\\:getCommonRaw\\(\\) expects array\\<int\\|string, bool\\|int\\|string\\>, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: src/Footer.php
-
-		-
-			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
-			count: 1
-			path: src/Gis/GisGeometry.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 1
-			path: src/Gis/GisGeometry.php
 
 		-
 			message: "#^Only numeric types are allowed in \\+, int\\<0, max\\>\\|false given on the left side\\.$#"
@@ -7806,11 +7651,6 @@ parameters:
 			path: src/Git.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 2
-			path: src/Git.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
 			count: 1
 			path: src/Git.php
@@ -7931,21 +7771,6 @@ parameters:
 			path: src/Html/Generator.php
 
 		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
-			count: 1
-			path: src/Html/Generator.php
-
-		-
-			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
-			count: 1
-			path: src/Html/Generator.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 1
-			path: src/Html/Generator.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
 			count: 1
 			path: src/Html/Generator.php
@@ -7984,11 +7809,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$method of method PhpMyAdmin\\\\Http\\\\Factory\\\\ServerRequestFactory\\:\\:createServerRequest\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Http/Factory/ServerRequestFactory.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 1
-			path: src/Http/Factory/UriFactory.php
 
 		-
 			message: "#^Parameter \\#1 \\$source of method PhpMyAdmin\\\\Config\\:\\:loadAndCheck\\(\\) expects string\\|null, mixed given\\.$#"
@@ -8157,16 +7977,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
-			count: 1
-			path: src/Import/Import.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/Import/Import.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
 			count: 1
 			path: src/Import/Import.php
 
@@ -8396,18 +8206,8 @@ parameters:
 			path: src/InsertEdit.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/InsertEdit.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 2
-			path: src/InsertEdit.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 1
 			path: src/InsertEdit.php
 
 		-
@@ -8556,11 +8356,6 @@ parameters:
 			path: src/InsertEdit.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, int\\|false given\\.$#"
-			count: 1
-			path: src/InsertEditColumn.php
-
-		-
 			message: "#^Property PhpMyAdmin\\\\InsertEditColumn\\:\\:\\$trueType \\(string\\) does not accept string\\|null\\.$#"
 			count: 1
 			path: src/InsertEditColumn.php
@@ -8568,11 +8363,6 @@ parameters:
 		-
 			message: "#^Binary operation \"\\-\" between string and 1 results in an error\\.$#"
 			count: 1
-			path: src/IpAllowDeny.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 3
 			path: src/IpAllowDeny.php
 
 		-
@@ -8648,11 +8438,6 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
-			path: src/ListDatabase.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 2
 			path: src/ListDatabase.php
 
 		-
@@ -8892,11 +8677,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Navigation\\\\Nodes\\\\Node\\:\\:getDatabasesToSearch\\(\\) should return array but returns array\\<int, string\\>\\|string\\.$#"
-			count: 1
-			path: src/Navigation/Nodes/Node.php
-
-		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
 			count: 1
 			path: src/Navigation/Nodes/Node.php
 
@@ -9471,11 +9251,6 @@ parameters:
 			path: src/Plugins.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\<0, max\\>\\|false given\\.$#"
-			count: 1
-			path: src/Plugins.php
-
-		-
 			message: "#^Parameter \\#1 \\$link of static method PhpMyAdmin\\\\Html\\\\MySQLDocumentation\\:\\:show\\(\\) expects string, mixed given\\.$#"
 			count: 2
 			path: src/Plugins.php
@@ -9582,11 +9357,6 @@ parameters:
 
 		-
 			message: "#^Offset 'CaptchaSiteVerifyURL' on array\\{PmaAbsoluteUri\\: string, AuthLog\\: string, AuthLogSuccess\\: bool, PmaNoRelation_DisableWarning\\: bool, SuhosinDisableWarning\\: bool, LoginCookieValidityDisableWarning\\: bool, ReservedWordDisableWarning\\: bool, TranslationWarningThreshold\\: int, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: src/Plugins/Auth/AuthenticationCookie.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
 			count: 1
 			path: src/Plugins/Auth/AuthenticationCookie.php
 
@@ -9762,11 +9532,6 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: src/Plugins/Export/ExportCodegen.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
 			count: 1
 			path: src/Plugins/Export/ExportCodegen.php
 
@@ -10132,11 +9897,6 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: src/Plugins/Export/ExportPhparray.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
 			count: 1
 			path: src/Plugins/Export/ExportPhparray.php
 
@@ -10848,16 +10608,6 @@ parameters:
 		-
 			message: "#^Negated boolean expression is always true\\.$#"
 			count: 1
-			path: src/Plugins/Import/ImportMediawiki.php
-
-		-
-			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
-			count: 1
-			path: src/Plugins/Import/ImportMediawiki.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 2
 			path: src/Plugins/Import/ImportMediawiki.php
 
 		-
@@ -11581,16 +11331,6 @@ parameters:
 			path: src/Plugins/Transformations/Abs/Bool2TextTransformationsPlugin.php
 
 		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
-			count: 1
-			path: src/Plugins/Transformations/Abs/DateFormatTransformationsPlugin.php
-
-		-
-			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
-			count: 2
-			path: src/Plugins/Transformations/Abs/DateFormatTransformationsPlugin.php
-
-		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/Plugins/Transformations/Abs/DownloadTransformationsPlugin.php
@@ -11667,11 +11407,6 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: src/Plugins/Transformations/Abs/RegexValidationTransformationsPlugin.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
 			count: 1
 			path: src/Plugins/Transformations/Abs/RegexValidationTransformationsPlugin.php
 
@@ -12196,11 +11931,6 @@ parameters:
 			path: src/Sanitize.php
 
 		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
-			count: 1
-			path: src/Sanitize.php
-
-		-
 			message: "#^Parameter \\#1 \\$name of class PhpMyAdmin\\\\Server\\\\Plugin constructor expects string, mixed given\\.$#"
 			count: 1
 			path: src/Server/Plugin.php
@@ -12391,11 +12121,6 @@ parameters:
 			path: src/Server/Privileges.php
 
 		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
-			count: 1
-			path: src/Server/Privileges.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
 			count: 13
 			path: src/Server/Privileges.php
@@ -12403,11 +12128,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an if condition, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
 			count: 5
-			path: src/Server/Privileges.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 1
 			path: src/Server/Privileges.php
 
 		-
@@ -12693,16 +12413,6 @@ parameters:
 		-
 			message: "#^Method PhpMyAdmin\\\\Server\\\\Status\\\\Monitor\\:\\:getJsonForLogDataTypeSlow\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: src/Server/Status/Monitor.php
-
-		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
-			count: 1
-			path: src/Server/Status/Monitor.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 3
 			path: src/Server/Status/Monitor.php
 
 		-
@@ -13331,11 +13041,6 @@ parameters:
 			path: src/Table/Search.php
 
 		-
-			message: "#^Only booleans are allowed in \\|\\|, int\\|false given on the left side\\.$#"
-			count: 1
-			path: src/Table/Search.php
-
-		-
 			message: "#^Parameter \\#1 \\$gisString of static method PhpMyAdmin\\\\Utils\\\\Gis\\:\\:createData\\(\\) expects string, mixed given\\.$#"
 			count: 2
 			path: src/Table/Search.php
@@ -13536,11 +13241,6 @@ parameters:
 			path: src/Table/Table.php
 
 		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
-			count: 3
-			path: src/Table/Table.php
-
-		-
 			message: "#^Only booleans are allowed in &&, string given on the left side\\.$#"
 			count: 2
 			path: src/Table/Table.php
@@ -13551,28 +13251,13 @@ parameters:
 			path: src/Table/Table.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/Table/Table.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\|null given\\.$#"
-			count: 1
-			path: src/Table/Table.php
-
-		-
-			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
 			count: 1
 			path: src/Table/Table.php
 
 		-
 			message: "#^Only booleans are allowed in an if condition, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
 			count: 1
-			path: src/Table/Table.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 2
 			path: src/Table/Table.php
 
 		-
@@ -13911,16 +13596,6 @@ parameters:
 			path: src/Transformations.php
 
 		-
-			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
-			count: 1
-			path: src/Transformations.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 1
-			path: src/Transformations.php
-
-		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/Triggers/Triggers.php
@@ -14021,11 +13696,6 @@ parameters:
 			path: src/Url.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/UrlRedirector.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: src/UserPassword.php
@@ -14101,17 +13771,7 @@ parameters:
 			path: src/UserPrivilegesFactory.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/UserPrivilegesFactory.php
-
-		-
 			message: "#^Only booleans are allowed in \\|\\|, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given on the left side\\.$#"
-			count: 1
-			path: src/UserPrivilegesFactory.php
-
-		-
-			message: "#^Only booleans are allowed in \\|\\|, int\\|false given on the right side\\.$#"
 			count: 1
 			path: src/UserPrivilegesFactory.php
 
@@ -14256,32 +13916,12 @@ parameters:
 			path: src/Util.php
 
 		-
-			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
-			count: 1
-			path: src/Util.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\<0, 2\\> given\\.$#"
 			count: 1
 			path: src/Util.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
-			path: src/Util.php
-
-		-
-			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
-			count: 2
-			path: src/Util.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, int\\<0, max\\>\\|false given\\.$#"
-			count: 1
-			path: src/Util.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
 			count: 1
 			path: src/Util.php
 
@@ -14376,11 +14016,6 @@ parameters:
 			path: src/Utils/Gis.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 2
-			path: src/Utils/Gis.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Utils\\\\HttpRequest\\:\\:response\\(\\) should return bool\\|string\\|null but returns mixed\\.$#"
 			count: 1
 			path: src/Utils/HttpRequest.php
@@ -14421,11 +14056,6 @@ parameters:
 			path: src/VersionInformation.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 1
-			path: src/VersionInformation.php
-
-		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
 			count: 1
 			path: src/VersionInformation.php
@@ -14453,11 +14083,6 @@ parameters:
 		-
 			message: "#^Method PhpMyAdmin\\\\ZipExtension\\:\\:getContents\\(\\) should return array\\{error\\: string, data\\: string\\} but returns array\\{error\\: string, data\\: string\\|false\\}\\.$#"
 			count: 1
-			path: src/ZipExtension.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 2
 			path: src/ZipExtension.php
 
 		-
@@ -14558,11 +14183,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
 			count: 2
-			path: tests/end-to-end/TestBase.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
 			path: tests/end-to-end/TestBase.php
 
 		-
@@ -14933,11 +14553,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in &&, int\\<0, 2\\> given on the right side\\.$#"
 			count: 2
-			path: tests/unit/ConfigTest.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 1
 			path: tests/unit/ConfigTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -154,7 +154,7 @@
       <code><![CDATA[static function (int $level, string $message, string $file, int $line) use (&$prevErrorHandler) {
                     if ($level === E_USER_DEPRECATED) {
                         $templateLine = 0;
-                        if (preg_match('/ at line (\d+)[ .]/', $message, $matches)) {
+                        if (preg_match('/ at line (\d+)[ .]/', $message, $matches) === 1) {
                             $templateLine = (int) $matches[1];
                         }
 
@@ -7548,7 +7548,6 @@
       <code><![CDATA[$subgroupHeader->getName()]]></code>
     </PossiblyNullOperand>
     <RiskyTruthyFalsyComparison>
-      <code><![CDATA[! preg_match_all('/(str[A-Z][A-Za-z0-9]*)/', (string) $config->settings[$section][$opt], $matches)]]></code>
       <code><![CDATA[empty(Config::getInstance()->settings[$section][$opt])]]></code>
     </RiskyTruthyFalsyComparison>
     <TypeDoesNotContainType>

--- a/src/Command/SetVersionCommand.php
+++ b/src/Command/SetVersionCommand.php
@@ -72,8 +72,7 @@ PHP;
     private function getGeneratedClass(string $version): string
     {
         // Do not allow any major below 5
-        $return = preg_match('/^([5-9]+)\.(\d{1,2})\.(\d{1,2})(-([a-z0-9]+))?$/', $version, $matches);
-        if ($return === false || $return === 0) {
+        if (preg_match('/^([5-9]+)\.(\d{1,2})\.(\d{1,2})(-([a-z0-9]+))?$/', $version, $matches) !== 1) {
             throw new RangeException('The version number is in the wrong format: ' . $version);
         }
 

--- a/src/Command/TwigLintCommand.php
+++ b/src/Command/TwigLintCommand.php
@@ -114,7 +114,7 @@ class TwigLintCommand extends Command
                 static function (int $level, string $message, string $file, int $line) use (&$prevErrorHandler) {
                     if ($level === E_USER_DEPRECATED) {
                         $templateLine = 0;
-                        if (preg_match('/ at line (\d+)[ .]/', $message, $matches)) {
+                        if (preg_match('/ at line (\d+)[ .]/', $message, $matches) === 1) {
                             $templateLine = (int) $matches[1];
                         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -218,45 +218,45 @@ class Config
         // 2. browser and version
         // (must check everything else before Mozilla)
 
-        $isMozilla = preg_match('@Mozilla/([0-9]\.[0-9]{1,2})@', $httpUserAgent, $mozillaVersion);
+        $isMozilla = preg_match('@Mozilla/([0-9]\.[0-9]{1,2})@', $httpUserAgent, $mozillaVersion) === 1;
 
-        if (preg_match('@Opera(/| )([0-9]\.[0-9]{1,2})@', $httpUserAgent, $logVersion)) {
+        if (preg_match('@Opera(/| )([0-9]\.[0-9]{1,2})@', $httpUserAgent, $logVersion) === 1) {
             $this->set('PMA_USR_BROWSER_VER', $logVersion[2]);
             $this->set('PMA_USR_BROWSER_AGENT', 'OPERA');
-        } elseif (preg_match('@(MS)?IE ([0-9]{1,2}\.[0-9]{1,2})@', $httpUserAgent, $logVersion)) {
+        } elseif (preg_match('@(MS)?IE ([0-9]{1,2}\.[0-9]{1,2})@', $httpUserAgent, $logVersion) === 1) {
             $this->set('PMA_USR_BROWSER_VER', $logVersion[2]);
             $this->set('PMA_USR_BROWSER_AGENT', 'IE');
-        } elseif (preg_match('@Trident/(7)\.0@', $httpUserAgent, $logVersion)) {
+        } elseif (preg_match('@Trident/(7)\.0@', $httpUserAgent, $logVersion) === 1) {
             $this->set('PMA_USR_BROWSER_VER', (int) $logVersion[1] + 4);
             $this->set('PMA_USR_BROWSER_AGENT', 'IE');
-        } elseif (preg_match('@OmniWeb/([0-9]{1,3})@', $httpUserAgent, $logVersion)) {
+        } elseif (preg_match('@OmniWeb/([0-9]{1,3})@', $httpUserAgent, $logVersion) === 1) {
             $this->set('PMA_USR_BROWSER_VER', $logVersion[1]);
             $this->set('PMA_USR_BROWSER_AGENT', 'OMNIWEB');
             // Konqueror 2.2.2 says Konqueror/2.2.2
             // Konqueror 3.0.3 says Konqueror/3
-        } elseif (preg_match('@(Konqueror/)(.*)(;)@', $httpUserAgent, $logVersion)) {
+        } elseif (preg_match('@(Konqueror/)(.*)(;)@', $httpUserAgent, $logVersion) === 1) {
             $this->set('PMA_USR_BROWSER_VER', $logVersion[2]);
             $this->set('PMA_USR_BROWSER_AGENT', 'KONQUEROR');
             // must check Chrome before Safari
-        } elseif ($isMozilla && preg_match('@Chrome/([0-9.]*)@', $httpUserAgent, $logVersion)) {
+        } elseif ($isMozilla && preg_match('@Chrome/([0-9.]*)@', $httpUserAgent, $logVersion) === 1) {
             $this->set('PMA_USR_BROWSER_VER', $logVersion[1]);
             $this->set('PMA_USR_BROWSER_AGENT', 'CHROME');
             // newer Safari
-        } elseif ($isMozilla && preg_match('@Version/(.*) Safari@', $httpUserAgent, $logVersion)) {
+        } elseif ($isMozilla && preg_match('@Version/(.*) Safari@', $httpUserAgent, $logVersion) === 1) {
             $this->set('PMA_USR_BROWSER_VER', $logVersion[1]);
             $this->set('PMA_USR_BROWSER_AGENT', 'SAFARI');
             // older Safari
-        } elseif ($isMozilla && preg_match('@Safari/([0-9]*)@', $httpUserAgent, $logVersion)) {
+        } elseif ($isMozilla && preg_match('@Safari/([0-9]*)@', $httpUserAgent, $logVersion) === 1) {
             $this->set('PMA_USR_BROWSER_VER', $mozillaVersion[1] . '.' . $logVersion[1]);
             $this->set('PMA_USR_BROWSER_AGENT', 'SAFARI');
             // Firefox
         } elseif (
             ! str_contains($httpUserAgent, 'compatible')
-            && preg_match('@Firefox/([\w.]+)@', $httpUserAgent, $logVersion)
+            && preg_match('@Firefox/([\w.]+)@', $httpUserAgent, $logVersion) === 1
         ) {
             $this->set('PMA_USR_BROWSER_VER', $logVersion[1]);
             $this->set('PMA_USR_BROWSER_AGENT', 'FIREFOX');
-        } elseif (preg_match('@rv:1\.9(.*)Gecko@', $httpUserAgent)) {
+        } elseif (preg_match('@rv:1\.9(.*)Gecko@', $httpUserAgent) === 1) {
             $this->set('PMA_USR_BROWSER_VER', '1.9');
             $this->set('PMA_USR_BROWSER_AGENT', 'GECKO');
         } elseif ($isMozilla) {

--- a/src/Config/FormDisplay.php
+++ b/src/Config/FormDisplay.php
@@ -408,7 +408,7 @@ class FormDisplay
         // TrustedProxies requires changes before displaying
         if ($systemPath === 'TrustedProxies') {
             foreach ($value as $ip => &$v) {
-                if (preg_match('/^-\d+$/', $ip)) {
+                if (preg_match('/^-\d+$/', $ip) === 1) {
                     continue;
                 }
 
@@ -667,8 +667,7 @@ class FormDisplay
                 $i = 0;
                 foreach ($values[$path] as $value) {
                     $matches = [];
-                    $match = preg_match('/^(.+):(?:[ ]?)(\\w+)$/', $value, $matches);
-                    if ($match) {
+                    if (preg_match('/^(.+):(?:[ ]?)(\\w+)$/', $value, $matches) === 1) {
                         // correct 'IP: HTTP header' pair
                         $ip = trim($matches[1]);
                         $proxies[$ip] = trim($matches[2]);

--- a/src/Config/Validator.php
+++ b/src/Config/Validator.php
@@ -440,9 +440,7 @@ class Validator
             $lines = [];
             foreach ($values[$path] as $ip => $v) {
                 $v = Util::requestString($v);
-                $lines[] = preg_match('/^-\d+$/', $ip)
-                    ? $v
-                    : $ip . ': ' . $v;
+                $lines[] = preg_match('/^-\d+$/', $ip) === 1 ? $v : $ip . ': ' . $v;
             }
         } else {
             // AJAX validation
@@ -453,7 +451,7 @@ class Validator
             $line = trim($line);
             $matches = [];
             // we catch anything that may (or may not) be an IP
-            if (! preg_match('/^(.+):(?:[ ]?)\\w+$/', $line, $matches)) {
+            if (preg_match('/^(.+):(?:[ ]?)\\w+$/', $line, $matches) !== 1) {
                 $result[$path][] = __('Incorrect value:') . ' '
                     . htmlspecialchars($line);
                 continue;
@@ -593,9 +591,7 @@ class Validator
             return '';
         }
 
-        $result = preg_match($regex, Util::requestString($values[$path]));
-
-        return [$path => $result ? '' : __('Incorrect value!')];
+        return [$path => preg_match($regex, Util::requestString($values[$path])) === 1 ? '' : __('Incorrect value!')];
     }
 
     /**

--- a/src/ConfigStorage/Relation.php
+++ b/src/ConfigStorage/Relation.php
@@ -750,7 +750,10 @@ class Relation
             $key = (string) $key;
             $value = (string) $value;
 
-            if (mb_check_encoding($key, 'utf-8') && ! preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x80-\x9F]/u', $key)) {
+            if (
+                mb_check_encoding($key, 'utf-8')
+                && preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x80-\x9F]/u', $key) !== 1
+            ) {
                 $selected = $key === $data;
                 // show as text if it's valid utf-8
                 $key = htmlspecialchars($key);
@@ -765,7 +768,7 @@ class Relation
 
             if (
                 mb_check_encoding($value, 'utf-8')
-                && ! preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x80-\x9F]/u', $value)
+                && preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x80-\x9F]/u', $value) !== 1
             ) {
                 if (mb_strlen($value) <= $this->config->settings['LimitChars']) {
                     // show as text if it's valid utf-8
@@ -1375,7 +1378,7 @@ class Relation
         $queries = explode(';', $createTablesFile);
 
         foreach ($queries as $query) {
-            if (! preg_match('/CREATE TABLE IF NOT EXISTS `(.*)` \(/', $query, $table)) {
+            if (preg_match('/CREATE TABLE IF NOT EXISTS `(.*)` \(/', $query, $table) !== 1) {
                 continue;
             }
 

--- a/src/Controllers/Database/StructureController.php
+++ b/src/Controllers/Database/StructureController.php
@@ -633,7 +633,7 @@ final class StructureController implements InvocableController
                     '@^' .
                     preg_quote(mb_substr($this->replication->extractDbOrTable($dbTable, 'table'), 0, -1), '@') . '@',
                     $truename,
-                )
+                ) === 1
             ) {
                 return true;
             }

--- a/src/Controllers/GisDataEditorController.php
+++ b/src/Controllers/GisDataEditorController.php
@@ -132,7 +132,7 @@ final class GisDataEditorController implements InvocableController
                 $gisType = mb_strtoupper($type);
             }
 
-            if ($value !== null && trim($value) !== '' && preg_match('/^\'?(\w+)\b/', $value, $matches)) {
+            if ($value !== null && trim($value) !== '' && preg_match('/^\'?(\w+)\b/', $value, $matches) === 1) {
                 $gisType = $matches[1];
             }
 

--- a/src/Controllers/HomeController.php
+++ b/src/Controllers/HomeController.php
@@ -179,7 +179,7 @@ final class HomeController implements InvocableController
 
             if (Current::$server > 0) {
                 $clientVersion = $this->dbi->getClientInfo();
-                if (preg_match('#\d+\.\d+\.\d+#', $clientVersion)) {
+                if (preg_match('#\d+\.\d+\.\d+#', $clientVersion) === 1) {
                     $clientVersion = 'libmysql - ' . $clientVersion;
                 }
 

--- a/src/Controllers/Import/ImportController.php
+++ b/src/Controllers/Import/ImportController.php
@@ -129,20 +129,24 @@ final class ImportController implements InvocableController
             }
 
             // refresh navigation and main panels
-            if (preg_match('/^(DROP)\s+(VIEW|TABLE|DATABASE|SCHEMA)\s+/i', $GLOBALS['sql_query'])) {
+            if (preg_match('/^(DROP)\s+(VIEW|TABLE|DATABASE|SCHEMA)\s+/i', $GLOBALS['sql_query']) === 1) {
                 $GLOBALS['reload'] = true;
                 $GLOBALS['ajax_reload']['reload'] = true;
             }
 
             // refresh navigation panel only
-            if (preg_match('/^(CREATE|ALTER)\s+(VIEW|TABLE|DATABASE|SCHEMA)\s+/i', $GLOBALS['sql_query'])) {
+            if (preg_match('/^(CREATE|ALTER)\s+(VIEW|TABLE|DATABASE|SCHEMA)\s+/i', $GLOBALS['sql_query']) === 1) {
                 $GLOBALS['ajax_reload']['reload'] = true;
             }
 
             // do a dynamic reload if table is RENAMED
             // (by sending the instruction to the AJAX response handler)
             if (
-                preg_match('/^RENAME\s+TABLE\s+(.*?)\s+TO\s+(.*?)($|;|\s)/i', $GLOBALS['sql_query'], $renameTableNames)
+                preg_match(
+                    '/^RENAME\s+TABLE\s+(.*?)\s+TO\s+(.*?)($|;|\s)/i',
+                    $GLOBALS['sql_query'],
+                    $renameTableNames,
+                ) === 1
             ) {
                 $GLOBALS['ajax_reload']['reload'] = true;
                 $GLOBALS['ajax_reload']['table_name'] = Util::unQuote($renameTableNames[2]);
@@ -209,7 +213,7 @@ final class ImportController implements InvocableController
             $GLOBALS['goto'] = Url::getFromRoute('/database/import');
         } elseif (ImportSettings::$importType === 'server') {
             $GLOBALS['goto'] = Url::getFromRoute('/server/import');
-        } elseif (empty($GLOBALS['goto']) || ! preg_match('@^index\.php$@i', $GLOBALS['goto'])) {
+        } elseif (empty($GLOBALS['goto']) || preg_match('@^index\.php$@i', $GLOBALS['goto']) !== 1) {
             if (Current::$table !== '' && Current::$database !== '') {
                 $GLOBALS['goto'] = Url::getFromRoute('/table/structure');
             } elseif (Current::$database !== '') {
@@ -279,13 +283,18 @@ final class ImportController implements InvocableController
                     }
 
                     // refresh navigation and main panels
-                    if (preg_match('/^(DROP)\s+(VIEW|TABLE|DATABASE|SCHEMA)\s+/i', $GLOBALS['import_text'])) {
+                    if (preg_match('/^(DROP)\s+(VIEW|TABLE|DATABASE|SCHEMA)\s+/i', $GLOBALS['import_text']) === 1) {
                         $GLOBALS['reload'] = true;
                         $GLOBALS['ajax_reload']['reload'] = true;
                     }
 
                     // refresh navigation panel only
-                    if (preg_match('/^(CREATE|ALTER)\s+(VIEW|TABLE|DATABASE|SCHEMA)\s+/i', $GLOBALS['import_text'])) {
+                    if (
+                        preg_match(
+                            '/^(CREATE|ALTER)\s+(VIEW|TABLE|DATABASE|SCHEMA)\s+/i',
+                            $GLOBALS['import_text'],
+                        ) === 1
+                    ) {
                         $GLOBALS['ajax_reload']['reload'] = true;
                     }
 

--- a/src/Controllers/Server/Variables/SetVariableController.php
+++ b/src/Controllers/Server/Variables/SetVariableController.php
@@ -51,7 +51,7 @@ final class SetVariableController implements InvocableController
                 '/^\s*(\d+(\.\d+)?)\s*(mb|kb|mib|kib|gb|gib)\s*$/i',
                 $value,
                 $matches,
-            )
+            ) === 1
         ) {
             $exp = ['kb' => 1, 'kib' => 1, 'mb' => 2, 'mib' => 2, 'gb' => 3, 'gib' => 3];
             $value = (float) $matches[1] * 1024 ** $exp[mb_strtolower($matches[3])];
@@ -64,7 +64,7 @@ final class SetVariableController implements InvocableController
         }
 
         $json = [];
-        if (! preg_match('/[^a-zA-Z0-9_]+/', $variableName)) {
+        if (preg_match('/[^a-zA-Z0-9_]+/', $variableName) !== 1) {
             $this->dbi->query('SET GLOBAL ' . $variableName . ' = ' . $value);
             // Some values are rounded down etc.
             $varValue = $this->dbi->fetchSingleRow(

--- a/src/Controllers/Table/FindReplaceController.php
+++ b/src/Controllers/Table/FindReplaceController.php
@@ -149,7 +149,7 @@ final class FindReplaceController implements InvocableController
             } else {
                 // strip the "BINARY" attribute, except if we find "BINARY(" because
                 // this would be a BINARY or VARBINARY column type
-                if (! preg_match('@BINARY[\(]@i', $type)) {
+                if (preg_match('@BINARY[\(]@i', $type) !== 1) {
                     $type = str_ireplace('BINARY', '', $type);
                 }
 

--- a/src/Controllers/Table/SearchController.php
+++ b/src/Controllers/Table/SearchController.php
@@ -126,7 +126,7 @@ final class SearchController implements InvocableController
             } else {
                 // strip the "BINARY" attribute, except if we find "BINARY(" because
                 // this would be a BINARY or VARBINARY column type
-                if (! preg_match('@BINARY[\(]@i', $type)) {
+                if (preg_match('@BINARY[\(]@i', $type) !== 1) {
                     $type = str_ireplace('BINARY', '', $type);
                 }
 

--- a/src/Controllers/Table/ZoomSearchController.php
+++ b/src/Controllers/Table/ZoomSearchController.php
@@ -215,7 +215,7 @@ final class ZoomSearchController implements InvocableController
             } else {
                 // strip the "BINARY" attribute, except if we find "BINARY(" because
                 // this would be a BINARY or VARBINARY column type
-                if (! preg_match('@BINARY[\(]@i', $type)) {
+                if (preg_match('@BINARY[\(]@i', $type) !== 1) {
                     $type = str_ireplace('BINARY', '', $type);
                 }
 

--- a/src/Core.php
+++ b/src/Core.php
@@ -143,7 +143,7 @@ class Core
             'k' => 1024,
         ];
 
-        if (preg_match('/^([0-9]+)([KMGT])/i', (string) $size, $matches)) {
+        if (preg_match('/^([0-9]+)([KMGT])/i', (string) $size, $matches) === 1) {
             return (int) ($matches[1] * $binaryprefixes[$matches[2]]);
         }
 
@@ -396,7 +396,7 @@ class Core
      */
     public static function linkURL(string $url): string
     {
-        if (! preg_match('#^https?://#', $url)) {
+        if (preg_match('#^https?://#', $url) !== 1) {
             return $url;
         }
 

--- a/src/Database/Routines.php
+++ b/src/Database/Routines.php
@@ -637,15 +637,15 @@ class Routines
 
             if (
                 $itemParamLength[$i] != ''
-                && ! preg_match(
+                && preg_match(
                     '@^(DATE|TINYBLOB|TINYTEXT|BLOB|TEXT|MEDIUMBLOB|MEDIUMTEXT|LONGBLOB|LONGTEXT|SERIAL|BOOLEAN)$@i',
                     $itemParamType[$i],
-                )
+                ) !== 1
             ) {
                 $params .= '(' . $itemParamLength[$i] . ')';
             } elseif (
                 $itemParamLength[$i] == ''
-                && preg_match('@^(ENUM|SET|VARCHAR|VARBINARY)$@i', $itemParamType[$i])
+                && preg_match('@^(ENUM|SET|VARCHAR|VARBINARY)$@i', $itemParamType[$i]) === 1
             ) {
                 if (! $warnedAboutLength) {
                     $warnedAboutLength = true;
@@ -704,16 +704,16 @@ class Routines
 
         if (
             ! empty($_POST['item_returnlength'])
-            && ! preg_match(
+            && preg_match(
                 '@^(DATE|DATETIME|TIME|TINYBLOB|TINYTEXT|BLOB|TEXT|'
                 . 'MEDIUMBLOB|MEDIUMTEXT|LONGBLOB|LONGTEXT|SERIAL|BOOLEAN)$@i',
                 $itemReturnType,
-            )
+            ) !== 1
         ) {
             $query .= '(' . $_POST['item_returnlength'] . ')';
         } elseif (
             empty($_POST['item_returnlength'])
-            && preg_match('@^(ENUM|SET|VARCHAR|VARBINARY)$@i', $itemReturnType)
+            && preg_match('@^(ENUM|SET|VARCHAR|VARBINARY)$@i', $itemReturnType) === 1
         ) {
             if (! $warnedAboutLength) {
                 $GLOBALS['errors'][] = __(

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -906,7 +906,7 @@ class Results
                     '@(.*)([[:space:]](LIMIT (.*)|PROCEDURE (.*)|FOR UPDATE|LOCK IN SHARE MODE))@is',
                     $unsortedSqlQuery,
                     $myReg,
-                )
+                ) === 1
             ) {
                 $unsortedSqlQueryFirstPart = $myReg[1];
                 $unsortedSqlQuerySecondPart = $myReg[2];
@@ -2041,7 +2041,7 @@ class Results
                     ];
                 }
 
-                $isShowCreateTable = preg_match('@CREATE[[:space:]]+TABLE@i', $this->sqlQuery);
+                $isShowCreateTable = preg_match('@CREATE[[:space:]]+TABLE@i', $this->sqlQuery) === 1;
                 if ($isShowCreateTable) {
                     $mediaTypeMap['..Create Table'] = [
                         'mimetype' => 'Text_Plain',
@@ -3705,7 +3705,7 @@ class Results
             // in this case, restart from the original $content
             if (
                 mb_check_encoding($content, 'utf-8')
-                && ! preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x80-\x9F]/u', $content)
+                && preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x80-\x9F]/u', $content) !== 1
             ) {
                 // show as text if it's valid utf-8
                 $result = htmlspecialchars($content);

--- a/src/Engines/Pbxt.php
+++ b/src/Engines/Pbxt.php
@@ -148,7 +148,7 @@ class Pbxt extends StorageEngine
      */
     public function resolveTypeSize(int|string $value): array
     {
-        if (is_string($value) && preg_match('/^[0-9]+[a-zA-Z]+$/', $value)) {
+        if (is_string($value) && preg_match('/^[0-9]+[a-zA-Z]+$/', $value) === 1) {
             $value = Util::extractValueFromFormattedSize($value);
         }
 

--- a/src/Error/ErrorReport.php
+++ b/src/Error/ErrorReport.php
@@ -168,7 +168,7 @@ class ErrorReport
             $components = [];
         }
 
-        if (isset($components['fragment']) && preg_match('<PMAURL-\d+:>', $components['fragment'], $matches)) {
+        if (isset($components['fragment']) && preg_match('<PMAURL-\d+:>', $components['fragment'], $matches) === 1) {
             $uri = str_replace($matches[0], '', $components['fragment']);
             $url = 'https://example.com/' . $uri;
             $components = parse_url($url);

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -1201,7 +1201,7 @@ class Export
         /**
          * default is PDF, otherwise validate it's only letters a-z
          */
-        if (! preg_match('/^[a-zA-Z]+$/', $exportType)) {
+        if (preg_match('/^[a-zA-Z]+$/', $exportType) !== 1) {
             $exportType = 'pdf';
         }
 

--- a/src/FileListing.php
+++ b/src/FileListing.php
@@ -56,7 +56,7 @@ class FileListing
             if (
                 ! @is_file($dir . $file)
                 || @is_link($dir . $file)
-                || ($expression !== '' && ! preg_match($expression, $file))
+                || ($expression !== '' && preg_match($expression, $file) !== 1)
             ) {
                 continue;
             }

--- a/src/Gis/GisGeometry.php
+++ b/src/Gis/GisGeometry.php
@@ -186,11 +186,11 @@ abstract class GisGeometry
         $srid = 0;
         $wkt = '';
 
-        if (preg_match("/^'" . $geomTypes . "\(.*\)',[0-9]*$/i", $value)) {
+        if (preg_match("/^'" . $geomTypes . "\(.*\)',[0-9]*$/i", $value) === 1) {
             $lastComma = mb_strripos($value, ',');
             $srid = (int) trim(mb_substr($value, $lastComma + 1));
             $wkt = trim(mb_substr($value, 1, $lastComma - 2));
-        } elseif (preg_match('/^' . $geomTypes . '\(.*\)$/i', $value)) {
+        } elseif (preg_match('/^' . $geomTypes . '\(.*\)$/i', $value) === 1) {
             $wkt = $value;
         }
 

--- a/src/Git.php
+++ b/src/Git.php
@@ -105,7 +105,7 @@ class Git
             $contents = (string) file_get_contents($git);
             $gitmatch = [];
             // Matches expected format
-            if (! preg_match('/^gitdir: (.*)$/', $contents, $gitmatch)) {
+            if (preg_match('/^gitdir: (.*)$/', $contents, $gitmatch) !== 1) {
                 $_SESSION['git_location'] = null;
                 $_SESSION['is_git_revision'] = false;
 
@@ -560,7 +560,7 @@ class Git
         }
 
         $commit = false;
-        if (! preg_match('/^[0-9a-f]{40}$/i', $hash)) {
+        if (preg_match('/^[0-9a-f]{40}$/i', $hash) !== 1) {
             $commit = false;
         } elseif (isset($_SESSION['PMA_VERSION_COMMITDATA_' . $hash])) {
             $commit = $_SESSION['PMA_VERSION_COMMITDATA_' . $hash];

--- a/src/Html/Generator.php
+++ b/src/Html/Generator.php
@@ -480,7 +480,7 @@ class Generator
         /* SQL-Parser-Analyzer */
         $explainLink = '';
         $queryTooBig = mb_strlen($sqlQuery) > $config->settings['MaxCharactersInDisplayedSQL'];
-        $isSelect = preg_match('@^SELECT[[:space:]]+@i', $sqlQuery);
+        $isSelect = preg_match('@^SELECT[[:space:]]+@i', $sqlQuery) === 1;
         if (! empty($config->settings['SQLQuery']['Explain']) && ! $queryTooBig) {
             $explainParams = $urlParams;
             if ($isSelect) {
@@ -492,7 +492,7 @@ class Generator
                         __('Explain SQL'),
                         ['class' => 'btn btn-link'],
                     ) . '</div>' . "\n";
-            } elseif (preg_match('@^EXPLAIN[[:space:]]+SELECT[[:space:]]+@i', $sqlQuery)) {
+            } elseif (preg_match('@^EXPLAIN[[:space:]]+SELECT[[:space:]]+@i', $sqlQuery) === 1) {
                 $explainParams['sql_query'] = mb_substr($sqlQuery, 8);
                 $explainLink = '<div class="col-auto">'
                     . self::linkOrButton(
@@ -563,7 +563,7 @@ class Generator
         if (
             ! empty($config->settings['SQLQuery']['Refresh'])
             && ! isset($GLOBALS['show_as_php']) // 'Submit query' does the same
-            && preg_match('@^(SELECT|SHOW)[[:space:]]+@i', $sqlQuery)
+            && preg_match('@^(SELECT|SHOW)[[:space:]]+@i', $sqlQuery) === 1
         ) {
             $refreshLink = Url::getFromRoute('/sql', $urlParams);
             $refreshLink = '<div class="col-auto">'

--- a/src/Http/Factory/UriFactory.php
+++ b/src/Http/Factory/UriFactory.php
@@ -90,7 +90,7 @@ final class UriFactory implements UriFactoryInterface
             $uri = $uri->withPort($uri->getScheme() === 'https' ? 443 : 80);
         }
 
-        if (preg_match('/^(\[[a-fA-F0-9:.]+])(:\d+)?\z/', $uri->getHost(), $matches)) {
+        if (preg_match('/^(\[[a-fA-F0-9:.]+])(:\d+)?\z/', $uri->getHost(), $matches) === 1) {
             $uri = $uri->withHost($matches[1]);
             if (isset($matches[2])) {
                 $uri = $uri->withPort((int) substr($matches[2], 1));

--- a/src/Import/Import.php
+++ b/src/Import/Import.php
@@ -151,7 +151,7 @@ class Import
         }
 
         $pattern = '@^[\s]*(DROP|CREATE)[\s]+(IF EXISTS[[:space:]]+)?(TABLE|DATABASE)[[:space:]]+(.+)@im';
-        if ($GLOBALS['result'] == false || ! preg_match($pattern, $sql)) {
+        if ($GLOBALS['result'] == false || preg_match($pattern, $sql) !== 1) {
             return;
         }
 
@@ -253,7 +253,7 @@ class Import
      */
     public function lookForUse(string $buffer): string
     {
-        if (preg_match('@^[\s]*USE[[:space:]]+([\S]+)@i', $buffer, $match)) {
+        if (preg_match('@^[\s]*USE[[:space:]]+([\S]+)@i', $buffer, $match) === 1) {
             $db = trim($match[1]);
             $db = trim($db, ';'); // for example, USE abc;
 

--- a/src/InsertEdit.php
+++ b/src/InsertEdit.php
@@ -868,7 +868,7 @@ class InsertEdit
         }
 
         if (! empty($GLOBALS['goto'])) {
-            if (! preg_match('@^[a-z_]+\.php$@', $GLOBALS['goto'])) {
+            if (preg_match('@^[a-z_]+\.php$@', $GLOBALS['goto']) !== 1) {
                 // this should NOT happen
                 //$GLOBALS['goto'] = false;
                 $gotoInclude = str_contains($GLOBALS['goto'], 'index.php?route=/sql') ? '/sql' : false;
@@ -1326,7 +1326,7 @@ class InsertEdit
 
         if (
             ($editField->type !== 'datetime' && $editField->type !== 'timestamp' && $editField->type !== 'date')
-            || preg_match('/^current_timestamp(\([0-6]?\))?$/i', $editField->value) < 1
+            || preg_match('/^current_timestamp(\([0-6]?\))?$/i', $editField->value) !== 1
         ) {
             return $this->dbi->quoteString($editField->value);
         }
@@ -1664,7 +1664,7 @@ class InsertEdit
         //add data attributes "no of decimals" and "data type"
         $noDecimals = 0;
         $type = current(explode('(', $column->pmaType));
-        if (preg_match('/\(([^()]+)\)/', $column->pmaType, $match)) {
+        if (preg_match('/\(([^()]+)\)/', $column->pmaType, $match) === 1) {
             $match[0] = trim($match[0], '()');
             $noDecimals = $match[0];
         }

--- a/src/InsertEditColumn.php
+++ b/src/InsertEditColumn.php
@@ -53,7 +53,7 @@ final class InsertEditColumn
             $columnLength = 30;
         }
 
-        $this->length = preg_match('@float|double@', $this->type) ? 100 : $columnLength;
+        $this->length = preg_match('@float|double@', $this->type) === 1 ? 100 : $columnLength;
         $this->pmaType = match ($this->trueType) {
             'set', 'enum' => $this->trueType,
             default => $this->type,

--- a/src/IpAllowDeny.php
+++ b/src/IpAllowDeny.php
@@ -71,8 +71,7 @@ class IpAllowDeny
     public function ipv4MaskTest(string $testRange, string $ipToTest): bool
     {
         $result = true;
-        $match = preg_match('|([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)/([0-9]+)|', $testRange, $regs);
-        if ($match) {
+        if (preg_match('|([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)/([0-9]+)|', $testRange, $regs) === 1) {
             // performs a mask match
             $ipl = ip2long($ipToTest);
             $rangel = ip2long($regs[1] . '.' . $regs[2] . '.' . $regs[3] . '.' . $regs[4]);
@@ -97,7 +96,7 @@ class IpAllowDeny
 
         // perform a range match
         for ($i = 0; $i < 4; $i++) {
-            if (preg_match('|\[([0-9]+)\-([0-9]+)\]|', $maskocts[$i], $regs)) {
+            if (preg_match('|\[([0-9]+)\-([0-9]+)\]|', $maskocts[$i], $regs) === 1) {
                 if ($ipocts[$i] > $regs[2] || $ipocts[$i] < $regs[1]) {
                     $result = false;
                 }
@@ -152,8 +151,7 @@ class IpAllowDeny
         if ($isRange) {
             // what range do we operate on?
             $rangeMatch = [];
-            $match = preg_match('/\[([0-9a-f]+)\-([0-9a-f]+)\]/', $testRange, $rangeMatch);
-            if ($match) {
+            if (preg_match('/\[([0-9a-f]+)\-([0-9a-f]+)\]/', $testRange, $rangeMatch) === 1) {
                 $rangeStart = $rangeMatch[1];
                 $rangeEnd = $rangeMatch[2];
 

--- a/src/Language.php
+++ b/src/Language.php
@@ -122,7 +122,7 @@ class Language
             . addcslashes($this->regex, '/')
             . ')(;q=[0-9]\\.[0-9])?$/i';
 
-        return (bool) preg_match($pattern, $header);
+        return preg_match($pattern, $header) === 1;
     }
 
     /**
@@ -136,7 +136,7 @@ class Language
             . addcslashes($this->regex, '/')
             . ')(;|\]|\))/i';
 
-        return (bool) preg_match($pattern, $header);
+        return preg_match($pattern, $header) === 1;
     }
 
     /**

--- a/src/ListDatabase.php
+++ b/src/ListDatabase.php
@@ -61,7 +61,7 @@ class ListDatabase extends ArrayObject
         }
 
         foreach ($this->getArrayCopy() as $key => $db) {
-            if (! preg_match('/' . $this->config->selectedServer['hide_db'] . '/', $db)) {
+            if (preg_match('/' . $this->config->selectedServer['hide_db'] . '/', $db) !== 1) {
                 continue;
             }
 
@@ -147,7 +147,7 @@ class ListDatabase extends ArrayObject
         foreach ($this->config->selectedServer['only_db'] as $eachOnlyDb) {
             // check if the db name contains wildcard,
             // thus containing not escaped _ or %
-            if (! preg_match('/(^|[^\\\\])(_|%)/', $eachOnlyDb)) {
+            if (preg_match('/(^|[^\\\\])(_|%)/', $eachOnlyDb) !== 1) {
                 // ... not contains wildcard
                 $items[] = strtr($eachOnlyDb, ['\\\\' => '\\', '\\_' => '_', '\\%' => '%']);
                 continue;

--- a/src/Navigation/Nodes/Node.php
+++ b/src/Navigation/Nodes/Node.php
@@ -486,7 +486,7 @@ class Node
     private function isHideDb(string $db): bool
     {
         return ! empty($this->config->selectedServer['hide_db'])
-            && preg_match('/' . $this->config->selectedServer['hide_db'] . '/', $db);
+            && preg_match('/' . $this->config->selectedServer['hide_db'] . '/', $db) === 1;
     }
 
     /**

--- a/src/Plugins.php
+++ b/src/Plugins.php
@@ -238,7 +238,7 @@ class Plugins
 
         $matches = [];
         /* Possibly replace localised texts */
-        if (! preg_match_all('/(str[A-Z][A-Za-z0-9]*)/', (string) $config->settings[$section][$opt], $matches)) {
+        if (preg_match_all('/(str[A-Z][A-Za-z0-9]*)/', (string) $config->settings[$section][$opt], $matches) < 1) {
             return htmlspecialchars((string) $config->settings[$section][$opt]);
         }
 

--- a/src/Plugins/Auth/AuthenticationCookie.php
+++ b/src/Plugins/Auth/AuthenticationCookie.php
@@ -304,8 +304,7 @@ class AuthenticationCookie extends AuthenticationPlugin
                         $tmpHost = $_REQUEST['pma_servername'];
                     }
 
-                    $match = preg_match($config->settings['ArbitraryServerRegexp'], $tmpHost);
-                    if (! $match) {
+                    if (preg_match($config->settings['ArbitraryServerRegexp'], $tmpHost) !== 1) {
                         $GLOBALS['conn_error'] = __('You are not allowed to log in to this MySQL server!');
 
                         return false;

--- a/src/Plugins/Export/ExportCodegen.php
+++ b/src/Plugins/Export/ExportCodegen.php
@@ -167,7 +167,7 @@ class ExportCodegen extends ExportPlugin
         // remove unsafe characters
         $str = (string) preg_replace('/[^\p{L}\p{Nl}_]/u', '', $str);
         // make sure first character is a letter or _
-        if (! preg_match('/^\pL/u', $str)) {
+        if (preg_match('/^\pL/u', $str) !== 1) {
             $str = '_' . $str;
         }
 

--- a/src/Plugins/Export/ExportPhparray.php
+++ b/src/Plugins/Export/ExportPhparray.php
@@ -175,7 +175,7 @@ class ExportPhparray extends ExportPlugin
 
         // fix variable names (based on
         // https://www.php.net/manual/en/language.variables.basics.php)
-        if (! preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $tableAlias)) {
+        if (preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $tableAlias) !== 1) {
             // fix invalid characters in variable names by replacing them with
             // underscores
             $tableFixed = preg_replace('/[^a-zA-Z0-9_\x7f-\xff]/', '_', $tableAlias);

--- a/src/Plugins/Import/ImportMediawiki.php
+++ b/src/Plugins/Import/ImportMediawiki.php
@@ -177,12 +177,12 @@ class ImportMediawiki extends ImportPlugin
                     } else {
                         // Check table name
                         $matchTableName = [];
-                        if (preg_match('/^Table data for `(.*)`$/', $curBufferLine, $matchTableName)) {
+                        if (preg_match('/^Table data for `(.*)`$/', $curBufferLine, $matchTableName) === 1) {
                             $curTableName = $matchTableName[1];
                             $insideDataComment = true;
 
                             $insideStructureComment = false;
-                        } elseif (preg_match('/^Table structure for `(.*)`$/', $curBufferLine, $matchTableName)) {
+                        } elseif (preg_match('/^Table structure for `(.*)`$/', $curBufferLine, $matchTableName) === 1) {
                             // The structure comments will be ignored
                             $insideStructureComment = true;
                         }
@@ -191,7 +191,7 @@ class ImportMediawiki extends ImportPlugin
                     continue;
                 }
 
-                if (preg_match('/^\{\|(.*)$/', $curBufferLine)) {
+                if (preg_match('/^\{\|(.*)$/', $curBufferLine) === 1) {
                     // Check start of table
 
                     // This will store all the column info on all rows from

--- a/src/Plugins/Transformations/Abs/DateFormatTransformationsPlugin.php
+++ b/src/Plugins/Transformations/Abs/DateFormatTransformationsPlugin.php
@@ -76,7 +76,7 @@ abstract class DateFormatTransformationsPlugin extends TransformationsPlugin
             // TIMESTAMP (2 | 4) not supported here.
             // (Note: prior to MySQL 4.1, TIMESTAMP has a display size
             // for example TIMESTAMP(8) means YYYYMMDD)
-        } elseif (preg_match('/^(\d{2}){3,7}$/', $buffer)) {
+        } elseif (preg_match('/^(\d{2}){3,7}$/', $buffer) === 1) {
             if (mb_strlen($buffer) == 14 || mb_strlen($buffer) == 8) {
                 $offset = 4;
             } else {
@@ -103,14 +103,14 @@ abstract class DateFormatTransformationsPlugin extends TransformationsPlugin
 
             // If all fails, assume one of the dozens of valid strtime() syntaxes
             // (https://www.gnu.org/manual/tar-1.12/html_chapter/tar_7.html)
-        } elseif (preg_match('/^[0-9]\d{1,9}$/', $buffer)) {
+        } elseif (preg_match('/^[0-9]\d{1,9}$/', $buffer) === 1) {
             $timestamp = (int) $buffer;
         } else {
             $timestamp = strtotime($buffer);
         }
 
         // If all above failed, maybe it's a Unix timestamp already?
-        if ($timestamp < 0 && preg_match('/^[1-9]\d{1,9}$/', $buffer)) {
+        if ($timestamp < 0 && preg_match('/^[1-9]\d{1,9}$/', $buffer) === 1) {
             $timestamp = $buffer;
         }
 

--- a/src/Plugins/Transformations/Abs/RegexValidationTransformationsPlugin.php
+++ b/src/Plugins/Transformations/Abs/RegexValidationTransformationsPlugin.php
@@ -44,7 +44,7 @@ abstract class RegexValidationTransformationsPlugin extends IOTransformationsPlu
     {
         // reset properties of object
         $this->reset();
-        if (! empty($options[0]) && ! preg_match($options[0], $buffer)) {
+        if (! empty($options[0]) && preg_match($options[0], $buffer) !== 1) {
             $this->success = false;
             $this->error = sprintf(
                 __('Validation failed for the input string %s.'),

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -99,7 +99,7 @@ class Sanitize
         }
 
         /* a-z and _ allowed in target */
-        if (! empty($found[3]) && preg_match('/[^a-z_]+/i', $found[3])) {
+        if (! empty($found[3]) && preg_match('/[^a-z_]+/i', $found[3]) === 1) {
             return $found[0];
         }
 

--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -1352,7 +1352,7 @@ class Privileges
     ): array {
         if (isset($GLOBALS['dbname'])) {
             //if (preg_match('/\\\\(?:_|%)/i', $dbname)) {
-            if (preg_match('/(?<!\\\\)(?:_|%)/', $GLOBALS['dbname'])) {
+            if (preg_match('/(?<!\\\\)(?:_|%)/', $GLOBALS['dbname']) === 1) {
                 $dbnameIsWildcard = true;
             } else {
                 $dbnameIsWildcard = false;
@@ -2473,7 +2473,7 @@ class Privileges
         }
 
         // check if given $dbname is a wildcard or not
-        $databaseNameIsWildcard = is_string($dbname) && preg_match('/(?<!\\\\)(?:_|%)/', $dbname);
+        $databaseNameIsWildcard = is_string($dbname) && preg_match('/(?<!\\\\)(?:_|%)/', $dbname) === 1;
 
         return [$username, $hostname, $dbname, $tablename, $routinename, $databaseNameIsWildcard];
     }

--- a/src/Server/Status/Monitor.php
+++ b/src/Server/Status/Monitor.php
@@ -193,14 +193,14 @@ class Monitor
          */
         switch ($type) {
             case 'servervar':
-                if (! preg_match('/[^a-zA-Z_]+/', $pName)) {
+                if (preg_match('/[^a-zA-Z_]+/', $pName) !== 1) {
                     $serverVars[] = $pName;
                 }
 
                 break;
 
             case 'statusvar':
-                if (! preg_match('/[^a-zA-Z_]+/', $pName)) {
+                if (preg_match('/[^a-zA-Z_]+/', $pName) !== 1) {
                     $statusVars[] = $pName;
                 }
 
@@ -373,7 +373,7 @@ class Monitor
                             '/^INSERT INTO (`|\'|"|)([^\s\\1]+)\\1/i',
                             $row['argument'],
                             $matches,
-                        )
+                        ) === 1
                     ) {
                         if (! isset($insertTables[$matches[2]])) {
                             $insertTables[$matches[2]] = 0;
@@ -460,7 +460,7 @@ class Monitor
     public function getJsonForLoggingVars(string|null $name, string|null $value): array
     {
         if (isset($name, $value)) {
-            if (! preg_match('/[^a-zA-Z0-9_]+/', $name)) {
+            if (preg_match('/[^a-zA-Z0-9_]+/', $name) !== 1) {
                 $this->dbi->query('SET GLOBAL ' . $name . ' = ' . $this->dbi->quoteString($value));
             }
         }

--- a/src/Table/Search.php
+++ b/src/Table/Search.php
@@ -158,7 +158,7 @@ final class Search
             // (like INT), for a LIKE we always quote the value. MySQL converts
             // strings to numbers and numbers to strings as necessary
             // during the comparison
-            $needsQuoting = preg_match('@char|binary|blob|text|set|date|time|year|uuid@i', $types)
+            $needsQuoting = preg_match('@char|binary|blob|text|set|date|time|year|uuid@i', $types) === 1
                 || str_contains($funcType, 'LIKE');
 
             // LIKE %...%

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -446,7 +446,7 @@ class Table implements Stringable
         $dbi = DatabaseInterface::getInstance();
         if (
             $length !== ''
-            && ! preg_match($pattern, $type)
+            && preg_match($pattern, $type) !== 1
             && Compatibility::isIntegersSupportLength($type, $length, $dbi)
         ) {
             // Note: The variable $length here can contain several other things
@@ -470,7 +470,7 @@ class Table implements Stringable
         // supports no extra virtual column properties except CHARACTER SET for text column types
         $isVirtualColMariaDB = $virtuality && Compatibility::isMariaDb();
 
-        $matches = preg_match('@^(TINYTEXT|TEXT|MEDIUMTEXT|LONGTEXT|VARCHAR|CHAR|ENUM|SET)$@i', $type);
+        $matches = preg_match('@^(TINYTEXT|TEXT|MEDIUMTEXT|LONGTEXT|VARCHAR|CHAR|ENUM|SET)$@i', $type) === 1;
         if ($collation !== '' && $collation !== 'NULL' && $matches) {
             $query .= Util::getCharsetQueryPart(
                 $isVirtualColMariaDB ? (string) preg_replace('~_.+~s', '', $collation) : $collation,
@@ -500,7 +500,7 @@ class Table implements Stringable
                             $query .= ' DEFAULT 0';
                         } elseif (
                             $isTimestamp
-                            && preg_match('/^\'\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(\.\d{1,6})?\'$/', $defaultValue)
+                            && preg_match('/^\'\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(\.\d{1,6})?\'$/', $defaultValue) === 1
                         ) {
                             $query .= ' DEFAULT ' . $defaultValue;
                         } elseif ($type === 'BIT') {
@@ -508,9 +508,9 @@ class Table implements Stringable
                             . preg_replace('/[^01]/', '0', $defaultValue)
                             . '\'';
                         } elseif ($type === 'BOOLEAN') {
-                            if (preg_match('/^1|T|TRUE|YES$/i', $defaultValue)) {
+                            if (preg_match('/^1|T|TRUE|YES$/i', $defaultValue) === 1) {
                                 $query .= ' DEFAULT TRUE';
-                            } elseif (preg_match('/^0|F|FALSE|NO$/i', $defaultValue)) {
+                            } elseif (preg_match('/^0|F|FALSE|NO$/i', $defaultValue) === 1) {
                                 $query .= ' DEFAULT FALSE';
                             } else {
                                 // Invalid BOOLEAN value
@@ -781,7 +781,7 @@ class Table implements Stringable
             return false;
         }
 
-        if (! $isBackquoted && preg_match('/^[a-zA-Z0-9_$]+$/', $tableName)) {
+        if (! $isBackquoted && preg_match('/^[a-zA-Z0-9_$]+$/', $tableName) === 1) {
             // only allow the above regex in unquoted identifiers
             // see : https://dev.mysql.com/doc/refman/5.7/en/identifiers.html
             return true;
@@ -1327,7 +1327,7 @@ class Table implements Stringable
         foreach (
             $this->dbi->getColumnsFull($this->dbName, $this->name) as $row
         ) {
-            if (preg_match('@^(set|enum)\((.+)\)$@i', $row['Type'], $tmp)) {
+            if (preg_match('@^(set|enum)\((.+)\)$@i', $row['Type'], $tmp) === 1) {
                 $tmp[2] = mb_substr(
                     (string) preg_replace('@([^,])\'\'@', '\\1\\\'', ',' . $tmp[2]),
                     1,

--- a/src/Transformations.php
+++ b/src/Transformations.php
@@ -151,7 +151,7 @@ class Transformations
             sort($filestack);
 
             foreach ($filestack as $file) {
-                if (preg_match('|^[^.].*_.*_.*\.php$|', $file)) {
+                if (preg_match('|^[^.].*_.*_.*\.php$|', $file) === 1) {
                     // File contains transformation functions.
                     $parts = explode('_', str_replace('.php', '', $file));
                     $mimetype = $parts[0] . '/' . $parts[1];
@@ -163,7 +163,7 @@ class Transformations
                         $stack['input_transformation'][] = $mimetype . ': ' . $parts[2];
                         $stack['input_transformation_file'][] = $sd . $file;
                     }
-                } elseif (preg_match('|^[^.].*\.php$|', $file)) {
+                } elseif (preg_match('|^[^.].*\.php$|', $file) === 1) {
                     // File is a plain mimetype, no functions.
                     $base = str_replace('.php', '', $file);
 

--- a/src/UrlRedirector.php
+++ b/src/UrlRedirector.php
@@ -33,7 +33,7 @@ final class UrlRedirector
         $url = is_string($urlParam) ? $urlParam : '';
         if (
             $url === ''
-            || ! preg_match('/^https:\/\/[^\n\r]*$/', $url)
+            || preg_match('/^https:\/\/[^\n\r]*$/', $url) !== 1
             || ! Core::isAllowedDomain($url)
         ) {
             $response = $response->withHeader('Location', $this->response->fixRelativeUrlForRedirect('./'));

--- a/src/UserPrivilegesFactory.php
+++ b/src/UserPrivilegesFactory.php
@@ -169,8 +169,8 @@ class UserPrivilegesFactory
 
             // does this db exist?
             if (
-                (! preg_match('/' . $re0 . '%|_/', $showGrants->dbName)
-                || preg_match('/\\\\%|\\\\_/', $showGrants->dbName))
+                (preg_match('/' . $re0 . '%|_/', $showGrants->dbName) !== 1
+                || preg_match('/\\\\%|\\\\_/', $showGrants->dbName) === 1)
                 && ($this->dbi->tryQuery(
                     'USE ' . preg_replace(
                         '/' . $re1 . '(%|_)/',

--- a/src/Util.php
+++ b/src/Util.php
@@ -472,11 +472,11 @@ class Util
 
         $formattedSize = (string) $formattedSize;
 
-        if (preg_match('/^[0-9]+GB$/', $formattedSize)) {
+        if (preg_match('/^[0-9]+GB$/', $formattedSize) === 1) {
             $returnValue = (int) mb_substr($formattedSize, 0, -2) * 1024 ** 3;
-        } elseif (preg_match('/^[0-9]+MB$/', $formattedSize)) {
+        } elseif (preg_match('/^[0-9]+MB$/', $formattedSize) === 1) {
             $returnValue = (int) mb_substr($formattedSize, 0, -2) * 1024 ** 2;
-        } elseif (preg_match('/^[0-9]+K$/', $formattedSize)) {
+        } elseif (preg_match('/^[0-9]+K$/', $formattedSize) === 1) {
             $returnValue = (int) mb_substr($formattedSize, 0, -1) * 1024 ** 1;
         }
 
@@ -937,7 +937,7 @@ class Util
             // this would be a BINARY or VARBINARY column type;
             // by the way, a BLOB should not show the BINARY attribute
             // because this is not accepted in MySQL syntax.
-            if (str_contains($printType, 'binary') && ! preg_match('@binary[\(]@', $printType)) {
+            if (str_contains($printType, 'binary') && preg_match('@binary[\(]@', $printType) !== 1) {
                 $printType = str_replace('binary', '', $printType);
                 $binary = true;
             } else {
@@ -975,7 +975,7 @@ class Util
         }
 
         $canContainCollation = false;
-        if (! $binary && preg_match('@^(char|varchar|text|tinytext|mediumtext|longtext|set|enum)@', $type)) {
+        if (! $binary && preg_match('@^(char|varchar|text|tinytext|mediumtext|longtext|set|enum)@', $type) === 1) {
             $canContainCollation = true;
         }
 
@@ -1504,7 +1504,7 @@ class Util
      */
     public static function addMicroseconds(string $value): string
     {
-        if ($value === '' || preg_match('/^current_timestamp(\([0-6]?\))?$/i', $value) > 0) {
+        if ($value === '' || preg_match('/^current_timestamp(\([0-6]?\))?$/i', $value) === 1) {
             return $value;
         }
 

--- a/src/Utils/Gis.php
+++ b/src/Utils/Gis.php
@@ -101,11 +101,11 @@ final class Gis
         $geomFromText = $mysqlVersion >= 50600 ? 'ST_GeomFromText' : 'GeomFromText';
         $gisString = trim($gisString);
         $geomTypes = '(POINT|MULTIPOINT|LINESTRING|MULTILINESTRING|POLYGON|MULTIPOLYGON|GEOMETRYCOLLECTION)';
-        if (preg_match("/^'" . $geomTypes . "\(.*\)',[0-9]*$/i", $gisString)) {
+        if (preg_match("/^'" . $geomTypes . "\(.*\)',[0-9]*$/i", $gisString) === 1) {
             return $geomFromText . '(' . $gisString . ')';
         }
 
-        if (preg_match('/^' . $geomTypes . '\(.*\)$/i', $gisString)) {
+        if (preg_match('/^' . $geomTypes . '\(.*\)$/i', $gisString) === 1) {
             return $geomFromText . "('" . $gisString . "')";
         }
 

--- a/src/VersionInformation.php
+++ b/src/VersionInformation.php
@@ -114,7 +114,7 @@ class VersionInformation
 
         if ($suffix !== '') {
             $matches = [];
-            if (preg_match('/^(\D+)(\d+)$/', $suffix, $matches)) {
+            if (preg_match('/^(\D+)(\d+)$/', $suffix, $matches) === 1) {
                 $suffix = $matches[1];
                 $result += (int) $matches[2];
             }

--- a/src/ZipExtension.php
+++ b/src/ZipExtension.php
@@ -93,7 +93,7 @@ class ZipExtension
 
         /* Return the correct contents, not just the first entry */
         for ($i = 0; $i < $this->zip->numFiles; $i++) {
-            if (preg_match($specificEntry, (string) $this->zip->getNameIndex($i))) {
+            if (preg_match($specificEntry, (string) $this->zip->getNameIndex($i)) === 1) {
                 $fileData = $this->zip->getFromIndex($i);
                 break;
             }
@@ -129,7 +129,7 @@ class ZipExtension
 
         if ($res === true) {
             for ($i = 0; $i < $this->zip->numFiles; $i++) {
-                if (preg_match($regex, (string) $this->zip->getNameIndex($i))) {
+                if (preg_match($regex, (string) $this->zip->getNameIndex($i)) === 1) {
                     $filename = $this->zip->getNameIndex($i);
                     $this->zip->close();
 

--- a/tests/end-to-end/TestBase.php
+++ b/tests/end-to-end/TestBase.php
@@ -442,7 +442,7 @@ abstract class TestBase extends TestCase
     {
         $this->navigateTo('index.php?route=/check-relations');
         $pageContent = $this->waitForElement('id', 'page_content');
-        if (! preg_match('/Configuration of pmadb… not OK/i', $pageContent->getText())) {
+        if (preg_match('/Configuration of pmadb… not OK/i', $pageContent->getText()) !== 1) {
             return;
         }
 

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -296,7 +296,7 @@ PHP;
         phpinfo(INFO_MODULES); /* Only modules */
         $a = strip_tags((string) ob_get_clean());
 
-        if (! preg_match('@GD Version[[:space:]]*\(.*\)@', $a, $v)) {
+        if (preg_match('@GD Version[[:space:]]*\(.*\)@', $a, $v) !== 1) {
             return;
         }
 


### PR DESCRIPTION
`preg_match()` and `preg_match_all()` returns the number of pattern matches (which might be zero), or `false` on failure. However, `preg_match()` always returns `1` when a pattern is matched as it stops searching after the first match.

- https://www.php.net/manual/en/function.preg-match.php
- https://www.php.net/manual/en/function.preg-match-all.php


