### PR TITLE
Add double quotes for Windows

### DIFF
--- a/libraries/classes/Command/WriteGitRevisionCommand.php
+++ b/libraries/classes/Command/WriteGitRevisionCommand.php
@@ -117,7 +117,7 @@ PHP;
         }
 
         $commitDetails = $this->gitCli(
-            'show -s --pretty=\'tree %T%nparent %P%nauthor %an <%ae> %at%ncommitter %cn <%ce> %ct%n%n%B\''
+            'show -s --pretty="tree %T%nparent %P%nauthor %an <%ae> %at%ncommitter %cn <%ce> %ct%n%n%B"'
         );
         if ($commitDetails === null) {
             return null;

--- a/test/classes/Command/WriteGitRevisionCommandTest.php
+++ b/test/classes/Command/WriteGitRevisionCommandTest.php
@@ -39,7 +39,7 @@ class WriteGitRevisionCommandTest extends AbstractTestCase
                 ['describe --always'],
                 ['log -1 --format="%H"'],
                 ['symbolic-ref -q HEAD'],
-                ['show -s --pretty=\'tree %T%nparent %P%nauthor %an <%ae> %at%ncommitter %cn <%ce> %ct%n%n%B\'']
+                ['show -s --pretty="tree %T%nparent %P%nauthor %an <%ae> %at%ncommitter %cn <%ce> %ct%n%n%B"']
             )
             ->willReturnOnConsecutiveCalls(
                 'RELEASE_5_1_0-638-g1c018e2a6c',


### PR DESCRIPTION
### Description

Before:

```
PS E:\GitHub\phpmyadmin> php ./scripts/console write-revision-info                   
The system cannot find the file specified.
No revision information detected.
```

After:

```
PS E:\GitHub\phpmyadmin> php ./scripts/console write-revision-info
revision-info.php successfully generated!
```

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.