### PR TITLE
Remove the PHPMYADMIN constant

### DIFF
--- a/app/constants.php
+++ b/app/constants.php
@@ -2,10 +2,6 @@
 
 declare(strict_types=1);
 
-if (! defined('PHPMYADMIN')) {
-    exit;
-}
-
 $vendorConfig = require_once ROOT_PATH . 'app/vendor_config.php';
 if (
     ! is_array($vendorConfig) || ! isset(

--- a/app/vendor_config.php
+++ b/app/vendor_config.php
@@ -9,10 +9,6 @@
 
 declare(strict_types=1);
 
-if (! defined('PHPMYADMIN')) {
-    exit;
-}
-
 return [
     /**
      * Path to vendor autoload file. Useful when you want to have vendor dependencies somewhere else.

--- a/bin/console
+++ b/bin/console
@@ -16,7 +16,6 @@ if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', dirname(__DIR__) . DIRECTORY_SEPARATOR);
 }
 
-define('PHPMYADMIN', true);
 require_once ROOT_PATH . 'app/constants.php';
 require_once AUTOLOAD_FILE;
 

--- a/public/index.php
+++ b/public/index.php
@@ -9,7 +9,6 @@ if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', dirname(__DIR__) . DIRECTORY_SEPARATOR);
 }
 
-define('PHPMYADMIN', true);
 // phpcs:enable
 
 if (PHP_VERSION_ID < 80102) {

--- a/public/setup/index.php
+++ b/public/setup/index.php
@@ -9,7 +9,6 @@ if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', dirname(__DIR__, 2) . DIRECTORY_SEPARATOR);
 }
 
-define('PHPMYADMIN', true);
 // phpcs:enable
 
 if (PHP_VERSION_ID < 80102) {

--- a/tests/bootstrap-dist.php
+++ b/tests/bootstrap-dist.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 // phpcs:disable PSR1.Files.SideEffects
-
-define('PHPMYADMIN', true);
 define('TESTSUITE', true);
 
 if (! defined('ROOT_PATH')) {

--- a/tests/bootstrap-static.php
+++ b/tests/bootstrap-static.php
@@ -14,10 +14,6 @@ if (! defined('ROOT_PATH')) {
 }
 
 // phpcs:disable PSR1.Files.SideEffects
-if (! defined('PHPMYADMIN')) {
-    define('PHPMYADMIN', true);
-}
-
 if (! defined('TESTSUITE')) {
     define('TESTSUITE', true);
 }


### PR DESCRIPTION
This constant was used to avoid non-entry-points scripts being called directly. As phpMyAdmin has a public directory now, directly calling scripts outside public is not possible anymore.

Introduced by afbb2a9dc2ff6f612e01f86e85788610e19a0338.


