### PR TITLE
Fix #17182 - FK Relationship View constraint name natural ordering

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -3600,9 +3600,9 @@ Various display setting
     :type: boolean
     :default: true
 
-    Sorts database and table names according to natural order (for
-    example, t1, t2, t10). Currently implemented in the navigation panel
-    and in Database view, for the table list.
+    Sorts database, table names and foreign key constaint according to natural order (for
+    example, t1, t2, t10). Currently implemented in the navigation panel,
+    in Database view for the table list and Relation view for list of Foreign key constraints.
 
 .. config:option:: $cfg['InitialSlidersState']
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -3602,7 +3602,7 @@ Various display setting
 
     Sorts database, table names and foreign key constaint according to natural order (for
     example, t1, t2, t10). Currently implemented in the navigation panel,
-    in Database view for the table list and Relation view for list of Foreign key constraints.
+    in Database view for the table list and Relation view while listing Foreign key constraints.
 
 .. config:option:: $cfg['InitialSlidersState']
 

--- a/src/Controllers/Table/RelationController.php
+++ b/src/Controllers/Table/RelationController.php
@@ -18,6 +18,7 @@ use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Index;
 use PhpMyAdmin\MessageType;
 use PhpMyAdmin\ResponseRenderer;
+use PhpMyAdmin\SqlParser\Utils\ForeignKey as ForeignKeyObject;
 use PhpMyAdmin\Table\Table;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Util;
@@ -177,6 +178,12 @@ final class RelationController implements InvocableController
         $config = Config::getInstance();
         if ($config->settings['NaturalOrder']) {
             uksort($columnArray, strnatcasecmp(...));
+            usort(
+                $relationsForeign,
+                fn (ForeignKeyObject $before, ForeignKeyObject $after) => strnatcmp(
+                    $before->constraint, $after->constraint
+                )
+            );
         }
 
         $foreignKeyRow = '';

--- a/src/Controllers/Table/RelationController.php
+++ b/src/Controllers/Table/RelationController.php
@@ -29,6 +29,7 @@ use function array_keys;
 use function mb_strtoupper;
 use function md5;
 use function strnatcasecmp;
+use function strnatcmp;
 use function strtoupper;
 use function uksort;
 use function usort;
@@ -180,9 +181,10 @@ final class RelationController implements InvocableController
             uksort($columnArray, strnatcasecmp(...));
             usort(
                 $relationsForeign,
-                fn (ForeignKeyObject $before, ForeignKeyObject $after) => strnatcmp(
-                    $before->constraint, $after->constraint
-                )
+                static fn (ForeignKeyObject $before, ForeignKeyObject $after) => strnatcmp(
+                    $before->constraint ?? '',
+                    $after->constraint ?? '',
+                ),
             );
         }
 


### PR DESCRIPTION
### Description

When `$cfg['NaturalOrder']=true` sort foreign keys list in Table > relationship view.

Fixes https://github.com/phpmyadmin/phpmyadmin/issues/17182

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
