### PR TITLE
Fix multi-arch docker builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         include:
           - { php-version: '82', experimental: false, arch: 'amd64', exclude-phpunit-groups: 'extension-iconv' }
-          - { php-version: '82', experimental: false, arch: 'arm64v8', exclude-phpunit-groups: 'extension-iconv' }
-          - { php-version: '82', experimental: false, arch: 'arm32v7', exclude-phpunit-groups: 'extension-iconv,32bit-incompatible' }
+          - { php-version: '82', experimental: false, arch: 'arm64/v8', exclude-phpunit-groups: 'extension-iconv' }
+          - { php-version: '82', experimental: false, arch: 'arm/v7', exclude-phpunit-groups: 'extension-iconv,32bit-incompatible' }
           - { php-version: '82', experimental: false, arch: 'i386', exclude-phpunit-groups: 'extension-iconv,32bit-incompatible' }
           - { php-version: '82', experimental: true, arch: 'ppc64le', exclude-phpunit-groups: 'extension-iconv' }
           - { php-version: '82', experimental: false, arch: 's390x', exclude-phpunit-groups: 'extension-iconv,32bit-incompatible' }
@@ -55,10 +55,10 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
       - name: Print arch
-        run: docker run --rm ${{ matrix.arch }}/alpine:3.19 uname -a
+        run: docker run --rm --platform linux/${{ matrix.arch }} alpine:3.19 uname -a
 
       - name: Run tests on php ${{ matrix.php-version }}
-        run: docker run -v $PWD:/app --workdir /app --rm ${{ matrix.arch }}/alpine:3.19 sh /app/do-tests.sh
+        run: docker run -v $PWD:/app --workdir /app --rm --platform linux/${{ matrix.arch }} alpine:3.19 sh /app/do-tests.sh
 
   test-php:
     name: Test on PHP ${{ matrix.php-version }}, ${{ matrix.composer-dependency }} and ${{ matrix.os }}


### PR DESCRIPTION
Looks like the `--platform` option is needed now.

```diff
- docker run --rm arm64v8/alpine:3.19 uname -a
+ docker run --rm --platform linux/arm64/v8 alpine:3.19 uname -a
```

Error: https://github.com/phpmyadmin/phpmyadmin/actions/runs/12149900041/job/33881541169#step:5:7
```
Run docker run --rm arm64v8/alpine:3.19 uname -a
  docker run --rm arm64v8/alpine:3.19 uname -a
  shell: /usr/bin/bash -e {0}
Unable to find image 'arm64v8/alpine:3.19' locally
3.19: Pulling from arm64v8/alpine
docker: no matching manifest for linux/amd64 in the manifest list entries.
See 'docker run --help'.
Error: Process completed with exit code 125.
```