### PR TITLE
Fix #19155 - Column sorting does not work when names contain dots

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6729,7 +6729,7 @@ parameters:
 		-
 			message: '#^Cannot access property \$type on PhpMyAdmin\\SqlParser\\Token\|null\.$#'
 			identifier: property.nonObject
-			count: 5
+			count: 10
 			path: src/Display/Results.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6739,6 +6739,18 @@ parameters:
 			path: src/Display/Results.php
 
 		-
+			message: '#^Cannot access property \$type on PhpMyAdmin\\SqlParser\\Token\|null\.$#'
+			identifier: property.nonObject
+			count: 3
+			path: src/Display/Results.php
+
+		-
+			message: '#^Cannot access property \$value on PhpMyAdmin\\SqlParser\\Token\|null\.$#'
+			identifier: property.nonObject
+			count: 6
+			path: src/Display/Results.php
+
+		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
 			count: 6

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6985,12 +6985,6 @@ parameters:
 			path: src/Display/Results.php
 
 		-
-			message: '#^Parameter \#4 \$sortDirection of method PhpMyAdmin\\Display\\Results\:\:getSingleAndMultiSortUrls\(\) expects array\<string\>, array\<mixed\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Display/Results.php
-
-		-
 			message: '#^Parameter \#6 \$colVisib of method PhpMyAdmin\\Display\\Results\:\:getRowValues\(\) expects array\<mixed\>\|bool\|string, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6753,7 +6753,7 @@ parameters:
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 24
+			count: 23
 			path: src/Display/Results.php
 
 		-
@@ -6765,7 +6765,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 8
+			count: 6
 			path: src/Display/Results.php
 
 		-
@@ -6973,19 +6973,19 @@ parameters:
 			path: src/Display/Results.php
 
 		-
+			message: '#^Parameter \#3 \$sortExpressionNoDirection of method PhpMyAdmin\\Display\\Results\:\:getTableHeaders\(\) expects array\<int, string\>, list\<string\|null\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Display/Results.php
+
+		-
 			message: '#^Parameter \#4 \$database of class PhpMyAdmin\\Display\\ForeignKeyRelatedTable constructor expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Display/Results.php
 
 		-
-			message: '#^Parameter \#4 \$sortExpressionNoDirection of method PhpMyAdmin\\Display\\Results\:\:getTableHeaders\(\) expects array\<int, string\>, list\<string\|null\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Display/Results.php
-
-		-
-			message: '#^Parameter \#5 \$sortDirection of method PhpMyAdmin\\Display\\Results\:\:getSingleAndMultiSortUrls\(\) expects array\<string\>, array\<mixed\> given\.$#'
+			message: '#^Parameter \#4 \$sortDirection of method PhpMyAdmin\\Display\\Results\:\:getSingleAndMultiSortUrls\(\) expects array\<string\>, array\<mixed\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Display/Results.php
@@ -6997,13 +6997,13 @@ parameters:
 			path: src/Display/Results.php
 
 		-
-			message: '#^Parameter \#8 \$colVisib of method PhpMyAdmin\\Display\\Results\:\:getOrderLinkAndSortedHeaderHtml\(\) expects array\<mixed\>\|bool, mixed given\.$#'
+			message: '#^Parameter \#7 \$colVisib of method PhpMyAdmin\\Display\\Results\:\:getOrderLinkAndSortedHeaderHtml\(\) expects array\<mixed\>\|bool, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Display/Results.php
 
 		-
-			message: '#^Parameter \#9 \$colVisibElement of method PhpMyAdmin\\Display\\Results\:\:getOrderLinkAndSortedHeaderHtml\(\) expects int\|string\|null, mixed given\.$#'
+			message: '#^Parameter \#8 \$colVisibElement of method PhpMyAdmin\\Display\\Results\:\:getOrderLinkAndSortedHeaderHtml\(\) expects int\|string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Display/Results.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6577,18 +6577,6 @@ parameters:
 			path: src/Display/Results.php
 
 		-
-			message: '#^Binary operation "\." between non\-empty\-string and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/Display/Results.php
-
-		-
-			message: '#^Binary operation "\." between string and \(list\<string\>\|string\) results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/Display/Results.php
-
-		-
 			message: '#^Binary operation "/" between int and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
@@ -6883,12 +6871,6 @@ parameters:
 			path: src/Display/Results.php
 
 		-
-			message: '#^Parameter \#1 \$haystack of function str_contains expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 3
-			path: src/Display/Results.php
-
-		-
 			message: '#^Parameter \#1 \$offset of method PhpMyAdmin\\Dbal\\ResultInterface\:\:seek\(\) expects int, float\|int given\.$#'
 			identifier: argument.type
 			count: 2
@@ -6961,12 +6943,6 @@ parameters:
 			path: src/Display/Results.php
 
 		-
-			message: '#^Parameter \#2 \$string of function explode expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Display/Results.php
-
-		-
 			message: '#^Parameter \#2 \$string2 of function strcasecmp expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -6994,12 +6970,6 @@ parameters:
 			message: '#^Parameter \#3 \$colOrder of method PhpMyAdmin\\Display\\Results\:\:getRowValues\(\) expects array\<mixed\>\|false, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Display/Results.php
-
-		-
-			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 3
 			path: src/Display/Results.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6973,12 +6973,6 @@ parameters:
 			path: src/Display/Results.php
 
 		-
-			message: '#^Parameter \#3 \$direction of class PhpMyAdmin\\Display\\SortExpression constructor expects ''ASC''\|''DESC'', PhpMyAdmin\\SqlParser\\Components\\OrderSortKeyword given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Display/Results.php
-
-		-
 			message: '#^Parameter \#4 \$database of class PhpMyAdmin\\Display\\ForeignKeyRelatedTable constructor expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6591,7 +6591,7 @@ parameters:
 		-
 			message: '#^Call to function array_filter\(\) requires parameter \#2 to be passed to avoid loose comparison semantics\.$#'
 			identifier: arrayFilter.strict
-			count: 3
+			count: 2
 			path: src/Display/Results.php
 
 		-
@@ -6699,7 +6699,7 @@ parameters:
 		-
 			message: '#^Cannot access property \$expr on PhpMyAdmin\\SqlParser\\Components\\Expression\|null\.$#'
 			identifier: property.nonObject
