### PR TITLE
Fix failing end to end tests

### DIFF
--- a/.github/workflows/test-selenium.yml
+++ b/.github/workflows/test-selenium.yml
@@ -61,11 +61,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Refresh apt cache
-        run: sudo apt-get update
-
       - name: Install gettext
-        run: sudo apt-get install -y gettext
+        run: sudo apt-get update && sudo apt-get install -y gettext
 
       - name: Generate mo files
         run: ./scripts/generate-mo --quiet
@@ -85,18 +82,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 12
-
-      - name: Get Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Yarn dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
 
       - name: Install modules
         run: yarn install --non-interactive --production
@@ -143,4 +129,4 @@ jobs:
         with:
           name: selenium-screenshots
           path: ${{ github.workspace }}/build/selenium/**/*
-          retention-days: 1
+          retention-days: 3

--- a/test/selenium/TestBase.php
+++ b/test/selenium/TestBase.php
@@ -18,6 +18,7 @@ use Facebook\WebDriver\WebDriverElement;
 use Facebook\WebDriver\WebDriverExpectedCondition;
 use Facebook\WebDriver\WebDriverSelect;
 use InvalidArgumentException;
+use PHPUnit\Framework\SkippedTest;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
@@ -664,7 +665,7 @@ abstract class TestBase extends TestCase
             $this->waitAjax();
             $this->waitForElement('className', 'result_query');
             // If present then
-            $didSucceed = $this->isElementPresent('xpath', '//*[@class="result_query"]//*[contains(., "success")]');
+            $didSucceed = $this->isElementPresent('cssSelector', '.result_query .alert-success');
             if ($onResults !== null) {
                 $onResults->call($this);
             }
@@ -1197,6 +1198,10 @@ JS;
      */
     public function onNotSuccessfulTest(Throwable $t): void
     {
+        if ($t instanceof SkippedTest) {
+            parent::onNotSuccessfulTest($t);
+        }
+
         $this->markTestAs('failed', $t->getMessage());
         $this->takeScrenshot('test_failed');
         // End testing session


### PR DESCRIPTION
- Taking screenshots causes error for skipped tests
- Uses CSS selector instead of xPath to check for the success message