### PR TITLE
Fix #19284 - Delete_history_priv is not a valid column in mysql.tables_priv

### DIFF
--- a/templates/server/privileges/privileges_table.twig
+++ b/templates/server/privileges/privileges_table.twig
@@ -228,11 +228,11 @@
         </label>
       </div>
 
-      {% if row['Delete versioning rows_priv'] is defined or row['Delete_history_priv'] is defined %}
+      {% if row['Delete versioning rows_priv'] is defined %}
         <div class="item">
           <input type="checkbox" name="Delete_history_priv" id="checkbox_Delete_history_priv" value="Y" title="
             {%- trans 'Allows deleting historical rows.' %}"
-            {{- row['Delete versioning rows_priv'] == 'Y' or row['Delete_history_priv'] == 'Y' ? ' checked' }}>
+            {{- row['Delete versioning rows_priv'] == 'Y' ? ' checked' }}>
           <label for="checkbox_Delete_history_priv">
             <code>
               <dfn title="{% trans 'Allows deleting historical rows.' %}">


### PR DESCRIPTION
### Description

`Delete_history_priv` is not a valid column in mysql.tables_priv, from what I've read here https://mariadb.com/kb/en/mysqltables_priv-table/ and here https://github.com/phpmyadmin/phpmyadmin/commit/91c758aae4ec9f10fb32b0d28c395211d4654e0f.

The error happens only on `master`, but I targeted `QA_5_2`.

Fixes #19284

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
