### PR TITLE
Fix add PRIMARY key from More drop-down

### DIFF
--- a/src/Controllers/Table/Structure/AbstractIndexController.php
+++ b/src/Controllers/Table/Structure/AbstractIndexController.php
@@ -39,7 +39,7 @@ abstract class AbstractIndexController
         Assert::allString($selected);
 
         if ($indexType === 'PRIMARY') {
-            $hasPrimaryKey = $this->indexes->hasPrimaryKey(Current::$table);
+            $hasPrimaryKey = $this->indexes->hasPrimaryKey(Current::$database, Current::$table);
             $statement = Generator::getAddPrimaryKeyStatement(Current::$table, $selected[0], $hasPrimaryKey);
         } else {
             $statement = Generator::getAddIndexSql($indexType, Current::$table, $selected);

--- a/src/Table/Indexes.php
+++ b/src/Table/Indexes.php
@@ -189,9 +189,11 @@ final class Indexes
         return Message::success();
     }
 
-    public function hasPrimaryKey(string|TableName $table): bool
+    public function hasPrimaryKey(string|DatabaseName $db, string|TableName $table): bool
     {
+        $this->dbi->selectDb($db);
         $result = $this->dbi->query('SHOW KEYS FROM ' . Util::backquote($table));
+
         foreach ($result as $row) {
             if ($row['Key_name'] === 'PRIMARY') {
                 return true;


### PR DESCRIPTION
### Description

This PR Fixes a bug where you can't set a column as `PRIMARY` key from `More` drop-down.

Before:

https://github.com/user-attachments/assets/6596dea6-233b-4f5f-af5a-854057132a54

After:

https://github.com/user-attachments/assets/6ab2f790-af2a-4170-bc40-b9b76824624f

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
