### PR TITLE
Allow for redirects without showing a error

### DIFF
--- a/src/Http/Middleware/PhpExtensionsChecking.php
+++ b/src/Http/Middleware/PhpExtensionsChecking.php
@@ -27,6 +27,10 @@ final class PhpExtensionsChecking implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        if ($request->getRoute() === '/url') {
+            return $handler->handle($request);
+        }
+
         try {
             $this->checkRequiredPhpExtensions();
         } catch (MissingExtensionException $exception) {


### PR DESCRIPTION
### Description

This allows the user to click the URL provided in the error message to be redirected. Previously, it would just display the same error again.

Fixes #19425

Redone the pr cause I messed up

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [X] Any new functionality is covered by tests.
