### PR TITLE
Fix privileges

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12062,7 +12062,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Server/Privileges.php
 
 		-
@@ -12077,7 +12077,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 15
+			count: 14
 			path: src/Server/Privileges.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10323,6 +10323,7 @@
       <code><![CDATA[$GLOBALS['pred_username']]]></code>
       <code><![CDATA[$extraData['db_wildcard_privs']]]></code>
       <code><![CDATA[$foundRows[]]]></code>
+      <code><![CDATA[$grantValue]]></code>
       <code><![CDATA[$host]]></code>
       <code><![CDATA[$hostnameLength]]></code>
       <code><![CDATA[$name]]></code>
@@ -10360,8 +10361,6 @@
       <code><![CDATA[mb_strrpos($exportUser, ';')]]></code>
     </PossiblyFalseOperand>
     <PossiblyInvalidArgument>
-      <code><![CDATA[$GLOBALS[$currentGrant[0]]]]></code>
-      <code><![CDATA[$GLOBALS[$currentGrant[0]]]]></code>
       <code><![CDATA[$_GET['username']]]></code>
       <code><![CDATA[$_POST['authentication_plugin']]]></code>
       <code><![CDATA[$_POST['authentication_plugin']]]></code>
@@ -10380,6 +10379,9 @@
       <code><![CDATA[$hashedPassword]]></code>
       <code><![CDATA[$oldUserGroup]]></code>
     </PossiblyInvalidArgument>
+    <PossiblyInvalidArrayOffset>
+      <code><![CDATA[$_POST[$currentGrant[0]]]]></code>
+    </PossiblyInvalidArrayOffset>
     <PossiblyInvalidCast>
       <code><![CDATA[$_GET['username']]]></code>
       <code><![CDATA[$_POST['authentication_plugin']]]></code>
@@ -10460,9 +10462,8 @@
       <code><![CDATA[$_POST['max_user_connections']]]></code>
     </RiskyCast>
     <RiskyTruthyFalsyComparison>
-      <code><![CDATA[empty($GLOBALS[$currentGrant[0] . '_none'])]]></code>
-      <code><![CDATA[empty($GLOBALS[$currentGrant[0] . '_none'])]]></code>
-      <code><![CDATA[empty($GLOBALS[$currentGrant[0]])]]></code>
+      <code><![CDATA[empty($_POST[$currentGrant[0] . '_none'])]]></code>
+      <code><![CDATA[empty($_POST[$currentGrant[0] . '_none'])]]></code>
       <code><![CDATA[empty($_POST['change_copy'])]]></code>
       <code><![CDATA[empty($_POST['nopass'])]]></code>
       <code><![CDATA[empty($_POST['pma_pw'])]]></code>

--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -219,7 +219,7 @@ class Privileges
         foreach ($grants as $currentGrant) {
             if (
                 ($row === null || ! isset($row[$currentGrant[0]]))
-                && ($row !== null || ! isset($GLOBALS[$currentGrant[0]]))
+                && ($row !== null || ! isset($_POST[$currentGrant[0]]))
             ) {
                 continue;
             }
@@ -227,10 +227,10 @@ class Privileges
             if (
                 ($row !== null && $row[$currentGrant[0]] === 'Y')
                 || ($row === null
-                && ($GLOBALS[$currentGrant[0]] === 'Y'
-                || (is_array($GLOBALS[$currentGrant[0]])
-                && count($GLOBALS[$currentGrant[0]]) == $_REQUEST['column_count']
-                && empty($GLOBALS[$currentGrant[0] . '_none']))))
+                && ($_POST[$currentGrant[0]] === 'Y'
+                || (is_array($_POST[$currentGrant[0]])
+                && count($_POST[$currentGrant[0]]) == $_REQUEST['column_count']
+                && empty($_POST[$currentGrant[0] . '_none']))))
             ) {
                 if ($enableHTML) {
                     $privs[] = '<dfn title="' . $currentGrant[2] . '">'
@@ -239,14 +239,14 @@ class Privileges
                     $privs[] = $currentGrant[1];
                 }
             } elseif (
-                ! empty($GLOBALS[$currentGrant[0]])
-                && is_array($GLOBALS[$currentGrant[0]])
-                && empty($GLOBALS[$currentGrant[0] . '_none'])
+                ! empty($_POST[$currentGrant[0]])
+                && is_array($_POST[$currentGrant[0]])
+                && empty($_POST[$currentGrant[0] . '_none'])
             ) {
                 // Required for proper escaping of ` (backtick) in a column name
                 $grantCols = array_map(
                     Util::backquote(...),
-                    $GLOBALS[$currentGrant[0]],
+                    $_POST[$currentGrant[0]],
                 );
 
                 if ($enableHTML) {

--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -217,20 +217,20 @@ class Privileges
         $privs = [];
         $allPrivileges = true;
         foreach ($grants as $currentGrant) {
-            if (
-                ($row === null || ! isset($row[$currentGrant[0]]))
-                && ($row !== null || ! isset($_POST[$currentGrant[0]]))
-            ) {
+            if ($row !== null && isset($row[$currentGrant[0]])) {
+                $grantValue = $row[$currentGrant[0]];
+            } elseif ($row === null && isset($_POST[$currentGrant[0]])) {
+                $grantValue = $_POST[$currentGrant[0]];
+            } else {
                 continue;
             }
 
             if (
-                ($row !== null && $row[$currentGrant[0]] === 'Y')
+                ($grantValue === 'Y')
                 || ($row === null
-                && ($_POST[$currentGrant[0]] === 'Y'
-                || (is_array($_POST[$currentGrant[0]])
-                && count($_POST[$currentGrant[0]]) == $_REQUEST['column_count']
-                && empty($_POST[$currentGrant[0] . '_none']))))
+                && is_array($grantValue)
+                && count($grantValue) == $_REQUEST['column_count']
+                && empty($_POST[$currentGrant[0] . '_none']))
             ) {
                 if ($enableHTML) {
                     $privs[] = '<dfn title="' . $currentGrant[2] . '">'
@@ -239,14 +239,13 @@ class Privileges
                     $privs[] = $currentGrant[1];
                 }
             } elseif (
-                ! empty($_POST[$currentGrant[0]])
-                && is_array($_POST[$currentGrant[0]])
+                is_array($grantValue) && $grantValue !== []
                 && empty($_POST[$currentGrant[0] . '_none'])
             ) {
                 // Required for proper escaping of ` (backtick) in a column name
                 $grantCols = array_map(
                     Util::backquote(...),
-                    $_POST[$currentGrant[0]],
+                    $grantValue,
                 );
 
                 if ($enableHTML) {


### PR DESCRIPTION
While using PMA today I noticed I broke the privilege assignment page in https://github.com/phpmyadmin/phpmyadmin/pull/19054

This fixes the issue by replacing the `$GLOBALS` with `$_POST`. I still don't know why we used GLOBALS before so there could still be something I missed. But it seems to fix the issue I introduced earlier. 