### PR TITLE
Remove whitespace to avoid double whitespace

### DIFF
--- a/libraries/classes/Database/Search.php
+++ b/libraries/classes/Database/Search.php
@@ -179,7 +179,7 @@ class Search
         $where_clause = $this->getWhereClause($table);
         // Builds complete queries
         $sql = [];
-        $sql['select_columns'] = $sqlstr_select . ' * ' . $sqlstr_from
+        $sql['select_columns'] = $sqlstr_select . ' *' . $sqlstr_from
             . $where_clause;
         // here, I think we need to still use the COUNT clause, even for
         // VIEWs, anyway we have a WHERE clause that should limit results

--- a/libraries/classes/Table/Search.php
+++ b/libraries/classes/Table/Search.php
@@ -50,7 +50,7 @@ final class Search
         // (more efficient and this helps prevent a problem in IE
         // if one of the rows is edited and we come back to the Select results)
         if (isset($_POST['zoom_submit']) || ! empty($_POST['displayAllColumns'])) {
-            $sql_query .= '* ';
+            $sql_query .= '*';
         } else {
             $columnsToDisplay = $_POST['columnsToDisplay'];
             $quotedColumns = [];

--- a/test/classes/Database/SearchTest.php
+++ b/test/classes/Database/SearchTest.php
@@ -128,7 +128,7 @@ class SearchTest extends AbstractTestCase
     public function testGetSearchSqls(): void
     {
         self::assertSame([
-            'select_columns' => 'SELECT *  FROM `pma`.`table1` WHERE FALSE',
+            'select_columns' => 'SELECT * FROM `pma`.`table1` WHERE FALSE',
             'select_count' => 'SELECT COUNT(*) AS `count` FROM `pma`.`table1` WHERE FALSE',
             'delete' => 'DELETE FROM `pma`.`table1` WHERE FALSE',
         ], $this->callFunction(

--- a/test/classes/Table/SearchTest.php
+++ b/test/classes/Table/SearchTest.php
@@ -99,11 +99,11 @@ class SearchTest extends AbstractTestCase
         $_POST['zoom_submit'] = true;
         $_POST['table'] = 'PMA';
 
-        self::assertSame('SELECT *  FROM `PMA`', $this->search->buildSqlQuery());
+        self::assertSame('SELECT * FROM `PMA`', $this->search->buildSqlQuery());
 
         $_POST['customWhereClause'] = '`table` = \'WhereClause\'';
 
-        self::assertSame('SELECT *  FROM `PMA` WHERE `table` = \'WhereClause\'', $this->search->buildSqlQuery());
+        self::assertSame('SELECT * FROM `PMA` WHERE `table` = \'WhereClause\'', $this->search->buildSqlQuery());
 
         unset($_POST['customWhereClause']);
         $_POST['criteriaColumnNames'] = [
@@ -132,7 +132,7 @@ class SearchTest extends AbstractTestCase
         ];
 
         self::assertSame(
-            'SELECT *  FROM `PMA` WHERE `b` <= 10 AND `a` = 2 AND `c` IS NULL AND `d` IS NOT NULL',
+            'SELECT * FROM `PMA` WHERE `b` <= 10 AND `a` = 2 AND `c` IS NULL AND `d` IS NOT NULL',
             $this->search->buildSqlQuery()
         );
     }
@@ -142,11 +142,11 @@ class SearchTest extends AbstractTestCase
         $_POST['zoom_submit'] = true;
         $_POST['table'] = 'PMA';
 
-        self::assertSame('SELECT *  FROM `PMA`', $this->search->buildSqlQuery());
+        self::assertSame('SELECT * FROM `PMA`', $this->search->buildSqlQuery());
 
         $_POST['customWhereClause'] = '`table` = \'WhereClause\'';
 
-        self::assertSame('SELECT *  FROM `PMA` WHERE `table` = \'WhereClause\'', $this->search->buildSqlQuery());
+        self::assertSame('SELECT * FROM `PMA` WHERE `table` = \'WhereClause\'', $this->search->buildSqlQuery());
 
         unset($_POST['customWhereClause']);
         $_POST['criteriaColumnNames'] = ['b'];
@@ -155,7 +155,7 @@ class SearchTest extends AbstractTestCase
         $_POST['criteriaValues'] = ['1'];
         $_POST['criteriaColumnTypes'] = ['geometry'];
 
-        self::assertSame('SELECT *  FROM `PMA` WHERE Dimension(`b`) = \'1\'', $this->search->buildSqlQuery());
+        self::assertSame('SELECT * FROM `PMA` WHERE Dimension(`b`) = \'1\'', $this->search->buildSqlQuery());
     }
 
     public function testBuildSqlQueryWithWhereClauseEnum(): void
@@ -163,11 +163,11 @@ class SearchTest extends AbstractTestCase
         $_POST['zoom_submit'] = true;
         $_POST['table'] = 'PMA';
 
-        self::assertSame('SELECT *  FROM `PMA`', $this->search->buildSqlQuery());
+        self::assertSame('SELECT * FROM `PMA`', $this->search->buildSqlQuery());
 
         $_POST['customWhereClause'] = '`table` = \'WhereClause\'';
 
-        self::assertSame('SELECT *  FROM `PMA` WHERE `table` = \'WhereClause\'', $this->search->buildSqlQuery());
+        self::assertSame('SELECT * FROM `PMA` WHERE `table` = \'WhereClause\'', $this->search->buildSqlQuery());
 
         unset($_POST['customWhereClause']);
         $_POST['criteriaColumnNames'] = ['rating'];
@@ -176,7 +176,7 @@ class SearchTest extends AbstractTestCase
         $_POST['criteriaValues'] = ['PG-13'];
         $_POST['criteriaColumnTypes'] = ['enum(\'G\', \'PG\', \'PG-13\', \'R\', \'NC-17\')'];
 
-        self::assertSame('SELECT *  FROM `PMA` WHERE `rating` = \'PG-13\'', $this->search->buildSqlQuery());
+        self::assertSame('SELECT * FROM `PMA` WHERE `rating` = \'PG-13\'', $this->search->buildSqlQuery());
     }
 
     public function testBuildSqlQueryWithWhereClauseUUID(): void
@@ -184,11 +184,11 @@ class SearchTest extends AbstractTestCase
         $_POST['zoom_submit'] = true;
         $_POST['table'] = 'PMA';
 
-        self::assertSame('SELECT *  FROM `PMA`', $this->search->buildSqlQuery());
+        self::assertSame('SELECT * FROM `PMA`', $this->search->buildSqlQuery());
 
         $_POST['customWhereClause'] = '';
 
-        self::assertSame('SELECT *  FROM `PMA`', $this->search->buildSqlQuery());
+        self::assertSame('SELECT * FROM `PMA`', $this->search->buildSqlQuery());
 
         unset($_POST['customWhereClause']);
         $_POST['criteriaColumnNames'] = ['id'];
@@ -198,7 +198,7 @@ class SearchTest extends AbstractTestCase
         $_POST['criteriaColumnTypes'] = ['uuid'];
 
         self::assertSame(
-            "SELECT *  FROM `PMA` WHERE `id` = '07ca1fdd-4805-11ed-a4dc-0242ac110002'",
+            "SELECT * FROM `PMA` WHERE `id` = '07ca1fdd-4805-11ed-a4dc-0242ac110002'",
             $this->search->buildSqlQuery()
         );
     }
