### PR TITLE
Fix #19138 - Adjust chart size in System Monitor

### DIFF
--- a/resources/js/src/server/status/monitor.ts
+++ b/resources/js/src/server/status/monitor.ts
@@ -1209,7 +1209,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
 
         chartSize = {
             width: Math.floor(wdt),
-            height: Math.floor(0.75 * wdt)
+            height: Math.floor(0.55 * wdt)
         };
     }
 


### PR DESCRIPTION
### Description

Adjust chart size in System Monitor. By default cPanel who has a large user base, uses 6 charts, exactly those. It should have supported 9 charts without any additional scroll, but charts look odd. This is the best size.

Before:

![before](https://github.com/user-attachments/assets/e1b21487-4fe9-490d-824f-84cb6039c9a3)

After:

![after](https://github.com/user-attachments/assets/822d615c-7f64-4cf0-8012-88cc83e999f0)

Fixes #19138

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
