### PR TITLE
Don't abuse name attribute of exported gis svg elements

### DIFF
--- a/js/src/table/gis_visualization.js
+++ b/js/src/table/gis_visualization.js
@@ -338,7 +338,7 @@ AJAX.registerOnload('table/gis_visualization.js', function () {
      * Detect the mousemove event and show tooltips.
      */
     $('.vector').on('mousemove', function (event) {
-        var contents = Functions.escapeHtml($(this).attr('name')).trim();
+        var contents = Functions.escapeHtml($(this).attr('data-label')).trim();
         $('#tooltip').remove();
         if (contents !== '') {
             $('<div id="tooltip">' + contents + '</div>').css({

--- a/libraries/classes/Gis/GisLineString.php
+++ b/libraries/classes/Gis/GisLineString.php
@@ -183,7 +183,7 @@ class GisLineString extends GisGeometry
     public function prepareRowAsSvg($spatial, $label, $line_color, array $scale_data)
     {
         $line_options = [
-            'name' => $label,
+            'data-label' => $label,
             'id' => $label . $this->getRandomId(),
             'class' => 'linestring vector',
             'fill' => 'none',

--- a/libraries/classes/Gis/GisMultiLineString.php
+++ b/libraries/classes/Gis/GisMultiLineString.php
@@ -208,7 +208,7 @@ class GisMultiLineString extends GisGeometry
     public function prepareRowAsSvg($spatial, $label, $line_color, array $scale_data)
     {
         $line_options = [
-            'name' => $label,
+            'data-label' => $label,
             'class' => 'linestring vector',
             'fill' => 'none',
             'stroke' => $line_color,

--- a/libraries/classes/Gis/GisMultiPoint.php
+++ b/libraries/classes/Gis/GisMultiPoint.php
@@ -186,7 +186,7 @@ class GisMultiPoint extends GisGeometry
     public function prepareRowAsSvg($spatial, $label, $point_color, array $scale_data)
     {
         $point_options = [
-            'name' => $label,
+            'data-label' => $label,
             'class' => 'multipoint vector',
             'fill' => 'white',
             'stroke' => $point_color,

--- a/libraries/classes/Gis/GisMultiPolygon.php
+++ b/libraries/classes/Gis/GisMultiPolygon.php
@@ -247,7 +247,7 @@ class GisMultiPolygon extends GisGeometry
     public function prepareRowAsSvg($spatial, $label, $fill_color, array $scale_data)
     {
         $polygon_options = [
-            'name' => $label,
+            'data-label' => $label,
             'class' => 'multipolygon vector',
             'stroke' => 'black',
             'stroke-width' => 0.5,

--- a/libraries/classes/Gis/GisPoint.php
+++ b/libraries/classes/Gis/GisPoint.php
@@ -179,7 +179,7 @@ class GisPoint extends GisGeometry
     public function prepareRowAsSvg($spatial, $label, $point_color, array $scale_data)
     {
         $point_options = [
-            'name' => $label,
+            'data-label' => $label,
             'id' => $label . $this->getRandomId(),
             'class' => 'point vector',
             'fill' => 'white',

--- a/libraries/classes/Gis/GisPolygon.php
+++ b/libraries/classes/Gis/GisPolygon.php
@@ -212,7 +212,7 @@ class GisPolygon extends GisGeometry
     public function prepareRowAsSvg($spatial, $label, $fill_color, array $scale_data)
     {
         $polygon_options = [
-            'name' => $label,
+            'data-label' => $label,
             'id' => $label . $this->getRandomId(),
             'class' => 'polygon vector',
             'stroke' => 'black',

--- a/test/classes/Gis/GisGeometryCollectionTest.php
+++ b/test/classes/Gis/GisGeometryCollectionTest.php
@@ -341,7 +341,7 @@ class GisGeometryCollectionTest extends AbstractTestCase
                     'height' => 150,
                 ],
                 '/^(<path d=" M 46, 268 L -4, 248 L 6, 208 L 66, 198 Z  M 16,'
-                    . ' 228 L 46, 224 L 36, 248 Z " name="svg" id="svg)(\d+)'
+                    . ' 228 L 46, 224 L 36, 248 Z " data-label="svg" id="svg)(\d+)'
                     . '(" class="polygon vector" stroke="black" stroke-width="0.5"'
                     . ' fill="#B02EE0" fill-rule="evenodd" fill-opacity="0.8"\/>)$/',
             ],

--- a/test/classes/Gis/GisLineStringTest.php
+++ b/test/classes/Gis/GisLineStringTest.php
@@ -267,7 +267,7 @@ class GisLineStringTest extends GisGeomTestCase
                     'height' => 150,
                 ],
                 '/^(<polyline points="0,218 72,138 114,242 26,198 4,182 46,132 " '
-                . 'name="svg" id="svg)(\d+)(" class="linestring vector" fill="none" '
+                . 'data-label="svg" id="svg)(\d+)(" class="linestring vector" fill="none" '
                 . 'stroke="#B02EE0" stroke-width="2"\/>)$/',
             ],
         ];

--- a/test/classes/Gis/GisMultiLineStringTest.php
+++ b/test/classes/Gis/GisMultiLineStringTest.php
@@ -348,10 +348,10 @@ class GisMultiLineStringTest extends GisGeomTestCase
                     'scale' => 2,
                     'height' => 150,
                 ],
-                '/^(<polyline points="48,260 70,242 100,138 " name="svg" '
+                '/^(<polyline points="48,260 70,242 100,138 " data-label="svg" '
                 . 'class="linestring vector" fill="none" stroke="#B02EE0" '
                 . 'stroke-width="2" id="svg)(\d+)("\/><polyline points="48,268 10,'
-                . '242 332,182 " name="svg" class="linestring vector" fill="none" '
+                . '242 332,182 " data-label="svg" class="linestring vector" fill="none" '
                 . 'stroke="#B02EE0" stroke-width="2" id="svg)(\d+)("\/>)$/',
             ],
         ];

--- a/test/classes/Gis/GisMultiPointTest.php
+++ b/test/classes/Gis/GisMultiPointTest.php
@@ -265,15 +265,15 @@ class GisMultiPointTest extends GisGeomTestCase
                     'scale' => 2,
                     'height' => 150,
                 ],
-                '/^(<circle cx="72" cy="138" r="3" name="svg" class="multipoint '
+                '/^(<circle cx="72" cy="138" r="3" data-label="svg" class="multipoint '
                 . 'vector" fill="white" stroke="#B02EE0" stroke-width="2" id="svg)'
-                . '(\d+)("\/><circle cx="114" cy="242" r="3" name="svg" class="mult'
+                . '(\d+)("\/><circle cx="114" cy="242" r="3" data-label="svg" class="mult'
                 . 'ipoint vector" fill="white" stroke="#B02EE0" stroke-width="2" id'
-                . '="svg)(\d+)("\/><circle cx="26" cy="198" r="3" name="svg" class='
+                . '="svg)(\d+)("\/><circle cx="26" cy="198" r="3" data-label="svg" class='
                 . '"multipoint vector" fill="white" stroke="#B02EE0" stroke-width='
-                . '"2" id="svg)(\d+)("\/><circle cx="4" cy="182" r="3" name="svg" '
+                . '"2" id="svg)(\d+)("\/><circle cx="4" cy="182" r="3" data-label="svg" '
                 . 'class="multipoint vector" fill="white" stroke="#B02EE0" stroke-'
-                . 'width="2" id="svg)(\d+)("\/><circle cx="46" cy="132" r="3" name='
+                . 'width="2" id="svg)(\d+)("\/><circle cx="46" cy="132" r="3" data-label='
                 . '"svg" class="multipoint vector" fill="white" stroke="#B02EE0" '
                 . 'stroke-width="2" id="svg)(\d+)("\/>)$/',
             ],

--- a/test/classes/Gis/GisMultiPolygonTest.php
+++ b/test/classes/Gis/GisMultiPolygonTest.php
@@ -433,10 +433,10 @@ class GisMultiPolygonTest extends GisGeomTestCase
                     'scale' => 2,
                     'height' => 150,
                 ],
-                '/^(<path d=" M 248, 208 L 270, 122 L 8, 138 Z " name="svg" class="'
+                '/^(<path d=" M 248, 208 L 270, 122 L 8, 138 Z " data-label="svg" class="'
                 . 'multipolygon vector" stroke="black" stroke-width="0.5" fill="'
                 . '#B02EE0" fill-rule="evenodd" fill-opacity="0.8" id="svg)(\d+)'
-                . '("\/><path d=" M 186, 288 L 88, 248 L 132, 142 Z " name="svg" '
+                . '("\/><path d=" M 186, 288 L 88, 248 L 132, 142 Z " data-label="svg" '
                 . 'class="multipolygon vector" stroke="black" stroke-width="0.5" '
                 . 'fill="#B02EE0" fill-rule="evenodd" fill-opacity="0.8" id="svg)'
                 . '(\d+)("\/>)$/',

--- a/test/classes/Gis/GisPolygonTest.php
+++ b/test/classes/Gis/GisPolygonTest.php
@@ -516,7 +516,7 @@ class GisPolygonTest extends GisGeomTestCase
                     'scale' => 2,
                     'height' => 150,
                 ],
-                '/^(<path d=" M 222, 288 L 22, 228 L 10, 162 Z " name="svg" '
+                '/^(<path d=" M 222, 288 L 22, 228 L 10, 162 Z " data-label="svg" '
                 . 'id="svg)(\d+)(" class="polygon vector" stroke="black" '
                 . 'stroke-width="0.5" fill="#B02EE0" fill-rule="evenodd" '
                 . 'fill-opacity="0.8"\/>)$/',


### PR DESCRIPTION
The [name attribute](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/name) should not be used for custom data.