### PR TITLE
Fix input size for hexadecimal values

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -2327,7 +2327,7 @@ class InsertEdit
                         $column,
                         $columnNameAppendix,
                         $specialChars,
-                        min(max($column['len'], 4), $GLOBALS['cfg']['LimitChars']),
+                        min(max($column['len'] * 2, 4), $GLOBALS['cfg']['LimitChars']),
                         $onChangeClause,
                         $tabindex,
                         $tabindexForValue,


### PR DESCRIPTION
### Description

Input size for hexadecimal values should be double in size.

Before:

![before](https://github.com/user-attachments/assets/12b157a5-6b90-4364-aac8-5e9128611fcb)

After:

![after](https://github.com/user-attachments/assets/6094e725-02ee-4359-becc-a90f35c7c6c0)

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
