### PR TITLE
Fix #17262 - Add warning when setting a password to a blank value if AllowNoPassword is false

### DIFF
--- a/app/services.php
+++ b/app/services.php
@@ -158,7 +158,7 @@ return [
         'server_plugins' => ['class' => Plugins::class, 'arguments' => ['@dbi']],
         'server_privileges' => [
             'class' => Privileges::class,
-            'arguments' => ['@template', '@dbi', '@relation', '@relation_cleanup', '@server_plugins'],
+            'arguments' => ['@template', '@dbi', '@relation', '@relation_cleanup', '@server_plugins', '@config'],
         ],
         'server_privileges_account_locking' => [
             'class' => AccountLocking::class,

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -700,6 +700,7 @@ return [
                 '$relation' => '@relation',
                 '$dbi' => '@dbi',
                 '$userPrivilegesFactory' => '@' . UserPrivilegesFactory::class,
+                '$config' => '@config',
             ],
         ],
         Server\ReplicationController::class => [

--- a/resources/js/src/server/privileges.ts
+++ b/resources/js/src/server/privileges.ts
@@ -1,6 +1,13 @@
 import $ from 'jquery';
 import { AJAX } from '../modules/ajax.ts';
-import { checkPassword, checkPasswordStrength, checkboxesSel, displayPasswordGenerateButton, getSqlEditor } from '../modules/functions.ts';
+import {
+    checkPassword,
+    checkPasswordStrength,
+    checkboxesSel,
+    displayPasswordGenerateButton,
+    getSqlEditor,
+    shouldShowEmptyPasswordWarning
+} from '../modules/functions.ts';
 import { CommonParams } from '../modules/common.ts';
 import { Navigation } from '../modules/navigation.ts';
 import { ajaxRemoveMessage, ajaxShowMessage } from '../modules/ajax-message.ts';
@@ -475,6 +482,26 @@ const CheckAddUser = {
     }
 };
 
+const CheckEmptyPasswordWhenAllowNoPasswordIsEnabled = {
+    handleEvent: function () {
+        const theForm = this;
+
+        if (shouldShowEmptyPasswordWarning($(theForm))) {
+            $(this).confirm(window.Messages.strPasswordEmptyWhenAllowNoPasswordIsEnabled, '', function () {
+                theForm.submit();
+
+                return true;
+            });
+
+            return false;
+        } else {
+            theForm.submit();
+
+            return true;
+        }
+    }
+};
+
 const selectPasswordRadioWhenChangingPassword = () => {
     $('#nopass_0').prop('checked', true);
 };
@@ -561,4 +588,5 @@ AJAX.registerOnload('server/privileges.js', function () {
 
     $('#addUsersForm').on('submit', CheckAddUser.handleEvent);
     $('#copyUserForm').on('submit', CheckAddUser.handleEvent);
+    $('#change_password_form').on('submit', CheckEmptyPasswordWhenAllowNoPasswordIsEnabled.handleEvent);
 });

--- a/resources/templates/server/privileges/change_password.twig
+++ b/resources/templates/server/privileges/change_password.twig
@@ -1,5 +1,5 @@
 <form method="post" id="change_password_form" action="
-  {{- is_privileges ? url('/server/privileges') : url('/user-password') }}" name="chgPassword" class="{{ is_privileges ? 'submenu-item' }}" autocomplete="off">
+  {{- is_privileges ? url('/server/privileges') : url('/user-password') }}" name="chgPassword" class="{{ is_privileges ? 'submenu-item' }}" autocomplete="off" data-allow-no-password="{{ allow_no_password ? 1 : 0 }}">
   {{ get_hidden_inputs() }}
   {% if is_privileges %}
     <input type="hidden" name="username" value="{{ username }}">

--- a/src/Controllers/JavaScriptMessagesController.php
+++ b/src/Controllers/JavaScriptMessagesController.php
@@ -143,6 +143,11 @@ final class JavaScriptMessagesController implements InvocableController
             'strUserEmpty' => __('The user name is empty!'),
             'strPasswordEmpty' => __('The password is empty!'),
             'strPasswordNotSame' => __('The passwords aren\'t the same!'),
+            'strPasswordEmptyWhenAllowNoPasswordIsEnabled' => __(
+                'You are trying to set this account to log in with no password, but the configuration directive ' .
+                '<code>AllowNoPassword</code> is false. If you proceed, the account will not be able to log in through ' .
+                'phpMyAdmin.',
+            ),
             'strRemovingSelectedUsers' => __('Removing Selected Users'),
             'strClose' => __('Close'),
             'strLock' => _pgettext('Lock the account.', 'Lock'),

--- a/src/Controllers/JavaScriptMessagesController.php
+++ b/src/Controllers/JavaScriptMessagesController.php
@@ -145,8 +145,8 @@ final class JavaScriptMessagesController implements InvocableController
             'strPasswordNotSame' => __('The passwords aren\'t the same!'),
             'strPasswordEmptyWhenAllowNoPasswordIsEnabled' => __(
                 'You are trying to set this account to log in with no password, but the configuration directive ' .
-                '<code>AllowNoPassword</code> is false. If you proceed, the account will not be able to log in through ' .
-                'phpMyAdmin.',
+                '<code>AllowNoPassword</code> is false. If you proceed, the account will not be able to log in ' .
+                'through phpMyAdmin.',
             ),
             'strRemovingSelectedUsers' => __('Removing Selected Users'),
             'strClose' => __('Close'),

--- a/src/Controllers/Server/PrivilegesController.php
+++ b/src/Controllers/Server/PrivilegesController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Server;
 
+use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\Controllers\InvocableController;
@@ -38,6 +39,7 @@ final class PrivilegesController implements InvocableController
         private readonly Relation $relation,
         private readonly DatabaseInterface $dbi,
         private readonly UserPrivilegesFactory $userPrivilegesFactory,
+        private readonly Config $config,
     ) {
     }
 
