### PR TITLE
Fix #19096 - A 64-char hex string should be allowed for the blowfish_secret config directive

### DIFF
--- a/src/Controllers/HomeController.php
+++ b/src/Controllers/HomeController.php
@@ -329,17 +329,24 @@ final class HomeController implements InvocableController
                     'severity' => 'warning',
                 ];
             } elseif ($encryptionKeyLength > SODIUM_CRYPTO_SECRETBOX_KEYBYTES) {
-                $this->errors[] = [
-                    'message' => sprintf(
-                        __(
-                            'The cookie encryption key in the configuration file is longer than necessary.'
-                            . ' It should only be %d bytes long.'
-                            . ' Please refer to the [doc@cfg_blowfish_secret]documentation[/doc].',
+                if ($encryptionKeyLength === 64 && ctype_xdigit($blowfishSecret)) {
+                    // Convert the hexadecimal string to binary
+                    $blowfishSecret = hex2bin($blowfishSecret);
+                    // Override the original blowfish_secret
+                    $config->settings['blowfish_secret'] = $blowfishSecret;
+                } else {
+                    $this->errors[] = [
+                        'message' => sprintf(
+                            __(
+                                'The cookie encryption key in the configuration file is longer than necessary.'
+                                . ' It should only be %d bytes long.'
+                                . ' Please refer to the [doc@cfg_blowfish_secret]documentation[/doc].',
+                            ),
+                            SODIUM_CRYPTO_SECRETBOX_KEYBYTES,
                         ),
-                        SODIUM_CRYPTO_SECRETBOX_KEYBYTES,
-                    ),
-                    'severity' => 'warning',
-                ];
+                        'severity' => 'warning',
+                    ];
+                }
             }
         }
 


### PR DESCRIPTION
Enhance blowfish_secret Configuration to Accept 64-Character Hexadecimal Strings

Description:
* Extended blowfish_secret Validation: Updated the configuration handling to accept 64-character hexadecimal strings for the blowfish_secret directive. This enhancement allows users to specify the encryption key in a more flexible format.
* Hexadecimal String Conversion: Implemented a check to determine if the provided blowfish_secret is a 64-character hexadecimal string. If true, the string is converted to a 32-byte binary key using the hex2bin() function, ensuring compatibility with encryption requirements.
* Maintained Backward Compatibility: If the blowfish_secret does not meet the new criteria, the existing validation process remains unchanged, preserving current functionality.

Changes enacted within HomeController.php lines 320-340

