### PR TITLE
Refactor pmaType

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10870,6 +10870,12 @@ parameters:
 			path: src/InsertEdit.php
 
 		-
+			message: '#^Method PhpMyAdmin\\InsertEditColumn\:\:getDisplayType\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: src/InsertEditColumn.php
+
+		-
 			message: '#^Property PhpMyAdmin\\InsertEditColumn\:\:\$trueType \(string\) does not accept string\|null\.$#'
 			identifier: assign.propertyType
 			count: 1

--- a/resources/js/src/table/change.ts
+++ b/resources/js/src/table/change.ts
@@ -432,7 +432,7 @@ function verificationsAfterFieldChange (urlField, multiEdit, theType) {
         // call validate before adding rules
         $($thisInput[0].form).validate();
         // validate for date time
-        if (theType === 'datetime' || theType === 'time' || theType === 'date' || theType === 'timestamp') {
+        if (theType.startsWith('time') || theType.startsWith('date')) {
             $thisInput.rules('add', {
                 validationFunctionForDateTime: {
                     param: theType,

--- a/resources/templates/table/insert/column_row.twig
+++ b/resources/templates/table/insert/column_row.twig
@@ -6,7 +6,7 @@
 
   {% if show_field_types_in_data_edit_view %}
     <td class="text-center{{ column.trueType not in ['set', 'enum'] ? ' text-nowrap' }}">
-      <span class="column_type" dir="ltr">{{ column.pmaType }}</span>
+      <span class="column_type" dir="ltr">{{ displayType }}</span>
     </td>
   {% endif %}
 
@@ -17,7 +17,7 @@
       <td class="text-center">--</td>
     {% else %}
       <td>
-        <select name="funcs[multi_edit][{{ row_id }}][{{ column.md5 }}]" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')" id="field_{{ id_index }}_1">
+        <select name="funcs[multi_edit][{{ row_id }}][{{ column.md5 }}]" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')" id="field_{{ id_index }}_1">
           {{ function_options|raw }}
         </select>
       </td>
@@ -44,31 +44,31 @@
       {% if is_value_foreign_link %}
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="foreign">
-        <input type="text" name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" tabindex="{{ id_index }}" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')" id="field_{{ id_index }}_3" value="{{ data }}">
+        <input type="text" name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" tabindex="{{ id_index }}" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')" id="field_{{ id_index }}_3" value="{{ data }}">
         <a class="ajax browse_foreign" href="{{ url('/browse-foreigners') }}" data-post="{{ get_common({'db': db, 'table': table, 'field': column.field, 'rownumber': row_id, 'data': data}) }}">{{ get_icon('b_browse', t('Browse foreign values')) }}</a>
       {% elseif foreign_dropdown is not empty %}
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="{{ column.isBinary ? 'hex' : 'foreign' }}">
-        <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" tabindex="{{ id_index }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')">
+        <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" tabindex="{{ id_index }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')">
           {{ foreign_dropdown|raw }}
         </select>
-      {% elseif (longtext_double_textarea and 'longtext' in column.pmaType) or 'json' in column.pmaType or 'text' in column.pmaType %}
+      {% elseif (longtext_double_textarea and 'longtext' in column.trueType) or 'json' in column.trueType or 'text' in column.trueType %}
         {{ backup_field|raw }}
         <textarea name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" id="field_{{ id_index }}_3" data-type="{{ data_type }}" dir="{{ pma.text_dir }}" rows="{{ textarea_rows }}" cols="{{ textarea_cols }}" tabindex="{{ id_index }}"
-          {{- max_length ? ' data-maxlength="' ~ max_length ~ '"' }}{{ column.isChar ? ' class="charField"' }} onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')">
+          {{- max_length ? ' data-maxlength="' ~ max_length ~ '"' }}{{ column.isChar ? ' class="charField"' }} onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')">
           {#- We need to duplicate the first \n or otherwise we will lose the first newline entered in a VARCHAR or TEXT column -#}
           {{- special_chars starts with "\r\n" ? "\n" }}{{ special_chars|raw -}}
         </textarea>
-        {% if 'text' in column.pmaType and special_chars|length > 32000 %}
+        {% if 'text' in column.trueType and special_chars|length > 32000 %}
           </td>
           <td>
           {{ t('Because of its length,<br> this column might not be editable.')|raw }}
         {% endif %}
-      {% elseif column.pmaType == 'enum' %}
+      {% elseif column.trueType == 'enum' %}
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="enum">
         {% if column.type|length > 20 %}
-          <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" tabindex="{{ id_index }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')">
+          <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" tabindex="{{ id_index }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')">
             <option value=""></option>
             {% for enum_value in enum_values %}
               <option value="{{ enum_value }}"{{ enum_value == enum_selected_value ? ' selected' }}>{{ enum_value }}</option>
@@ -76,14 +76,14 @@
           </select>
         {% else %}
           {% for enum_value in enum_values %}
-            <input type="radio" name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="{{ enum_value }}" class="textfield" tabindex="{{ id_index }}" id="field_{{ id_index }}_3_{{ loop.index0 }}" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')"{{ enum_value == enum_selected_value ? ' checked' }}>
+            <input type="radio" name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="{{ enum_value }}" class="textfield" tabindex="{{ id_index }}" id="field_{{ id_index }}_3_{{ loop.index0 }}" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')"{{ enum_value == enum_selected_value ? ' checked' }}>
             <label for="field_{{ id_index }}_3_{{ loop.index0 }}">{{ enum_value }}</label>
           {% endfor %}
         {% endif %}
-      {% elseif column.pmaType == 'set' %}
+      {% elseif column.trueType == 'set' %}
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="set">
-        <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}][]" class="textfield" tabindex="{{ id_index }}" size="{{ set_select_size }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')" multiple>
+        <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}][]" class="textfield" tabindex="{{ id_index }}" size="{{ set_select_size }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')" multiple>
           {% for set_value in set_values %}
             <option value="{{ set_value }}"{{ set_value in data|split(',') ? ' selected' }}>{{ set_value }}</option>
           {% endfor %}
@@ -98,7 +98,7 @@
           {{ backup_field|raw }}
           <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="hex">
           <textarea name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" id="field_{{ id_index }}_3" data-type="HEX" dir="{{ pma.text_dir }}" rows="{{ textarea_rows }}" cols="{{ textarea_cols }}" tabindex="{{ id_index }}"
-            {{- max_length ? ' data-maxlength="' ~ max_length ~ '"' }}{{ column.isChar ? ' class="charField"' }} onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')">
+            {{- max_length ? ' data-maxlength="' ~ max_length ~ '"' }}{{ column.isChar ? ' class="charField"' }} onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')">
             {#- We need to duplicate the first \n or otherwise we will lose the first newline entered in a VARCHAR or TEXT column -#}
             {{- special_chars starts with "\r\n" ? "\n" }}{{ special_chars|raw -}}
           </textarea>
@@ -110,11 +110,11 @@
         {% if is_upload and column.isBlob %}
           <br>
           {# We don't want to prevent users from using browser's default drag-drop feature on some page(s), so we add noDragDrop class to the input #}
-          <input type="file" name="fields_upload[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield noDragDrop" id="field_{{ id_index }}_3" size="10" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')">
+          <input type="file" name="fields_upload[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield noDragDrop" id="field_{{ id_index }}_3" size="10" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')">
           {{ max_upload_size }}
         {% endif %}
         {{ select_option_for_upload|raw }}
-      {% elseif column.pmaType in gis_data_types %}
+      {% elseif column.trueType in gis_data_types %}
         {{ value|raw }}
         <button type="button" class="btn btn-link open_gis_editor" data-bs-toggle="modal" data-bs-target="#gisEditorModal" data-row-id="{{ row_id }}">
           {{ get_icon('b_edit', t('Edit/Insert')) }}

--- a/resources/templates/table/insert/value_column_for_other_datatype.twig
+++ b/resources/templates/table/insert/value_column_for_other_datatype.twig
@@ -3,21 +3,13 @@
   {{- html_field|raw -}}
 {% else %}
   {{- html_field|raw -}}
-  {%- if column.extra matches '/(VIRTUAL|PERSISTENT|GENERATED)/' and 'DEFAULT_GENERATED' not in column.extra -%}
+  {%- if extra matches '/(VIRTUAL|PERSISTENT|GENERATED)/' and 'DEFAULT_GENERATED' not in extra -%}
     <input type="hidden" name="virtual{{ columnNameAppendix }}" value="1">
   {%- endif -%}
-  {%- if column.extra == 'auto_increment' -%}
+  {%- if extra == 'auto_increment' -%}
     <input type="hidden" name="auto_increment{{ columnNameAppendix }}" value="1">
   {%- endif -%}
-  {%- if column.pmaType starts with 'timestamp' -%}
-    <input type="hidden" name="fields_type{{ columnNameAppendix }}" value="timestamp">
-  {%- endif -%}
-  {%- if column.pmaType starts with 'datetime' -%}
-    <input type="hidden" name="fields_type{{ columnNameAppendix }}" value="datetime">
-  {%- elseif column.pmaType starts with 'date' -%}
-    <input type="hidden" name="fields_type{{ columnNameAppendix }}" value="date">
-  {%- endif -%}
-  {%- if column.trueType == 'bit' or column.trueType == 'uuid' -%}
-    <input type="hidden" name="fields_type{{ columnNameAppendix }}" value="{{ column.trueType }}">
+  {%- if trueType == 'bit' or trueType == 'uuid' or trueType == 'timestamp' or trueType == 'datetime' or trueType == 'date' -%}
+    <input type="hidden" name="fields_type{{ columnNameAppendix }}" value="{{ trueType }}">
   {%- endif -%}
 {% endif %}

--- a/src/InsertEdit.php
+++ b/src/InsertEdit.php
@@ -19,7 +19,6 @@ use function array_merge;
 use function array_values;
 use function bin2hex;
 use function count;
-use function explode;
 use function htmlspecialchars;
 use function implode;
 use function in_array;
@@ -340,9 +339,9 @@ class InsertEdit
         bool $foreignLink,
     ): string {
         $foreigner = $this->relation->searchColumnInForeigners($foreigners, $column->field);
-        if (str_contains($column->trueType, 'enum')) {
+        if ($column->trueType === 'enum') {
             $nullifyCode = mb_strlen($column->type) > 20 ? '1' : '2';
-        } elseif (str_contains($column->trueType, 'set')) {
+        } elseif ($column->trueType === 'set') {
             $nullifyCode = '3';
         } elseif ($foreigner !== false && ! $foreignLink) {
             // foreign key in a drop-down
@@ -392,7 +391,7 @@ class InsertEdit
             $textareaCols = $this->config->settings['CharTextareaCols'];
             $extractedColumnspec = Util::extractColumnSpec($column->type);
             $maxlength = $extractedColumnspec['spec_in_brackets'];
-        } elseif ($this->config->settings['LongtextDoubleTextarea'] && str_contains($column->pmaType, 'longtext')) {
+        } elseif ($this->config->settings['LongtextDoubleTextarea'] && $column->trueType === 'longtext') {
             $textAreaRows = $this->config->settings['TextareaRows'] * 2;
             $textareaCols = $this->config->settings['TextareaCols'] * 2;
         }
@@ -433,7 +432,6 @@ class InsertEdit
         string $dataType,
     ): string {
         $theClass = 'textfield';
-        // verify True_Type which does not contain the parentheses and length
         if ($column->trueType === 'date') {
             $theClass .= ' datefield';
         } elseif ($column->trueType === 'time') {
@@ -505,14 +503,14 @@ class InsertEdit
     /**
      * Retrieve the maximum upload file size
      */
-    private function getMaxUploadSize(string $pmaType): string
+    private function getMaxUploadSize(string $type): string
     {
         // find maximum upload size, based on field type
         /**
          * @todo with functions this is not so easy, as you can basically
          * process any data with function like MD5
          */
-        $maxFieldSize = match ($pmaType) {
+        $maxFieldSize = match ($type) {
             'tinyblob' => 256,
             'blob' => 65536,
             'mediumblob' => 16777216,
@@ -587,7 +585,8 @@ class InsertEdit
             'backup_field' => $backupField,
             'is_textarea' => $isTextareaRequired,
             'columnNameAppendix' => $columnNameAppendix,
-            'column' => $column,
+            'extra' => $column->extra,
+            'trueType' => $column->trueType,
         ]);
     }
 
@@ -747,7 +746,7 @@ class InsertEdit
                     (int) $extractedColumnspec['spec_in_brackets'],
                 );
         } elseif (
-            (str_starts_with($column->trueType, 'timestamp')
+            ($column->trueType === 'timestamp'
                 || $column->trueType === 'datetime'
                 || $column->trueType === 'time')
             && (str_contains($currentRow[$column->field], '.'))
@@ -814,7 +813,7 @@ class InsertEdit
 
         if ($trueType === 'bit') {
             $specialChars = Util::convertBitDefaultValue($defaultValue);
-        } elseif (str_starts_with($trueType, 'timestamp') || $trueType === 'datetime' || $trueType === 'time') {
+        } elseif ($trueType === 'timestamp' || $trueType === 'datetime' || $trueType === 'time') {
             $specialChars = Util::addMicroseconds($defaultValue);
         } elseif ($trueType === 'binary' || $trueType === 'varbinary') {
             $specialChars = bin2hex($defaultValue);
@@ -1597,7 +1596,7 @@ class InsertEdit
         //Call validation when the form submitted...
         $onChangeClause = 'return verificationsAfterFieldChange('
             . json_encode($fieldHashMd5) . ', '
-            . json_encode((string) $rowId) . ',' . json_encode($column->pmaType) . ')';
+            . json_encode((string) $rowId) . ',' . json_encode($column->type) . ')';
 
         $vkey = '[multi_edit][' . $rowId . ']';
         // Use an MD5 as an array index to avoid having special characters
@@ -1661,14 +1660,6 @@ class InsertEdit
         // ----------------
         // See bug #1667887 for the reason why we don't use the maxlength
         // HTML attribute
-
-        //add data attributes "no of decimals" and "data type"
-        $noDecimals = 0;
-        $type = explode('(', $column->pmaType)[0];
-        if (preg_match('/\(([^()]+)\)/', $column->pmaType, $match) === 1) {
-            $match[0] = trim($match[0], '()');
-            $noDecimals = $match[0];
-        }
 
         // Check input transformation of column
         $transformedHtml = '';
@@ -1736,12 +1727,12 @@ class InsertEdit
                 $textAreaRows = max($this->config->settings['CharTextareaRows'], 7);
                 $textareaCols = $this->config->settings['CharTextareaCols'];
                 $maxlength = $extractedColumnspec['spec_in_brackets'];
-            } elseif ($this->config->settings['LongtextDoubleTextarea'] && str_contains($column->pmaType, 'longtext')) {
+            } elseif ($this->config->settings['LongtextDoubleTextarea'] && $column->trueType === 'longtext') {
                 $textAreaRows = $this->config->settings['TextareaRows'] * 2;
                 $textareaCols = $this->config->settings['TextareaCols'] * 2;
             }
 
-            if ($column->pmaType === 'enum') {
+            if ($column->trueType === 'enum') {
                 $enumValues = $extractedColumnspec['enum_set_values'];
 
                 foreach ($enumValues as $enumValue) {
@@ -1754,7 +1745,7 @@ class InsertEdit
                         break;
                     }
                 }
-            } elseif ($column->pmaType === 'set') {
+            } elseif ($column->trueType === 'set') {
                 $columnSetValues = $extractedColumnspec['enum_set_values'];
                 $setSelectSize = min(4, count($extractedColumnspec['enum_set_values']));
             } elseif ($column->isBinary || $column->isBlob) {
@@ -1766,7 +1757,7 @@ class InsertEdit
                 }
 
                 if ($isUpload && $column->isBlob) {
-                    $maxUploadSize = $this->getMaxUploadSize($column->pmaType);
+                    $maxUploadSize = $this->getMaxUploadSize($column->trueType);
                 }
 
                 if (! empty($this->config->settings['UploadDir'])) {
@@ -1813,8 +1804,9 @@ class InsertEdit
             'nullify_code' => $nullifyCode,
             'real_null_value' => $realNullValue,
             'id_index' => $this->fieldIndex,
-            'type' => $type,
-            'decimals' => $noDecimals,
+            'type' => $column->trueType,
+            'displayType' => $column->getDisplayType(),
+            'decimals' => $column->getFractionalSecondsPrecision(),
             'special_chars' => $specialChars,
             'transformed_value' => $transformedHtml,
             'value' => $columnValue,

--- a/tests/unit/InsertEditTest.php
+++ b/tests/unit/InsertEditTest.php
@@ -689,24 +689,24 @@ class InsertEditTest extends AbstractTestCase
     {
         $config = Config::getInstance();
         $config->set('max_upload_size', 257);
-        $pmaType = 'tinyblob';
+        $type = 'tinyblob';
         $result = $this->callFunction(
             $this->insertEdit,
             InsertEdit::class,
             'getMaxUploadSize',
-            [$pmaType],
+            [$type],
         );
 
         self::assertSame("(Max: 256B)\n", $result);
 
         // case 2
         $config->set('max_upload_size', 250);
-        $pmaType = 'tinyblob';
+        $type = 'tinyblob';
         $result = $this->callFunction(
             $this->insertEdit,
             InsertEdit::class,
             'getMaxUploadSize',
-            [$pmaType],
+            [$type],
         );
 
         self::assertSame("(Max: 250B)\n", $result);


### PR DESCRIPTION
Fixes #19426 on master. This PR attempts to improve the code by removing the confusing `pmaType` property. Some of it is merged into `trueType`. After the comments are stripped from the type, it's enough to just do an equality comparison in a lot of places. 

The JavaScript code seems to still contain errors, but I am not very good at debugging JS so I couldn't figure out how to fix it. Instead of `pmaType` the `type` is passed to JS in hopes that it won't be more broken than it already is.

The `getDisplayType()` method was added to keep the old behaviour of not displaying the set/enum values. An addition was made to strip the comments as well. It would also make sense to strip brackets from integer values but that would be off-topic for this PR.

The method `getFractionalSecondsPrecision` was added. I assume that the purpose of "decimals" was to indicate to JS datepicker whether the time has microseconds and milliseconds. If so, calling it "decimals" was a strange choice. The new method reflects the presumed true purpose. 

After the PR the type exists in two variants:
- `type` - exact value as provided by DB
- `trueType` - stripped value that represents the actual data type name 