### PR TITLE
Remove padding around varchar textarea

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -563,7 +563,7 @@ class InsertEdit
              * @todo clarify the meaning of the "textfield" class and explain
              *       why character columns have the "char" class instead
              */
-            $theClass = 'char charField';
+            $theClass = 'charField';
             $textAreaRows = $GLOBALS['cfg']['CharTextareaRows'];
             $textareaCols = $GLOBALS['cfg']['CharTextareaCols'];
             $extractedColumnspec = Util::extractColumnSpec($column['Type']);

--- a/templates/table/insert/column_row.twig
+++ b/templates/table/insert/column_row.twig
@@ -55,7 +55,7 @@
       {% elseif (longtext_double_textarea and 'longtext' in column.pma_type) or 'json' in column.pma_type or 'text' in column.pma_type %}
         {{ backup_field|raw }}
         <textarea name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" id="field_{{ id_index }}_3" data-type="{{ data_type }}" dir="{{ text_dir }}" rows="{{ textarea_rows }}" cols="{{ textarea_cols }}" tabindex="{{ tab_index + tab_index_for_value }}"
-          {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.is_char ? ' class="char charField"' }} onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')">
+          {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.is_char ? ' class="charField"' }} onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')">
           {#- We need to duplicate the first \n or otherwise we will lose the first newline entered in a VARCHAR or TEXT column -#}
           {{- special_chars starts with "\r\n" ? "\n" }}{{ special_chars|raw -}}
         </textarea>
@@ -98,7 +98,7 @@
           {{ backup_field|raw }}
           <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="hex">
           <textarea name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" id="field_{{ id_index }}_3" data-type="HEX" dir="{{ text_dir }}" rows="{{ textarea_rows }}" cols="{{ textarea_cols }}" tabindex="{{ tab_index + tab_index_for_value }}"
-            {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.is_char ? ' class="char charField"' }} onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')">
+            {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.is_char ? ' class="charField"' }} onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')">
             {#- We need to duplicate the first \n or otherwise we will lose the first newline entered in a VARCHAR or TEXT column -#}
             {{- special_chars starts with "\r\n" ? "\n" }}{{ special_chars|raw -}}
           </textarea>

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -822,7 +822,7 @@ class InsertEditTest extends AbstractTestCase
 
         $result = $this->parseString($result);
 
-        self::assertStringContainsString('<textarea name="fieldsb" class="char charField" '
+        self::assertStringContainsString('<textarea name="fieldsb" class="charField" '
         . 'data-maxlength="10" rows="7" cols="1" dir="abc/" '
         . 'id="field_1_3" tabindex="2" data-type="CHAR">', $result);
     }
@@ -1076,7 +1076,7 @@ class InsertEditTest extends AbstractTestCase
         );
 
         self::assertSame("a\n\na\n"
-        . '<textarea name="fieldsb" class="char charField" '
+        . '<textarea name="fieldsb" class="charField" '
         . 'data-maxlength="25" rows="7" cols="1" dir="/" '
         . 'id="field_1_3" c tabindex="34" data-type="CHAR">'
         . '&lt;</textarea>', $result);


### PR DESCRIPTION
### Description

This PR removes the padding around varchar textarea. This is visible on Bootstrap theme.

Before:

![before](https://github.com/user-attachments/assets/059727ce-5510-456f-bdcb-1ab5a521fd93)

After:

![after](https://github.com/user-attachments/assets/784ee834-84b7-4613-9f97-a88a639c0172)

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
