### PR TITLE
Fix #19242 - Removing the popup with auto-saved query message

### DIFF
--- a/resources/js/src/sql.ts
+++ b/resources/js/src/sql.ts
@@ -52,6 +52,8 @@ function autoSave (query): void {
         } else {
             window.Cookies.set(key, query, { path: CommonParams.get('rootPath') });
         }
+
+        checkSavedQuery();
     }
 }
 
@@ -309,8 +311,6 @@ const insertQuery = function (queryType) {
         } else if (window.Cookies.get(key, { path: CommonParams.get('rootPath') })) {
             // @ts-ignore
             setQuery(window.Cookies.get(key, { path: CommonParams.get('rootPath') }));
-        } else {
-            ajaxShowMessage(window.Messages.strNoAutoSavedQuery);
         }
 
         return;
@@ -1269,15 +1269,20 @@ function getAutoSavedKey () {
 }
 
 function checkSavedQuery () {
-    var key = Sql.getAutoSavedKey();
+    let key = Sql.getAutoSavedKey();
+    let buttonGetAutoSavedQuery = $('#saved');
 
-    if (isStorageSupported('localStorage') &&
-        typeof window.localStorage.getItem(key) === 'string') {
-        ajaxShowMessage(window.Messages.strPreviousSaveQuery);
-        // @ts-ignore
-    } else if (window.Cookies.get(key, { path: CommonParams.get('rootPath') })) {
-        ajaxShowMessage(window.Messages.strPreviousSaveQuery);
+    let isAutoSavedInLocalStorage = isStorageSupported('localStorage') && (typeof window.localStorage.getItem(key) === 'string');
+    // @ts-ignore
+    let isAutoSavedInCookie = window.Cookies.get(key, { path: CommonParams.get('rootPath') });
+
+    if (isAutoSavedInLocalStorage || isAutoSavedInCookie) {
+        buttonGetAutoSavedQuery.prop('disabled', false);
+
+        return;
     }
+
+    buttonGetAutoSavedQuery.prop('disabled', true);
 }
 
 AJAX.registerOnload('sql.js', function () {

--- a/src/Controllers/JavaScriptMessagesController.php
+++ b/src/Controllers/JavaScriptMessagesController.php
@@ -408,10 +408,6 @@ final class JavaScriptMessagesController implements InvocableController
             'strDelete' => __('Delete'),
             'strNotValidRowNumber' => __('%d is not valid row number.'),
             'strBrowseForeignValues' => __('Browse foreign values'),
-            'strNoAutoSavedQuery' => __('No previously auto-saved query is available. Loading default query.'),
-            'strPreviousSaveQuery' => __(
-                'You have a previously saved query. Click Get auto-saved query to load the query.',
-            ),
             'strBookmarkVariable' => __('Variable %d:'),
 
             /* For Central list of columns */


### PR DESCRIPTION
### Description

This pull request aims to remove the pop-up displaying the message 'You have a previously saved query. Click Get auto-saved query to load the query.' This pop-up is shown multiple times and, as reported in some issues, negatively impacts the user experience.

The code was based on pull request #16456, where it was mentioned that this change is acceptable but may hide the feature from the user. Therefore, this implementation keeps the 'Get auto-saved query' button, but it is only enabled if there is a query available to be retrieved. Otherwise, the button is displayed but remains disabled.

If this change is still not acceptable, we could add a tooltip to the button, explaining that it is enabled only when there are saved queries, or we could consider other solutions.

Fixes #19242

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
