### PR TITLE
[Query Generator] support for `BETWEEN` and `NOT BETWEEN`

### DIFF
--- a/resources/js/src/database/multi_table_query.ts
+++ b/resources/js/src/database/multi_table_query.ts
@@ -51,6 +51,10 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
         return ['IN (...)', 'NOT IN (...)'];
     }
 
+    function opsWithTwoArgs (): string[] {
+        return ['BETWEEN', 'NOT BETWEEN'];
+    }
+
     $('#update_query_button').on('click', function () {
         var columns = [];
         var tableAliases = {};
@@ -200,10 +204,13 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
     });
 
     const acceptsMultipleArgs: string[] = opsWithMultipleArgs();
+    const acceptsTwoArgs: string[] = opsWithTwoArgs();
     $('.criteria_op').each(function () {
         $(this).on('change', function () {
             if (acceptsMultipleArgs.includes($(this).val().toString())) {
                 showMultiFields($(this));
+            } else if (acceptsTwoArgs.includes($(this).val().toString())) {
+                showTwoFields($(this));
             } else {
                 const options: JQuery<HTMLElement> = $(this).closest('table').find('.options');
                 options.parent().prepend('<input type="text" class="rhs_text_val query-form__input--wide" placeholder="Enter criteria as free text"></input>');
@@ -212,14 +219,33 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
         });
     });
 
-    function showMultiFields (opSelect: JQuery<HTMLElement>) {
-        const criteriaInput: JQuery<HTMLElement> = opSelect.closest('table').find('.rhs_text_val');
-        const criteriaInputCol: JQuery<HTMLElement> = criteriaInput.parent();
-        const hasAtLeastOneOption: boolean = criteriaInputCol.find('.option').length > 0;
+    function showTwoFields (opSelect: JQuery<HTMLElement>) {
+        const critetiaRow: JQuery<HTMLElement> = opSelect.closest('table').find('.rhs_text');
+        const critetiaCol: JQuery<HTMLElement> = critetiaRow.find('td').last();
+        const criteriaInput: JQuery<HTMLElement> = critetiaCol.find('input').first();
 
-        if (!hasAtLeastOneOption) {
-            criteriaInputCol.append(`
-                <div class="options">
+        if (critetiaCol.find('.binary').length === 0) {
+            critetiaCol.empty();
+
+            critetiaCol.append(`
+                <div class="options binary">
+                    <input type="text" class="val" placeholder="${window.Messages.strFirstValuePlaceholder}" value="${criteriaInput.val()}" />
+                    <input type="text" class="val" placeholder="${window.Messages.strSecondValuePlaceholder}" />
+                </div>
+            `);
+        }
+    }
+
+    function showMultiFields (opSelect: JQuery<HTMLElement>) {
+        const critetiaRow: JQuery<HTMLElement> = opSelect.closest('table').find('.rhs_text');
+        const critetiaCol: JQuery<HTMLElement> = critetiaRow.find('td').last();
+        const criteriaInput: JQuery<HTMLElement> = critetiaCol.find('input').first();
+
+        if (critetiaCol.find('.multi').length === 0) {
+            critetiaCol.empty();
+
+            critetiaCol.append(`
+                <div class="options multi">
                     <div class="option">
                         <input type="text" class="val" placeholder="Enter an option" value="${criteriaInput.val()}" />
                         <input type="button" class="btn btn-secondary add-option" value="+" />
@@ -227,8 +253,6 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
                 </div>
             `);
         }
-
-        criteriaInput.remove();
     }
 
     $('body').on('click', 'input.add-option', function () {

--- a/resources/js/src/database/query_generator.ts
+++ b/resources/js/src/database/query_generator.ts
@@ -29,8 +29,8 @@ function getFormatsText () {
         'NOT LIKE %...%': ' NOT LIKE \'%%%s%%\'',
         'IN (...)': ' IN (%s)',
         'NOT IN (...)': ' NOT IN (%s)',
-        'BETWEEN': ' BETWEEN \'%s\'',
-        'NOT BETWEEN': ' NOT BETWEEN \'%s\'',
+        'BETWEEN': ' BETWEEN \'%s\' AND \'%s\'',
+        'NOT BETWEEN': ' NOT BETWEEN \'%s\' AND \'%s\'',
         'REGEXP': ' REGEXP \'%s\'',
         'REGEXP ^...$': ' REGEXP \'^%s$\'',
         'NOT REGEXP': ' NOT REGEXP \'%s\''
@@ -45,12 +45,20 @@ function opsWithMultipleArgs (): string[] {
     return ['IN (...)', 'NOT IN (...)'];
 }
 
+function opsWithTwoArgs (): string[] {
+    return ['BETWEEN', 'NOT BETWEEN'];
+}
+
 function isOpWithoutArg (op) {
     return opsWithoutArg().includes(op);
 }
 
 function acceptsMultipleValues (op: string): boolean {
     return opsWithMultipleArgs().includes(op);
+}
+
+function acceptsTwoValues (op: string): boolean {
+    return opsWithTwoArgs().includes(op);
 }
 
 function joinWrappingElementsWith (array: string[], char: string, separator: string = ','): string {
@@ -94,6 +102,11 @@ function generateCondition (criteriaDiv, table) {
             criteriaText = joinWrappingElementsWith(critertiaTextArray, '\'');
 
             query += window.sprintf(formatsText[criteriaOp], criteriaText);
+        } else if (acceptsTwoValues(criteriaOp)) {
+            const formatsText = getFormatsText();
+            const valuesInputs = criteriaDiv.find('input.val');
+
+            query += window.sprintf(formatsText[criteriaOp], valuesInputs[0].value, valuesInputs[1].value);
         } else {
             const formatsText = getFormatsText();
 

--- a/src/Controllers/JavaScriptMessagesController.php
+++ b/src/Controllers/JavaScriptMessagesController.php
@@ -451,6 +451,8 @@ final class JavaScriptMessagesController implements InvocableController
             'strConfirmTd' => __('Confirm transitive dependencies'),
             'strSelectedTd' => __('Selected dependencies are as follows:'),
             'strNoTdSelected' => __('No dependencies selected!'),
+            'strFirstValuePlaceholder' => __('Enter first value'),
+            'strSecondValuePlaceholder' => __('Enter second value'),
 
             /* For server/variables.js */
             'strSave' => __('Save'),


### PR DESCRIPTION
Hello 👋🏻 

I have added support for `BETWEEN` and `NOT BETWEEN` for the Query Generator.

### Current
![Screenshot 2024-11-02 183108](https://github.com/user-attachments/assets/f68d3e35-c17c-4d3d-9e01-bb2fd4a0fb89)

### After
![Screenshot 2024-11-02 183233](https://github.com/user-attachments/assets/cc5a432f-4157-4fef-b314-c60f6d58c93a)

It generates the needed inputs depending on the choosen op:
- op that accepts multiple arguments (eg: IN / NOT IN): It allows to add multiple inputs.
- op that accepts two arguments (eg: BETWEEN / NOT BETWEEN): It generates only the needed two inputs.
- op that accepts one argument (eg: LIKE / NOT LIKE): It generates only the needed one input.
- op that accepts no argument (eg: IS NULL / IS NOT NULL): it removes all inputs.



https://github.com/user-attachments/assets/d5bb1327-5c4d-4e49-872e-5e6de2d9e990

