### PR TITLE
Drop Protocol version

### DIFF
--- a/resources/templates/home/index.twig
+++ b/resources/templates/home/index.twig
@@ -195,10 +195,6 @@
                 {{ database_server.version }}
               </li>
               <li class="list-group-item">
-                {{ t('Protocol version:') }}
-                {{ database_server.protocol }}
-              </li>
-              <li class="list-group-item">
                 {{ t('User:') }}
                 {{ database_server.user }}
               </li>

--- a/src/Controllers/HomeController.php
+++ b/src/Controllers/HomeController.php
@@ -167,7 +167,6 @@ final class HomeController implements InvocableController
                 'type' => Util::getServerType(),
                 'connection' => Generator::getServerSSL(),
                 'version' => $this->dbi->getVersionString() . ' - ' . $this->dbi->getVersionComment(),
-                'protocol' => $this->dbi->getProtoInfo(),
                 'user' => $this->dbi->fetchValue('SELECT USER();'),
                 'charset' => $serverCharset->getDescription() . ' (' . $serverCharset->getName() . ')',
             ];

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -1734,20 +1734,6 @@ class DatabaseInterface implements DbalInterface
     }
 
     /**
-     * Returns the version of the MySQL protocol used
-     *
-     * @return int|bool version of the MySQL protocol used
-     */
-    public function getProtoInfo(ConnectionType $connectionType = ConnectionType::User): int|bool
-    {
-        if (! isset($this->connections[$connectionType->value])) {
-            return false;
-        }
-
-        return $this->extension->getProtoInfo($this->connections[$connectionType->value]);
-    }
-
-    /**
      * returns a string that represents the client library version
      *
      * @return string MySQL client library version

--- a/src/Dbal/DbalInterface.php
+++ b/src/Dbal/DbalInterface.php
@@ -453,13 +453,6 @@ interface DbalInterface
     public function getHostInfo(ConnectionType $connectionType = ConnectionType::User): string|bool;
 
     /**
-     * Returns the version of the MySQL protocol used
-     *
-     * @return int|bool version of the MySQL protocol used
-     */
-    public function getProtoInfo(ConnectionType $connectionType = ConnectionType::User): int|bool;
-
-    /**
      * returns a string that represents the client library version
      *
      * @return string MySQL client library version

--- a/src/Dbal/DbiExtension.php
+++ b/src/Dbal/DbiExtension.php
@@ -66,13 +66,6 @@ interface DbiExtension
     public function getHostInfo(Connection $connection): string;
 
     /**
-     * Returns the version of the MySQL protocol used
-     *
-     * @return int version of the MySQL protocol used
-     */
-    public function getProtoInfo(Connection $connection): int;
-
-    /**
      * returns a string that represents the client library version
      *
      * @return string MySQL client library version

--- a/src/Dbal/DbiMysqli.php
+++ b/src/Dbal/DbiMysqli.php
@@ -230,20 +230,6 @@ class DbiMysqli implements DbiExtension
     }
 
     /**
-     * Returns the version of the MySQL protocol used
-     *
-     * @return int version of the MySQL protocol used
-     */
-    public function getProtoInfo(Connection $connection): int
-    {
-        /** @var mysqli $mysqli */
-        $mysqli = $connection->connection;
-
-        // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-        return $mysqli->protocol_version;
-    }
-
-    /**
      * returns a string that represents the client library version
      *
      * @return string MySQL client library version

--- a/tests/unit/Stubs/DbiDummy.php
+++ b/tests/unit/Stubs/DbiDummy.php
@@ -237,16 +237,6 @@ class DbiDummy implements DbiExtension
     }
 
     /**
-     * Returns the version of the MySQL protocol used
-     *
-     * @return int version of the MySQL protocol used
-     */
-    public function getProtoInfo(Connection $connection): int
-    {
-        return -1;
-    }
-
-    /**
      * returns a string that represents the client library version
      *
      * @return string MySQL client library version


### PR DESCRIPTION
This information is no longer relevant. It might have been relevant 20 years ago when protocol 9 was still used, but nowadays I doubt PHP can even support protocol 9. I am not aware of any further iterations of this protocol. This information can be easily confused with the one line above it. 