### PR TITLE
Fix duplicate message being shown

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -3683,7 +3683,7 @@ class Results
 
         // 2.1 Prepares a messages with position information
         $sqlQueryMessage = '';
-        if ($displayParts['query_stats'] == '1') {
+        if ($displayParts['query_stats'] == '1' && $total > 0) {
             $message = $this->setMessageInformation(
                 $sortedColumnMessage,
                 $analyzedSqlResults,


### PR DESCRIPTION
### Description

This PR will fix a bug introduced in https://github.com/phpmyadmin/phpmyadmin/commit/ed1ca2084854bfbfe2c9c8446b7d3716db214d46. If a table has 0 rows, a duplicate message is shown.

Before:

![before](https://github.com/user-attachments/assets/632ef9aa-5ab0-48c8-91a7-311139a9bbe4)

After:

![after](https://github.com/user-attachments/assets/c2215f88-d108-44f4-a6ec-1d24aca1c745)

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