@@ -62,6 +64,7 @@ final class PrivilegesController implements InvocableController
             $this->relation,
             $relationCleanup,
             new Plugins($this->dbi),
+            $this->config,
         );
 
         $this->response->addHTML('<div class="container-fluid">');

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -2044,11 +2044,6 @@ class DatabaseInterface implements DbalInterface
         return $this->databaseList;
     }
 
-    public function getConfig(): Config
-    {
-        return $this->config;
-    }
-
     /**
      * Returns the number of warnings from the last query.
      */

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -2044,6 +2044,11 @@ class DatabaseInterface implements DbalInterface
         return $this->databaseList;
     }
 
+    public function getConfig(): Config
+    {
+        return $this->config;
+    }
+
     /**
      * Returns the number of warnings from the last query.
      */

--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -76,6 +76,7 @@ class Privileges
         public Relation $relation,
         private RelationCleanup $relationCleanup,
         private Plugins $plugins,
+        private readonly Config $config,
     ) {
     }
 
@@ -3270,7 +3271,7 @@ class Privileges
             'has_more_auth_plugins' => $hasMoreAuthPlugins,
             'active_auth_plugins' => $activeAuthPlugins,
             'orig_auth_plugin' => $origAuthPlugin,
-            'allow_no_password' => $this->dbi->getConfig()->selectedServer['AllowNoPassword'],
+            'allow_no_password' => $this->config->selectedServer['AllowNoPassword'],
         ]);
     }
 

--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -3270,6 +3270,7 @@ class Privileges
             'has_more_auth_plugins' => $hasMoreAuthPlugins,
             'active_auth_plugins' => $activeAuthPlugins,
             'orig_auth_plugin' => $origAuthPlugin,
+            'allow_no_password' => $this->dbi->getConfig()->selectedServer['AllowNoPassword'],
         ]);
     }
 

--- a/tests/unit/Controllers/Server/PrivilegesControllerTest.php
+++ b/tests/unit/Controllers/Server/PrivilegesControllerTest.php
@@ -75,6 +75,7 @@ class PrivilegesControllerTest extends AbstractTestCase
             new Relation($this->dbi),
             $this->dbi,
             new UserPrivilegesFactory($this->dbi),
+            new Config(),
         ))($request);
 
         $actual = $response->getHTMLResult();

--- a/tests/unit/Server/PrivilegesTest.php
+++ b/tests/unit/Server/PrivilegesTest.php
@@ -1889,6 +1889,7 @@ class PrivilegesTest extends AbstractTestCase
             $relation,
             new RelationCleanup($this->dbi, $relation),
             new Plugins($this->dbi),
+            new Config(),
         );
         $method = new ReflectionMethod(Privileges::class, 'getUserPrivileges');
 
@@ -1902,7 +1903,14 @@ class PrivilegesTest extends AbstractTestCase
     {
         $relation = new Relation($dbi);
 
-        return new Privileges(new Template(), $dbi, $relation, new RelationCleanup($dbi, $relation), new Plugins($dbi));
+        return new Privileges(
+            new Template(),
+            $dbi,
+            $relation,
+            new RelationCleanup($dbi, $relation),
+            new Plugins($dbi),
+            new Config(),
+        );
     }
 
     /**

--- a/tests/unit/UserPasswordTest.php
+++ b/tests/unit/UserPasswordTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests;
 
+use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\Message;
@@ -35,6 +36,7 @@ class UserPasswordTest extends AbstractTestCase
             $relation,
             new RelationCleanup($dbi, $relation),
             new Plugins($dbi),
+            new Config(),
         );
         $this->object = new UserPassword(
             $serverPrivileges,


### PR DESCRIPTION
### Description

Fixes #17262 : Changing password should respect `AllowNoPassword`.

If `AllowNoPassword` is `false` then a warning modal will be displayed, both under the "Change password" link on the main page and in the change password section on the "User accounts" tab.

![r1](https://github.com/user-attachments/assets/a90fa0bc-3f72-4db3-ba26-b2e4244db89a)
![r2](https://github.com/user-attachments/assets/31aa3afa-0cc9-4a78-b89c-c946f41faea2)


