### PR TITLE
Foreigners refactoring

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.1",
+            "version": "1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "063d9aa8696582f5a41dffbbaf3c81024f0a604a"
+                "reference": "48a792895a2b7a6ee65dd5442c299d7b835b6137"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/063d9aa8696582f5a41dffbbaf3c81024f0a604a",
-                "reference": "063d9aa8696582f5a41dffbbaf3c81024f0a604a",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/48a792895a2b7a6ee65dd5442c299d7b835b6137",
+                "reference": "48a792895a2b7a6ee65dd5442c299d7b835b6137",
                 "shasum": ""
             },
             "require": {
@@ -27,8 +27,8 @@
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8 || ^9",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
-                "symfony/phpunit-bridge": "^4.2 || ^5",
                 "symfony/process": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "type": "library",
@@ -64,7 +64,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.1"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.2"
             },
             "funding": [
                 {
@@ -80,7 +80,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-08T15:28:20+00:00"
+            "time": "2024-09-25T07:49:53+00:00"
         },
         {
             "name": "fig/http-message-util",
@@ -3188,16 +3188,16 @@
         },
         {
             "name": "felixfbecker/language-server-protocol",
-            "version": "v1.5.2",
+            "version": "v1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
-                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842"
+                "reference": "a9e113dbc7d849e35b8776da39edaf4313b7b6c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/6e82196ffd7c62f7794d778ca52b69feec9f2842",
-                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/a9e113dbc7d849e35b8776da39edaf4313b7b6c9",
+                "reference": "a9e113dbc7d849e35b8776da39edaf4313b7b6c9",
                 "shasum": ""
             },
             "require": {
@@ -3238,9 +3238,9 @@
             ],
             "support": {
                 "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
-                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.2"
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.3"
             },
-            "time": "2022-03-02T22:36:06+00:00"
+            "time": "2024-04-30T00:40:11+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -3569,34 +3569,34 @@
         },
         {
             "name": "lcobucci/clock",
-            "version": "3.2.0",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/clock.git",
-                "reference": "6f28b826ea01306b07980cb8320ab30b966cd715"
+                "reference": "db3713a61addfffd615b79bf0bc22f0ccc61b86b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/clock/zipball/6f28b826ea01306b07980cb8320ab30b966cd715",
-                "reference": "6f28b826ea01306b07980cb8320ab30b966cd715",
+                "url": "https://api.github.com/repos/lcobucci/clock/zipball/db3713a61addfffd615b79bf0bc22f0ccc61b86b",
+                "reference": "db3713a61addfffd615b79bf0bc22f0ccc61b86b",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.2.0 || ~8.3.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
                 "psr/clock": "^1.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
             },
             "require-dev": {
-                "infection/infection": "^0.27",
-                "lcobucci/coding-standard": "^11.0.0",
+                "infection/infection": "^0.29",
+                "lcobucci/coding-standard": "^11.1.0",
                 "phpstan/extension-installer": "^1.3.1",
                 "phpstan/phpstan": "^1.10.25",
                 "phpstan/phpstan-deprecation-rules": "^1.1.3",
                 "phpstan/phpstan-phpunit": "^1.3.13",
                 "phpstan/phpstan-strict-rules": "^1.5.1",
-                "phpunit/phpunit": "^10.2.3"
+                "phpunit/phpunit": "^11.3.6"
             },
             "type": "library",
             "autoload": {
@@ -3617,7 +3617,7 @@
             "description": "Yet another clock abstraction",
             "support": {
                 "issues": "https://github.com/lcobucci/clock/issues",
-                "source": "https://github.com/lcobucci/clock/tree/3.2.0"
+                "source": "https://github.com/lcobucci/clock/tree/3.3.1"
             },
             "funding": [
                 {
@@ -3629,7 +3629,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2023-11-17T17:00:27+00:00"
+            "time": "2024-09-24T20:45:14+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -4395,16 +4395,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.31.0",
+            "version": "1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "249f15fb843bf240cf058372dad29e100cee6c17"
+                "reference": "6ca22b154efdd9e3c68c56f5d94670920a1c19a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/249f15fb843bf240cf058372dad29e100cee6c17",
-                "reference": "249f15fb843bf240cf058372dad29e100cee6c17",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6ca22b154efdd9e3c68c56f5d94670920a1c19a4",
+                "reference": "6ca22b154efdd9e3c68c56f5d94670920a1c19a4",
                 "shasum": ""
             },
             "require": {
@@ -4436,22 +4436,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.31.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.32.0"
             },
-            "time": "2024-09-22T11:32:18+00:00"
+            "time": "2024-09-26T07:23:32+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.4",
+            "version": "1.12.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "ffa517cb918591b93acc9b95c0bebdcd0e4538bd"
+                "reference": "7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ffa517cb918591b93acc9b95c0bebdcd0e4538bd",
-                "reference": "ffa517cb918591b93acc9b95c0bebdcd0e4538bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17",
+                "reference": "7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17",
                 "shasum": ""
             },
             "require": {
@@ -4496,7 +4496,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-19T07:58:01+00:00"
+            "time": "2024-09-26T12:45:22+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -5407,12 +5407,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "4d2e39c44028ba729fe50efdf731d3d2ede4046b"
+                "reference": "5bd374d4b964c449fc99b871b6d9f139d0b41502"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/4d2e39c44028ba729fe50efdf731d3d2ede4046b",
-                "reference": "4d2e39c44028ba729fe50efdf731d3d2ede4046b",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/5bd374d4b964c449fc99b871b6d9f139d0b41502",
+                "reference": "5bd374d4b964c449fc99b871b6d9f139d0b41502",
                 "shasum": ""
             },
             "conflict": {
@@ -5423,7 +5423,7 @@
                 "aimeos/ai-admin-graphql": ">=2022.04.1,<2022.10.10|>=2023.04.1,<2023.10.6|>=2024.04.1,<2024.04.6",
                 "aimeos/ai-admin-jsonadm": "<2020.10.13|>=2021.04.1,<2021.10.6|>=2022.04.1,<2022.10.3|>=2023.04.1,<2023.10.4|==2024.04.1",
                 "aimeos/ai-client-html": ">=2020.04.1,<2020.10.27|>=2021.04.1,<2021.10.22|>=2022.04.1,<2022.10.13|>=2023.04.1,<2023.10.15|>=2024.04.1,<2024.04.7",
-                "aimeos/ai-controller-frontend": "<2020.10.15|>=2021.04.1,<2021.10.8|>=2022.04.1,<2022.10.8|>=2023.04.1,<2023.10.9",
+                "aimeos/ai-controller-frontend": "<2020.10.15|>=2021.04.1,<2021.10.8|>=2022.04.1,<2022.10.8|>=2023.04.1,<2023.10.9|==2024.04.1",
                 "aimeos/aimeos-core": ">=2022.04.1,<2022.10.17|>=2023.04.1,<2023.10.17|>=2024.04.1,<2024.04.7",
                 "aimeos/aimeos-typo3": "<19.10.12|>=20,<20.10.5",
                 "airesvsg/acf-to-rest-api": "<=3.1",
@@ -5595,6 +5595,8 @@
                 "feehi/cms": "<=2.1.1",
                 "feehi/feehicms": "<=2.1.1",
                 "fenom/fenom": "<=2.12.1",
+                "filament/infolists": ">=3,<3.2.115",
+                "filament/tables": ">=3,<3.2.115",
                 "filegator/filegator": "<7.8",
                 "filp/whoops": "<2.1.13",
                 "fineuploader/php-traditional-server": "<=1.2.2",
@@ -6224,7 +6226,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-23T20:04:53+00:00"
+            "time": "2024-09-27T21:04:39+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4306,11 +4306,6 @@ parameters:
 			path: src/Controllers/Table/RelationController.php
 
 		-
-			message: "#^Parameter \\#7 \\$existrelForeign of method PhpMyAdmin\\\\Table\\\\Table\\:\\:updateForeignKeys\\(\\) expects array\\<PhpMyAdmin\\\\SqlParser\\\\Utils\\\\ForeignKey\\>, array given\\.$#"
-			count: 1
-			path: src/Controllers/Table/RelationController.php
-
-		-
 			message: "#^Argument of an invalid type array\\|string supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/Controllers/Table/ReplaceController.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4546,16 +4546,6 @@ parameters:
 			path: src/Controllers/Table/SearchController.php
 
 		-
-			message: "#^Only booleans are allowed in &&, array given on the left side\\.$#"
-			count: 1
-			path: src/Controllers/Table/SearchController.php
-
-		-
-			message: "#^Only booleans are allowed in &&, array\\|false given on the right side\\.$#"
-			count: 1
-			path: src/Controllers/Table/SearchController.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/Table/SearchController.php
@@ -5021,17 +5011,7 @@ parameters:
 			path: src/Controllers/Table/ZoomSearchController.php
 
 		-
-			message: "#^Only booleans are allowed in &&, array\\|false given on the left side\\.$#"
-			count: 1
-			path: src/Controllers/Table/ZoomSearchController.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
-			count: 1
-			path: src/Controllers/Table/ZoomSearchController.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, array given\\.$#"
 			count: 1
 			path: src/Controllers/Table/ZoomSearchController.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1256,11 +1256,6 @@ parameters:
 			path: src/ConfigStorage/Relation.php
 
 		-
-			message: "#^Parameter \\#1 \\$foreigners of method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:searchColumnInForeigners\\(\\) expects array, array\\|true given\\.$#"
-			count: 1
-			path: src/ConfigStorage/Relation.php
-
-		-
 			message: "#^Parameter \\#1 \\$identifier of static method PhpMyAdmin\\\\Util\\:\\:backquote\\(\\) expects string\\|Stringable\\|null, mixed given\\.$#"
 			count: 7
 			path: src/ConfigStorage/Relation.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1032,7 +1032,7 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 2
+			count: 1
 			path: src/ConfigStorage/Relation.php
 
 		-
@@ -1056,16 +1056,6 @@ parameters:
 			path: src/ConfigStorage/Relation.php
 
 		-
-			message: "#^Cannot access offset 'table_name' on mixed\\.$#"
-			count: 1
-			path: src/ConfigStorage/Relation.php
-
-		-
-			message: "#^Cannot access offset 'table_schema' on mixed\\.$#"
-			count: 1
-			path: src/ConfigStorage/Relation.php
-
-		-
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 1
 			path: src/ConfigStorage/Relation.php
@@ -1077,6 +1067,11 @@ parameters:
 
 		-
 			message: "#^Do\\-while loop condition is always false\\.$#"
+			count: 1
+			path: src/ConfigStorage/Relation.php
+
+		-
+			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getChildReferences\\(\\) should return array\\<array\\<int, array\\>\\> but returns array\\.$#"
 			count: 1
 			path: src/ConfigStorage/Relation.php
 
@@ -1272,7 +1267,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
-			count: 3
+			count: 1
 			path: src/ConfigStorage/Relation.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1031,11 +1031,6 @@ parameters:
 			path: src/Config/Validator.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: src/ConfigStorage/Relation.php
-
-		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
 			path: src/ConfigStorage/Relation.php
@@ -1216,17 +1211,7 @@ parameters:
 			path: src/ConfigStorage/Relation.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, array\\|false given\\.$#"
-			count: 1
-			path: src/ConfigStorage/Relation.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, bool\\|string\\|null given\\.$#"
-			count: 1
-			path: src/ConfigStorage/Relation.php
-
-		-
-			message: "#^Only booleans are allowed in \\|\\|, array\\|false given on the right side\\.$#"
 			count: 1
 			path: src/ConfigStorage/Relation.php
 
@@ -5636,11 +5621,6 @@ parameters:
 			path: src/Database/Designer/Common.php
 
 		-
-			message: "#^Only booleans are allowed in &&, array\\|false given on the left side\\.$#"
-			count: 1
-			path: src/Database/Designer/Common.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
 			count: 1
 			path: src/Database/Designer/Common.php
@@ -5648,11 +5628,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an if condition, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
 			count: 2
-			path: src/Database/Designer/Common.php
-
-		-
-			message: "#^Parameter \\#1 \\$identifier of static method PhpMyAdmin\\\\Util\\:\\:backquote\\(\\) expects string\\|Stringable\\|null, mixed given\\.$#"
-			count: 1
 			path: src/Database/Designer/Common.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4421,7 +4421,7 @@ parameters:
 			path: src/Controllers/Table/ReplaceController.php
 
 		-
-			message: "#^Parameter \\#1 \\$array of function array_values expects array, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$array of function array_values expects array\\<T\\>, mixed given\\.$#"
 			count: 1
 			path: src/Controllers/Table/ReplaceController.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8454,12 +8454,12 @@
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$comments[$fieldName]]]></code>
+      <code><![CDATA[$foreigners[$fieldName]]]></code>
+      <code><![CDATA[$foreigners[$fieldName]]]></code>
+      <code><![CDATA[$foreigners[$fieldName]['foreign_field']]]></code>
+      <code><![CDATA[$foreigners[$fieldName]['foreign_table']]]></code>
       <code><![CDATA[$mimeMap[$fieldName]]]></code>
       <code><![CDATA[$mimeMap[$fieldName]['mimetype']]]></code>
