### PR TITLE
Fix #18170 - window.makeGrid is not a function

### DIFF
--- a/js/src/sql.js
+++ b/js/src/sql.js
@@ -189,7 +189,7 @@ AJAX.registerTeardown('sql.js', function () {
     $(document).off('click', 'a.delete_row.ajax');
     $(document).off('submit', '.bookmarkQueryForm');
     $('input#bkm_label').off('input');
-    $(document).off('makegrid', '.sqlqueryresults');
+    $(document).off('makeGrid', '.sqlqueryresults');
     $('#togglequerybox').off('click');
     $(document).off('click', '#button_submit_query');
     $(document).off('change', '#id_bookmark');
@@ -401,11 +401,11 @@ AJAX.registerOnload('sql.js', function () {
     }); // end of Copy to Clipboard action
 
     /**
-     * Attach the {@link makegrid} function to a custom event, which will be
+     * Attach the {@link makeGrid} function to a custom event, which will be
      * triggered manually everytime the table of results is reloaded
      * @memberOf    jQuery
      */
-    $(document).on('makegrid', '.sqlqueryresults', function () {
+    $(document).on('makeGrid', '.sqlqueryresults', function () {
         $('.table_results').each(function () {
             makeGrid(this);
         });
@@ -625,7 +625,7 @@ AJAX.registerOnload('sql.js', function () {
                     });
                 }
 
-                $('.sqlqueryresults').trigger('makegrid');
+                $('.sqlqueryresults').trigger('makeGrid');
                 $('#togglequerybox').show();
 
                 if (typeof data.action_bookmark === 'undefined') {
@@ -663,7 +663,7 @@ AJAX.registerOnload('sql.js', function () {
             var $sqlqueryresults = $form.parents('.sqlqueryresults');
             $sqlqueryresults
                 .html(data.message)
-                .trigger('makegrid');
+                .trigger('makeGrid');
             Functions.highlightSql($sqlqueryresults);
         }); // end $.post()
     }); // end displayOptionsForm handler
@@ -1014,7 +1014,7 @@ AJAX.registerOnload('sql.js', function () {
     /**
      * create resizable table
      */
-    $('.sqlqueryresults').trigger('makegrid');
+    $('.sqlqueryresults').trigger('makeGrid');
 
     /**
      * Check if there is any saved query

--- a/js/src/table/select.js
+++ b/js/src/table/select.js
@@ -161,7 +161,7 @@ AJAX.registerOnload('table/select.js', function () {
                     $('#sqlqueryresultsouter').html(data.sql_query);
                 } else { // results found
                     $('#sqlqueryresultsouter').html(data.message);
-                    $('.sqlqueryresults').trigger('makegrid');
+                    $('.sqlqueryresults').trigger('makeGrid');
                 }
                 $('#tbl_search_form')
                     // workaround for bug #3168569 - Issue on toggling the "Hide search criteria" in chrome.


### PR DESCRIPTION
### Description

This PR fixes the `window.makeGrid is not a function`. The bug was caused by `makeGrid` written lowercase as `makegrid`. While I don't know how to reproduce it on 5.2.2-dev, there are numerous ways to reproduce it on 6.0.0-dev.

Recordings from 6.0.0-dev:

Before:

https://github.com/user-attachments/assets/e0febab9-b500-473e-86d3-833ce67b6f17

After:

https://github.com/user-attachments/assets/168aa1cb-bf30-4862-bfa9-9fdc274c392a

Fixes #18170

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
