### PR TITLE
Fix table detected as view, when table is in use

### DIFF
--- a/libraries/classes/Controllers/Database/StructureController.php
+++ b/libraries/classes/Controllers/Database/StructureController.php
@@ -356,16 +356,13 @@ class StructureController extends AbstractController
             if (! $this->dbIsSystemSchema) {
                 $dropQuery = sprintf(
                     'DROP %s %s',
-                    $tableIsView || $currentTable['ENGINE'] == null ? 'VIEW'
-                    : 'TABLE',
+                    $tableIsView ? 'VIEW' : 'TABLE',
                     Util::backquote(
                         $currentTable['TABLE_NAME']
                     )
                 );
                 $dropMessage = sprintf(
-                    ($tableIsView || $currentTable['ENGINE'] == null
-                        ? __('View %s has been dropped.')
-                        : __('Table %s has been dropped.')),
+                    ($tableIsView ? __('View %s has been dropped.') : __('Table %s has been dropped.')),
                     str_replace(
                         ' ',
                         '&nbsp;',

--- a/templates/database/structure/structure_table_row.twig
+++ b/templates/database/structure/structure_table_row.twig
@@ -77,7 +77,7 @@
         {% endif %}
         <td class="text-center d-print-none">
             <a class="ajax drop_table_anchor
-                {{- table_is_view or current_table['ENGINE'] == null ? ' view' }}" href="{{ url('/sql') }}" data-post="
+                {{- table_is_view ? ' view' }}" href="{{ url('/sql') }}" data-post="
                 {{- get_common(table_url_params|merge({
                   'reload': 1,
                   'purge': 1,


### PR DESCRIPTION
### Description

On databases with MYISAM engine, if .MYD or .MYI files are missing, and only if .frm is present, the table will show as `in use`.

Before this PR, table was detected as VIEW, because engine is null in this case.

Before:

https://github.com/user-attachments/assets/d2e55509-b420-4ece-88e9-dc5849578380

After:

https://github.com/user-attachments/assets/753f63aa-6657-4c83-a81c-c1ae46bd1c9b

To test this, I've attached a database folder.

[test5.zip](https://github.com/user-attachments/files/18140717/test5.zip)

After copy to data folder, a mysql server restart is needed.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
