### PR TITLE
Fix issue when updating privileges for various databases

### DIFF
--- a/libraries/classes/Controllers/Server/PrivilegesController.php
+++ b/libraries/classes/Controllers/Server/PrivilegesController.php
@@ -234,8 +234,9 @@ class PrivilegesController extends AbstractController
          */
         if (! empty($_POST['update_privs'])) {
             if (is_array($dbname)) {
+                $statements = [];
                 foreach ($dbname as $key => $db_name) {
-                    [$sql_query[$key], $message] = $serverPrivileges->updatePrivileges(
+                    [$statements[$key], $message] = $serverPrivileges->updatePrivileges(
                         ($username ?? ''),
                         ($hostname ?? ''),
                         ($tablename ?? ($routinename ?? '')),
@@ -244,7 +245,7 @@ class PrivilegesController extends AbstractController
                     );
                 }
 
-                $sql_query = implode("\n", $sql_query);
+                $sql_query = implode("\n", $statements);
             } else {
                 [$sql_query, $message] = $serverPrivileges->updatePrivileges(
                     ($username ?? ''),

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -2539,7 +2539,7 @@ class Privileges
         $message = null;
         $queries = null;
         $queriesForDisplay = null;
-        $sqlQuery = null;
+        $sqlQuery = '';
 
         if (! isset($_POST['adduser_submit']) && ! isset($_POST['change_copy'])) {
             return [
@@ -2551,7 +2551,6 @@ class Privileges
             ];
         }
 
-        $sqlQuery = '';
         // Some reports where sent to the error reporting server with phpMyAdmin 5.1.0
         // pred_username was reported to be not defined
         $predUsername = $_POST['pred_username'] ?? '';

--- a/test/classes/AbstractTestCase.php
+++ b/test/classes/AbstractTestCase.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\Cache;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\DbiExtension;
 use PhpMyAdmin\LanguageManager;
 use PhpMyAdmin\SqlParser\Translator;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
@@ -99,6 +100,16 @@ abstract class AbstractTestCase extends TestCase
         $this->setGlobalDbi();
         $this->loadDbiIntoContainerBuilder();
         Cache::purge();
+    }
+
+    protected function createDatabaseInterface(?DbiExtension $extension = null): DatabaseInterface
+    {
+        return new DatabaseInterface($extension ?? $this->createDbiDummy());
+    }
+
+    protected function createDbiDummy(): DbiDummy
+    {
+        return new DbiDummy();
     }
 
     protected function assertAllQueriesConsumed(): void

--- a/test/classes/Controllers/Server/PrivilegesControllerTest.php
+++ b/test/classes/Controllers/Server/PrivilegesControllerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Controllers\Server;
+
+use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\Controllers\Server\PrivilegesController;
+use PhpMyAdmin\Template;
+use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
+
+/** @covers \PhpMyAdmin\Controllers\Server\PrivilegesController */
+final class PrivilegesControllerTest extends AbstractTestCase
+{
+    public function testUpdatePrivilegesForMultipleDatabases(): void
+    {
+        $GLOBALS['cfg']['Server']['DisableIS'] = true;
+
+        $_REQUEST['username'] = $_POST['username'] = 'pma_test';
+        $_REQUEST['hostname'] = $_POST['hostname'] = 'localhost';
+        $_REQUEST['dbname'] = $_POST['dbname'] = ['test_db_1', 'test_db_2'];
+        $_POST['Select_priv'] = 'Y';
+        $_POST['grant_count'] = '18';
+        $_POST['update_privs'] = '1';
+
+        $dbiDummy = $this->createDbiDummy();
+        $dbiDummy->addSelectDb('mysql');
+        // phpcs:disable Generic.Files.LineLength.TooLong
+        $dbiDummy->addResult('SHOW GRANTS FOR CURRENT_USER();', [['GRANT ALL PRIVILEGES ON *.* TO `pma_test`@`localhost` WITH GRANT OPTION']], ['Grants for pma_test@localhost']);
+        $dbiDummy->addResult('SHOW GRANTS FOR CURRENT_USER();', [['GRANT ALL PRIVILEGES ON *.* TO `pma_test`@`localhost` WITH GRANT OPTION']], ['Grants for pma_test@localhost']);
+        $dbiDummy->addResult("REVOKE ALL PRIVILEGES ON `test_db_1`.* FROM 'pma_test'@'localhost';", []);
+        $dbiDummy->addResult("REVOKE GRANT OPTION ON `test_db_1`.* FROM 'pma_test'@'localhost';", []);
+        $dbiDummy->addResult("GRANT SELECT ON `test_db_1`.* TO 'pma_test'@'localhost';", []);
+        $dbiDummy->addResult("REVOKE ALL PRIVILEGES ON `test_db_2`.* FROM 'pma_test'@'localhost';", []);
+        $dbiDummy->addResult("REVOKE GRANT OPTION ON `test_db_2`.* FROM 'pma_test'@'localhost';", []);
+        $dbiDummy->addResult("GRANT SELECT ON `test_db_2`.* TO 'pma_test'@'localhost';", []);
+        $dbiDummy->addResult("SELECT '1' FROM `mysql`.`user` WHERE `User` = 'pma_test' AND `Host` = 'localhost';", [['1']]);
+        $dbiDummy->addResult("SELECT * FROM `mysql`.`db` WHERE `User` = 'pma_test' AND `Host` = 'localhost' AND `Db` = 'test_db_1'", []);
+        $dbiDummy->addResult('SHOW COLUMNS FROM `mysql`.`db`;', [['Host', 'char(255)', 'NO', 'PRI', '', ''], ['Db', 'char(64)', 'NO', 'PRI', '', ''], ['User', 'char(128)', 'NO', 'PRI', '', ''], ['Select_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Insert_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Update_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Delete_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Create_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Drop_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Grant_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['References_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Index_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Alter_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Create_tmp_table_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Lock_tables_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Create_view_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Show_view_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Create_routine_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Alter_routine_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Execute_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Event_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Trigger_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Delete_history_priv', "enum('N','Y')", 'NO', '', 'N', ''], ['Show_create_routine_priv', "enum('N','Y')", 'NO', '', 'N', '']], ['Field', 'Type', 'Null', 'Key', 'Default', 'Extra']);
+        // phpcs:enable
+
+        $GLOBALS['dbi'] = $dbi = $this->createDatabaseInterface($dbiDummy);
+        $responseRenderer = new ResponseRenderer();
+
+        $GLOBALS['dblist'] = (object) ['databases' => ['test_db_1', 'test_db_2']];
+
+        $controller = new PrivilegesController($responseRenderer, new Template(), new Relation($dbi), $dbi);
+        $controller();
+
+        $output = $responseRenderer->getHTMLResult();
+        self::assertStringContainsString("You have updated the privileges for 'pma_test'@'localhost'.", $output);
+
+        // phpcs:disable Generic.Files.LineLength.TooLong
+        $expectedSql = '<pre>' . "\n"
+            . "REVOKE ALL PRIVILEGES ON  `test_db_1`.* FROM 'pma_test'@'localhost'; REVOKE GRANT OPTION ON  `test_db_1`.* FROM 'pma_test'@'localhost'; GRANT SELECT ON  `test_db_1`.* TO 'pma_test'@'localhost'; \n"
+            . "REVOKE ALL PRIVILEGES ON  `test_db_2`.* FROM 'pma_test'@'localhost'; REVOKE GRANT OPTION ON  `test_db_2`.* FROM 'pma_test'@'localhost'; GRANT SELECT ON  `test_db_2`.* TO 'pma_test'@'localhost'; \n"
+            . '</pre>';
+        // phpcs:enable
+        self::assertStringContainsString($expectedSql, $output);
+
+        $this->assertAllSelectsConsumed();
+        $this->assertAllQueriesConsumed();
+    }
+}


### PR DESCRIPTION
The sql_query global variable should be a string, and it can be a string in this case, which will cause an error as the string will not be converted to array.