-			count: 2
+			count: 3
 			path: src/Display/Results.php
 
 		-
@@ -6765,7 +6765,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 6
+			count: 4
 			path: src/Display/Results.php
 
 		-
@@ -6973,7 +6973,7 @@ parameters:
 			path: src/Display/Results.php
 
 		-
-			message: '#^Parameter \#3 \$sortExpressionNoDirection of method PhpMyAdmin\\Display\\Results\:\:getTableHeaders\(\) expects array\<int, string\>, list\<string\|null\> given\.$#'
+			message: '#^Parameter \#3 \$direction of class PhpMyAdmin\\Display\\SortExpression constructor expects ''ASC''\|''DESC'', PhpMyAdmin\\SqlParser\\Components\\OrderSortKeyword given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Display/Results.php
@@ -6985,19 +6985,19 @@ parameters:
 			path: src/Display/Results.php
 
 		-
+			message: '#^Parameter \#6 \$colVisib of method PhpMyAdmin\\Display\\Results\:\:getOrderLinkAndSortedHeaderHtml\(\) expects array\<mixed\>\|bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Display/Results.php
+
+		-
 			message: '#^Parameter \#6 \$colVisib of method PhpMyAdmin\\Display\\Results\:\:getRowValues\(\) expects array\<mixed\>\|bool\|string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Display/Results.php
 
 		-
-			message: '#^Parameter \#7 \$colVisib of method PhpMyAdmin\\Display\\Results\:\:getOrderLinkAndSortedHeaderHtml\(\) expects array\<mixed\>\|bool, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Display/Results.php
-
-		-
-			message: '#^Parameter \#8 \$colVisibElement of method PhpMyAdmin\\Display\\Results\:\:getOrderLinkAndSortedHeaderHtml\(\) expects int\|string\|null, mixed given\.$#'
+			message: '#^Parameter \#7 \$colVisibElement of method PhpMyAdmin\\Display\\Results\:\:getOrderLinkAndSortedHeaderHtml\(\) expects int\|string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Display/Results.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6729,13 +6729,13 @@ parameters:
 		-
 			message: '#^Cannot access property \$type on PhpMyAdmin\\SqlParser\\Token\|null\.$#'
 			identifier: property.nonObject
-			count: 3
+			count: 5
 			path: src/Display/Results.php
 
 		-
 			message: '#^Cannot access property \$value on PhpMyAdmin\\SqlParser\\Token\|null\.$#'
 			identifier: property.nonObject
-			count: 6
+			count: 10
 			path: src/Display/Results.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4372,7 +4372,6 @@
       <code><![CDATA[$posMimeOctetstream]]></code>
       <code><![CDATA[empty($linkRelations['link_dependancy_params'])]]></code>
       <code><![CDATA[empty($rowInfo['routine_type'])]]></code>
