### PR TITLE
Fix #18897 - Unknown storage engine InnoDB

### DIFF
--- a/libraries/classes/Database/Routines.php
+++ b/libraries/classes/Database/Routines.php
@@ -405,8 +405,7 @@ class Routines
     {
         if ($flushPrivileges) {
             // Flush the Privileges
-            $flushPrivQuery = 'FLUSH PRIVILEGES;';
-            $this->dbi->query($flushPrivQuery);
+            $this->dbi->tryQuery('FLUSH PRIVILEGES;');
 
             $message = Message::success(
                 __(

--- a/libraries/classes/Operations.php
+++ b/libraries/classes/Operations.php
@@ -345,8 +345,7 @@ class Operations
         $this->dbi->query($query_proc_specific);
 
         // Finally FLUSH the new privileges
-        $flush_query = 'FLUSH PRIVILEGES;';
-        $this->dbi->query($flush_query);
+        $this->dbi->tryQuery('FLUSH PRIVILEGES;');
     }
 
     /**
@@ -442,8 +441,7 @@ class Operations
         }
 
         // Finally FLUSH the new privileges
-        $flush_query = 'FLUSH PRIVILEGES;';
-        $this->dbi->query($flush_query);
+        $this->dbi->tryQuery('FLUSH PRIVILEGES;');
     }
 
     /**
@@ -816,8 +814,7 @@ class Operations
         $this->dbi->query($query_col_specific);
 
         // Finally FLUSH the new privileges
-        $flush_query = 'FLUSH PRIVILEGES;';
-        $this->dbi->query($flush_query);
+        $this->dbi->tryQuery('FLUSH PRIVILEGES;');
     }
 
     /**
@@ -871,8 +868,7 @@ class Operations
         }
 
         // Finally FLUSH the new privileges
-        $flush_query = 'FLUSH PRIVILEGES;';
-        $this->dbi->query($flush_query);
+        $this->dbi->tryQuery('FLUSH PRIVILEGES;');
     }
 
     /**

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -2477,8 +2477,7 @@ class Privileges
     {
         $message = null;
         if (isset($_GET['flush_privileges'])) {
-            $sqlQuery = 'FLUSH PRIVILEGES;';
-            $this->dbi->query($sqlQuery);
+            $this->dbi->tryQuery('FLUSH PRIVILEGES;');
             $message = Message::success(
                 __('The privileges were reloaded successfully.')
             );


### PR DESCRIPTION
### Description

If MySQL/MariaDB is started with `skip-innodb`, `FLUSH PRIVILEGES;` query won't work.

Fixes #18897

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
