### PR TITLE
Replace static variables with static class properties

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -897,7 +897,7 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Config\\\\Validator\\:\\:getValidators\\(\\) should return array but returns mixed\\.$#"
-			count: 3
+			count: 2
 			path: src/Config/Validator.php
 
 		-
@@ -1018,6 +1018,11 @@ parameters:
 		-
 			message: "#^Parameter \\#5 \\$pass of static method PhpMyAdmin\\\\Config\\\\Validator\\:\\:testDBConnection\\(\\) expects string, mixed given\\.$#"
 			count: 2
+			path: src/Config/Validator.php
+
+		-
+			message: "#^Static property PhpMyAdmin\\\\Config\\\\Validator\\:\\:\\$validators \\(array\\|null\\) does not accept mixed\\.$#"
+			count: 1
 			path: src/Config/Validator.php
 
 		-
@@ -9066,11 +9071,6 @@ parameters:
 			path: src/Partitioning/Partition.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Partitioning\\\\Partition\\:\\:havePartitioning\\(\\) should return bool but returns mixed\\.$#"
-			count: 1
-			path: src/Partitioning/Partition.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, string\\|false\\|null given\\.$#"
 			count: 1
 			path: src/Partitioning/Partition.php
@@ -12901,11 +12901,6 @@ parameters:
 			path: src/StorageEngine.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\StorageEngine\\:\\:getStorageEngines\\(\\) should return array\\<string, array\\{Engine\\: string, Comment\\: string, Support\\: string\\}\\> but returns mixed\\.$#"
-			count: 1
-			path: src/StorageEngine.php
-
-		-
 			message: "#^Parameter \\#1 \\$haystack of function mb_stripos expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/StorageEngine.php