-      <code><![CDATA[empty($sortExpression[$indexInExpression])]]></code>
       <code><![CDATA[empty($statement->order)]]></code>
       <code><![CDATA[empty($this->mediaTypeMap[$orgFullColName]['input_transformation'])]]></code>
       <code><![CDATA[empty($this->mediaTypeMap[$orgFullColName]['transformation'])]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4347,7 +4347,11 @@
       <code><![CDATA[$lexer->list[0]->value]]></code>
       <code><![CDATA[$lexer->list[0]->value]]></code>
       <code><![CDATA[$lexer->list[2]->type]]></code>
+      <code><![CDATA[$lexer->list[2]->type]]></code>
       <code><![CDATA[$lexer->list[2]->value]]></code>
+      <code><![CDATA[$lexer->list[2]->value]]></code>
+      <code><![CDATA[$lexer->list[4]->type]]></code>
+      <code><![CDATA[$lexer->list[4]->value]]></code>
       <code><![CDATA[$o->expr->expr]]></code>
       <code><![CDATA[$order->expr->column]]></code>
     </PossiblyNullPropertyFetch>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4161,7 +4161,6 @@
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$sortDirection]]></code>
-      <code><![CDATA[$sortExpression]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code><![CDATA[$_SESSION['tmpval']['display_binary']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4351,6 +4351,12 @@
       <code><![CDATA[$o->expr->expr]]></code>
     </PossiblyNullOperand>
     <PossiblyNullPropertyFetch>
+      <code><![CDATA[$lexer->list[0]->type]]></code>
+      <code><![CDATA[$lexer->list[0]->type]]></code>
+      <code><![CDATA[$lexer->list[0]->value]]></code>
+      <code><![CDATA[$lexer->list[0]->value]]></code>
+      <code><![CDATA[$lexer->list[2]->type]]></code>
+      <code><![CDATA[$lexer->list[2]->value]]></code>
       <code><![CDATA[$o->expr->expr]]></code>
       <code><![CDATA[$order->expr->column]]></code>
     </PossiblyNullPropertyFetch>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4123,6 +4123,9 @@
     </MixedReturnTypeCoercion>
   </file>
   <file src="src/Display/Results.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$sortDirection]]></code>
+    </ArgumentTypeCoercion>
     <InvalidArgument>
       <code><![CDATA[$linkingUrlParams]]></code>
       <code><![CDATA[$linkingUrlParams]]></code>
@@ -4159,9 +4162,6 @@
       <code><![CDATA[(int) $this->unlimNumRows / $_SESSION['tmpval']['max_rows']]]></code>
       <code><![CDATA[empty($field->database) ? $this->db : $field->database]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$sortDirection]]></code>
-    </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code><![CDATA[$_SESSION['tmpval']['display_binary']]]></code>
       <code><![CDATA[$_SESSION['tmpval']['display_binary']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4123,9 +4123,6 @@
     </MixedReturnTypeCoercion>
   </file>
   <file src="src/Display/Results.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$o->type]]></code>
-    </ArgumentTypeCoercion>
     <InvalidArgument>
       <code><![CDATA[$linkingUrlParams]]></code>
       <code><![CDATA[$linkingUrlParams]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4124,12 +4124,11 @@
   </file>
   <file src="src/Display/Results.php">
     <ArgumentTypeCoercion>
-      <code><![CDATA[$sortDirection]]></code>
+      <code><![CDATA[$o->type]]></code>
     </ArgumentTypeCoercion>
     <InvalidArgument>
       <code><![CDATA[$linkingUrlParams]]></code>
       <code><![CDATA[$linkingUrlParams]]></code>
-      <code><![CDATA[$sortExpressionNoDirection]]></code>
     </InvalidArgument>
     <InvalidArrayOffset>
       <code><![CDATA[$delUrlParams]]></code>
@@ -4339,7 +4338,6 @@
     </PossiblyNullArrayAccess>
     <PossiblyNullOperand>
       <code><![CDATA[$dispval]]></code>
-      <code><![CDATA[$o->expr->expr]]></code>
     </PossiblyNullOperand>
     <PossiblyNullPropertyFetch>
       <code><![CDATA[$lexer->list[0]->type]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4142,22 +4142,17 @@
       <code><![CDATA[$_SESSION['tmpval']['pos'] / $_SESSION['tmpval']['max_rows']]]></code>
       <code><![CDATA[$_SESSION['tmpval']['query']]]></code>
       <code><![CDATA[$_SESSION['tmpval']['query']]]></code>
-      <code><![CDATA[$clause]]></code>
       <code><![CDATA[$colOrder]]></code>
       <code><![CDATA[$colVisib]]></code>
       <code><![CDATA[$colVisib]]></code>
       <code><![CDATA[$colVisibCurrent]]></code>
       <code><![CDATA[$expr->alias]]></code>
       <code><![CDATA[$field->table]]></code>
-      <code><![CDATA[$newSortExpressionNoDirection]]></code>
       <code><![CDATA[$rel['foreign_db']]]></code>
       <code><![CDATA[$rel['foreign_db']]]></code>
       <code><![CDATA[$rel['foreign_field']]]></code>
       <code><![CDATA[$rel['foreign_table']]]></code>
       <code><![CDATA[$rel['foreign_table']]]></code>
-      <code><![CDATA[$sortExpressionNoDirection[$indexInExpression]]]></code>
-      <code><![CDATA[$sortExpressionNoDirection[$indexInExpression]]]></code>
-      <code><![CDATA[$sortExpressionNoDirection[$indexInExpression]]]></code>
       <code><![CDATA[$statementInfo->statement->from]]></code>
       <code><![CDATA[$urlParams['where_clause']]]></code>
       <code><![CDATA[(int) $this->unlimNumRows / $_SESSION['tmpval']['max_rows']]]></code>
@@ -4283,7 +4278,6 @@
       <code><![CDATA[$_SESSION['tmpval']['query'][$sqlMd5]]]></code>
       <code><![CDATA[$_SESSION['tmpval']['relational_display']]]></code>
       <code><![CDATA[$_SESSION['tmpval']['repeat_cells']]]></code>
-      <code><![CDATA[$clause]]></code>
       <code><![CDATA[$colOrder]]></code>
       <code><![CDATA[$colVisib]]></code>
       <code><![CDATA[$colVisibCurrent]]></code>
@@ -4295,7 +4289,6 @@
       <code><![CDATA[$i]]></code>
       <code><![CDATA[$identifier]]></code>
       <code><![CDATA[$meta->name]]></code>
-      <code><![CDATA[$newSortExpressionNoDirection]]></code>
       <code><![CDATA[$query]]></code>
       <code><![CDATA[$relationalDisplay]]></code>
       <code><![CDATA[$value]]></code>
@@ -4308,7 +4301,6 @@
       <code><![CDATA[$_SESSION['tmpval']['max_rows']]]></code>
       <code><![CDATA[$_SESSION['tmpval']['pos']]]></code>
       <code><![CDATA[$_SESSION['tmpval']['repeat_cells']]]></code>
-      <code><![CDATA[$sortExpressionNoDirection[$indexInExpression]]]></code>
     </MixedOperand>
     <MixedPropertyFetch>
       <code><![CDATA[$expr->alias]]></code>
@@ -4380,6 +4372,7 @@
       <code><![CDATA[$posMimeOctetstream]]></code>
       <code><![CDATA[empty($linkRelations['link_dependancy_params'])]]></code>
       <code><![CDATA[empty($rowInfo['routine_type'])]]></code>
+      <code><![CDATA[empty($sortExpression[$indexInExpression])]]></code>
       <code><![CDATA[empty($statement->order)]]></code>
       <code><![CDATA[empty($this->mediaTypeMap[$orgFullColName]['input_transformation'])]]></code>
       <code><![CDATA[empty($this->mediaTypeMap[$orgFullColName]['transformation'])]]></code>

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -3848,9 +3848,9 @@ class Results
 
         if (
             $lexer->list->count === 6
-            && $lexer->list[2]->type === TokenType::Symbol
+            && ($lexer->list[2]->type === TokenType::Symbol || $lexer->list[2]->type === TokenType::None)
             && is_string($lexer->list[2]->value)
-            && $lexer->list[4]->type === TokenType::Symbol
+            && ($lexer->list[4]->type === TokenType::Symbol || $lexer->list[4]->type === TokenType::None)
             && is_string($lexer->list[4]->value)
         ) {
             // If a database name, table name, and column name were provided
@@ -3859,9 +3859,9 @@ class Results
 
         if (
             $lexer->list->count === 4
-            && $lexer->list[0]->type === TokenType::Symbol
+            && ($lexer->list[0]->type === TokenType::Symbol || $lexer->list[0]->type === TokenType::None)
             && is_string($lexer->list[0]->value)
-            && $lexer->list[2]->type === TokenType::Symbol
+            && ($lexer->list[2]->type === TokenType::Symbol || $lexer->list[2]->type === TokenType::None)
             && is_string($lexer->list[2]->value)
         ) {
             // If a table name and column name were provided
@@ -3870,7 +3870,7 @@ class Results
 
         if (
             $lexer->list->count === 2
-            && $lexer->list[0]->type === TokenType::Symbol
+            && ($lexer->list[0]->type === TokenType::Symbol || $lexer->list[0]->type === TokenType::None)
             && is_string($lexer->list[0]->value)
         ) {
             // If only a column name was provided

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -3867,6 +3867,18 @@ class Results
     private function parseStringIntoTableAndColumn(string $nameToUseInSort): array|null
     {
         $lexer = new Lexer($nameToUseInSort);
+
+        if (
+            $lexer->list->count === 6
+            && $lexer->list[2]->type === TokenType::Symbol
+            && is_string($lexer->list[2]->value)
+            && $lexer->list[4]->type === TokenType::Symbol
+            && is_string($lexer->list[4]->value)
+        ) {
+            // If a database name, table name, and column name were provided
+            return [$lexer->list[2]->value, $lexer->list[4]->value];
+        }
+
         if (
             $lexer->list->count === 4
             && $lexer->list[0]->type === TokenType::Symbol

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -1250,9 +1250,9 @@ class Results
      * Prepare parameters and html for sorted table header fields
      *
      * @param array<int, string> $sortExpressionNoDirection sort expression without direction
-     * @param string             $sortTable                 The name of the table to which
-     *                                                      the current column belongs to
-     * @param string             $currentName               The current column under consideration
+     * @param string             $currentTable              The name of the table to which
+     *                                                   the current column belongs to
+     * @param string             $currentColumn             The current column under consideration
      * @param ('ASC'|'DESC')[]   $sortDirection             sort direction
      * @param FieldMetadata      $fieldsMeta                set of field properties
      *
@@ -1260,19 +1260,19 @@ class Results
      */
     private function getSingleAndMultiSortUrls(
         array $sortExpressionNoDirection,
-        string $sortTable,
-        string $currentName,
+        string $currentTable,
+        string $currentColumn,
         array $sortDirection,
         FieldMetadata $fieldsMeta,
     ): array {
         // Check if the current column is in the order by clause
-        $isInSort = $this->isInSorted($sortExpressionNoDirection, $sortTable, $currentName);
+        $isInSort = $this->isInSorted($sortExpressionNoDirection, $currentTable, $currentColumn);
         if ($sortExpressionNoDirection[0] == '' || ! $isInSort) {
             $specialIndex = $sortExpressionNoDirection[0] == ''
                 ? 0
                 : count($sortExpressionNoDirection);
-            $tableName = $sortTable === '' ? '' : Util::backquote($sortTable) . '.';
-            $sortExpressionNoDirection[$specialIndex] = $tableName . Util::backquote($currentName);
+            $tableName = $currentTable === '' ? '' : Util::backquote($currentTable) . '.';
+            $sortExpressionNoDirection[$specialIndex] = $tableName . Util::backquote($currentColumn);
             // Set the direction to the config value
             // Or perform SMART mode
             if ($this->config->settings['Order'] === self::SMART_SORT_ORDER) {
@@ -1307,13 +1307,13 @@ class Results
             }
 
             // Incase this is the current column save $single_sort_order
-            if ($currentName === $expression) {
+            if ($currentColumn === $expression) {
                 $singleSortOrder = 'ORDER BY ';
-                if ($sortTable !== '') {
-                    $singleSortOrder .= Util::backquote($sortTable) . '.';
+                if ($currentTable !== '') {
+                    $singleSortOrder .= Util::backquote($currentTable) . '.';
                 }
 
-                $singleSortOrder .= Util::backquote($currentName) . ' ';
+                $singleSortOrder .= Util::backquote($currentColumn) . ' ';
 
                 if ($isInSort) {
                     $singleSortOrder .= match ($sortDirection[$index]) {
@@ -1326,7 +1326,7 @@ class Results
             }
 
             $sortOrder .= ' ';
-            if ($currentName === $expression && $isInSort) {
+            if ($currentColumn === $expression && $isInSort) {
                 // We need to generate the arrow button and related html
                 $orderImg = $this->getSortingUrlParams($sortDirection[$index]);
                 $orderImg .= ' <small>' . ($index + 1) . '</small>';
@@ -1338,7 +1338,6 @@ class Results
                 $sortOrder .= $sortDirection[$index];
             }
 
-            // Separate columns by a comma
             $sortOrderColumns[] = $sortOrder;
         }
 

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Dbal\ResultInterface;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Index;
+use PhpMyAdmin\IndexColumn;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\MessageType;
 use PhpMyAdmin\Plugins\Transformations\Output\Text_Octetstream_Sql;
@@ -42,7 +43,7 @@ use PhpMyAdmin\Utils\Gis;
 
 use function __;
 use function array_filter;
-use function array_keys;
+use function array_map;
 use function array_merge;
 use function array_shift;
 use function bin2hex;
@@ -883,13 +884,15 @@ class Results
 
         $options = [];
         foreach ($indexes as $index) {
-            $ascSort = '`'
-                . implode('` ASC, `', array_keys($index->getColumns()))
-                . '` ASC';
+            $ascSort = implode(', ', array_map(
+                static fn (IndexColumn $indexName) => Util::backquote($indexName->getName()) . ' ASC',
+                $index->getColumns(),
+            ));
 
-            $descSort = '`'
-                . implode('` DESC, `', array_keys($index->getColumns()))
-                . '` DESC';
+            $descSort = implode(', ', array_map(
+                static fn (IndexColumn $indexName) => Util::backquote($indexName->getName()) . ' DESC',
+                $index->getColumns(),
+            ));
 
             $isIndexUsed = $isIndexUsed
                 || $localOrder === $ascSort

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -1279,7 +1279,8 @@ class Results
             $specialIndex = $sortExpressionNoDirection[0] == ''
                 ? 0
                 : count($sortExpressionNoDirection);
-            $sortExpressionNoDirection[$specialIndex] = Util::backquote($currentName);
+            $tableName = $sortTable === '' ? '' : Util::backquote($sortTable) . '.';
+            $sortExpressionNoDirection[$specialIndex] = $tableName . Util::backquote($currentName);
             // Set the direction to the config value
             $sortDirection[$specialIndex] = $this->config->settings['Order'];
             // Or perform SMART mode
@@ -1309,13 +1310,16 @@ class Results
                 $sortOrder .= Util::backquote($tableAndColumn[0]) . '.' . Util::backquote($expression);
             } else {
                 $expression = $tableAndColumn[0];
-                $sortOrder .= Util::backquote($sortTable) . '.' . Util::backquote($expression);
+                $sortOrder .= Util::backquote($expression);
             }
 
             // Incase this is the current column save $single_sort_order
             if ($currentName === $expression) {
                 $singleSortOrder = 'ORDER BY ';
-                $singleSortOrder .= Util::backquote($sortTable) . '.';
+                if ($sortTable !== '') {
+                    $singleSortOrder .= Util::backquote($sortTable) . '.';
+                }
+
                 $singleSortOrder .= Util::backquote($currentName) . ' ';
 
                 if ($isInSort) {

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -670,7 +670,7 @@ class Results
      *
      * @see getTableHeaders()
      *
-     * @param mixed[]            $sortExpression            sort expression
+     * @param string[]           $sortExpression            sort expression
      * @param array<int, string> $sortExpressionNoDirection sort expression
      *                                                        without direction
      * @param mixed[]            $sortDirection             sort direction
@@ -770,7 +770,7 @@ class Results
      *
      * @see getTable()
      *
-     * @param mixed[]            $sortExpression            sort expression
+     * @param string[]           $sortExpression            sort expression
      * @param array<int, string> $sortExpressionNoDirection sort expression without direction
      * @param mixed[]            $sortDirection             sort direction
      * @param bool               $isLimitedDisplay          with limited operations or not
@@ -1154,7 +1154,7 @@ class Results
      * @see getTableHeaders()
      *
      * @param FieldMetadata      $fieldsMeta                set of field properties
-     * @param mixed[]            $sortExpression            sort expression
+     * @param string[]           $sortExpression            sort expression
      * @param array<int, string> $sortExpressionNoDirection sort expression without direction
      * @param int                $sessionMaxRows            maximum rows resulted by sql
      * @param string             $comments                  comment for row
@@ -1255,7 +1255,7 @@ class Results
     /**
      * Prepare parameters and html for sorted table header fields
      *
-     * @param mixed[]            $sortExpression            sort expression
+     * @param string[]           $sortExpression            sort expression
      * @param array<int, string> $sortExpressionNoDirection sort expression without direction
      * @param string             $sortTable                 The name of the table to which
      *                                                      the current column belongs to
@@ -1349,10 +1349,10 @@ class Results
      *
      * @see getTableHeaders()
      *
-     * @param mixed[] $sortExpression            sort expression
-     * @param mixed[] $sortExpressionNoDirection sort expression without direction
-     * @param string  $sortTable                 the table name
-     * @param string  $nameToUseInSort           the sorting column name
+     * @param string[] $sortExpression            sort expression
+     * @param string[] $sortExpressionNoDirection sort expression without direction
+     * @param string   $sortTable                 the table name
+     * @param string   $nameToUseInSort           the sorting column name
      */
     private function isInSorted(
         array $sortExpression,

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -848,14 +848,14 @@ class Results
      *
      * @see getTableHeaders()
      *
-     * @param mixed[]|null $sortExpression   the sort expression
-     * @param string       $unsortedSqlQuery the unsorted sql query
+     * @param string[] $sortExpression   the sort expression
+     * @param string   $unsortedSqlQuery the unsorted sql query
      *
      * @return mixed[][]
      * @psalm-return array{hidden_fields?:array, options?:array}
      */
     private function getSortByKeyDropDown(
-        array|null $sortExpression,
+        array $sortExpression,
         string $unsortedSqlQuery,
     ): array {
         // grab indexes data:
@@ -879,7 +879,7 @@ class Results
         }
 
         $isIndexUsed = false;
-        $localOrder = is_array($sortExpression) ? implode(', ', $sortExpression) : '';
+        $localOrder = implode(', ', $sortExpression);
 
         $options = [];
         foreach ($indexes as $index) {

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -3910,7 +3910,7 @@ class Results
                 ] = $this->parseStringIntoTableAndColumn($normalizedExpression);
             }
 
-            $expressions[] = new SortExpression($tableName, $columnName, $o->type, $normalizedExpression);
+            $expressions[] = new SortExpression($tableName, $columnName, $o->type->value, $normalizedExpression);
         }
 
         return $expressions;

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -1294,6 +1294,8 @@ class Results
             // order by clause to the  column name
             $sortOrder = $index === 0 ? 'ORDER BY ' : '';
 
+            $tableOfColumn = $currentTable;
+
             // Test to detect if the column name is a standard name
             // Standard name has the table name prefixed to the column name
             if ($tableAndColumn === null) {
@@ -1301,13 +1303,14 @@ class Results
             } elseif (count($tableAndColumn) === 2) {
                 $expression = $tableAndColumn[1];
                 $sortOrder .= Util::backquote($tableAndColumn[0]) . '.' . Util::backquote($expression);
+                $tableOfColumn = $tableAndColumn[0];
             } else {
                 $expression = $tableAndColumn[0];
                 $sortOrder .= Util::backquote($expression);
             }
 
             // Incase this is the current column save $single_sort_order
-            if ($currentColumn === $expression) {
+            if ($currentColumn === $expression && $currentTable === $tableOfColumn) {
                 $singleSortOrder = 'ORDER BY ';
                 if ($currentTable !== '') {
                     $singleSortOrder .= Util::backquote($currentTable) . '.';
@@ -1326,7 +1329,7 @@ class Results
             }
 
             $sortOrder .= ' ';
-            if ($currentColumn === $expression && $isInSort) {
+            if ($currentColumn === $expression && $currentTable === $tableOfColumn && $isInSort) {
                 // We need to generate the arrow button and related html
                 $orderImg = $this->getSortingUrlParams($sortDirection[$index]);
                 $orderImg .= ' <small>' . ($index + 1) . '</small>';

--- a/src/Display/SortExpression.php
+++ b/src/Display/SortExpression.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Display;
+
+final readonly class SortExpression
+{
+    /** @param 'ASC'|'DESC' $direction */
+    public function __construct(
+        public string|null $tableName,
+        public string|null $columnName,
+        public string $direction,
+        public string $expression = '',
+    ) {
+    }
+}

--- a/tests/unit/Display/ResultsTest.php
+++ b/tests/unit/Display/ResultsTest.php
@@ -1227,13 +1227,13 @@ class ResultsTest extends AbstractTestCase
                 [
                     'column_name' => 'id',
                     'order_link' => '<a href="index.php?route=/sql&db=test_db&table=test_table'
-                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60%0AORDER+BY+%60id%60+ASC'
-                        . '&sql_signature=8e37a2f4521e45af28e26a01518e63de65737b7028e73c9536a86e83046ac1be'
+                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60+ORDER+BY+%60id%60+ASC'
+                        . '&sql_signature=73befb6d61047cd774152967254d1efb6a8bf79e01c0cabfd7f434bb43094dc1'
                         . '&session_max_rows=25&is_browse_distinct=0&server=2&lang=en" class="sortlink">id'
                         . '<input type="hidden" value="'
                         . 'index.php?route=/sql&db=test_db&table=test_table'
-                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60%0AORDER+BY+%60id%60+ASC'
-                        . '&sql_signature=8e37a2f4521e45af28e26a01518e63de65737b7028e73c9536a86e83046ac1be'
+                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60+ORDER+BY+%60id%60+ASC'
+                        . '&sql_signature=73befb6d61047cd774152967254d1efb6a8bf79e01c0cabfd7f434bb43094dc1'
                         . '&session_max_rows=25&is_browse_distinct=0&server=2&lang=en"></a>'
                         . '<input type="hidden" name="url-remove-order" value="index.php?route=/sql&db=test_db'
                         . '&table=test_table&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60'
@@ -1242,8 +1242,8 @@ class ResultsTest extends AbstractTestCase
                         . '&discard_remembered_sort=1">' . "\n"
                         . '<input type="hidden" name="url-add-order" value="'
                         . 'index.php?route=/sql&db=test_db&table=test_table'
-                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60%0AORDER+BY+%60id%60+ASC'
-                        . '&sql_signature=8e37a2f4521e45af28e26a01518e63de65737b7028e73c9536a86e83046ac1be'
+                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60+ORDER+BY+%60id%60+ASC'
+                        . '&sql_signature=73befb6d61047cd774152967254d1efb6a8bf79e01c0cabfd7f434bb43094dc1'
                         . '&session_max_rows=25&is_browse_distinct=0&server=2&lang=en">',
                     'comments' => '',
                     'is_browse_pointer_enabled' => true,
@@ -1254,13 +1254,13 @@ class ResultsTest extends AbstractTestCase
                 [
                     'column_name' => 'name',
                     'order_link' => '<a href="index.php?route=/sql&db=test_db&table=test_table'
-                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60%0AORDER+BY+%60name%60+ASC'
-                        . '&sql_signature=aec7d5c52573ac9d51c318d643fc62a8578baab162d902ce6d10318d6c5e0674'
+                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60+ORDER+BY+%60name%60+ASC'
+                        . '&sql_signature=848cc55530c90276732424e88b62d91144cc2a8c827e006c196cdcf744e457b7'
                         . '&session_max_rows=25&is_browse_distinct=0&server=2&lang=en" class="sortlink">name'
                         . '<input type="hidden" value="'
                         . 'index.php?route=/sql&db=test_db&table=test_table'
-                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60%0AORDER+BY+%60name%60+ASC'
-                        . '&sql_signature=aec7d5c52573ac9d51c318d643fc62a8578baab162d902ce6d10318d6c5e0674'
+                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60+ORDER+BY+%60name%60+ASC'
+                        . '&sql_signature=848cc55530c90276732424e88b62d91144cc2a8c827e006c196cdcf744e457b7'
                         . '&session_max_rows=25&is_browse_distinct=0&server=2&lang=en"></a>'
                         . '<input type="hidden" name="url-remove-order" value="index.php?route=/sql&db=test_db'
                         . '&table=test_table&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60'
@@ -1269,8 +1269,8 @@ class ResultsTest extends AbstractTestCase
                         . '&discard_remembered_sort=1">' . "\n"
                         . '<input type="hidden" name="url-add-order" value="'
                         . 'index.php?route=/sql&db=test_db&table=test_table'
-                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60%0AORDER+BY+%60name%60+ASC'
-                        . '&sql_signature=aec7d5c52573ac9d51c318d643fc62a8578baab162d902ce6d10318d6c5e0674'
+                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60+ORDER+BY+%60name%60+ASC'
+                        . '&sql_signature=848cc55530c90276732424e88b62d91144cc2a8c827e006c196cdcf744e457b7'
                         . '&session_max_rows=25&is_browse_distinct=0&server=2&lang=en">',
                     'comments' => '',
                     'is_browse_pointer_enabled' => true,
@@ -1281,15 +1281,15 @@ class ResultsTest extends AbstractTestCase
                 [
                     'column_name' => 'datetimefield',
                     'order_link' => '<a href="index.php?route=/sql&db=test_db&table=test_table'
-                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60%0A'
+                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60+'
                         . 'ORDER+BY+%60datetimefield%60+DESC'
-                        . '&sql_signature=6c53a00ab0e73234883b7190dab079c6e9b9b0f96eca2ee78453305599d66fc1'
+                        . '&sql_signature=c9a3b990f85df73464dafec8ecf477df6165d4d51eba1e94ba87c484b97b175c'
                         . '&session_max_rows=25&is_browse_distinct=0&server=2&lang=en" class="sortlink">datetimefield'
                         . '<input type="hidden" value="'
                         . 'index.php?route=/sql&db=test_db&table=test_table'
-                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60%0A'
+                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60+'
                         . 'ORDER+BY+%60datetimefield%60+DESC'
-                        . '&sql_signature=6c53a00ab0e73234883b7190dab079c6e9b9b0f96eca2ee78453305599d66fc1'
+                        . '&sql_signature=c9a3b990f85df73464dafec8ecf477df6165d4d51eba1e94ba87c484b97b175c'
                         . '&session_max_rows=25&is_browse_distinct=0&server=2&lang=en"></a>'
                         . '<input type="hidden" name="url-remove-order" value="index.php?route=/sql&db=test_db'
                         . '&table=test_table&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60'
@@ -1298,9 +1298,9 @@ class ResultsTest extends AbstractTestCase
                         . '&discard_remembered_sort=1">' . "\n"
                         . '<input type="hidden" name="url-add-order" value="'
                         . 'index.php?route=/sql&db=test_db&table=test_table'
-                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60%0A'
+                        . '&sql_query=SELECT+%2A+FROM+%60test_db%60.%60test_table%60+'
                         . 'ORDER+BY+%60datetimefield%60+DESC'
-                        . '&sql_signature=6c53a00ab0e73234883b7190dab079c6e9b9b0f96eca2ee78453305599d66fc1'
+                        . '&sql_signature=c9a3b990f85df73464dafec8ecf477df6165d4d51eba1e94ba87c484b97b175c'
                         . '&session_max_rows=25&is_browse_distinct=0&server=2&lang=en">',
                     'comments' => '',
                     'is_browse_pointer_enabled' => true,
@@ -1520,13 +1520,13 @@ class ResultsTest extends AbstractTestCase
                     'column_name' => 'Rows',
                     'order_link' => '<a href="index.php?route=/sql&db=test_db&table=test_table'
                         . '&sql_query=SELECT+COUNT%28%2A%29+AS+%60Rows%60%2C+%60name%60+FROM+%60test_table'
-                        . '%60+GROUP+BY+%60name%60%0AORDER+BY+%60Rows%60+ASC&sql_signature='
-                        . '9711b509280946a71dcad03bf3c85b2d4b3062cab1ffd59119b299d80c07b577&session_max_rows=25'
+                        . '%60+GROUP+BY+%60name%60+ORDER+BY+%60Rows%60+ASC&sql_signature='
+                        . '5384a639efa206f521eeb74e4d4d9aff0b53cc19093bd1b406b088a082e9fedc&session_max_rows=25'
                         . '&is_browse_distinct=1&server=2&lang=en" class="sortlink">Rows<input type="hidden" value="'
                         . 'index.php?route=/sql&db=test_db&table=test_table&sql_query='
                         . 'SELECT+COUNT%28%2A%29+AS+%60Rows%60%2C+%60name%60+FROM+%60test_table%60+GROUP+BY+'
-                        . '%60name%60%0AORDER+BY+%60name%60+ASC%2C+%60Rows%60+ASC&sql_signature='
-                        . 'faa662252a63157194e38f4b46b9cb425807cd110147664855decc2899d4ccc0&session_max_rows=25'
+                        . '%60name%60+ORDER+BY+%60name%60+ASC%2C+%60Rows%60+ASC&sql_signature='
+                        . '82594c89d410923f7ded15d65c798b4f1c1325d9453cfd450e20f8c941f2a5e6&session_max_rows=25'
                         . '&is_browse_distinct=1&server=2&lang=en"></a><input type="hidden" name="url-remove-order"'
                         . ' value="index.php?route=/sql&db=test_db&table=test_table&sql_query='
                         . 'SELECT+COUNT%28%2A%29+AS+%60Rows%60%2C+%60name%60+FROM+%60test_table%60+GROUP+BY+%60name'
@@ -1536,8 +1536,8 @@ class ResultsTest extends AbstractTestCase
                         . '<input type="hidden" name="url-add-order" value="'
                         . 'index.php?route=/sql&db=test_db&table=test_table&sql_query='
                         . 'SELECT+COUNT%28%2A%29+AS+%60Rows%60%2C+%60name%60+FROM+%60test_table%60+GROUP+BY+'
-                        . '%60name%60%0AORDER+BY+%60name%60+ASC%2C+%60Rows%60+ASC&sql_signature='
-                        . 'faa662252a63157194e38f4b46b9cb425807cd110147664855decc2899d4ccc0&session_max_rows=25'
+                        . '%60name%60+ORDER+BY+%60name%60+ASC%2C+%60Rows%60+ASC&sql_signature='
+                        . '82594c89d410923f7ded15d65c798b4f1c1325d9453cfd450e20f8c941f2a5e6&session_max_rows=25'
                         . '&is_browse_distinct=1&server=2&lang=en">',
                     'comments' => '',
                     'is_browse_pointer_enabled' => true,
@@ -1549,15 +1549,15 @@ class ResultsTest extends AbstractTestCase
                     'column_name' => 'name',
                     'order_link' => '<a href="index.php?route=/sql&db=test_db&table=test_table'
                         . '&sql_query=SELECT+COUNT%28%2A%29+AS+%60Rows%60%2C+%60name%60+FROM+%60test_table'
-                        . '%60+GROUP+BY+%60name%60%0AORDER+BY+%60name%60+DESC&sql_signature='
-                        . '5a8c171115c591960b9da8efe375a2f7f4faf44030b33230ad82053648f860ae&session_max_rows=25'
+                        . '%60+GROUP+BY+%60name%60+ORDER+BY+%60name%60+DESC&sql_signature='
+                        . '7157bdc2027884de0d40394faa9780e4e15f4343f564869fc18e5b17206eecfd&session_max_rows=25'
                         . '&is_browse_distinct=1&server=2&lang=en" class="sortlink">name <img src="themes/dot.gif"'
                         . ' title="" alt="Ascending" class="icon ic_s_asc soimg"> <img src="themes/dot.gif" title=""'
                         . ' alt="Descending" class="icon ic_s_desc soimg hide"> <small>1</small><input type="hidden"'
                         . ' value="index.php?route=/sql&db=test_db&table=test_table&sql_query='
                         . 'SELECT+COUNT%28%2A%29+AS+%60Rows%60%2C+%60name%60+FROM+%60test_table%60+GROUP+BY+'
-                        . '%60name%60%0AORDER+BY+%60name%60+DESC&sql_signature='
-                        . '5a8c171115c591960b9da8efe375a2f7f4faf44030b33230ad82053648f860ae&session_max_rows=25'
+                        . '%60name%60+ORDER+BY+%60name%60+DESC&sql_signature='
+                        . '7157bdc2027884de0d40394faa9780e4e15f4343f564869fc18e5b17206eecfd&session_max_rows=25'
                         . '&is_browse_distinct=1&server=2&lang=en"></a><input type="hidden" name="url-remove-order"'
                         . ' value="index.php?route=/sql&db=test_db&table=test_table&sql_query='
                         . 'SELECT+COUNT%28%2A%29+AS+%60Rows%60%2C+%60name%60+FROM+%60test_table%60+GROUP+BY+'
@@ -1566,8 +1566,8 @@ class ResultsTest extends AbstractTestCase
                         . '&discard_remembered_sort=1">' . "\n" . '<input type="hidden" name="url-add-order" value="'
                         . 'index.php?route=/sql&db=test_db&table=test_table&sql_query='
                         . 'SELECT+COUNT%28%2A%29+AS+%60Rows%60%2C+%60name%60+FROM+%60test_table%60+GROUP+BY+'
-                        . '%60name%60%0AORDER+BY+%60name%60+DESC&sql_signature='
-                        . '5a8c171115c591960b9da8efe375a2f7f4faf44030b33230ad82053648f860ae&session_max_rows=25'
+                        . '%60name%60+ORDER+BY+%60name%60+DESC&sql_signature='
+                        . '7157bdc2027884de0d40394faa9780e4e15f4343f564869fc18e5b17206eecfd&session_max_rows=25'
                         . '&is_browse_distinct=1&server=2&lang=en">',
                     'comments' => '',
                     'is_browse_pointer_enabled' => true,
@@ -1772,8 +1772,8 @@ class ResultsTest extends AbstractTestCase
         );
 
         self::assertSame([
-            "\n" . 'ORDER BY `Country`.`FoundedIn` ' . $querySortDirection, // singleSortOrder
-            "\n" . 'ORDER BY `Country`.`Code` ASC, `Country`.`FoundedIn` ' . $querySortDirection, // sortOrderColumns
+            'ORDER BY `Country`.`FoundedIn` ' . $querySortDirection, // singleSortOrder
+            'ORDER BY `Country`.`Code` ASC, `Country`.`FoundedIn` ' . $querySortDirection, // sortOrderColumns
             '', // orderImg
         ], $data);
 
@@ -1792,8 +1792,8 @@ class ResultsTest extends AbstractTestCase
         );
 
         self::assertSame([
-            "\n" . 'ORDER BY `Country`.`Code2` ' . $querySortDirection, // singleSortOrder
-            "\n" . 'ORDER BY `Country`.`Code` ASC, `Country`.`Code2` ' . $querySortDirection, // sortOrderColumns
+            'ORDER BY `Country`.`Code2` ' . $querySortDirection, // singleSortOrder
+            'ORDER BY `Country`.`Code` ASC, `Country`.`Code2` ' . $querySortDirection, // sortOrderColumns
             '', // orderImg
         ], $data);
 
@@ -1819,8 +1819,8 @@ class ResultsTest extends AbstractTestCase
         );
 
         self::assertSame([
-            "\n" . 'ORDER BY `Country`.`Code2` ' . $querySortDirection, // singleSortOrder
-            "\n" . 'ORDER BY `Country`.`Continent` DESC, `Country`.`Region` ASC'
+            'ORDER BY `Country`.`Code2` ' . $querySortDirection, // singleSortOrder
+            'ORDER BY `Country`.`Continent` DESC, `Country`.`Region` ASC'
                 . ', `Country`.`Population` ASC, `Country`.`Code2` ' . $querySortDirection, // sortOrderColumns
             '', // orderImg
         ], $data);

--- a/tests/unit/Display/ResultsTest.php
+++ b/tests/unit/Display/ResultsTest.php
@@ -12,6 +12,7 @@ use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Display\DeleteLinkEnum;
 use PhpMyAdmin\Display\DisplayParts;
 use PhpMyAdmin\Display\Results as DisplayResults;
+use PhpMyAdmin\Display\SortExpression;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Message;
@@ -1762,10 +1763,9 @@ class ResultsTest extends AbstractTestCase
             DisplayResults::class,
             'getSingleAndMultiSortUrls',
             [
-                ['`Country`.`Code`'], // sortExpressionNoDirection,
+                [new SortExpression('Country', 'Code', 'ASC', '`Country`.`Code`')],
                 'Country',
                 'FoundedIn',
-                ['ASC'], // sortDirection,
                 FieldHelper::fromArray(['type' => $metaType]),
             ],
         );
@@ -1781,10 +1781,9 @@ class ResultsTest extends AbstractTestCase
             DisplayResults::class,
             'getSingleAndMultiSortUrls',
             [
-                ['`Country`.`Code`'], // sortExpressionNoDirection,
+                [new SortExpression('Country', 'Code', 'ASC', '`Country`.`Code`')],
                 'Country',
                 'Code2',
-                ['ASC'], // sortDirection,
                 FieldHelper::fromArray(['type' => $metaType]),
             ],
         );
@@ -1801,13 +1800,12 @@ class ResultsTest extends AbstractTestCase
             'getSingleAndMultiSortUrls',
             [
                 [
-                    '`Country`.`Continent`',
-                    '`Country`.`Region`',
-                    '`Country`.`Population`',
-                ], // sortExpressionNoDirection,
+                    new SortExpression('Country', 'Continent', 'DESC', '`Country`.`Continent`'),
+                    new SortExpression('Country', 'Region', 'ASC', '`Country`.`Region`'),
+                    new SortExpression('Country', 'Population', 'ASC', '`Country`.`Population`'),
+                ],
                 'Country',
                 'Code2',
-                ['DESC', 'ASC', 'ASC'], // sortDirection,
                 FieldHelper::fromArray(['type' => $metaType]),
             ],
         );

--- a/tests/unit/Display/ResultsTest.php
+++ b/tests/unit/Display/ResultsTest.php
@@ -1762,9 +1762,8 @@ class ResultsTest extends AbstractTestCase
             DisplayResults::class,
             'getSingleAndMultiSortUrls',
             [
-                ['`Country`.`Code` ASC'], // sortExpression,
                 ['`Country`.`Code`'], // sortExpressionNoDirection,
-                '`Country`.',
+                'Country',
                 'FoundedIn',
                 ['ASC'], // sortDirection,
                 FieldHelper::fromArray(['type' => $metaType]),
@@ -1782,9 +1781,8 @@ class ResultsTest extends AbstractTestCase
             DisplayResults::class,
             'getSingleAndMultiSortUrls',
             [
-                ['`Country`.`Code` ASC'], // sortExpression,
                 ['`Country`.`Code`'], // sortExpressionNoDirection,
-                '`Country`.',
+                'Country',
                 'Code2',
                 ['ASC'], // sortDirection,
                 FieldHelper::fromArray(['type' => $metaType]),
@@ -1803,15 +1801,11 @@ class ResultsTest extends AbstractTestCase
             'getSingleAndMultiSortUrls',
             [
                 [
-                    '`Country`.`Continent` DESC","`Country`.`Region` ASC',
-                    '`Country`.`Population` ASC',
-                ], // sortExpression,
-                [
                     '`Country`.`Continent`',
                     '`Country`.`Region`',
                     '`Country`.`Population`',
                 ], // sortExpressionNoDirection,
-                '`Country`.',
+                'Country',
                 'Code2',
                 ['DESC', 'ASC', 'ASC'], // sortDirection,
                 FieldHelper::fromArray(['type' => $metaType]),


### PR DESCRIPTION
Fixes #19155

@MauricioFauth Do you know if there is a better way to write the `parseStringIntoTableAndColumn` function?