### PR TITLE
Add yarn 1.22 to the package.json's packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,6 @@
     "css-lint": "stylelint \"public/themes/**/scss/*.scss\" \"public/setup/scss/*.scss\"",
     "js-lint": "eslint resources/js/src tests/javascript jest.config.cjs",
     "test": "yarn node --experimental-vm-modules $(yarn bin jest)"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
This defines which package manager is expected to be used.

- https://nodejs.org/api/packages.html#packagemanager
- https://yarnpkg.com/corepack
- https://yarnpkg.com/getting-started/install
- https://nodejs.org/api/corepack.html