-      <code><![CDATA[$resRel[$fieldName]]]></code>
-      <code><![CDATA[$resRel[$fieldName]]]></code>
-      <code><![CDATA[$resRel[$fieldName]['foreign_field']]]></code>
-      <code><![CDATA[$resRel[$fieldName]['foreign_table']]]></code>
       <code><![CDATA[$this->pagedim[$oldpage]]]></code>
       <code><![CDATA[$this->pagedim[$oldpage]]]></code>
       <code><![CDATA[$this->pagedim[$oldpage]['olm']]]></code>
@@ -8561,6 +8561,8 @@
     </MixedAssignment>
     <MixedOperand>
       <code><![CDATA[$availableWidth]]></code>
+      <code><![CDATA[$foreigners[$fieldName]['foreign_field']]]></code>
+      <code><![CDATA[$foreigners[$fieldName]['foreign_table']]]></code>
       <code><![CDATA[$fullwidth]]></code>
       <code><![CDATA[$fullwidth]]></code>
       <code><![CDATA[$fullwidth]]></code>
@@ -8581,8 +8583,6 @@
       <code><![CDATA[$maxpage]]></code>
       <code><![CDATA[$maxpage]]></code>
       <code><![CDATA[$maxpage]]></code>
-      <code><![CDATA[$resRel[$fieldName]['foreign_field']]]></code>
-      <code><![CDATA[$resRel[$fieldName]['foreign_table']]]></code>
       <code><![CDATA[$sColWidth]]></code>
       <code><![CDATA[$sColWidth]]></code>
       <code><![CDATA[$sColWidth]]></code>
