### PR TITLE
Allow opening server breadcrumb links in new tab with Ctrl/Meta key

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -137,6 +137,7 @@ phpMyAdmin - ChangeLog
 - issue #19321 Suppress deprecation message of E_STRICT constant
 - issue        Fix PHP 8.4 `str_getcsv` `$escape` parameter deprecation
 - issue #19426 Fix PHP warnings when the column is a `COMPRESSED BLOB`
+- issue        Allow opening server breadcrumb links in new tab with Ctrl/Meta key
 
 5.2.1 (2023-02-07)
 - issue #17522 Fix case where the routes cache file is invalid

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -4188,9 +4188,14 @@ $(function () {
 
 /**
  * Scrolls the page to the top if clicking the server-breadcrumb bar
+ * If the user holds the Ctrl (or Meta on macOS) key, it prevents the scroll
+ * so they can open the link in a new tab.
  */
 $(function () {
     $(document).on('click', '#server-breadcrumb, #goto_pagetop', function (event) {
+        if (event.ctrlKey || event.metaKey) {
+            return;
+        }
         event.preventDefault();
         $('html, body').animate({ scrollTop: 0 }, 'fast');
     });


### PR DESCRIPTION
### Description

Lately, I’ve been frustrated with this server breadcrumb, where opening a link in a new tab requires right-clicking and selecting "open in new tab" because the usual Ctrl/Meta key shortcut doesn’t work. So, I decided to fix it myself.

![image](https://github.com/user-attachments/assets/a97fe63f-70a0-4d74-a05e-0fab0072428d)

---

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
