### PR TITLE
[PHP 8.4] `str_getcsv`: Fix `$escape` parameter deprecation

### DIFF
--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -1913,7 +1913,7 @@ class Util
         // It future replace str_getcsv with $dbi->fetchSingleRow('SELECT '.$expressionInBrackets[1]);
 
         preg_match('/\((.*)\)/', $definition, $expressionInBrackets);
-        $matches = str_getcsv($expressionInBrackets[1], ',', "'");
+        $matches = str_getcsv($expressionInBrackets[1], ',', "'", '\\');
 
         $values = [];
         foreach ($matches as $value) {


### PR DESCRIPTION
In PHP 8.4, not passing the `$escape` parameter to the `str_getcsv` function emits a deprecation error. This fixes the notice by passing an empty string which disables the buggy escaping mechanism.

 - [Initiating RFC](https://wiki.php.net/rfc/kill-csv-escaping)
 - [Deprecation RFC](https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_proprietary_csv_escaping_mechanism)
 - [PHP 8.4: CSV: The `$escape` parameter must be provided](https://php.watch/versions/8.4/csv-functions-escape-parameter)


Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
