### PR TITLE
Add check fox Sodium extension

### DIFF
--- a/src/Http/Middleware/PhpExtensionsChecking.php
+++ b/src/Http/Middleware/PhpExtensionsChecking.php
@@ -15,6 +15,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 use function __;
+use function defined;
 use function function_exists;
 use function sprintf;
 
@@ -84,6 +85,10 @@ final class PhpExtensionsChecking implements MiddlewareInterface
 
         if (! function_exists('session_name')) {
             Core::warnMissingExtension('session', true);
+        }
+
+        if (! defined('SODIUM_CRYPTO_SECRETBOX_KEYBYTES')) {
+            Core::warnMissingExtension('sodium', true);
         }
 
         /**


### PR DESCRIPTION
The link doesn't work. I tried to solve it, but to be honest, I do not understand why it's not a direct link to php.net. It sends the URL to the server only for it to generate a JavaScript to redirect to php.net. 