@@ -13579,11 +13574,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$tableName of static method PhpMyAdmin\\\\Tracking\\\\Tracker\\:\\:createVersion\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Tracking/Tracking.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Transformations\\:\\:getAvailableMimeTypes\\(\\) should return array\\<array\\<string\\>\\> but returns mixed\\.$#"
-			count: 1
-			path: src/Transformations.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Transformations\\:\\:getClassName\\(\\) should return class\\-string\\<PhpMyAdmin\\\\Plugins\\\\TransformationsInterface\\> but returns string\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -609,15 +609,15 @@
       <code><![CDATA[$k]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
-      <code><![CDATA[$validators[$field]]]></code>
+      <code><![CDATA[self::$validators[$field]]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
-      <code><![CDATA[$validators[$field]]]></code>
+      <code><![CDATA[self::$validators[$field]]]></code>
     </MixedArrayAssignment>
     <MixedArrayOffset>
-      <code><![CDATA[$validators[$field]]]></code>
-      <code><![CDATA[$validators[$field]]]></code>
-      <code><![CDATA[$validators[$field]]]></code>
+      <code><![CDATA[self::$validators[$field]]]></code>
+      <code><![CDATA[self::$validators[$field]]]></code>
+      <code><![CDATA[self::$validators[$field]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
       <code><![CDATA[$arguments[$k2]]]></code>
@@ -631,8 +631,8 @@
       <code><![CDATA[$v]]></code>
       <code><![CDATA[$v]]></code>
       <code><![CDATA[$validator]]></code>
-      <code><![CDATA[$validators]]></code>
       <code><![CDATA[$vname]]></code>
+      <code><![CDATA[self::$validators]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
       <code><![CDATA[mixed[]]]></code>
@@ -641,10 +641,9 @@
       <code><![CDATA[$ip]]></code>
     </MixedOperand>
     <MixedReturnStatement>
-      <code><![CDATA[$validators]]></code>
-      <code><![CDATA[$validators]]></code>
-      <code><![CDATA[$validators]]></code>
-      <code><![CDATA[$validators]]></code>
+      <code><![CDATA[self::$validators]]></code>
+      <code><![CDATA[self::$validators]]></code>
+      <code><![CDATA[self::$validators]]></code>
     </MixedReturnStatement>
     <PossiblyInvalidArgument>
       <code><![CDATA[$k2]]></code>
@@ -7388,12 +7387,9 @@
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code><![CDATA[bool]]></code>
       <code><![CDATA[string|null]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code><![CDATA[$havePartitioning]]></code>
-      <code><![CDATA[$havePartitioning]]></code>
       <code><![CDATA[$partitionMethod[0]]]></code>
     </MixedReturnStatement>
     <PossiblyUnusedMethod>
@@ -10892,7 +10888,6 @@
       <code><![CDATA[$mysqlVars[$row['Variable_name']]]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code><![CDATA[array<string, array{Engine: string, Comment: string, Support: string}>]]></code>
       <code><![CDATA[string]]></code>
     </MixedInferredReturnType>
     <MixedOperand>
@@ -10900,8 +10895,6 @@
       <code><![CDATA[$decodedData['disk_usage']]]></code>
     </MixedOperand>
     <MixedReturnStatement>
-      <code><![CDATA[$storageEngines]]></code>
-      <code><![CDATA[$storageEngines]]></code>
       <code><![CDATA[$this->$id()]]></code>
     </MixedReturnStatement>
     <MixedReturnTypeCoercion>
@@ -11527,12 +11520,6 @@
     <MixedArgument>
       <code><![CDATA[$updQuery]]></code>
     </MixedArgument>
-    <MixedInferredReturnType>
-      <code><![CDATA[string[][]]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$stack]]></code>
-    </MixedReturnStatement>
     <MoreSpecificReturnType>
       <code><![CDATA[class-string<TransformationsInterface>]]></code>
     </MoreSpecificReturnType>

--- a/src/Config/Descriptions.php
+++ b/src/Config/Descriptions.php
@@ -18,6 +18,15 @@ use function str_replace;
  */
 class Descriptions
 {
+    /** @var array<string, string> $commentsMap */
+    private static array $commentsMap = [];
+
+    /** @var array<string, string> $descriptionsMap */
+    private static array $descriptionsMap = [];
+
+    /** @var array<string, string> $namesMap */
+    private static array $namesMap = [];
+
     /**
      * Return name or description for a configuration path.
      *
@@ -44,14 +53,11 @@ class Descriptions
     /** @return array<string, string> */
     private static function getComments(): array
     {
-        /** @var array<string, string> $commentsMap */
-        static $commentsMap = [];
-
-        if ($commentsMap !== []) {
-            return $commentsMap;
+        if (self::$commentsMap !== []) {
+            return self::$commentsMap;
         }
 
-        return $commentsMap = [
+        return self::$commentsMap = [
             'MaxDbList_cmt' => __('Users cannot set a higher value'),
             'MaxTableList_cmt' => __('Users cannot set a higher value'),
             'QueryHistoryMax_cmt' => __('Users cannot set a higher value'),
@@ -61,14 +67,11 @@ class Descriptions
     /** @return array<string, string> */
     private static function getDescriptions(): array
     {
-        /** @var array<string, string> $descriptionsMap */
-        static $descriptionsMap = [];
-
-        if ($descriptionsMap !== []) {
-            return $descriptionsMap;
+        if (self::$descriptionsMap !== []) {
+            return self::$descriptionsMap;
         }
 
-        return $descriptionsMap = [
+        return self::$descriptionsMap = [
             'AllowArbitraryServer_desc' => __(
                 'If enabled, user can enter any MySQL server in login form for cookie auth.',
             ),
@@ -586,14 +589,11 @@ class Descriptions
     /** @return array<string, string> */
     private static function getNames(): array
     {
-        /** @var array<string, string> $namesMap */
-        static $namesMap = [];
-
-        if ($namesMap !== []) {
-            return $namesMap;
+        if (self::$namesMap !== []) {
+            return self::$namesMap;
         }
 
-        return $namesMap = [
+        return self::$namesMap = [
             'AllowArbitraryServer_name' => __('Allow login to any MySQL server'),
             'ArbitraryServerRegexp_name' => __('Restrict login to MySQL server'),
             'AllowThirdPartyFraming_name' => __('Allow third party framing'),

--- a/src/Config/FormDisplay.php
+++ b/src/Config/FormDisplay.php
@@ -100,6 +100,8 @@ class FormDisplay
 
     private bool $isSetupScript;
 
+    private static bool $hasCheckPageRefresh = false;
+
     public function __construct(private ConfigFile $configFile)
     {
         $this->formDisplayTemplate = new FormDisplayTemplate(Config::getInstance());
@@ -221,9 +223,8 @@ class FormDisplay
          * We do validation on page refresh when browser remembers field values,
          * add a field with known value which will be used for checks.
          */
-        static $hasCheckPageRefresh = false;
-        if (! $hasCheckPageRefresh) {
-            $hasCheckPageRefresh = true;
+        if (! self::$hasCheckPageRefresh) {
+            self::$hasCheckPageRefresh = true;
         }
 
         $tabs = [];
@@ -291,7 +292,7 @@ class FormDisplay
 
         return $this->formDisplayTemplate->display([
             'action' => $formAction,
-            'has_check_page_refresh' => $hasCheckPageRefresh,
+            'has_check_page_refresh' => self::$hasCheckPageRefresh,
             'hidden_fields' => (array) $hiddenFields,
             'tabs' => $tabs,
             'forms' => $forms,

--- a/src/Config/Validator.php
+++ b/src/Config/Validator.php
@@ -52,6 +52,9 @@ use const PHP_INT_MAX;
  */
 class Validator
 {
+    /** @var mixed[]|null */
+    private static array|null $validators = null;
+
     /**
      * Returns validator list
      *
@@ -61,16 +64,14 @@ class Validator
      */
     public static function getValidators(ConfigFile $cf): array
     {
-        static $validators = null;
-
-        if ($validators !== null) {
-            return $validators;
+        if (self::$validators !== null) {
+            return self::$validators;
         }
 
-        $validators = $cf->getDbEntry('_validators', []);
+        self::$validators = $cf->getDbEntry('_validators', []);
         $config = Config::getInstance();
         if ($config->get('is_setup')) {
-            return $validators;
+            return self::$validators;
         }
 
         // not in setup script: load additional validators for user
@@ -97,12 +98,12 @@ class Validator
                 }
             }
 
-            $validators[$field] = isset($validators[$field])
-                ? array_merge((array) $validators[$field], $uvList)
+            self::$validators[$field] = isset(self::$validators[$field])
+                ? array_merge((array) self::$validators[$field], $uvList)
                 : $uvList;
         }
 
-        return $validators;
+        return self::$validators;
     }
 
     /**

--- a/src/Controllers/Setup/ConfigController.php
+++ b/src/Controllers/Setup/ConfigController.php
@@ -23,6 +23,8 @@ use const CONFIG_FILE;
 
 final class ConfigController implements InvocableController
 {
+    private static bool $hasCheckPageRefresh = false;
+
     public function __construct(
         private readonly ResponseFactory $responseFactory,
         private readonly ResponseRenderer $responseRenderer,
@@ -49,9 +51,8 @@ final class ConfigController implements InvocableController
 
         $pages = SetupHelper::getPages();
 
-        static $hasCheckPageRefresh = false;
-        if (! $hasCheckPageRefresh) {
-            $hasCheckPageRefresh = true;
+        if (! self::$hasCheckPageRefresh) {
+            self::$hasCheckPageRefresh = true;
         }
 
         $configFile = SetupHelper::createConfigFile();
@@ -63,7 +64,7 @@ final class ConfigController implements InvocableController
             'pages' => $pages,
             'eol' => $this->getEolParam($request->getQueryParam('eol')),
             'config' => $config,
-            'has_check_page_refresh' => $hasCheckPageRefresh,
+            'has_check_page_refresh' => self::$hasCheckPageRefresh,
         ]));
     }
 

--- a/src/Controllers/Setup/HomeController.php
+++ b/src/Controllers/Setup/HomeController.php
@@ -27,6 +27,8 @@ use const CONFIG_FILE;
 
 final class HomeController implements InvocableController
 {
+    private static bool $hasCheckPageRefresh = false;
+
     public function __construct(
         private readonly ResponseFactory $responseFactory,
         private readonly ResponseRenderer $responseRenderer,
@@ -108,9 +110,8 @@ final class HomeController implements InvocableController
             ];
         }
 
-        static $hasCheckPageRefresh = false;
-        if (! $hasCheckPageRefresh) {
-            $hasCheckPageRefresh = true;
+        if (! self::$hasCheckPageRefresh) {
+            self::$hasCheckPageRefresh = true;
         }
 
         return $response->write($this->template->render('setup/home/index', [
@@ -120,7 +121,7 @@ final class HomeController implements InvocableController
             'server_count' => $configFile->getServerCount(),
             'servers' => $servers,
             'pages' => $pages,
-            'has_check_page_refresh' => $hasCheckPageRefresh,
+            'has_check_page_refresh' => self::$hasCheckPageRefresh,
             'eol' => isset($_SESSION['eol']) && is_scalar($_SESSION['eol'])
                 ? $_SESSION['eol']
                 : ($this->config->get('PMA_IS_WINDOWS') ? 'win' : 'unix'),

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -31,6 +31,13 @@ use const JSON_HEX_TAG;
 class Sanitize
 {
     /**
+     * Interpret bb code
+     *
+     * @var array<string, string>
+     */
+    private static array $replacePairs = [];
+
+    /**
      * Checks whether given link is valid
      *
      * @param string $url   URL to check
@@ -163,14 +170,8 @@ class Sanitize
             $message = strtr($message, ['<' => '&lt;', '>' => '&gt;', '"' => '&quot;', "'" => '&#039;']);
         }
 
-        /**
-         * Interpret bb code
-         *
-         * @var array<string, string> $replacePairs
-         */
-        static $replacePairs = [];
-        if ($replacePairs === []) {
-            $replacePairs = [
+        if (self::$replacePairs === []) {
+            self::$replacePairs = [
                 '[em]' => '<em>',
                 '[/em]' => '</em>',
                 '[strong]' => '<strong>',
@@ -189,7 +190,7 @@ class Sanitize
             ];
         }
 
-        $message = strtr($message, $replacePairs);
+        $message = strtr($message, self::$replacePairs);
 
         /* Match links in bb code ([a@url@target], where @target is options) */
         $pattern = '/\[a@([^]"@]*)(@([^]"]*))?\]/';

--- a/src/StorageEngine.php
+++ b/src/StorageEngine.php
@@ -63,6 +63,9 @@ class StorageEngine
      */
     public int $support = self::SUPPORT_NO;
 
+    /** @psalm-var array<string, array{Engine: string, Comment: string, Support: string}>|null */
+    private static array|null $storageEngines = null;
+
     /** @param string $engine The engine ID */
     public function __construct(string $engine)
     {
@@ -86,14 +89,10 @@ class StorageEngine
      * Returns array of storage engines
      *
      * @return array<string, array{Engine: string, Comment: string, Support: string}>
-     *
-     * @staticvar array $storage_engines storage engines
      */
     public static function getStorageEngines(): array
     {
-        static $storageEngines = null;
-
-        if ($storageEngines == null) {
+        if (self::$storageEngines === null) {
             $dbi = DatabaseInterface::getInstance();
             /** @var array<string, array{Engine: string, Comment: string, Support: string}> $storageEngines */
             $storageEngines = $dbi->fetchResult('SHOW STORAGE ENGINES', 'Engine');
@@ -113,9 +112,11 @@ class StorageEngine
                     $storageEngines[$engine]['Support'] = 'DISABLED';
                 }
             }
+
+            self::$storageEngines = $storageEngines;
         }
 
-        return $storageEngines;
+        return self::$storageEngines;
     }
 
     /**

--- a/src/Transformations.php
+++ b/src/Transformations.php
@@ -48,6 +48,9 @@ use function ucwords;
  */
 class Transformations
 {
+    /** @var string[][]|null */
+    private static array|null $availableMimeTypesStack = null;
+
     /**
      * Returns array of options from string with options separated by comma,
      * removes quotes
@@ -109,15 +112,11 @@ class Transformations
      * Gets all available MIME-types
      *
      * @return string[][]    array[mimetype], array[transformation]
-     *
-     * @staticvar array $stack
      */
     public function getAvailableMimeTypes(): array
     {
-        static $stack = null;
-
-        if ($stack !== null) {
-            return $stack;
+        if (self::$availableMimeTypesStack !== null) {
+            return self::$availableMimeTypesStack;
         }
 
         $stack = [];
@@ -176,7 +175,9 @@ class Transformations
             }
         }
 
-        return $stack;
+        self::$availableMimeTypesStack = $stack;
+
+        return self::$availableMimeTypesStack;
     }
 
     /**


### PR DESCRIPTION
Static variables are better suitable for standalone functions. For methods, static properties are better because they are easier to handle.