@@ -8625,9 +8625,9 @@
       <code><![CDATA[$comments]]></code>
       <code><![CDATA[$data]]></code>
       <code><![CDATA[$data]]></code>
+      <code><![CDATA[$foreigners]]></code>
+      <code><![CDATA[$foreigners]]></code>
       <code><![CDATA[$mimeMap]]></code>
-      <code><![CDATA[$resRel]]></code>
-      <code><![CDATA[$resRel]]></code>
     </PossiblyUndefinedVariable>
     <PropertyNotSetInConstructor>
       <code><![CDATA[$results]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -755,9 +755,6 @@
       <code><![CDATA[$this->config->selectedServer['column_info']]]></code>
       <code><![CDATA[$this->config->selectedServer['column_info']]]></code>
     </PossiblyFalseArgument>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$foreigners]]></code>
-    </PossiblyInvalidArgument>
     <PossiblyUnusedReturnValue>
       <code><![CDATA[bool]]></code>
     </PossiblyUnusedReturnValue>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -759,8 +759,6 @@
     </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[! $maxTime]]></code>
-      <code><![CDATA[$foreigner]]></code>
-      <code><![CDATA[$foreigner]]></code>
       <code><![CDATA[$relationParams[$work]]]></code>
       <code><![CDATA[empty($this->config->selectedServer[$feature])]]></code>
       <code><![CDATA[empty($this->config->selectedServer['bookmarktable'])]]></code>
@@ -4610,7 +4608,6 @@
       <code><![CDATA[$_POST['t_x'][$key]]]></code>
       <code><![CDATA[$_POST['t_y'][$key]]]></code>
       <code><![CDATA[$db]]></code>
-      <code><![CDATA[$foreigner['constraint']]]></code>
       <code><![CDATA[$tab]]></code>
       <code><![CDATA[$value['foreign_field']]]></code>
     </MixedArgument>
@@ -4662,9 +4659,6 @@
     <PossiblyNullOperand>
       <code><![CDATA[$oneKey->refTableName]]></code>
     </PossiblyNullOperand>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$foreigner]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Database/Designer/DesignerTable.php">
     <PossiblyUnusedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3813,7 +3813,6 @@
       <code><![CDATA[(int) $config->settings['MaxRows']]]></code>
     </RedundantCastGivenDocblockType>
     <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$searchColumnInForeigners]]></code>
       <code><![CDATA[empty($row->collation)]]></code>
     </RiskyTruthyFalsyComparison>
   </file>
@@ -4153,7 +4152,6 @@
       <code><![CDATA[$_POST['maxPlotLimit']]]></code>
     </RiskyCast>
     <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$searchColumnInForeigners]]></code>
       <code><![CDATA[empty($_POST['maxPlotLimit'])]]></code>
       <code><![CDATA[empty($row->collation)]]></code>
     </RiskyTruthyFalsyComparison>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -703,8 +703,6 @@
       <code><![CDATA[$_SESSION['sql_history']]]></code>
       <code><![CDATA[$_SESSION['sql_history']]]></code>
       <code><![CDATA[$_SESSION['sql_history']]]></code>
-      <code><![CDATA[$childReferences]]></code>
-      <code><![CDATA[$childReferences]]></code>
       <code><![CDATA[$column['DATA_TYPE']]]></code>
       <code><![CDATA[$columns['table_name']]]></code>
       <code><![CDATA[$columns['table_schema']]]></code>
@@ -720,8 +718,6 @@
     <MixedArrayAccess>
       <code><![CDATA[$column['COLUMN_NAME']]]></code>
       <code><![CDATA[$column['DATA_TYPE']]]></code>
