### PR TITLE
Remove TEST_PATH constant

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,7 +19,6 @@ parameters:
         - tests/doctum-config.php
     dynamicConstantNames:
         - ROOT_PATH
-        - TEST_PATH
         - VERSION_SUFFIX
     checkBenevolentUnionTypes: true
     checkUninitializedProperties: true

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13553,7 +13553,8 @@
   </file>
   <file src="tests/unit/Error/ErrorTest.php">
     <PossiblyUnusedMethod>
-      <code><![CDATA[filePathProvider]]></code>
+      <code><![CDATA[invalidFilePathsProvider]]></code>
+      <code><![CDATA[validFilePathsProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Export/ExportTest.php">

--- a/tests/bootstrap-dist.php
+++ b/tests/bootstrap-dist.php
@@ -11,12 +11,6 @@ if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', dirname(__DIR__) . DIRECTORY_SEPARATOR);
 }
 
-if (! defined('TEST_PATH')) {
-    // This is used at Debian because tests
-    // can be in a different place than the source code
-    define('TEST_PATH', ROOT_PATH);
-}
-
 /**
  * Set precision to sane value, with higher values
  * things behave slightly unexpectedly, for example

--- a/tests/bootstrap-static.php
+++ b/tests/bootstrap-static.php
@@ -13,12 +13,6 @@ if (! defined('ROOT_PATH')) {
     // phpcs:enable
 }
 
-if (! defined('TEST_PATH')) {
-    // phpcs:disable PSR1.Files.SideEffects
-    define('TEST_PATH', dirname(__DIR__) . DIRECTORY_SEPARATOR);
-    // phpcs:enable
-}
-
 // phpcs:disable PSR1.Files.SideEffects
 if (! defined('PHPMYADMIN')) {
     define('PHPMYADMIN', true);

--- a/tests/unit/Command/TwigLintCommandTest.php
+++ b/tests/unit/Command/TwigLintCommandTest.php
@@ -18,7 +18,6 @@ use function sort;
 use const DIRECTORY_SEPARATOR;
 use const SORT_NATURAL;
 use const SORT_REGULAR;
-use const TEST_PATH;
 
 #[CoversClass(TwigLintCommand::class)]
 class TwigLintCommandTest extends AbstractTestCase
@@ -41,7 +40,7 @@ class TwigLintCommandTest extends AbstractTestCase
     public function testGetTemplateContents(): void
     {
         $contents = $this->callFunction($this->command, TwigLintCommand::class, 'getTemplateContents', [
-            TEST_PATH . 'tests/unit/_data/file_listing/subfolder/one.ini',
+            __DIR__ . '/../_data/file_listing/subfolder/one.ini',
         ]);
 
         self::assertSame('key=value' . "\n", $contents);
@@ -49,7 +48,7 @@ class TwigLintCommandTest extends AbstractTestCase
 
     public function testFindFiles(): void
     {
-        $path = TEST_PATH . 'tests/unit/_data/file_listing';
+        $path = __DIR__ . '/../_data/file_listing';
         $filesFound = $this->callFunction($this->command, TwigLintCommand::class, 'findFiles', [$path]);
 
         // Sort results to avoid file system test specific failures
@@ -65,7 +64,7 @@ class TwigLintCommandTest extends AbstractTestCase
 
     public function testGetFilesInfo(): void
     {
-        $path = TEST_PATH . 'tests/unit/_data/file_listing';
+        $path = __DIR__ . '/../_data/file_listing';
         $filesInfos = $this->callFunction($this->command, TwigLintCommand::class, 'getFilesInfo', [$path]);
 
         // Sort results to avoid file system test specific failures
@@ -105,7 +104,7 @@ class TwigLintCommandTest extends AbstractTestCase
         ]);
 
         $filesFound = $this->callFunction($command, TwigLintCommand::class, 'getFilesInfo', [
-            TEST_PATH . 'tests/unit/_data/file_listing',
+            __DIR__ . '/../_data/file_listing',
         ]);
 
         self::assertEquals([

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -39,7 +39,6 @@ use const CONFIG_FILE;
 use const DIRECTORY_SEPARATOR;
 use const INFO_MODULES;
 use const PHP_OS;
-use const TEST_PATH;
 
 #[CoversClass(Config::class)]
 class ConfigTest extends AbstractTestCase
@@ -364,7 +363,7 @@ PHP;
         self::assertFalse($this->object->checkConfigSource());
         self::assertSame(0, $this->object->sourceMtime);
 
-        $this->object->setSource(TEST_PATH . 'tests/test_data/config.inc.php');
+        $this->object->setSource(__DIR__ . '/../test_data/config.inc.php');
 
         self::assertNotEmpty($this->object->getSource());
         self::assertTrue($this->object->checkConfigSource());
@@ -545,8 +544,8 @@ PHP;
     public static function configPaths(): array
     {
         return [
-            [TEST_PATH . 'tests/test_data/config.inc.php', true],
-            [TEST_PATH . 'tests/test_data/config-nonexisting.inc.php', false],
+            [__DIR__ . '/../test_data/config.inc.php', true],
+            [__DIR__ . '/../test_data/config-nonexisting.inc.php', false],
         ];
     }
 

--- a/tests/unit/Controllers/ChangeLogControllerTest.php
+++ b/tests/unit/Controllers/ChangeLogControllerTest.php
@@ -15,15 +15,13 @@ use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-use const TEST_PATH;
-
 #[CoversClass(ChangeLogController::class)]
 final class ChangeLogControllerTest extends AbstractTestCase
 {
     public function testWithValidFile(): void
     {
         $config = self::createStub(Config::class);
-        $config->method('getChangeLogFilePath')->willReturn(TEST_PATH . 'tests/test_data/changelog/ChangeLog');
+        $config->method('getChangeLogFilePath')->willReturn(__DIR__ . '/../../test_data/changelog/ChangeLog');
 
         $request = ServerRequestFactory::create()->createServerRequest('GET', 'http://example.com/');
 
@@ -62,7 +60,7 @@ final class ChangeLogControllerTest extends AbstractTestCase
     public function testWithCompressedFile(): void
     {
         $config = self::createStub(Config::class);
-        $config->method('getChangeLogFilePath')->willReturn(TEST_PATH . 'tests/test_data/changelog/ChangeLog.gz');
+        $config->method('getChangeLogFilePath')->willReturn(__DIR__ . '/../../test_data/changelog/ChangeLog.gz');
 
         $request = ServerRequestFactory::create()->createServerRequest('GET', 'http://example.com/');
 
@@ -85,7 +83,7 @@ final class ChangeLogControllerTest extends AbstractTestCase
     public function testWithInvalidFile(): void
     {
         $config = self::createStub(Config::class);
-        $config->method('getChangeLogFilePath')->willReturn(TEST_PATH . 'tests/test_data/changelog/InvalidChangeLog');
+        $config->method('getChangeLogFilePath')->willReturn(__DIR__ . '/../../test_data/changelog/InvalidChangeLog');
 
         $request = ServerRequestFactory::create()->createServerRequest('GET', 'http://example.com/');
 

--- a/tests/unit/FileListingTest.php
+++ b/tests/unit/FileListingTest.php
@@ -13,8 +13,6 @@ use function array_values;
 use function extension_loaded;
 use function is_bool;
 
-use const TEST_PATH;
-
 #[CoversClass(FileListing::class)]
 class FileListingTest extends AbstractTestCase
 {
@@ -31,7 +29,7 @@ class FileListingTest extends AbstractTestCase
     {
         self::assertFalse($this->fileListing->getDirContent('nonexistent directory'));
 
-        $fixturesDir = TEST_PATH . 'tests/unit/_data/file_listing';
+        $fixturesDir = __DIR__ . '/_data/file_listing';
 
         $dirContent = $this->fileListing->getDirContent($fixturesDir);
         if (is_bool($dirContent)) {
@@ -46,7 +44,7 @@ class FileListingTest extends AbstractTestCase
 
     public function testGetFileSelectOptions(): void
     {
-        $fixturesDir = TEST_PATH . 'tests/unit/_data/file_listing';
+        $fixturesDir = __DIR__ . '/_data/file_listing';
 
         self::assertFalse($this->fileListing->getFileSelectOptions('nonexistent directory'));
 

--- a/tests/unit/Theme/ThemeTest.php
+++ b/tests/unit/Theme/ThemeTest.php
@@ -16,7 +16,6 @@ use function filemtime;
 
 use const DIRECTORY_SEPARATOR;
 use const ROOT_PATH;
-use const TEST_PATH;
 
 #[CoversClass(Theme::class)]
 class ThemeTest extends AbstractTestCase
@@ -51,7 +50,7 @@ class ThemeTest extends AbstractTestCase
      */
     public function testCheckImgPathIncorrect(): void
     {
-        $this->object->setPath(TEST_PATH . 'tests/unit/_data/incorrect_theme');
+        $this->object->setPath(__DIR__ . '/../_data/incorrect_theme');
         self::assertFalse(
             $this->object->loadInfo(),
             'Theme name is not properly set',
@@ -63,7 +62,7 @@ class ThemeTest extends AbstractTestCase
      */
     public function testCheckImgPathFull(): void
     {
-        $this->object->setFsPath(TEST_PATH . 'tests/unit/_data/gen_version_info/');
+        $this->object->setFsPath(__DIR__ . '/../_data/gen_version_info/');
         self::assertTrue($this->object->loadInfo());
         self::assertSame('Test Theme', $this->object->getName());
         self::assertSame('6.0', $this->object->getVersion());

--- a/tests/unit/Twig/I18nExtensionTest.php
+++ b/tests/unit/Twig/I18nExtensionTest.php
@@ -13,8 +13,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionProperty;
 use Twig\Loader\FilesystemLoader;
 
-use const TEST_PATH;
-
 #[CoversClass(I18nExtension::class)]
 #[CoversClass(TransExpression::class)]
 final class I18nExtensionTest extends AbstractTestCase
@@ -24,7 +22,7 @@ final class I18nExtensionTest extends AbstractTestCase
         parent::setUp();
 
         $twigEnvironment = Template::getTwigEnvironment(null, true);
-        $twigEnvironment->setLoader(new FilesystemLoader(TEST_PATH . 'tests/unit/_data/templates'));
+        $twigEnvironment->setLoader(new FilesystemLoader(__DIR__ . '/../_data/templates'));
         (new ReflectionProperty(Template::class, 'twig'))->setValue(null, $twigEnvironment);
     }
 

--- a/tests/unit/Twig/PmaGlobalVariableTest.php
+++ b/tests/unit/Twig/PmaGlobalVariableTest.php
@@ -24,7 +24,7 @@ final class PmaGlobalVariableTest extends AbstractTestCase
         parent::setUp();
 
         $twigEnvironment = Template::getTwigEnvironment(null, true);
-        $twigEnvironment->setLoader(new FilesystemLoader(TEST_PATH . 'tests/unit/_data/templates'));
+        $twigEnvironment->setLoader(new FilesystemLoader(__DIR__ . '/../_data/templates'));
         (new ReflectionProperty(Template::class, 'twig'))->setValue(null, $twigEnvironment);
     }
 


### PR DESCRIPTION
Replace the `TEST_PATH` constant with `__DIR__` to make the tests more portable.

