### PR TITLE
Suppress deprecation message of E_STRICT constant

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -134,6 +134,7 @@ phpMyAdmin - ChangeLog
 - issue #19283 Fix issue when the server starts with skip-innodb option
 - issue #19299 Fix charset in procedure's parameter type
 - issue #19316 Fix input size for hexadecimal values
+- issue #19321 Suppress deprecation message of E_STRICT constant
 
 5.2.1 (2023-02-07)
 - issue #17522 Fix case where the routes cache file is invalid

--- a/libraries/classes/Error.php
+++ b/libraries/classes/Error.php
@@ -38,7 +38,6 @@ use const E_ERROR;
 use const E_NOTICE;
 use const E_PARSE;
 use const E_RECOVERABLE_ERROR;
-use const E_STRICT;
 use const E_USER_DEPRECATED;
 use const E_USER_ERROR;
 use const E_USER_NOTICE;
@@ -54,7 +53,7 @@ class Error extends Message
     /**
      * Error types
      *
-     * @var array
+     * @var array<int, string>
      */
     public static $errortype = [
         0 => 'Internal error',
@@ -69,7 +68,7 @@ class Error extends Message
         E_USER_ERROR => 'User Error',
         E_USER_WARNING => 'User Warning',
         E_USER_NOTICE => 'User Notice',
-        E_STRICT => 'Runtime Notice',
+        2048 => 'Runtime Notice', // E_STRICT
         E_DEPRECATED => 'Deprecation Notice',
         E_USER_DEPRECATED => 'Deprecation Notice',
         E_RECOVERABLE_ERROR => 'Catchable Fatal Error',
@@ -78,7 +77,7 @@ class Error extends Message
     /**
      * Error levels
      *
-     * @var array
+     * @var array<int, string>
      */
     public static $errorlevel = [
         0 => 'error',
@@ -93,7 +92,7 @@ class Error extends Message
         E_USER_ERROR => 'error',
         E_USER_WARNING => 'error',
         E_USER_NOTICE => 'notice',
-        E_STRICT => 'notice',
+        2048 => 'notice', // E_STRICT
         E_DEPRECATED => 'notice',
         E_USER_DEPRECATED => 'notice',
         E_RECOVERABLE_ERROR => 'error',
@@ -316,7 +315,7 @@ class Error extends Message
      */
     public function getType(): string
     {
-        return self::$errortype[$this->getNumber()];
+        return self::$errortype[$this->getNumber()] ?? 'Internal error';
     }
 
     /**
@@ -326,7 +325,7 @@ class Error extends Message
      */
     public function getLevel(): string
     {
-        return self::$errorlevel[$this->getNumber()];
+        return self::$errorlevel[$this->getNumber()] ?? 'error';
     }
 
     /**

--- a/libraries/classes/ErrorHandler.php
+++ b/libraries/classes/ErrorHandler.php
@@ -27,7 +27,6 @@ use const E_ERROR;
 use const E_NOTICE;
 use const E_PARSE;
 use const E_RECOVERABLE_ERROR;
-use const E_STRICT;
 use const E_USER_DEPRECATED;
 use const E_USER_ERROR;
 use const E_USER_NOTICE;
@@ -281,7 +280,7 @@ class ErrorHandler
         }
 
         switch ($error->getNumber()) {
-            case E_STRICT:
+            case 2048: // E_STRICT
             case E_DEPRECATED:
             case E_NOTICE:
             case E_WARNING:
@@ -306,7 +305,7 @@ class ErrorHandler
                 // FATAL error, display it and exit
                 $this->dispFatalError($error);
                 if (! defined('TESTSUITE')) {
-                    exit;
+                    exit; // @codeCoverageIgnore
                 }
         }
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3436,16 +3436,6 @@ parameters:
 			path: libraries/classes/Error.php
 
 		-
-			message: "#^Property PhpMyAdmin\\\\Error\\:\\:\\$errorlevel type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Error.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\Error\\:\\:\\$errortype type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Error.php
-
-		-
 			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int, array\\)\\: bool\\)\\|null, array\\{\\$this\\(PhpMyAdmin\\\\ErrorHandler\\), 'handleError'\\} given\\.$#"
 			count: 1
 			path: libraries/classes/ErrorHandler.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6445,10 +6445,6 @@
       <code>$step</code>
       <code>$step</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
-      <code>string</code>
-      <code>string</code>
-    </MixedInferredReturnType>
     <MixedOperand occurrences="5">
       <code>$arg</code>
       <code>$arg</code>
@@ -6456,10 +6452,6 @@
       <code>$step['function']</code>
       <code>$step['line']</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="2">
-      <code>self::$errorlevel[$this-&gt;getNumber()]</code>
-      <code>self::$errortype[$this-&gt;getNumber()]</code>
-    </MixedReturnStatement>
   </file>
   <file src="libraries/classes/ErrorHandler.php">
     <DocblockTypeContradiction occurrences="1">

--- a/test/classes/ErrorHandlerTest.php
+++ b/test/classes/ErrorHandlerTest.php
@@ -14,8 +14,14 @@ use ReflectionProperty;
 use function array_keys;
 use function array_pop;
 
+use const E_COMPILE_WARNING;
+use const E_CORE_WARNING;
 use const E_ERROR;
+use const E_NOTICE;
 use const E_RECOVERABLE_ERROR;
+use const E_STRICT;
+use const E_USER_DEPRECATED;
+use const E_USER_ERROR;
 use const E_USER_NOTICE;
 use const E_USER_WARNING;
 use const E_WARNING;
@@ -168,6 +174,33 @@ class ErrorHandlerTest extends AbstractTestCase
     {
         $this->object->addError('Compile Error', E_WARNING, 'error.txt', 15);
         self::assertSame(1, $this->object->countErrors());
+    }
+
+    /** @dataProvider addErrorProvider */
+    public function testAddError(int $errorNumber, string $expected): void
+    {
+        $errorHandler = new ErrorHandler();
+        $errorHandler->addError('[em]Error[/em]', $errorNumber, 'error.txt', 15);
+        $errors = $errorHandler->getCurrentErrors();
+        self::assertCount(1, $errors);
+        $error = array_pop($errors);
+        self::assertSame($errorNumber, $error->getNumber());
+        self::assertSame($expected, $error->getMessage());
+    }
+
+    /** @return iterable<string, array{int, string}> */
+    public static function addErrorProvider(): iterable
+    {
+        yield 'E_STRICT' => [@E_STRICT, '[em]Error[/em]'];
+        yield 'E_NOTICE' => [E_NOTICE, '[em]Error[/em]'];
+        yield 'E_WARNING' => [E_WARNING, '[em]Error[/em]'];
+        yield 'E_CORE_WARNING' => [E_CORE_WARNING, '[em]Error[/em]'];
+        yield 'E_COMPILE_WARNING' => [E_COMPILE_WARNING, '[em]Error[/em]'];
+        yield 'E_RECOVERABLE_ERROR' => [E_RECOVERABLE_ERROR, '[em]Error[/em]'];
+        yield 'E_USER_NOTICE' => [E_USER_NOTICE, '<em>Error</em>'];
+        yield 'E_USER_WARNING' => [E_USER_WARNING, '<em>Error</em>'];
+        yield 'E_USER_ERROR' => [E_USER_ERROR, '<em>Error</em>'];
+        yield 'E_USER_DEPRECATED' => [E_USER_DEPRECATED, '<em>Error</em>'];
     }
 
     /**

--- a/test/classes/ErrorTest.php
+++ b/test/classes/ErrorTest.php
@@ -9,6 +9,21 @@ use PhpMyAdmin\Error;
 use function preg_match;
 
 use const DIRECTORY_SEPARATOR;
+use const E_COMPILE_ERROR;
+use const E_COMPILE_WARNING;
+use const E_CORE_ERROR;
+use const E_CORE_WARNING;
+use const E_DEPRECATED;
+use const E_ERROR;
+use const E_NOTICE;
+use const E_PARSE;
+use const E_RECOVERABLE_ERROR;
+use const E_STRICT;
+use const E_USER_DEPRECATED;
+use const E_USER_ERROR;
+use const E_USER_NOTICE;
+use const E_USER_WARNING;
+use const E_WARNING;
 
 /**
  * @covers \PhpMyAdmin\Error
@@ -133,6 +148,60 @@ class ErrorTest extends AbstractTestCase
             '<div class="alert alert-danger" role="alert"><strong>Warning</strong>',
             $this->object->getDisplay()
         );
+    }
+
+    /** @dataProvider errorLevelProvider */
+    public function testGetLevel(int $errorNumber, string $expected): void
+    {
+        self::assertSame($expected, (new Error($errorNumber, 'Error', 'error.txt', 15))->getLevel());
+    }
+
+    /** @return iterable<string, array{int, string}> */
+    public static function errorLevelProvider(): iterable
+    {
+        yield 'internal error' => [0, 'error'];
+        yield 'E_ERROR error' => [E_ERROR, 'error'];
+        yield 'E_WARNING error' => [E_WARNING, 'error'];
+        yield 'E_PARSE error' => [E_PARSE, 'error'];
+        yield 'E_NOTICE notice' => [E_NOTICE, 'notice'];
+        yield 'E_CORE_ERROR error' => [E_CORE_ERROR, 'error'];
+        yield 'E_CORE_WARNING error' => [E_CORE_WARNING, 'error'];
+        yield 'E_COMPILE_ERROR error' => [E_COMPILE_ERROR, 'error'];
+        yield 'E_COMPILE_WARNING error' => [E_COMPILE_WARNING, 'error'];
+        yield 'E_USER_ERROR error' => [E_USER_ERROR, 'error'];
+        yield 'E_USER_WARNING error' => [E_USER_WARNING, 'error'];
+        yield 'E_USER_NOTICE notice' => [E_USER_NOTICE, 'notice'];
+        yield 'E_STRICT notice' => [@E_STRICT, 'notice'];
+        yield 'E_DEPRECATED notice' => [E_DEPRECATED, 'notice'];
+        yield 'E_USER_DEPRECATED notice' => [E_USER_DEPRECATED, 'notice'];
+        yield 'E_RECOVERABLE_ERROR error' => [E_RECOVERABLE_ERROR, 'error'];
+    }
+
+    /** @dataProvider errorTypeProvider */
+    public function testGetType(int $errorNumber, string $expected): void
+    {
+        self::assertSame($expected, (new Error($errorNumber, 'Error', 'error.txt', 15))->getType());
+    }
+
+    /** @return iterable<string, array{int, string}> */
+    public static function errorTypeProvider(): iterable
+    {
+        yield 'internal error' => [0, 'Internal error'];
+        yield 'E_ERROR error' => [E_ERROR, 'Error'];
+        yield 'E_WARNING warning' => [E_WARNING, 'Warning'];
+        yield 'E_PARSE error' => [E_PARSE, 'Parsing Error'];
+        yield 'E_NOTICE notice' => [E_NOTICE, 'Notice'];
+        yield 'E_CORE_ERROR error' => [E_CORE_ERROR, 'Core Error'];
+        yield 'E_CORE_WARNING warning' => [E_CORE_WARNING, 'Core Warning'];
+        yield 'E_COMPILE_ERROR error' => [E_COMPILE_ERROR, 'Compile Error'];
+        yield 'E_COMPILE_WARNING warning' => [E_COMPILE_WARNING, 'Compile Warning'];
+        yield 'E_USER_ERROR error' => [E_USER_ERROR, 'User Error'];
+        yield 'E_USER_WARNING warning' => [E_USER_WARNING, 'User Warning'];
+        yield 'E_USER_NOTICE notice' => [E_USER_NOTICE, 'User Notice'];
+        yield 'E_STRICT notice' => [@E_STRICT, 'Runtime Notice'];
+        yield 'E_DEPRECATED notice' => [E_DEPRECATED, 'Deprecation Notice'];
+        yield 'E_USER_DEPRECATED notice' => [E_USER_DEPRECATED, 'Deprecation Notice'];
+        yield 'E_RECOVERABLE_ERROR error' => [E_RECOVERABLE_ERROR, 'Catchable Fatal Error'];
     }
 
     /**


### PR DESCRIPTION
The `E_STRICT` constant was deprecated in PHP 8.4.

It's still a possible error level when using PHP 7.2 and PHP 7.3.

See: https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant
