### PR TITLE
add optional support for binary data in database search

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13481,7 +13481,7 @@
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
     <PossiblyUnusedMethod>
-      <code><![CDATA[searchTypes]]></code>
+      <code><![CDATA[searchTypesAndOptions]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/DatabaseInterfaceTest.php">

--- a/resources/templates/database/search/main.twig
+++ b/resources/templates/database/search/main.twig
@@ -33,6 +33,12 @@
           <input class="form-check-input" type="radio" name="criteriaSearchType" id="criteriaSearchTypeRadio5" value="5"{{ criteria_search_type == '5' ? ' checked' }}>
           <label class="form-check-label" for="criteriaSearchTypeRadio5">{{ t('as regular expression') }} {{ show_mysql_docu('Regexp') }}</label>
         </div>
+        <legend>{{ t('Options:') }}</legend>
+        <div class="form-check">
+          <input class="form-check-input" value='0' type="hidden" name="criteriaSearchOptionIncludeHex" id="criteriaSearchOptionHidden1">
+          <input class="form-check-input" value='1' type="checkbox" name="criteriaSearchOptionIncludeHex" id="criteriaSearchOptionCheckbox1" {{ criteria_search_options_include_hex ? ' checked' }}>
+          <label class="form-check-label" for="criteriaSearchOptionCheckbox1">{{ t('include hex matches') }} {{ show_mysql_docu('string-functions',false,null,null,'function_hex') }}</label>
+        </div>
       </fieldset>
 
       <fieldset class="mb-3">

--- a/src/Database/Search.php
+++ b/src/Database/Search.php
@@ -45,6 +45,13 @@ class Search
     private int $criteriaSearchType;
 
     /**
+     * Options to apply to search
+     *
+     * @var bool criteriaSearchOptionsIncludeHex
+     */
+    private bool $criteriaSearchOptionsIncludeHex;
+
+    /**
      * Already set search type's description
      */
     private string $searchTypeDescription = '';
@@ -75,6 +82,7 @@ class Search
             4 => __('the exact phrase as whole field'),
             5 => __('as regular expression'),
         ];
+        $this->criteriaSearchOptionsIncludeHex = false;
         // Sets criteria parameters
         $this->setSearchParams();
     }
@@ -115,6 +123,11 @@ class Search
             $this->criteriaColumnName = '';
         } else {
             $this->criteriaColumnName = $_POST['criteriaColumnName'];
+        }
+
+        //phpcs:ignore SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
+        if (isset($_POST['criteriaSearchOptionIncludeHex']) && $_POST['criteriaSearchOptionIncludeHex'] === '1') {
+            $this->criteriaSearchOptionsIncludeHex = true;
         }
     }
 
@@ -189,6 +202,14 @@ class Search
                 $likeClausesPerColumn[] = 'CONVERT(' . Util::backquote($column->field) . ' USING utf8)'
                     . ' ' . $likeOrRegex . ' '
                     . $this->dbi->quoteString($automaticWildcard . $searchWord . $automaticWildcard);
+
+                if (! $this->criteriaSearchOptionsIncludeHex) {
+                    continue;
+                }
+
+                $likeClausesPerColumn[] = 'HEX(' . Util::backquote($column->field) . ')'
+                    . ' ' . $likeOrRegex . ' '
+                    . $this->dbi->quoteString($automaticWildcard . $searchWord . $automaticWildcard);
             }
 
             if ($likeClausesPerColumn === []) {
@@ -237,6 +258,7 @@ class Search
             'criteria_tables' => $this->criteriaTables,
             'criteria_search_string' => $this->criteriaSearchString,
             'search_type_description' => $this->searchTypeDescription,
+            'criteria_search_options_include_hex' => $this->criteriaSearchOptionsIncludeHex,
         ]);
     }
 
@@ -254,6 +276,7 @@ class Search
             'criteria_tables' => $this->criteriaTables,
             'tables_names_only' => $this->tablesNamesOnly,
             'criteria_column_name' => $this->criteriaColumnName,
+            'criteria_search_options_include_hex' => $this->criteriaSearchOptionsIncludeHex,
         ]);
     }
 }

--- a/tests/unit/Database/SearchTest.php
+++ b/tests/unit/Database/SearchTest.php
@@ -64,14 +64,16 @@ class SearchTest extends AbstractTestCase
     /**
      * Test for generating where clause for different search types
      *
-     * @param string $type     type
-     * @param string $expected expected result
+     * @param string $type       type
+     * @param string $includeHex includeHex
+     * @param string $expected   expected
      */
