### PR TITLE
Split getForeigners into getForeignersInternal

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10682,12 +10682,12 @@ parameters:
 
 		-
 			message: "#^Cannot access offset mixed on mixed\\.$#"
-			count: 13
+			count: 3
 			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
 
 		-
 			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 4
+			count: 14
 			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
 
 		-
@@ -10721,11 +10721,6 @@ parameters:
 			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
 
 		-
-			message: "#^Parameter \\#1 \\$txt of method TCPDF\\:\\:Bookmark\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
-
-		-
 			message: "#^Parameter \\#1 \\$value of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\Pdf\\\\PdfRelationSchema\\:\\:setTableOrder\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
@@ -10737,31 +10732,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$masterField of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\Pdf\\\\PdfRelationSchema\\:\\:addRelation\\(\\) expects string, int\\|string given\\.$#"
-			count: 1
-			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
-
-		-
-			message: "#^Parameter \\#2 \\$table of method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getComments\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
-
-		-
-			message: "#^Parameter \\#2 \\$table of method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getForeigners\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
-
-		-
-			message: "#^Parameter \\#2 \\$table of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getColumns\\(\\) expects string, mixed given\\.$#"
-			count: 2
-			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
-
-		-
-			message: "#^Parameter \\#2 \\$table of method PhpMyAdmin\\\\Transformations\\:\\:getMime\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
-
-		-
-			message: "#^Parameter \\#2 \\$tableName of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getTable\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Plugins/Schema/Pdf/PdfRelationSchema.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9238,9 +9238,6 @@
     <MixedArgument>
       <code><![CDATA[$mimeMap[$fieldName]['mimetype']]]></code>
       <code><![CDATA[$rel['foreign_field']]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
       <code><![CDATA[$this->pdf->customLinks['RT']['-']]]></code>
       <code><![CDATA[$this->pdf->customLinks['doc'][$table][$fieldName]]]></code>
       <code><![CDATA[$this->pdf->customLinks['doc'][$table]['-']]]></code>
@@ -9272,20 +9269,15 @@
     </MixedArrayAssignment>
     <MixedArrayOffset>
       <code><![CDATA[$foreignTable[$foreigner['foreign_field']]]]></code>
-      <code><![CDATA[$this->pdf->customLinks['RT'][$table]]]></code>
       <code><![CDATA[$this->pdf->customLinks['doc'][$foreigner['foreign_table']]]]></code>
       <code><![CDATA[$this->pdf->customLinks['doc'][$foreigner['foreign_table']]]]></code>
       <code><![CDATA[$this->pdf->customLinks['doc'][$foreigner['foreign_table']][$foreigner['foreign_field']]]]></code>
-      <code><![CDATA[$this->pdf->customLinks['doc'][$table]]]></code>
-      <code><![CDATA[$this->pdf->customLinks['doc'][$table]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
       <code><![CDATA[$attribute]]></code>
       <code><![CDATA[$foreignTable]]></code>
       <code><![CDATA[$links[0]]]></code>
       <code><![CDATA[$links[6]]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
       <code><![CDATA[$type]]></code>
     </MixedAssignment>
     <MixedOperand>
@@ -9294,8 +9286,6 @@
       <code><![CDATA[$foreigner['foreign_table']]]></code>
       <code><![CDATA[$foreigner['on_delete']]]></code>
       <code><![CDATA[$foreigner['on_update']]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
     </MixedOperand>
     <PossiblyInvalidArgument>
       <code><![CDATA[$_REQUEST['pdf_table_order']]]></code>

--- a/src/ConfigStorage/Relation.php
+++ b/src/ConfigStorage/Relation.php
@@ -369,12 +369,27 @@ class Relation
      * @param string $db     the name of the db to check for
      * @param string $table  the name of the table to check for
      * @param string $column the name of the column to check for
-     * @param string $source the source for foreign key information
-     * @psalm-param 'both'|'internal' $source
      *
      * @return array<array<mixed>>
      */
-    public function getForeigners(string $db, string $table, string $column = '', string $source = 'both'): array
+    public function getForeigners(string $db, string $table, string $column = ''): array
+    {
+        $foreign = $this->getForeignersInternal($db, $table, $column);
+
+        if ($table !== '') {
+            $foreign['foreign_keys_data'] = $this->getForeignKeysData($db, $table);
+        }
+
+        return $foreign;
+    }
+
+    /**
+     * Gets all Relations to foreign tables for a given table or
+     * optionally a given column in a table
+     *
+     * @return array<array<mixed>>
+     */
+    public function getForeignersInternal(string $db, string $table, string $column = ''): array
     {
         $relationFeature = $this->getRelationParameters()->relationFeature;
         $foreign = [];
@@ -392,10 +407,6 @@ class Relation
 
             /** @var array<array<string|null>> $foreign */
             $foreign = $this->dbi->fetchResult($relQuery, 'master_field', null, ConnectionType::ControlUser);
-        }
-
-        if ($source === 'both' && $table !== '') {
-            $foreign['foreign_keys_data'] = $this->getForeignKeysData($db, $table);
         }
 
         /**

--- a/src/Controllers/Table/RelationController.php
+++ b/src/Controllers/Table/RelationController.php
@@ -66,7 +66,7 @@ final class RelationController implements InvocableController
 
         $relations = [];
         if ($relationParameters->relationFeature !== null) {
-            $relations = $this->relation->getForeigners(Current::$database, Current::$table, '', 'internal');
+            $relations = $this->relation->getForeignersInternal(Current::$database, Current::$table);
         }
 
         $relationsForeign = [];
@@ -149,7 +149,7 @@ final class RelationController implements InvocableController
 
         // If we did an update, refresh our data
         if (isset($_POST['destination_db']) && $relationParameters->relationFeature !== null) {
-            $relations = $this->relation->getForeigners(Current::$database, Current::$table, '', 'internal');
+            $relations = $this->relation->getForeignersInternal(Current::$database, Current::$table);
         }
 
         if (isset($_POST['destination_foreign_db']) && ForeignKey::isSupported($storageEngine)) {

--- a/src/Database/Designer/Common.php
+++ b/src/Database/Designer/Common.php
@@ -116,7 +116,7 @@ class Common
         while ($val = $allTabRs->fetchRow()) {
             $val = (string) $val[0];
 
-            $row = $this->relation->getForeigners(Current::$database, $val, '', 'internal');
+            $row = $this->relation->getForeignersInternal(Current::$database, $val);
 
             foreach ($row as $field => $value) {
                 $con['C_NAME'][$i] = '';

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -3478,7 +3478,7 @@ class Results
         // the name related to a numeric id).
 
         $map = [];
-        foreach ($this->relation->getForeigners($this->db, $this->table, '', 'internal') as $masterField => $rel) {
+        foreach ($this->relation->getForeignersInternal($this->db, $this->table) as $masterField => $rel) {
             $map[$masterField] = new ForeignKeyRelatedTable(
                 $rel['foreign_table'],
                 $rel['foreign_field'],

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -555,7 +555,7 @@ class Operations
 
         $foreigners = [];
         $this->dbi->selectDb(Current::$database);
-        $foreign = $this->relation->getForeigners(Current::$database, Current::$table, '', 'internal');
+        $foreign = $this->relation->getForeignersInternal(Current::$database, Current::$table);
 
         foreach ($foreign as $master => $arr) {
             $joinQuery = 'SELECT '

--- a/src/Plugins/Export/ExportSql.php
+++ b/src/Plugins/Export/ExportSql.php
@@ -1778,7 +1778,7 @@ class ExportSql extends ExportPlugin
 
         // Check if we can use Relations
         $foreigners = $doRelation && $relationParameters->relationFeature !== null ?
-            $this->relation->getForeigners($db, $table, '', 'internal')
+            $this->relation->getForeignersInternal($db, $table)
             : [];
 
         if ($foreigners !== []) {

--- a/src/Plugins/Schema/Dia/DiaRelationSchema.php
+++ b/src/Plugins/Schema/Dia/DiaRelationSchema.php
@@ -92,7 +92,7 @@ class DiaRelationSchema extends ExportRelationSchema
 
         $seenARelation = false;
         foreach ($alltables as $oneTable) {
-            $existRel = $this->relation->getForeigners($this->db->getName(), $oneTable, '', 'internal');
+            $existRel = $this->relation->getForeignersInternal($this->db->getName(), $oneTable);
 
             $seenARelation = true;
             foreach ($existRel as $masterField => $rel) {

--- a/src/Plugins/Schema/Eps/EpsRelationSchema.php
+++ b/src/Plugins/Schema/Eps/EpsRelationSchema.php
@@ -98,7 +98,7 @@ class EpsRelationSchema extends ExportRelationSchema
 
         $seenARelation = false;
         foreach ($alltables as $oneTable) {
-            $existRel = $this->relation->getForeigners($this->db->getName(), $oneTable, '', 'internal');
+            $existRel = $this->relation->getForeignersInternal($this->db->getName(), $oneTable);
 
             $seenARelation = true;
             foreach ($existRel as $masterField => $rel) {

--- a/src/Plugins/Schema/Pdf/PdfRelationSchema.php
+++ b/src/Plugins/Schema/Pdf/PdfRelationSchema.php
@@ -196,7 +196,7 @@ class PdfRelationSchema extends ExportRelationSchema
         // and finding its foreigns is OK (then we can support innodb)
         $seenARelation = false;
         foreach ($alltables as $oneTable) {
-            $existRel = $this->relation->getForeigners($this->db->getName(), $oneTable, '', 'internal');
+            $existRel = $this->relation->getForeignersInternal($this->db->getName(), $oneTable);
 
             $seenARelation = true;
             foreach ($existRel as $masterField => $rel) {
@@ -438,7 +438,7 @@ class PdfRelationSchema extends ExportRelationSchema
     /**
      * Generates data dictionary pages.
      *
-     * @param mixed[] $alltables Tables to document.
+     * @param string[] $alltables Tables to document.
      */
     public function dataDictionaryDoc(array $alltables): void
     {

--- a/src/Plugins/Schema/Svg/SvgRelationSchema.php
+++ b/src/Plugins/Schema/Svg/SvgRelationSchema.php
@@ -113,7 +113,7 @@ class SvgRelationSchema extends ExportRelationSchema
 
         $seenARelation = false;
         foreach ($alltables as $oneTable) {
-            $existRel = $this->relation->getForeigners($this->db->getName(), $oneTable, '', 'internal');
+            $existRel = $this->relation->getForeignersInternal($this->db->getName(), $oneTable);
             if ($existRel === []) {
                 continue;
             }


### PR DESCRIPTION
@MauricioFauth Thanks for the idea. While it still doesn't address the fact that internal and external is still mixed up, at least we get rid of the `$source` parameter. 

While at it, I also fix a type hint in PdfRelationSchema.