### PR TITLE
Fix error report generation with null context

### DIFF
--- a/libraries/classes/ErrorReport.php
+++ b/libraries/classes/ErrorReport.php
@@ -246,12 +246,14 @@ class ErrorReport
     private function translateStacktrace(array $stack): array
     {
         foreach ($stack as &$level) {
-            foreach ($level['context'] as &$line) {
-                if (mb_strlen($line) <= 80) {
-                    continue;
-                }
+            if (is_array($level['context'])) {
+                foreach ($level['context'] as &$line) {
+                    if (mb_strlen($line) <= 80) {
+                        continue;
+                    }
 
-                $line = mb_substr($line, 0, 75) . '//...';
+                    $line = mb_substr($line, 0, 75) . '//...';
+                }
             }
 
             [$uri, $scriptName] = $this->sanitizeUrl($level['url']);

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6484,7 +6484,8 @@
       <code>$line</code>
       <code>$line</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="3">
+    <MixedArrayAccess occurrences="4">
+      <code>$level['context']</code>
       <code>$level['context']</code>
       <code>$level['url']</code>
       <code>$level['url']</code>


### PR DESCRIPTION
### Description

context may be null, which transferred as post parameter is received as empty string, but that wasn't handled when shortening the lines.