-    #[DataProvider('searchTypes')]
-    public function testGetWhereClause(string $type, string $expected): void
+    #[DataProvider('searchTypesAndOptions')]
+    public function testGetWhereClause(string $type, string $includeHex, string $expected): void
     {
         $_POST['criteriaSearchType'] = $type;
         $_POST['criteriaSearchString'] = 'search string';
+        $_POST['criteriaSearchOptionIncludeHex'] = $includeHex;
 
         $this->object = new Search(DatabaseInterface::getInstance(), 'pma_test', new Template());
         self::assertSame(
@@ -88,13 +90,14 @@ class SearchTest extends AbstractTestCase
     /**
      * Data provider for testGetWhereClause
      *
-     * @return array<array{string, string}>
+     * @return array<array<string>>
      */
-    public static function searchTypes(): array
+    public static function searchTypesAndOptions(): array
     {
         return [
             [
                 '1',
+                '0',
                 " WHERE (CONVERT(`column1` USING utf8) LIKE '%search%'"
                 . " OR CONVERT(`column2` USING utf8) LIKE '%search%') "
                 . " OR  (CONVERT(`column1` USING utf8) LIKE '%string%'"
@@ -102,6 +105,7 @@ class SearchTest extends AbstractTestCase
             ],
             [
                 '2',
+                '0',
                 " WHERE (CONVERT(`column1` USING utf8) LIKE '%search%'"
                 . " OR CONVERT(`column2` USING utf8) LIKE '%search%') "
                 . " AND  (CONVERT(`column1` USING utf8) LIKE '%string%'"
@@ -109,18 +113,70 @@ class SearchTest extends AbstractTestCase
             ],
             [
                 '3',
+                '0',
                 " WHERE (CONVERT(`column1` USING utf8) LIKE '%search string%'"
                 . " OR CONVERT(`column2` USING utf8) LIKE '%search string%')",
             ],
             [
                 '4',
+                '0',
                 " WHERE (CONVERT(`column1` USING utf8) LIKE 'search string'"
                 . " OR CONVERT(`column2` USING utf8) LIKE 'search string')",
             ],
             [
                 '5',
+                '0',
                 " WHERE (CONVERT(`column1` USING utf8) REGEXP 'search string'"
                 . " OR CONVERT(`column2` USING utf8) REGEXP 'search string')",
+            ],
+            [
+                '1',
+                '1',
+                " WHERE (CONVERT(`column1` USING utf8) LIKE '%search%'"
+                . " OR HEX(`column1`) LIKE '%search%'"
+                . " OR CONVERT(`column2` USING utf8) LIKE '%search%'"
+                . " OR HEX(`column2`) LIKE '%search%') "
+                . " OR  (CONVERT(`column1` USING utf8) LIKE '%string%'"
+                . " OR HEX(`column1`) LIKE '%string%'"
+                . " OR CONVERT(`column2` USING utf8) LIKE '%string%'"
+                . " OR HEX(`column2`) LIKE '%string%')",
+            ],
+            [
+                '2',
+                '1',
+                " WHERE (CONVERT(`column1` USING utf8) LIKE '%search%'"
+                . " OR HEX(`column1`) LIKE '%search%'"
+                . " OR CONVERT(`column2` USING utf8) LIKE '%search%'"
+                . " OR HEX(`column2`) LIKE '%search%') "
+                . " AND  (CONVERT(`column1` USING utf8) LIKE '%string%'"
+                . " OR HEX(`column1`) LIKE '%string%'"
+                . " OR CONVERT(`column2` USING utf8) LIKE '%string%'"
+                . " OR HEX(`column2`) LIKE '%string%')",
+            ],
+            [
+                '3',
+                '1',
+                " WHERE (CONVERT(`column1` USING utf8) LIKE '%search string%'"
+                . " OR HEX(`column1`) LIKE '%search string%'"
+                . " OR CONVERT(`column2` USING utf8) LIKE '%search string%'"
+                . " OR HEX(`column2`) LIKE '%search string%')",
+                'on',
+            ],
+            [
+                '4',
+                '1',
+                " WHERE (CONVERT(`column1` USING utf8) LIKE 'search string'"
+                . " OR HEX(`column1`) LIKE 'search string'"
+                . " OR CONVERT(`column2` USING utf8) LIKE 'search string'"
+                . " OR HEX(`column2`) LIKE 'search string')",
+            ],
+            [
+                '5',
+                '1',
+                " WHERE (CONVERT(`column1` USING utf8) REGEXP 'search string'"
+                . " OR HEX(`column1`) REGEXP 'search string'"
+                . " OR CONVERT(`column2` USING utf8) REGEXP 'search string'"
+                . " OR HEX(`column2`) REGEXP 'search string')",
             ],
         ];
     }


### PR DESCRIPTION
Signed-off-by: Gregor Lohaus <lohausgregor@gmail.com>

### Description

Recently I had to search for some binary data in a database, globally. 
Unfortunately neither LIKE nor REGEXP work with hex literals, so i added an option to include matches on hexed column data in the database search module. 
I think some people could benefit from this.