@@ -217,6 +217,6 @@ class SearchTest extends AbstractTestCase
         $_POST['ajax_request'] = 'true';
         $_POST['displayAllColumns'] = 'true';
 
-        self::assertSame('SELECT *  FROM `world_cities`', $this->search->buildSqlQuery());
+        self::assertSame('SELECT * FROM `world_cities`', $this->search->buildSqlQuery());
     }
 }

--- a/test/classes/Table/SearchTest.php
+++ b/test/classes/Table/SearchTest.php
@@ -33,7 +33,7 @@ class SearchTest extends AbstractTestCase
         $_POST['customWhereClause'] = "name='pma'";
 
         self::assertSame(
-            'SELECT DISTINCT *  FROM `PMA` WHERE name=\'pma\' ORDER BY `name` asc',
+            'SELECT DISTINCT * FROM `PMA` WHERE name=\'pma\' ORDER BY `name` asc',
             $this->search->buildSqlQuery()
         );
 

--- a/test/classes/Table/SearchTest.php
+++ b/test/classes/Table/SearchTest.php
@@ -39,7 +39,7 @@ class SearchTest extends AbstractTestCase
 
         unset($_POST['customWhereClause']);
 
-        self::assertSame('SELECT DISTINCT *  FROM `PMA` ORDER BY `name` asc', $this->search->buildSqlQuery());
+        self::assertSame('SELECT DISTINCT * FROM `PMA` ORDER BY `name` asc', $this->search->buildSqlQuery());
 
         $_POST['criteriaValues'] = [
             'value1',
@@ -87,7 +87,7 @@ class SearchTest extends AbstractTestCase
             'BETWEEN',
         ];
 
-        $expected = 'SELECT DISTINCT *  FROM `PMA` WHERE `name` != \'value1\''
+        $expected = 'SELECT DISTINCT * FROM `PMA` WHERE `name` != \'value1\''
             . ' AND `id` > value2 AND `index` IS NULL AND `index2` LIKE \'%value4%\''
             . ' AND `index3` REGEXP ^value5$ AND `index4` IN (value6) AND `index5`'
             . ' BETWEEN value7 AND value8 ORDER BY `name` asc';


### PR DESCRIPTION
### Description

Remove whitespace to avoid double whitespace in `SELECT *  FROM`, when using `Search`. There's no need for it, because whitespace is added here: https://github.com/phpmyadmin/phpmyadmin/blob/7280713fcb9ca72544d6d922b4eac9aa9035a130/libraries/classes/Table/Search.php#L64

Before:

https://github.com/user-attachments/assets/842f1c44-6593-4712-a5ad-66913e601019

After:

https://github.com/user-attachments/assets/0946e0ec-3f04-420f-a890-e5090e5cc128

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
