### PR TITLE
Fix #19302 - Prevent invalid SQL queries when no table selected in SQL tab

### DIFF
--- a/src/Controllers/Database/MultiTableQuery/QueryController.php
+++ b/src/Controllers/Database/MultiTableQuery/QueryController.php
@@ -6,22 +6,58 @@ namespace PhpMyAdmin\Controllers\Database\MultiTableQuery;
 
 use PhpMyAdmin\Controllers\InvocableController;
 use PhpMyAdmin\Database\MultiTableQuery;
+use PhpMyAdmin\Database\QueryValidator;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\ResponseRenderer;
 
+use function is_string;
+
 final class QueryController implements InvocableController
 {
-    public function __construct(private readonly ResponseRenderer $response)
-    {
+    public function __construct(
+        private readonly ResponseRenderer $response,
+        private readonly QueryValidator|null $validator = null,
+    ) {
     }
 
     public function __invoke(ServerRequest $request): Response
     {
-        $this->response->addHTML(MultiTableQuery::displayResults(
-            $request->getParsedBodyParamAsString('sql_query'),
-            $request->getParam('db'),
-        ));
+        // Ensure 'sql_query' parameter is always a string
+        $query = $request->getParsedBodyParamAsString('sql_query');
+        $db = $request->getParam('db');
+        $table = $request->getParam('table');
+
+        if (! is_string($db)) {
+            $this->response->addJSON('error', 'Invalid query or database name.');
+
+            return $this->response->response();
+        }
+
+        $context = ['db' => $db];
+
+        // Revised: Only add 'table' to $context if it is a string
+        if (is_string($table)) {
+            $context['table'] = $table;
+        }
+
+        if ($this->validator !== null) {
+            $validationResult =
+                $this->validator->validateQuery($query, $table !== null && is_string($table) ? $table : null, $context);
+
+            if (! $validationResult['isValid']) {
+                $this->response->addJSON('error', $validationResult['error']);
+
+                return $this->response->response();
+            }
+
+            $this->response->addHTML(
+                MultiTableQuery::displayResults(
+                    $validationResult['query'],
+                    $db,
+                ),
+            );
+        }
 
         return $this->response->response();
     }

--- a/src/Controllers/Database/QueryValidator.php
+++ b/src/Controllers/Database/QueryValidator.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Database;
+
+use function preg_match;
+use function preg_replace;
+use function trim;
+
+class QueryValidator
+{
+    /**
+     * Validates and processes a SQL query before execution
+     *
+     * @param string                              $query   The SQL query to validate
+     * @param string|null                         $table   Selected table name
+     * @param array<string, string|int|bool|null> $context Additional context like database name
+     *
+     * @return array{isValid: bool, query: string, error: string|null}
+     */
+    public function validateQuery(
+        string $query,
+        string|null $table,
+        array $context = [],
+    ): array {
+        // Check if query contains metadata requests without table context
+        if ($this->hasMetadataRequests($query) && $table === null) {
+            return [
+                'isValid' => false,
+                'query' => $query,
+                'error' => 'Table must be selected for metadata queries',
+            ];
+        }
+
+        // Process and clean the query
+        $processedQuery = $this->processQuery($query, $table, $context);
+
+        // Check for SQL injection attempts in metadata queries
+        if ($table !== null && $this->hasMetadataRequests($query) && $this->containsSuspiciousPatterns($query)) {
+            return [
+                'isValid' => false,
+                'query' => $query,
+                'error' => 'Invalid query',
+            ];
+        }
+
+        return [
+            'isValid' => true,
+            'query' => $processedQuery,
+            'error' => null,
+        ];
+    }
+
+    /**
+     * Checks if query contains metadata requests
+     */
+    private function hasMetadataRequests(string $query): bool
+    {
+        $metadataPatterns = [
+            '/SHOW\s+COLUMNS\s+FROM/i',
+            '/SHOW\s+INDEXES\s+FROM/i',
+            '/SHOW\s+INDEX\s+FROM/i',
+            '/SHOW\s+KEYS\s+FROM/i',
+        ];
+
+        foreach ($metadataPatterns as $pattern) {
+            $result = preg_match($pattern, $query);
+            if ($result === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Process and clean the query
+     *
+     * @param string                              $query   The SQL query to process
+     * @param string|null                         $table   Selected table name
+     * @param array<string, string|int|bool|null> $context Additional context like database name
+     */
+    private function processQuery(
+        string $query,
+        string|null $table,
+        array $context,
+    ): string {
+        // Remove any malformed metadata queries when no table is selected
+        if ($table === null) {
+            $cleanedQuery = preg_replace('/SHOW\s+(COLUMNS|INDEXES|INDEX|KEYS)\s+FROM\s+[^;]+;?/i', '', $query);
+            if ($cleanedQuery === null) {
+                return $query; // Return original if replacement fails
+            }
+
+            $query = $cleanedQuery;
+        }
+
+        // Clean up multiple semicolons and whitespace
+        $finalQuery = preg_replace('/;+\s*$/', ';', $query);
+
+        return trim($finalQuery ?? $query);
+    }
+
+    /**
+     * Check for suspicious patterns that might indicate SQL injection attempts
+     */
+    private function containsSuspiciousPatterns(string $query): bool
+    {
+        $suspiciousPatterns = [
+            '/;\s*DROP\s+/i',
+            '/;\s*DELETE\s+/i',
+            '/;\s*UPDATE\s+/i',
+            '/--\s*$/i',
+        ];
+
+        foreach ($suspiciousPatterns as $pattern) {
+            $result = preg_match($pattern, $query);
+            if ($result === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/end-to-end/Database/QueryValidatorTest.php
+++ b/tests/end-to-end/Database/QueryValidatorTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Database;
+
+use PhpMyAdmin\Database\QueryValidator;
+use PHPUnit\Framework\TestCase;
+
+class QueryValidatorTest extends TestCase
+{
+    private QueryValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new QueryValidator();
+    }
+
+    public function testValidatesSimpleQueryWithoutTable(): void
+    {
+        $result = $this->validator->validateQuery('SELECT 1;', null);
+        self::assertTrue($result['isValid']);
+        self::assertEquals('SELECT 1;', $result['query']);
+    }
+
+    public function testRejectsMetadataQueryWithoutTable(): void
+    {
+        $result = $this->validator->validateQuery('SHOW COLUMNS FROM test_db;', null);
+        self::assertFalse($result['isValid']);
+        self::assertNotNull($result['error']);
+    }
+
+    public function testAllowsShowColumnsWithTable(): void
+    {
+        $result = $this->validator->validateQuery('SHOW COLUMNS FROM `test_table`;', 'test_table');
+        self::assertTrue($result['isValid']);
+        self::assertEquals('SHOW COLUMNS FROM `test_table`;', $result['query']);
+    }
+
+    public function testAllowsShowIndexesWithTable(): void
+    {
+        $result = $this->validator->validateQuery('SHOW INDEXES FROM `test_table`;', 'test_table');
+        self::assertTrue($result['isValid']);
+        self::assertEquals('SHOW INDEXES FROM `test_table`;', $result['query']);
+    }
+
+    public function testHandlesMultipleQueriesWithoutTable(): void
+    {
+        $result = $this->validator->validateQuery('SELECT 1; SHOW COLUMNS FROM test_db; SELECT 2;', null);
+        self::assertFalse($result['isValid']);
+        if ($result['error'] === null) {
+            return;
+        }
+
+        self::assertStringContainsString('Table must be selected', $result['error']);
+    }
+
+    public function testHandlesMultipleQueriesWithTable(): void
+    {
+        $result = $this->validator->validateQuery('SELECT 1; SHOW COLUMNS FROM `test_table`; SELECT 2;', 'test_table');
+        self::assertTrue($result['isValid']);
+        self::assertEquals('SELECT 1; SHOW COLUMNS FROM `test_table`; SELECT 2;', $result['query']);
+    }
+
+    public function testCleansMultipleSemicolons(): void
+    {
+        $result = $this->validator->validateQuery('SELECT 1;;;;;', null);
+        self::assertTrue($result['isValid']);
+        self::assertEquals('SELECT 1;', $result['query']);
+    }
+
+    public function testTrimsWhitespace(): void
+    {
+        $result = $this->validator->validateQuery("  SELECT 1;  \n  \t  ", null);
+        self::assertTrue($result['isValid']);
+        self::assertEquals('SELECT 1;', $result['query']);
+    }
+
+    public function testPreventsSqlInjectionInMetadataQueries(): void
+    {
+        $result = $this->validator->validateQuery('SHOW COLUMNS FROM `test_table`; DROP TABLE users; --', 'test_table');
+        self::assertFalse($result['isValid']);
+        if ($result['error'] === null) {
+            return;
+        }
+
+        self::assertStringContainsString('Invalid query', $result['error']);
+    }
+}


### PR DESCRIPTION
Prevent invalid SQL queries when no table selected in SQL tab

### Description

- Validate and properly handle queries in the SQL tab when no table is selected
- Add tests to ensure correct behavior and prevent malformed metadata queries
- Clean and process queries to remove unnecessary semicolons and whitespace
- Add SQL injection prevention for metadata-related queries

Fixes #19302 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
