### PR TITLE
Fixed can't access property getUnits, sourceProj is null

### DIFF
--- a/resources/js/src/ol.mjs
+++ b/resources/js/src/ol.mjs
@@ -6,6 +6,7 @@ import { Tile, Vector as VectorLayer } from 'ol/layer.js';
 import { OSM, Vector as VectorSource } from 'ol/source.js';
 import { Circle, Fill, Stroke, Style, Text } from 'ol/style.js';
 import { Feature, Map, View } from 'ol';
+import { get as getProjection } from 'ol/proj.js';
 
 const ol = {
     control: {
@@ -29,7 +30,7 @@ const ol = {
     style: {
         Circle, Fill, Stroke, Style, Text
     },
-    Feature, Map, View
+    Feature, Map, View, getProjection
 };
 
 export default ol;

--- a/resources/js/src/table/gis_visualization.ts
+++ b/resources/js/src/table/gis_visualization.ts
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import { AJAX } from '../modules/ajax.ts';
 import { escapeHtml } from '../modules/functions/escape.ts';
+import {get as getProjection} from 'ol/proj.js';
 
 /**
  * @fileoverview    functions used for visualizing GIS data
@@ -527,10 +528,15 @@ function getFeaturesFromOpenLayersData (geometries: any[]): any[] {
         }
 
         if (geometry.geometry.srid !== 3857) {
-            olGeometry = olGeometry.transform(
-                'EPSG:' + (geometry.geometry.srid !== 0 ? geometry.geometry.srid : 4326),
-                'EPSG:3857'
-            );
+            let source  = 'EPSG:' + (geometry.geometry.srid !== 0 ? geometry.geometry.srid : 4326);
+            const sourceProj = getProjection(source);
+
+            if(sourceProj){
+                olGeometry = olGeometry.transform(
+                    source,
+                    'EPSG:3857'
+                );
+            }
         }
 
         if (geometry.style.text) {

--- a/resources/js/src/table/gis_visualization.ts
+++ b/resources/js/src/table/gis_visualization.ts
@@ -1,7 +1,6 @@
 import $ from 'jquery';
 import { AJAX } from '../modules/ajax.ts';
 import { escapeHtml } from '../modules/functions/escape.ts';
-import { get as getProjection } from 'ol/proj.js';
 
 /**
  * @fileoverview    functions used for visualizing GIS data
@@ -529,7 +528,7 @@ function getFeaturesFromOpenLayersData (geometries: any[]): any[] {
 
         if (geometry.geometry.srid !== 3857) {
             const source  = 'EPSG:' + (geometry.geometry.srid !== 0 ? geometry.geometry.srid : 4326);
-            const sourceProj = getProjection(source);
+            const sourceProj = window.ol.getProjection(source);
 
             if (sourceProj) {
                 olGeometry = olGeometry.transform(

--- a/resources/js/src/table/gis_visualization.ts
+++ b/resources/js/src/table/gis_visualization.ts
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import { AJAX } from '../modules/ajax.ts';
 import { escapeHtml } from '../modules/functions/escape.ts';
-import {get as getProjection} from 'ol/proj.js';
+import { get as getProjection } from 'ol/proj.js';
 
 /**
  * @fileoverview    functions used for visualizing GIS data
@@ -528,10 +528,10 @@ function getFeaturesFromOpenLayersData (geometries: any[]): any[] {
         }
 
         if (geometry.geometry.srid !== 3857) {
-            let source  = 'EPSG:' + (geometry.geometry.srid !== 0 ? geometry.geometry.srid : 4326);
+            const source  = 'EPSG:' + (geometry.geometry.srid !== 0 ? geometry.geometry.srid : 4326);
             const sourceProj = getProjection(source);
 
-            if(sourceProj){
+            if (sourceProj) {
                 olGeometry = olGeometry.transform(
                     source,
                     'EPSG:3857'


### PR DESCRIPTION
### Description

Fixes the issue coming up upon entering an invalid SRID.
Now the function would execute only if the `sourceProj` is a valid object.

Fixes: https://github.com/phpmyadmin/phpmyadmin/issues/19266