-      <code><![CDATA[$columns['table_name']]]></code>
-      <code><![CDATA[$columns['table_schema']]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
       <code><![CDATA[$_SESSION['sql_history'][]]]></code>
@@ -730,9 +726,7 @@
       <code><![CDATA[$foreign[$key]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
-      <code><![CDATA[$childReferences]]></code>
       <code><![CDATA[$column]]></code>
-      <code><![CDATA[$columns]]></code>
       <code><![CDATA[$foreignDb]]></code>
       <code><![CDATA[$foreignField]]></code>
       <code><![CDATA[$foreignTable]]></code>
@@ -749,6 +743,13 @@
       <code><![CDATA[$column['COLUMN_NAME']]]></code>
       <code><![CDATA[$foreigners[$column]]]></code>
     </MixedReturnStatement>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->dbi->fetchResult(
+                $relQuery,
+                ['referenced_column_name', null],
+            )]]></code>
+      <code><![CDATA[array<list<mixed[]>>]]></code>
+    </MixedReturnTypeCoercion>
     <PossiblyFalseArgument>
       <code><![CDATA[$this->config->selectedServer['column_info']]]></code>
       <code><![CDATA[$this->config->selectedServer['column_info']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -737,8 +737,6 @@
       <code><![CDATA[$foreignField]]></code>
       <code><![CDATA[$foreignTable]]></code>
       <code><![CDATA[$foreign[$key]]]></code>
-      <code><![CDATA[$foreigners[$column]]]></code>
-      <code><![CDATA[$foreigners['foreign_keys_data']]]></code>
       <code><![CDATA[$key]]></code>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
@@ -3657,11 +3655,6 @@
     <InvalidArgument>
       <code><![CDATA[usort($tables, strnatcasecmp(...))]]></code>
     </InvalidArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[array_key_exists('foreign_keys_data', $relationsForeign)
-                    ? $relationsForeign['foreign_keys_data']
-                    : []]]></code>
-    </MixedArgumentTypeCoercion>
     <PossiblyInvalidArgument>
       <code><![CDATA[$_POST['destination_column']]]></code>
       <code><![CDATA[$_POST['destination_db']]]></code>

--- a/resources/templates/table/search/input_box.twig
+++ b/resources/templates/table/search/input_box.twig
@@ -1,5 +1,5 @@
 {# Get inputbox based on different column types (Foreign key, geometrical, enum) #}
-{% if foreigners and search_column_in_foreigners %}
+{% if has_foreigner %}
     {% if foreign_data.dispRow is iterable %}
         <select name="criteriaValues[{{ column_index }}]"
             id="{{ column_id }}{{ column_index }}">

--- a/resources/templates/table/zoom_search/result_form.twig
+++ b/resources/templates/table/zoom_search/result_form.twig
@@ -55,7 +55,6 @@
                           'html_attributes': '',
                           'column_id': column_types[column_index] ? 'edit_fieldID_' : 'fieldID_',
                           'in_zoom_search_edit': true,
-                          'foreigners': foreigners,
                           'column_name': field_popup,
                           'column_name_hash': column_names_hashes[field_popup],
                           'foreign_data': foreign_data[column_index],
@@ -65,7 +64,7 @@
                           'db': db,
                           'in_fbs': false,
                           'foreign_dropdown': foreign_dropdown[column_index] ?? '',
-                          'search_column_in_foreigners': search_columns_in_foreigners[column_index],
+                          'has_foreigner': search_columns_in_foreigners[column_index],
                           'is_integer': column_data_types[column_index] == 'INT',
                           'is_float': column_data_types[column_index] == 'FLOAT',
                         } only %}

--- a/src/ConfigStorage/Relation.php
+++ b/src/ConfigStorage/Relation.php
@@ -887,17 +887,17 @@ class Relation
     /**
      * Gets foreign keys in preparation for a drop-down selector
      *
-     * @param mixed[]|bool $foreigners    array of the foreign keys
-     * @param string       $field         the foreign field name
-     * @param bool         $overrideTotal whether to override the total
-     * @param string       $foreignFilter a possible filter
-     * @param string       $foreignLimit  a possible LIMIT clause
-     * @param bool         $getTotal      optional, whether to get total num of rows
-     *                                    in $foreignData['the_total;]
-     *                                    (has an effect of performance)
+     * @param mixed[] $foreigners    array of the foreign keys
+     * @param string  $field         the foreign field name
+     * @param bool    $overrideTotal whether to override the total
+     * @param string  $foreignFilter a possible filter
+     * @param string  $foreignLimit  a possible LIMIT clause
+     * @param bool    $getTotal      optional, whether to get total num of rows
+     *                               in $foreignData['the_total;]
+     *                               (has an effect of performance)
      */
     public function getForeignData(
-        array|bool $foreigners,
+        array $foreigners,
         string $field,
         bool $overrideTotal,
         string $foreignFilter,
@@ -909,7 +909,7 @@ class Relation
         $foreignLink = false;
         $dispRow = $foreignDisplay = $theTotal = $foreignField = null;
         do {
-            if ($foreigners === false || $foreigners === []) {
+            if ($foreigners === []) {
                 break;
             }
 

--- a/src/ConfigStorage/Relation.php
+++ b/src/ConfigStorage/Relation.php
@@ -1248,7 +1248,7 @@ class Relation
      * @param string $table  name of master table.
      * @param string $column name of master table column.
      *
-     * @return mixed[]
+     * @return array<list<mixed[]>>
      */
     public function getChildReferences(string $db, string $table, string $column = ''): array
     {
@@ -1277,11 +1277,11 @@ class Relation
     /**
      * Check child table references and foreign key for a table column.
      *
-     * @param string                $db                  name of master table db.
-     * @param string                $table               name of master table.
-     * @param string                $column              name of master table column.
-     * @param list<ForeignKey>|null $foreignersFull      foreigners array for the whole table.
-     * @param mixed[]|null          $childReferencesFull child references for the whole table.
+     * @param string                    $db                  name of master table db.
+     * @param string                    $table               name of master table.
+     * @param string                    $column              name of master table column.
+     * @param list<ForeignKey>|null     $foreignersFull      foreigners array for the whole table.
+     * @param array<list<mixed[]>>|null $childReferencesFull child references for the whole table.
      *
      * @return array<string, mixed> telling about references if foreign key.
      * @psalm-return array{isEditable: bool, isForeignKey: bool, isReferenced: bool, references: string[]}
@@ -1313,9 +1313,9 @@ class Relation
             $childReferences = $this->getChildReferences($db, $table, $column);
         }
 
-        if (count($childReferences) > 0 || $foreigner) {
+        if ($childReferences !== [] || $foreigner) {
             $columnStatus['isEditable'] = false;
-            if (count($childReferences) > 0) {
+            if ($childReferences !== []) {
                 $columnStatus['isReferenced'] = true;
                 foreach ($childReferences as $columns) {
                     $columnStatus['references'][] = Util::backquote($columns['table_schema'])

--- a/src/ConfigStorage/Relation.php
+++ b/src/ConfigStorage/Relation.php
@@ -1351,7 +1351,14 @@ class Relation
     /**
      * @param list<ForeignKey> $foreignKeysData
      *
-     * @return non-empty-array<string, string|null>|false
+     * @return false|array{
+     *  foreign_field: string,
+     *  foreign_db: string,
+     *  foreign_table: string|null,
+     *  constraint: string|null,
+     *  on_update: string,
+     *  on_delete: string
+     * }
      */
     public function getColumnFromForeignKeysData(array $foreignKeysData, string $column): array|false
     {

--- a/src/Controllers/BrowseForeignersController.php
+++ b/src/Controllers/BrowseForeignersController.php
@@ -48,10 +48,9 @@ final class BrowseForeignersController implements InvocableController
         $header->disableMenuAndConsole();
         $header->setBodyId('body_browse_foreigners');
 
-        $foreigners = $this->relation->getForeigners($database, $table);
         $foreignLimit = $this->browseForeigners->getForeignLimit($foreignShowAll);
         $foreignData = $this->relation->getForeignData(
-            $foreigners,
+            $this->relation->getForeigners($database, $table),
             $field,
             true,
             $foreignFilter,

--- a/src/Controllers/Operations/TableController.php
+++ b/src/Controllers/Operations/TableController.php
@@ -466,7 +466,7 @@ final class TableController implements InvocableController
             $databaseList = $listDatabase->getList();
         }
 
-        $hasForeignKeys = $this->relation->getForeigners(Current::$database, Current::$table, '', 'foreign') !== [];
+        $hasForeignKeys = $this->relation->getForeignKeysData(Current::$database, Current::$table) !== [];
         $hasPrivileges = $userPrivileges->table && $userPrivileges->column && $userPrivileges->isReload;
         $switchToNew = isset($_SESSION['pma_switch_to_new']) && $_SESSION['pma_switch_to_new'];
 

--- a/src/Controllers/Table/RelationController.php
+++ b/src/Controllers/Table/RelationController.php
@@ -299,8 +299,6 @@ final class RelationController implements InvocableController
             'table' => Current::$table,
             'relation_parameters' => $relationParameters,
             'tbl_storage_engine' => $storageEngine,
-            'existrel' => $relations,
-            'existrel_foreign' => $existrelForeign,
             'options_array' => $options,
             'internal_relation_columns' => $internalRelationColumns,
             'url_params' => $GLOBALS['urlParams'],

--- a/src/Controllers/Table/ReplaceController.php
+++ b/src/Controllers/Table/ReplaceController.php
@@ -381,7 +381,7 @@ final class ReplaceController implements InvocableController
     {
         $relFieldsList = $request->getParsedBodyParam('rel_fields_list', '');
         if ($relFieldsList !== '') {
-            $map = $this->relation->getForeigners(Current::$database, Current::$table);
+            $foreigners = $this->relation->getForeigners(Current::$database, Current::$table);
 
             /** @var array<int,array> $relationFields */
             $relationFields = [];
@@ -393,12 +393,12 @@ final class ReplaceController implements InvocableController
                     $whereComparison = "='" . $relationFieldValue . "'";
                     $dispval = $this->insertEdit->getDisplayValueForForeignTableColumn(
                         $whereComparison,
-                        $map,
+                        $foreigners,
                         $relationField,
                     );
 
                     $extraData['relations'][$cellIndex] = $this->insertEdit->getLinkForRelationalDisplayField(
-                        $map,
+                        $foreigners,
                         $relationField,
                         $whereComparison,
                         $dispval,

--- a/src/Controllers/Table/SearchController.php
+++ b/src/Controllers/Table/SearchController.php
@@ -373,11 +373,9 @@ final class SearchController implements InvocableController
             $this->columnNames[$columnIndex],
         );
 
-        if (
-            $this->foreigners
-            && $searchColumnInForeigners
-            && $foreignData->dispRow !== null
-        ) {
+        $hasForeigner = $searchColumnInForeigners !== false && $searchColumnInForeigners !== [];
+
+        if ($hasForeigner && $foreignData->dispRow !== null) {
             $foreignDropdown = $this->relation->foreignDropdown(
                 $foreignData->dispRow,
                 $foreignData->foreignField,
@@ -394,7 +392,6 @@ final class SearchController implements InvocableController
             'html_attributes' => $htmlAttributes,
             'column_id' => 'fieldID_',
             'in_zoom_search_edit' => false,
-            'foreigners' => $this->foreigners,
             'column_name' => $this->columnNames[$columnIndex],
             'column_name_hash' => md5($this->columnNames[$columnIndex]),
             'foreign_data' => $foreignData,
@@ -404,7 +401,7 @@ final class SearchController implements InvocableController
             'db' => Current::$database,
             'in_fbs' => true,
             'foreign_dropdown' => $foreignDropdown,
-            'search_column_in_foreigners' => $searchColumnInForeigners,
+            'has_foreigner' => $hasForeigner,
             'is_integer' => $isInteger,
             'is_float' => $isFloat,
         ]);

--- a/src/Controllers/Table/ZoomSearchController.php
+++ b/src/Controllers/Table/ZoomSearchController.php
@@ -395,8 +395,7 @@ final class ZoomSearchController implements InvocableController
                 $columnName,
             );
             if (
-                $this->foreigners === []
-                || $searchColumnInForeigners[$columnIndex] === []
+                $searchColumnInForeigners[$columnIndex] === []
                 || $searchColumnInForeigners[$columnIndex] === false
                 || $foreignData[$columnIndex]->dispRow === null
             ) {
@@ -427,7 +426,6 @@ final class ZoomSearchController implements InvocableController
             'table' => Current::$table,
             'column_names' => $this->columnNames,
             'column_names_hashes' => $columnNamesHashes,
-            'foreigners' => $this->foreigners,
             'column_null_flags' => $this->columnNullFlags,
             'column_types' => $this->columnTypes,
             'column_data_types' => $columnDataTypes,
@@ -490,22 +488,22 @@ final class ZoomSearchController implements InvocableController
         $htmlAttributes .= ' onfocus="return '
                         . 'verifyAfterSearchFieldChange(' . $searchIndex . ', \'#zoom_search_form\')"';
 
-        $searchColumnInForeigners = false;
         $foreignDropdown = '';
-        if ($this->foreigners) {
-            $searchColumnInForeigners = $this->relation->searchColumnInForeigners(
-                $this->foreigners,
-                $this->columnNames[$columnIndex],
+        $searchColumnInForeigners = $this->relation->searchColumnInForeigners(
+            $this->foreigners,
+            $this->columnNames[$columnIndex],
+        );
+
+        $hasForeigner = $searchColumnInForeigners !== false && $searchColumnInForeigners !== [];
+
+        if ($hasForeigner && $foreignData->dispRow !== null) {
+            $foreignDropdown = $this->relation->foreignDropdown(
+                $foreignData->dispRow,
+                $foreignData->foreignField,
+                $foreignData->foreignDisplay,
+                '',
+                Config::getInstance()->settings['ForeignKeyMaxLimit'],
             );
-            if ($searchColumnInForeigners && $foreignData->dispRow !== null) {
-                $foreignDropdown = $this->relation->foreignDropdown(
-                    $foreignData->dispRow,
-                    $foreignData->foreignField,
-                    $foreignData->foreignDisplay,
-                    '',
-                    Config::getInstance()->settings['ForeignKeyMaxLimit'],
-                );
-            }
         }
 
         $value = $this->template->render('table/search/input_box', [
@@ -515,7 +513,6 @@ final class ZoomSearchController implements InvocableController
             'html_attributes' => $htmlAttributes,
             'column_id' => 'fieldID_',
             'in_zoom_search_edit' => false,
-            'foreigners' => $this->foreigners,
             'column_name' => $this->columnNames[$columnIndex],
             'column_name_hash' => md5($this->columnNames[$columnIndex]),
             'foreign_data' => $foreignData,
@@ -525,7 +522,7 @@ final class ZoomSearchController implements InvocableController
             'db' => Current::$database,
             'in_fbs' => true,
             'foreign_dropdown' => $foreignDropdown,
-            'search_column_in_foreigners' => $searchColumnInForeigners,
+            'has_foreigner' => $hasForeigner,
             'is_integer' => $isInteger,
             'is_float' => $isFloat,
         ]);

--- a/src/Database/Designer/Common.php
+++ b/src/Database/Designer/Common.php
@@ -11,7 +11,6 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Dbal\ConnectionType;
 use PhpMyAdmin\Index;
 use PhpMyAdmin\Query\Generator as QueryGenerator;
-use PhpMyAdmin\SqlParser\Utils\ForeignKey as UtilsForeignKey;
 use PhpMyAdmin\Table\Table;
 use PhpMyAdmin\Util;
 use PhpMyAdmin\Utils\ForeignKey;
@@ -129,10 +128,7 @@ class Common
                 $i++;
             }
 
-            $row = $this->relation->getForeigners(Current::$database, $val, '', 'foreign');
-
-            /** @var UtilsForeignKey $oneKey */
-            foreach ($row['foreign_keys_data'] as $oneKey) {
+            foreach ($this->relation->getForeignKeysData(Current::$database, $val) as $oneKey) {
                 foreach ($oneKey->indexList as $index => $oneField) {
                     $con['C_NAME'][$i] = rawurlencode($oneKey->constraint);
                     $con['DTN'][$i] = rawurlencode(Current::$database . '.' . $val);
@@ -492,8 +488,8 @@ class Common
         // native foreign key
         if (ForeignKey::isSupported($typeT1) && $typeT1 === $typeT2) {
             // relation exists?
-            $existRelForeign = $this->relation->getForeigners($db2, $t2, '', 'foreign');
-            $foreigner = $this->relation->searchColumnInForeigners($existRelForeign, $f2);
+            $existRelForeign = $this->relation->getForeignKeysData($db2, $t2);
+            $foreigner = $this->relation->searchColumnInForeigners(['foreign_keys_data' => $existRelForeign], $f2);
             if ($foreigner && isset($foreigner['constraint'])) {
                 return [false, __('Error: relationship already exists.')];
             }
@@ -606,8 +602,8 @@ class Common
 
         if (ForeignKey::isSupported($typeT1) && $typeT1 === $typeT2) {
             // InnoDB
-            $existRelForeign = $this->relation->getForeigners($db2, $t2, '', 'foreign');
-            $foreigner = $this->relation->searchColumnInForeigners($existRelForeign, $f2);
+            $existRelForeign = $this->relation->getForeignKeysData($db2, $t2);
+            $foreigner = $this->relation->searchColumnInForeigners(['foreign_keys_data' => $existRelForeign], $f2);
 
             if (is_array($foreigner) && isset($foreigner['constraint'])) {
                 $updQuery = 'ALTER TABLE ' . Util::backquote($db2)

--- a/src/Database/Designer/Common.php
+++ b/src/Database/Designer/Common.php
@@ -21,7 +21,6 @@ use function array_keys;
 use function count;
 use function explode;
 use function in_array;
-use function is_array;
 use function is_string;
 use function json_decode;
 use function json_encode;
@@ -489,8 +488,8 @@ class Common
         if (ForeignKey::isSupported($typeT1) && $typeT1 === $typeT2) {
             // relation exists?
             $existRelForeign = $this->relation->getForeignKeysData($db2, $t2);
-            $foreigner = $this->relation->searchColumnInForeigners(['foreign_keys_data' => $existRelForeign], $f2);
-            if ($foreigner && isset($foreigner['constraint'])) {
+            $foreigner = $this->relation->getColumnFromForeignKeysData($existRelForeign, $f2);
+            if ($foreigner !== false && isset($foreigner['constraint'])) {
                 return [false, __('Error: relationship already exists.')];
             }
 
@@ -603,9 +602,9 @@ class Common
         if (ForeignKey::isSupported($typeT1) && $typeT1 === $typeT2) {
             // InnoDB
             $existRelForeign = $this->relation->getForeignKeysData($db2, $t2);
-            $foreigner = $this->relation->searchColumnInForeigners(['foreign_keys_data' => $existRelForeign], $f2);
+            $foreigner = $this->relation->getColumnFromForeignKeysData($existRelForeign, $f2);
 
-            if (is_array($foreigner) && isset($foreigner['constraint'])) {
+            if ($foreigner !== false && isset($foreigner['constraint'])) {
                 $updQuery = 'ALTER TABLE ' . Util::backquote($db2)
                     . '.' . Util::backquote($t2) . ' DROP FOREIGN KEY '
                     . Util::backquote($foreigner['constraint']) . ';';

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -3479,10 +3479,6 @@ class Results
         // the name related to a numeric id).
         $existRel = $this->relation->getForeigners($this->db, $this->table, '', self::POSITION_BOTH);
 
-        if ($existRel === []) {
-            return [];
-        }
-
         $map = [];
         foreach ($existRel as $masterField => $rel) {
             if ($masterField !== 'foreign_keys_data') {

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -3476,14 +3476,9 @@ class Results
         // configuration storage. If no PMA storage, we won't be able
         // to use the "column to display" notion (for example show
         // the name related to a numeric id).
-        $existRel = $this->relation->getForeigners($this->db, $this->table, '', self::POSITION_BOTH);
 
         $map = [];
-        foreach ($existRel as $masterField => $rel) {
-            if ($masterField === 'foreign_keys_data') {
-                continue;
-            }
-
+        foreach ($this->relation->getForeigners($this->db, $this->table, '', 'internal') as $masterField => $rel) {
             $map[$masterField] = new ForeignKeyRelatedTable(
                 $rel['foreign_table'],
                 $rel['foreign_field'],

--- a/src/InsertEdit.php
+++ b/src/InsertEdit.php
@@ -976,18 +976,18 @@ class InsertEdit
      * Column to display from the foreign table?
      *
      * @param string  $whereComparison string that contain relation field value
-     * @param mixed[] $map             all Relations to foreign tables for a given
-     *                                            table or optionally a given column in a table
+     * @param mixed[] $foreigners      all Relations to foreign tables for a given
+     *                                     table or optionally a given column in a table
      * @param string  $relationField   relation field
      *
      * @return string display value from the foreign table
      */
     public function getDisplayValueForForeignTableColumn(
         string $whereComparison,
-        array $map,
+        array $foreigners,
         string $relationField,
     ): string {
-        $foreigner = $this->relation->searchColumnInForeigners($map, $relationField);
+        $foreigner = $this->relation->searchColumnInForeigners($foreigners, $relationField);
 
         if (! is_array($foreigner)) {
             return '';
@@ -1013,8 +1013,8 @@ class InsertEdit
     /**
      * Display option in the cell according to user choices
      *
-     * @param mixed[] $map                all Relations to foreign tables for a given
-     *                                                  table or optionally a given column in a table
+     * @param mixed[] $foreigners         all Relations to foreign tables for a given
+     *                                           table or optionally a given column in a table
      * @param string  $relationField      relation field
      * @param string  $whereComparison    string that contain relation field value
      * @param string  $dispval            display value from the foreign table
@@ -1023,13 +1023,13 @@ class InsertEdit
      * @return string HTML <a> tag
      */
     public function getLinkForRelationalDisplayField(
-        array $map,
+        array $foreigners,
         string $relationField,
         string $whereComparison,
         string $dispval,
         string $relationFieldValue,
     ): string {
-        $foreigner = $this->relation->searchColumnInForeigners($map, $relationField);
+        $foreigner = $this->relation->searchColumnInForeigners($foreigners, $relationField);
 
         if (! is_array($foreigner)) {
             return '';

--- a/src/Plugins/Export/Helpers/Pdf.php
+++ b/src/Plugins/Export/Helpers/Pdf.php
@@ -475,13 +475,12 @@ class Pdf extends PdfLib
          * it will be of use
          */
         // Check if we can use Relations
+        $haveRel = false;
         if ($doRelation) {
             // Find which tables are related with the current one and write it in
             // an array
-            $resRel = $this->relation->getForeigners($db, $table);
-            $haveRel = $resRel !== [];
-        } else {
-            $haveRel = false;
+            $foreigners = $this->relation->getForeigners($db, $table);
+            $haveRel = $foreigners !== [];
         }
 
         //column count and table heading
@@ -573,9 +572,9 @@ class Pdf extends PdfLib
             $fieldName = $column->field;
 
             if ($doRelation && $haveRel) {
-                $data[] = isset($resRel[$fieldName])
-                    ? $resRel[$fieldName]['foreign_table']
-                    . ' (' . $resRel[$fieldName]['foreign_field']
+                $data[] = isset($foreigners[$fieldName])
+                    ? $foreigners[$fieldName]['foreign_table']
+                    . ' (' . $foreigners[$fieldName]['foreign_field']
                     . ')'
                     : '';
             }

--- a/src/Plugins/Schema/Dia/DiaRelationSchema.php
+++ b/src/Plugins/Schema/Dia/DiaRelationSchema.php
@@ -10,7 +10,6 @@ namespace PhpMyAdmin\Plugins\Schema\Dia;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Plugins\Schema\ExportRelationSchema;
-use PhpMyAdmin\SqlParser\Utils\ForeignKey;
 
 use function in_array;
 
@@ -93,44 +92,37 @@ class DiaRelationSchema extends ExportRelationSchema
 
         $seenARelation = false;
         foreach ($alltables as $oneTable) {
-            $existRel = $this->relation->getForeigners($this->db->getName(), $oneTable);
-            if ($existRel === []) {
-                continue;
-            }
+            $existRel = $this->relation->getForeigners($this->db->getName(), $oneTable, '', 'internal');
 
             $seenARelation = true;
             foreach ($existRel as $masterField => $rel) {
                 // put the foreign table on the schema only if selected by the user
-                // (do not use array_search() because we would have to do a === false and this is not PHP3 compatible)
-                if ($masterField !== 'foreign_keys_data') {
-                    if (in_array($rel['foreign_table'], $alltables, true)) {
-                        $this->addRelation(
-                            $oneTable,
-                            $masterField,
-                            $rel['foreign_table'],
-                            $rel['foreign_field'],
-                            $this->showKeys,
-                        );
-                    }
-
+                if (! in_array($rel['foreign_table'], $alltables, true)) {
                     continue;
                 }
 
-                /** @var ForeignKey $oneKey */
-                foreach ($rel as $oneKey) {
-                    if (! in_array($oneKey->refTableName, $alltables, true)) {
-                        continue;
-                    }
+                $this->addRelation(
+                    $oneTable,
+                    $masterField,
+                    $rel['foreign_table'],
+                    $rel['foreign_field'],
+                    $this->showKeys,
+                );
+            }
 
-                    foreach ($oneKey->indexList as $index => $oneField) {
-                        $this->addRelation(
-                            $oneTable,
-                            $oneField,
-                            $oneKey->refTableName,
-                            $oneKey->refIndexList[$index],
-                            $this->showKeys,
-                        );
-                    }
+            foreach ($this->relation->getForeignKeysData($this->db->getName(), $oneTable) as $oneKey) {
+                if (! in_array($oneKey->refTableName, $alltables, true)) {
+                    continue;
+                }
+
+                foreach ($oneKey->indexList as $index => $oneField) {
+                    $this->addRelation(
+                        $oneTable,
+                        $oneField,
+                        $oneKey->refTableName,
+                        $oneKey->refIndexList[$index],
+                        $this->showKeys,
+                    );
                 }
             }
         }

--- a/src/Plugins/Schema/Eps/EpsRelationSchema.php
+++ b/src/Plugins/Schema/Eps/EpsRelationSchema.php
@@ -10,7 +10,6 @@ namespace PhpMyAdmin\Plugins\Schema\Eps;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Plugins\Schema\ExportRelationSchema;
-use PhpMyAdmin\SqlParser\Utils\ForeignKey;
 use PhpMyAdmin\Version;
 
 use function __;
@@ -99,51 +98,41 @@ class EpsRelationSchema extends ExportRelationSchema
 
         $seenARelation = false;
         foreach ($alltables as $oneTable) {
-            $existRel = $this->relation->getForeigners($this->db->getName(), $oneTable);
-            if ($existRel === []) {
-                continue;
-            }
+            $existRel = $this->relation->getForeigners($this->db->getName(), $oneTable, '', 'internal');
 
             $seenARelation = true;
             foreach ($existRel as $masterField => $rel) {
-                /* put the foreign table on the schema only if selected
-                * by the user
-                * (do not use array_search() because we would have to
-                * to do a === false and this is not PHP3 compatible)
-                */
-                if ($masterField !== 'foreign_keys_data') {
-                    if (in_array($rel['foreign_table'], $alltables, true)) {
-                        $this->addRelation(
-                            $oneTable,
-                            $this->eps->getFont(),
-                            $this->eps->getFontSize(),
-                            $masterField,
-                            $rel['foreign_table'],
-                            $rel['foreign_field'],
-                            $this->tableDimension,
-                        );
-                    }
-
+                // put the foreign table on the schema only if selected by the user
+                if (! in_array($rel['foreign_table'], $alltables, true)) {
                     continue;
                 }
 
-                /** @var ForeignKey $oneKey */
-                foreach ($rel as $oneKey) {
-                    if (! in_array($oneKey->refTableName, $alltables, true)) {
-                        continue;
-                    }
+                $this->addRelation(
+                    $oneTable,
+                    $this->eps->getFont(),
+                    $this->eps->getFontSize(),
+                    $masterField,
+                    $rel['foreign_table'],
+                    $rel['foreign_field'],
+                    $this->tableDimension,
+                );
+            }
 
-                    foreach ($oneKey->indexList as $index => $oneField) {
-                        $this->addRelation(
-                            $oneTable,
-                            $this->eps->getFont(),
-                            $this->eps->getFontSize(),
-                            $oneField,
-                            $oneKey->refTableName,
-                            $oneKey->refIndexList[$index],
-                            $this->tableDimension,
-                        );
-                    }
+            foreach ($this->relation->getForeignKeysData($this->db->getName(), $oneTable) as $oneKey) {
+                if (! in_array($oneKey->refTableName, $alltables, true)) {
+                    continue;
+                }
+
+                foreach ($oneKey->indexList as $index => $oneField) {
+                    $this->addRelation(
+                        $oneTable,
+                        $this->eps->getFont(),
+                        $this->eps->getFontSize(),
+                        $oneField,
+                        $oneKey->refTableName,
+                        $oneKey->refIndexList[$index],
+                        $this->tableDimension,
+                    );
                 }
             }
         }

--- a/src/Plugins/Schema/Pdf/PdfRelationSchema.php
+++ b/src/Plugins/Schema/Pdf/PdfRelationSchema.php
@@ -550,7 +550,7 @@ class PdfRelationSchema extends ExportRelationSchema
 
             // Find which tables are related with the current one and write it in
             // an array
-            $resRel = $this->relation->getForeigners($this->db->getName(), $table);
+            $foreigners = $this->relation->getForeigners($this->db->getName(), $table);
 
             /**
              * Displays the comments of the table if MySQL >= 3.23
@@ -654,7 +654,7 @@ class PdfRelationSchema extends ExportRelationSchema
                 $this->pdf->customLinks['RT'][$table][$fieldName] = $this->pdf->AddLink();
                 $this->pdf->Bookmark($fieldName, 1, -1);
                 $this->pdf->setLink($this->pdf->customLinks['doc'][$table][$fieldName], -1);
-                $foreigner = $this->relation->searchColumnInForeigners($resRel, $fieldName);
+                $foreigner = $this->relation->searchColumnInForeigners($foreigners, $fieldName);
 
                 $linksTo = '';
                 if ($foreigner) {

--- a/src/Plugins/Schema/Pdf/PdfRelationSchema.php
+++ b/src/Plugins/Schema/Pdf/PdfRelationSchema.php
@@ -13,7 +13,6 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Pdf as PdfLib;
 use PhpMyAdmin\Plugins\Schema\ExportRelationSchema;
-use PhpMyAdmin\SqlParser\Utils\ForeignKey;
 use PhpMyAdmin\Transformations;
 use PhpMyAdmin\Util;
 
@@ -197,34 +196,25 @@ class PdfRelationSchema extends ExportRelationSchema
         // and finding its foreigns is OK (then we can support innodb)
         $seenARelation = false;
         foreach ($alltables as $oneTable) {
-            $existRel = $this->relation->getForeigners($this->db->getName(), $oneTable);
-            if ($existRel === []) {
-                continue;
-            }
+            $existRel = $this->relation->getForeigners($this->db->getName(), $oneTable, '', 'internal');
 
             $seenARelation = true;
             foreach ($existRel as $masterField => $rel) {
-                // put the foreign table on the schema only if selected
-                // by the user
-                // (do not use array_search() because we would have to
-                // to do a === false and this is not PHP3 compatible)
-                if ($masterField !== 'foreign_keys_data') {
-                    if (in_array($rel['foreign_table'], $alltables, true)) {
-                        $this->addRelation($oneTable, $masterField, $rel['foreign_table'], $rel['foreign_field']);
-                    }
-
+                // put the foreign table on the schema only if selected by the user
+                if (! in_array($rel['foreign_table'], $alltables, true)) {
                     continue;
                 }
 
-                /** @var ForeignKey $oneKey */
-                foreach ($rel as $oneKey) {
-                    if (! in_array($oneKey->refTableName, $alltables, true)) {
-                        continue;
-                    }
+                $this->addRelation($oneTable, $masterField, $rel['foreign_table'], $rel['foreign_field']);
+            }
 
-                    foreach ($oneKey->indexList as $index => $oneField) {
-                        $this->addRelation($oneTable, $oneField, $oneKey->refTableName, $oneKey->refIndexList[$index]);
-                    }
+            foreach ($this->relation->getForeignKeysData($this->db->getName(), $oneTable) as $oneKey) {
+                if (! in_array($oneKey->refTableName, $alltables, true)) {
+                    continue;
+                }
+
+                foreach ($oneKey->indexList as $index => $oneField) {
+                    $this->addRelation($oneTable, $oneField, $oneKey->refTableName, $oneKey->refIndexList[$index]);
                 }
             }
         }

--- a/src/Sql.php
+++ b/src/Sql.php
@@ -223,9 +223,13 @@ class Sql
         string $column,
         string $currentValue,
     ): string {
-        $foreigners = $this->relation->getForeigners($db, $table, $column);
-
-        $foreignData = $this->relation->getForeignData($foreigners, $column, false, '', '');
+        $foreignData = $this->relation->getForeignData(
+            $this->relation->getForeigners($db, $table, $column),
+            $column,
+            false,
+            '',
+            '',
+        );
 
         if ($foreignData->dispRow === null) {
             //Handle the case when number of values

--- a/src/Table/ColumnsDefinition.php
+++ b/src/Table/ColumnsDefinition.php
@@ -140,7 +140,7 @@ final class ColumnsDefinition
             $regenerate = true;
         }
 
-        $foreigners = $this->relation->getForeigners(Current::$database, Current::$table, '', 'foreign');
+        $foreigners = $this->relation->getForeignKeysData(Current::$database, Current::$table);
         $childReferences = null;
         // From MySQL 5.6.6 onwards columns with foreign keys can be renamed.
         // Hence, no need to get child references

--- a/tests/unit/Controllers/Operations/TableControllerTest.php
+++ b/tests/unit/Controllers/Operations/TableControllerTest.php
@@ -72,6 +72,11 @@ class TableControllerTest extends AbstractTestCase
             [[null]],
             ['PARTITION_NAME'],
         );
+        $this->dummyDbi->addResult(
+            'SHOW CREATE TABLE `test_db`.`test_table`',
+            [['test_table', 'CREATE TABLE `test_table` (`ref` int(11) NOT NULL, CONSTRAINT `ref` FOREIGN KEY (`ref`) REFERENCES `refT` (`refC`) ON DELETE CASCADE ON UPDATE CASCADE )']],
+            ['Table', 'Create Table'],
+        );
         // phpcs:enable
 
         $storageEngines = StorageEngine::getArray();

--- a/tests/unit/Plugins/Export/ExportSqlTest.php
+++ b/tests/unit/Plugins/Export/ExportSqlTest.php
@@ -868,8 +868,8 @@ SQL;
         $dbi->expects(self::exactly(2))
             ->method('fetchResult')
             ->willReturn(
-                ['foo' => ['foreign_table' => 'ftable', 'foreign_field' => 'ffield']],
                 ['fieldname' => ['values' => 'test-', 'transformation' => 'testfoo', 'mimetype' => 'test<']],
+                ['foo' => ['foreign_table' => 'ftable', 'foreign_field' => 'ffield']],
             );
 
         DatabaseInterface::$instance = $dbi;


### PR DESCRIPTION
The goal here was to split the `getForeigners()` method and introduce more type safety in the process. It has only been a partial success as `'both'` is still allowed. It's difficult to untangle the whole thing. 