### PR TITLE
Creation of fetchResultSimple and fetchSingleColumn

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6184,12 +6184,6 @@ parameters:
 			path: src/Database/CentralColumns.php
 
 		-
-			message: '#^Cannot cast mixed to int\.$#'
-			identifier: cast.int
-			count: 1
-			path: src/Database/CentralColumns.php
-
-		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
 			count: 2

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6958,12 +6958,6 @@ parameters:
 			path: src/DatabaseInterface.php
 
 		-
-			message: '#^Method PhpMyAdmin\\DatabaseInterface\:\:affectedRows\(\) should return int\|numeric\-string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/DatabaseInterface.php
-
-		-
 			message: '#^Method PhpMyAdmin\\DatabaseInterface\:\:getColumnNames\(\) should return list\<string\> but returns array\<mixed\>\.$#'
 			identifier: return.type
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6186,7 +6186,7 @@ parameters:
 		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
-			count: 2
+			count: 1
 			path: src/Database/CentralColumns.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6958,7 +6958,7 @@ parameters:
 			path: src/DatabaseInterface.php
 
 		-
-			message: '#^Method PhpMyAdmin\\DatabaseInterface\:\:getColumnNames\(\) should return list\<string\> but returns array\<mixed\>\.$#'
+			message: '#^Method PhpMyAdmin\\DatabaseInterface\:\:getColumnNames\(\) should return list\<string\> but returns list\<string\|null\>\.$#'
 			identifier: return.type
 			count: 1
 			path: src/DatabaseInterface.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6196,7 +6196,7 @@ parameters:
 			path: src/Database/CentralColumns.php
 
 		-
-			message: '#^Method PhpMyAdmin\\Database\\CentralColumns\:\:findExistingColNames\(\) should return array\<string\> but returns array\<mixed\>\.$#'
+			message: '#^Method PhpMyAdmin\\Database\\CentralColumns\:\:findExistingColNames\(\) should return array\<string\> but returns list\<string\|null\>\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Database/CentralColumns.php
@@ -10681,13 +10681,13 @@ parameters:
 			path: src/Navigation/Nodes/NodeTable.php
 
 		-
-			message: '#^Method PhpMyAdmin\\Navigation\\Nodes\\ObjectFetcher\:\:getEventsFromDb\(\) should return array\<string\> but returns array\<mixed\>\.$#'
+			message: '#^Method PhpMyAdmin\\Navigation\\Nodes\\ObjectFetcher\:\:getEventsFromDb\(\) should return array\<string\> but returns list\<string\|null\>\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Navigation/Nodes/ObjectFetcher.php
 
 		-
-			message: '#^Method PhpMyAdmin\\Navigation\\Nodes\\ObjectFetcher\:\:getRoutines\(\) should return array\<string\> but returns array\<mixed\>\.$#'
+			message: '#^Method PhpMyAdmin\\Navigation\\Nodes\\ObjectFetcher\:\:getRoutines\(\) should return array\<string\> but returns list\<string\|null\>\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Navigation/Nodes/ObjectFetcher.php
@@ -11095,6 +11095,18 @@ parameters:
 			path: src/Partitioning/Partition.php
 
 		-
+			message: '#^Cannot access offset ''PARTITION_NAME'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: src/Partitioning/Partition.php
+
+		-
+			message: '#^Cannot access offset ''SUBPARTITION_NAME'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Partitioning/Partition.php
+
+		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
 			count: 1
@@ -11119,8 +11131,14 @@ parameters:
 			path: src/Partitioning/Partition.php
 
 		-
-			message: '#^PHPDoc tag @var for variable \$row has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: '#^Parameter \#1 \$row of class PhpMyAdmin\\Partitioning\\Partition constructor expects array\<mixed\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Partitioning/Partition.php
+
+		-
+			message: '#^Parameter \#1 \$row of class PhpMyAdmin\\Partitioning\\SubPartition constructor expects array\<mixed\>, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Partitioning/Partition.php
 
@@ -12606,7 +12624,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$identifier of static method PhpMyAdmin\\Util\:\:backquote\(\) expects string\|Stringable\|null, mixed given\.$#'
 			identifier: argument.type
-			count: 3
+			count: 2
 			path: src/Plugins/Export/ExportSql.php
 
 		-
@@ -12634,7 +12652,7 @@ parameters:
 			path: src/Plugins/Export/ExportSql.php
 
 		-
-			message: '#^Parameter \#3 \$name of static method PhpMyAdmin\\Database\\Events\:\:getDefinition\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#3 \$name of static method PhpMyAdmin\\Database\\Events\:\:getDefinition\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Plugins/Export/ExportSql.php
@@ -12823,7 +12841,7 @@ parameters:
 			path: src/Plugins/Export/ExportXml.php
 
 		-
-			message: '#^Parameter \#3 \$names of method PhpMyAdmin\\Plugins\\Export\\ExportXml\:\:exportDefinitions\(\) expects array\<string\>, array\<mixed\> given\.$#'
+			message: '#^Parameter \#3 \$names of method PhpMyAdmin\\Plugins\\Export\\ExportXml\:\:exportDefinitions\(\) expects array\<string\>, list\<string\|null\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Plugins/Export/ExportXml.php
@@ -15530,12 +15548,6 @@ parameters:
 
 		-
 			message: '#^Binary operation "\." between ''UPDATE `mysql`\.…'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/Server/Privileges.php
-
-		-
-			message: '#^Binary operation "\." between mixed and ";\\n\\n" results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
 			path: src/Server/Privileges.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4582,42 +4582,6 @@ parameters:
 			path: src/Controllers/Table/Maintenance/RepairController.php
 
 		-
-			message: '#^Parameter \#2 \$sqlQuery of static method PhpMyAdmin\\Html\\Generator\:\:getMessage\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Controllers/Table/Partition/AnalyzeController.php
-
-		-
-			message: '#^Parameter \#2 \$sqlQuery of static method PhpMyAdmin\\Html\\Generator\:\:getMessage\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Controllers/Table/Partition/CheckController.php
-
-		-
-			message: '#^Only booleans are allowed in an if condition, mixed given\.$#'
-			identifier: if.condNotBoolean
-			count: 1
-			path: src/Controllers/Table/Partition/DropController.php
-
-		-
-			message: '#^Parameter \#2 \$sqlQuery of static method PhpMyAdmin\\Html\\Generator\:\:getMessage\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Controllers/Table/Partition/DropController.php
-
-		-
-			message: '#^Parameter \#2 \$sqlQuery of static method PhpMyAdmin\\Html\\Generator\:\:getMessage\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Controllers/Table/Partition/OptimizeController.php
-
-		-
-			message: '#^Parameter \#2 \$sqlQuery of static method PhpMyAdmin\\Html\\Generator\:\:getMessage\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Controllers/Table/Partition/RepairController.php
-
-		-
 			message: '''
 				#^Call to deprecated method getInstance\(\) of class PhpMyAdmin\\Config\:
 				Use dependency injection instead\.$#
@@ -6136,30 +6100,6 @@ parameters:
 			path: src/Database/CentralColumns.php
 
 		-
-			message: '#^Cannot access offset ''col_attribute'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 5
-			path: src/Database/CentralColumns.php
-
-		-
-			message: '#^Cannot access offset ''col_default'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Database/CentralColumns.php
-
-		-
-			message: '#^Cannot access offset ''col_extra'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Database/CentralColumns.php
-
-		-
-			message: '#^Cannot access offset ''col_type'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Database/CentralColumns.php
-
-		-
 			message: '#^Cannot access offset int\<0, max\> on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 11
@@ -6168,7 +6108,7 @@ parameters:
 		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
-			count: 2
+			count: 1
 			path: src/Database/CentralColumns.php
 
 		-
@@ -6179,12 +6119,6 @@ parameters:
 
 		-
 			message: '#^Method PhpMyAdmin\\Database\\CentralColumns\:\:findExistingColNames\(\) should return array\<string\> but returns list\<string\|null\>\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Database/CentralColumns.php
-
-		-
-			message: '#^Method PhpMyAdmin\\Database\\CentralColumns\:\:findExistingColumns\(\) should return array\<array\<string\|null\>\> but returns array\<mixed\>\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Database/CentralColumns.php
@@ -6208,12 +6142,6 @@ parameters:
 			path: src/Database/CentralColumns.php
 
 		-
-			message: '#^Parameter \#1 \$bitDefaultValue of static method PhpMyAdmin\\Util\:\:convertBitDefaultValue\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Database/CentralColumns.php
-
-		-
 			message: '#^Parameter \#1 \$db of method PhpMyAdmin\\Database\\CentralColumns\:\:updateOneColumn\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -6227,12 +6155,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$str of method PhpMyAdmin\\DatabaseInterface\:\:quoteString\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Database/CentralColumns.php
-
-		-
-			message: '#^Parameter \#1 \$string of function bin2hex expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Database/CentralColumns.php
@@ -6262,7 +6184,7 @@ parameters:
 			path: src/Database/CentralColumns.php
 
 		-
-			message: '#^Parameter \#2 \$string of function explode expects string, mixed given\.$#'
+			message: '#^Parameter \#2 \$string of function explode expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Database/CentralColumns.php
@@ -17080,12 +17002,6 @@ parameters:
 			path: src/Table/Table.php
 
 		-
-			message: '#^Method PhpMyAdmin\\Table\\Table\:\:getNonGeneratedColumns\(\) should return array\<string\> but returns list\<string\|null\>\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Table/Table.php
-
-		-
 			message: '#^Method PhpMyAdmin\\Table\\Table\:\:getUiPrefsFromDb\(\) should return array\<mixed\> but returns mixed\.$#'
 			identifier: return.type
 			count: 1
@@ -17614,12 +17530,6 @@ parameters:
 			message: '#^Only booleans are allowed in a negated boolean, PhpMyAdmin\\Dbal\\ResultInterface\|false given\.$#'
 			identifier: booleanNot.exprNotBoolean
 			count: 4
-			path: src/Triggers/Triggers.php
-
-		-
-			message: '#^PHPDoc tag @var with type array\<array\<mixed\>\> is not subtype of type list\<array\<string\|null\>\>\.$#'
-			identifier: varTag.type
-			count: 1
 			path: src/Triggers/Triggers.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -312,13 +312,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$row of method PhpMyAdmin\\Bookmarks\\BookmarkRepository\:\:createFromRow\(\) expects array\<string\>, array\<string\|null\> given\.$#'
 			identifier: argument.type
-			count: 2
-			path: src/Bookmarks/BookmarkRepository.php
-
-		-
-			message: '#^Parameter \#1 \$row of method PhpMyAdmin\\Bookmarks\\BookmarkRepository\:\:createFromRow\(\) expects array\<string\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
+			count: 3
 			path: src/Bookmarks/BookmarkRepository.php
 
 		-
@@ -6982,7 +6976,7 @@ parameters:
 			path: src/DatabaseInterface.php
 
 		-
-			message: '#^Method PhpMyAdmin\\DatabaseInterface\:\:getTableIndexes\(\) should return array\<int, array\{Table\: string, Non_unique\: ''0''\|''1'', Key_name\: string, Seq_in_index\: string, Column_name\: string\|null, Collation\: ''A''\|''D''\|null, Cardinality\: string, Sub_part\: string\|null, \.\.\.\}\> but returns array\<mixed\>\.$#'
+			message: '#^Method PhpMyAdmin\\DatabaseInterface\:\:getTableIndexes\(\) should return array\<int, array\{Table\: string, Non_unique\: ''0''\|''1'', Key_name\: string, Seq_in_index\: string, Column_name\: string\|null, Collation\: ''A''\|''D''\|null, Cardinality\: string, Sub_part\: string\|null, \.\.\.\}\> but returns list\<array\<string\|null\>\>\.$#'
 			identifier: return.type
 			count: 1
 			path: src/DatabaseInterface.php
@@ -10693,7 +10687,7 @@ parameters:
 			path: src/Navigation/Nodes/ObjectFetcher.php
 
 		-
-			message: '#^Method PhpMyAdmin\\Navigation\\Nodes\\ObjectFetcher\:\:getTablesAndViews\(\) should return array\<array\{name\: string, type\: string\}\> but returns array\<mixed\>\.$#'
+			message: '#^Method PhpMyAdmin\\Navigation\\Nodes\\ObjectFetcher\:\:getTablesAndViews\(\) should return array\<array\{name\: string, type\: string\}\> but returns list\<array\<string\|null\>\>\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Navigation/Nodes/ObjectFetcher.php
@@ -11056,36 +11050,12 @@ parameters:
 			path: src/Operations.php
 
 		-
-			message: '#^Cannot access offset ''Table'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
-			path: src/Partitioning/Maintenance.php
-
-		-
 			message: '''
 				#^Call to deprecated method getInstance\(\) of class PhpMyAdmin\\DatabaseInterface\:
 				Use dependency injection instead\.$#
 			'''
 			identifier: staticMethod.deprecated
 			count: 4
-			path: src/Partitioning/Partition.php
-
-		-
-			message: '#^Cannot access offset ''Name'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Partitioning/Partition.php
-
-		-
-			message: '#^Cannot access offset ''PARTITION_NAME'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Partitioning/Partition.php
-
-		-
-			message: '#^Cannot access offset ''SUBPARTITION_NAME'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
 			path: src/Partitioning/Partition.php
 
 		-
@@ -11103,18 +11073,6 @@ parameters:
 		-
 			message: '#^Only booleans are allowed in an if condition, string\|false\|null given\.$#'
 			identifier: if.condNotBoolean
-			count: 1
-			path: src/Partitioning/Partition.php
-
-		-
-			message: '#^Parameter \#1 \$row of class PhpMyAdmin\\Partitioning\\Partition constructor expects array\<mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Partitioning/Partition.php
-
-		-
-			message: '#^Parameter \#1 \$row of class PhpMyAdmin\\Partitioning\\SubPartition constructor expects array\<mixed\>, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Partitioning/Partition.php
 
@@ -12745,18 +12703,6 @@ parameters:
 			path: src/Plugins/Export/ExportXml.php
 
 		-
-			message: '#^Cannot access offset ''DEFAULT_CHARACTER_SET_NAME'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Plugins/Export/ExportXml.php
-
-		-
-			message: '#^Cannot access offset ''DEFAULT_COLLATION_NAME'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Plugins/Export/ExportXml.php
-
-		-
 			message: '#^Cannot access offset ''columns'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -12807,13 +12753,13 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$string of function htmlspecialchars expects string, mixed given\.$#'
 			identifier: argument.type
-			count: 3
+			count: 1
 			path: src/Plugins/Export/ExportXml.php
 
 		-
 			message: '#^Parameter \#1 \$string of function htmlspecialchars expects string, string\|null given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 4
 			path: src/Plugins/Export/ExportXml.php
 
 		-
@@ -15130,25 +15076,13 @@ parameters:
 			path: src/Replication/Replication.php
 
 		-
-			message: '#^Cannot access offset ''File'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Replication/Replication.php
-
-		-
-			message: '#^Cannot access offset ''Position'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Replication/Replication.php
-
-		-
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
 			count: 1
 			path: src/Replication/Replication.php
 
 		-
-			message: '#^Method PhpMyAdmin\\Replication\\Replication\:\:replicaBinLogPrimary\(\) should return array\{File\?\: string, Position\?\: string\} but returns array\{\}\|array\{File\: mixed, Position\: mixed\}\.$#'
+			message: '#^Method PhpMyAdmin\\Replication\\Replication\:\:replicaBinLogPrimary\(\) should return array\{File\?\: string, Position\?\: string\} but returns array\{\}\|array\{File\: string\|null, Position\: string\|null\}\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Replication/Replication.php
@@ -15553,18 +15487,6 @@ parameters:
 			message: '#^Call to function array_filter\(\) requires parameter \#2 to be passed to avoid loose comparison semantics\.$#'
 			identifier: arrayFilter.strict
 			count: 2
-			path: src/Server/Privileges.php
-
-		-
-			message: '#^Cannot access offset ''CHARACTER_MAXIMUM_LENGTH'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Server/Privileges.php
-
-		-
-			message: '#^Cannot access offset ''COLUMN_NAME'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
 			path: src/Server/Privileges.php
 
 		-
@@ -17086,15 +17008,9 @@ parameters:
 			path: src/Table/Table.php
 
 		-
-			message: '#^Cannot access offset ''Extra'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
-			path: src/Table/Table.php
-
-		-
 			message: '#^Cannot access offset ''Field'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
+			count: 2
 			path: src/Table/Table.php
 
 		-
@@ -17194,7 +17110,7 @@ parameters:
 			path: src/Table/Table.php
 
 		-
-			message: '#^Method PhpMyAdmin\\Table\\Table\:\:getNonGeneratedColumns\(\) should return array\<string\> but returns list\<mixed\>\.$#'
+			message: '#^Method PhpMyAdmin\\Table\\Table\:\:getNonGeneratedColumns\(\) should return array\<string\> but returns list\<string\|null\>\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Table/Table.php
@@ -17230,7 +17146,7 @@ parameters:
 			path: src/Table/Table.php
 
 		-
-			message: '#^Parameter \#1 \$haystack of function str_contains expects string, mixed given\.$#'
+			message: '#^Parameter \#1 \$haystack of function str_contains expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 3
 			path: src/Table/Table.php
@@ -17238,7 +17154,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$identifier of static method PhpMyAdmin\\Util\:\:backquote\(\) expects string\|Stringable\|null, mixed given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
 			path: src/Table/Table.php
 
 		-
@@ -17728,6 +17644,12 @@ parameters:
 			message: '#^Only booleans are allowed in a negated boolean, PhpMyAdmin\\Dbal\\ResultInterface\|false given\.$#'
 			identifier: booleanNot.exprNotBoolean
 			count: 4
+			path: src/Triggers/Triggers.php
+
+		-
+			message: '#^PHPDoc tag @var with type array\<array\<mixed\>\> is not subtype of type list\<array\<string\|null\>\>\.$#'
+			identifier: varTag.type
+			count: 1
 			path: src/Triggers/Triggers.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3907,18 +3907,6 @@ parameters:
 			path: src/Controllers/Server/UserGroupsFormController.php
 
 		-
-			message: '#^Offset 1 might not exist on array\<string\|null\>\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 2
-			path: src/Controllers/Server/Variables/GetVariableController.php
-
-		-
-			message: '#^Offset 1 might not exist on array\<string\|null\>\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/Controllers/Server/Variables/SetVariableController.php
-
-		-
 			message: '#^Parameter \#1 \$string of function htmlspecialchars expects string, int\|string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -7068,12 +7056,6 @@ parameters:
 		-
 			message: '#^Property PhpMyAdmin\\DatabaseInterface\:\:\$versionString \(string\) does not accept mixed\.$#'
 			identifier: assign.propertyType
-			count: 1
-			path: src/DatabaseInterface.php
-
-		-
-			message: '#^Short ternary operator is not allowed\. Use null coalesce operator if applicable or consider using long ternary\.$#'
-			identifier: ternary.shortNotAllowed
 			count: 1
 			path: src/DatabaseInterface.php
 
@@ -15613,18 +15595,6 @@ parameters:
 			message: '#^Method PhpMyAdmin\\Server\\Privileges\:\:getDbname\(\) should return array\<string\>\|string\|null but returns array\<mixed\>\|string\|null\.$#'
 			identifier: return.type
 			count: 1
-			path: src/Server/Privileges.php
-
-		-
-			message: '#^Offset ''@@old_passwords'' might not exist on array\<string\|null\>\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/Server/Privileges.php
-
-		-
-			message: '#^Offset ''Type'' might not exist on array\<string\|null\>\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 4
 			path: src/Server/Privileges.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11119,12 +11119,6 @@ parameters:
 			path: src/Partitioning/Partition.php
 
 		-
-			message: '#^Method PhpMyAdmin\\Partitioning\\Partition\:\:getPartitionMethod\(\) should return string\|null but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Partitioning/Partition.php
-
-		-
 			message: '#^Only booleans are allowed in an if condition, string\|false\|null given\.$#'
 			identifier: if.condNotBoolean
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10738,18 +10738,6 @@ parameters:
 			path: src/Normalization.php
 
 		-
-			message: '#^Cannot access offset non\-falsy\-string on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Normalization.php
-
-		-
-			message: '#^Cannot cast mixed to int\.$#'
-			identifier: cast.int
-			count: 1
-			path: src/Normalization.php
-
-		-
 			message: '#^Casting to int something that''s already int\<1, max\>\.$#'
 			identifier: cast.useless
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10888,12 +10888,6 @@ parameters:
 			path: src/Normalization.php
 
 		-
-			message: '#^Parameter \#6 \$totalRows of method PhpMyAdmin\\Normalization\:\:checkPartialDependency\(\) expects int, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Normalization.php
-
-		-
 			message: '#^Variable property access on object\.$#'
 			identifier: property.dynamicName
 			count: 4

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3825,7 +3825,7 @@
     </MixedAssignment>
     <MixedReturnTypeCoercion>
       <code><![CDATA[$hasList]]></code>
-      <code><![CDATA[$this->dbi->fetchResult($query, null, null, ConnectionType::ControlUser)]]></code>
+      <code><![CDATA[$this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser)]]></code>
       <code><![CDATA[(string|null)[][]]]></code>
       <code><![CDATA[string[]]]></code>
     </MixedReturnTypeCoercion>
@@ -4230,7 +4230,7 @@
       <code><![CDATA[$row['Rows']]]></code>
     </InvalidOperand>
     <LessSpecificReturnStatement>
-      <code><![CDATA[$this->fetchResult($sql, null, 'Field', $connectionType)]]></code>
+      <code><![CDATA[$this->fetchResultSimple($sql, 'Field', $connectionType)]]></code>
     </LessSpecificReturnStatement>
     <MixedArgument>
       <code><![CDATA[$a]]></code>
@@ -4281,7 +4281,7 @@
       <code><![CDATA[reset($columns)]]></code>
     </MixedReturnStatement>
     <MixedReturnTypeCoercion>
-      <code><![CDATA[$this->fetchResult($sql, null, null, $connectionType)]]></code>
+      <code><![CDATA[$this->fetchResultSimple($sql, null, $connectionType)]]></code>
       <code><![CDATA[array<int, array{
      *   Table: string,
      *   Non_unique: '0'|'1',
@@ -6189,9 +6189,9 @@
   </file>
   <file src="src/Navigation/Nodes/ObjectFetcher.php">
     <MixedReturnTypeCoercion>
-      <code><![CDATA[$this->dbi->fetchResult($query)]]></code>
-      <code><![CDATA[$this->dbi->fetchResult($query)]]></code>
-      <code><![CDATA[$this->dbi->fetchResult($query)]]></code>
+      <code><![CDATA[$this->dbi->fetchResultSimple($query)]]></code>
+      <code><![CDATA[$this->dbi->fetchResultSimple($query)]]></code>
+      <code><![CDATA[$this->dbi->fetchResultSimple($query)]]></code>
       <code><![CDATA[array{name:string, type:string}[]]]></code>
       <code><![CDATA[string[]]]></code>
       <code><![CDATA[string[]]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6247,7 +6247,6 @@
       <code><![CDATA[$table]]></code>
       <code><![CDATA[$tablesName->$key]]></code>
       <code><![CDATA[$tablesName->$key]]></code>
-      <code><![CDATA[$totalRows]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$dependents]]></code>
@@ -6283,7 +6282,6 @@
       <code><![CDATA[$table]]></code>
       <code><![CDATA[$table]]></code>
       <code><![CDATA[$tablesList]]></code>
-      <code><![CDATA[$totalRows]]></code>
     </MixedAssignment>
     <MixedOperand>
       <code><![CDATA[$element]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6497,12 +6497,6 @@
       <code><![CDATA[$this->name]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[string|null]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$partitionMethod[0]]]></code>
-    </MixedReturnStatement>
     <PossiblyInvalidArgument>
       <code><![CDATA[$row]]></code>
     </PossiblyInvalidArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6280,7 +6280,6 @@
       <code><![CDATA[$dropCols]]></code>
       <code><![CDATA[$element]]></code>
       <code><![CDATA[$key]]></code>
-      <code><![CDATA[$pkColCnt]]></code>
       <code><![CDATA[$table]]></code>
       <code><![CDATA[$table]]></code>
       <code><![CDATA[$tablesList]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2867,34 +2867,21 @@
     </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Controllers/Table/Partition/AnalyzeController.php">
-    <MixedArgument>
-      <code><![CDATA[$query]]></code>
-    </MixedArgument>
     <PossiblyUnusedReturnValue>
       <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/Partition/CheckController.php">
-    <MixedArgument>
-      <code><![CDATA[$query]]></code>
-    </MixedArgument>
     <PossiblyUnusedReturnValue>
       <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/Partition/DropController.php">
-    <MixedArgument>
-      <code><![CDATA[$query]]></code>
-      <code><![CDATA[$query]]></code>
-    </MixedArgument>
     <PossiblyUnusedReturnValue>
       <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/Partition/OptimizeController.php">
-    <MixedArgument>
-      <code><![CDATA[$query]]></code>
-    </MixedArgument>
     <PossiblyUnusedReturnValue>
       <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
@@ -2905,9 +2892,6 @@
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/Partition/RepairController.php">
-    <MixedArgument>
-      <code><![CDATA[$query]]></code>
-    </MixedArgument>
     <PossiblyUnusedReturnValue>
       <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
@@ -3778,9 +3762,6 @@
       <code><![CDATA[$params['field_type'][$i]]]></code>
       <code><![CDATA[$params['orig_col_name']]]></code>
       <code><![CDATA[$params['orig_col_name'][$i]]]></code>
-      <code><![CDATA[$row['col_extra']]]></code>
-      <code><![CDATA[$rowsMeta[$rowNum]['DefaultValue']]]></code>
-      <code><![CDATA[$rowsMeta[$rowNum]['DefaultValue']]]></code>
       <code><![CDATA[$type]]></code>
     </MixedArgument>
     <MixedArrayAccess>
@@ -3794,40 +3775,25 @@
       <code><![CDATA[$params['field_name'][$i]]]></code>
       <code><![CDATA[$params['field_type'][$i]]]></code>
       <code><![CDATA[$params['orig_col_name'][$i]]]></code>
-      <code><![CDATA[$row['col_extra']]]></code>
-      <code><![CDATA[$row['col_type']]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
       <code><![CDATA[$columnDefault[$i]]]></code>
       <code><![CDATA[$columnDefault[$i]]]></code>
-      <code><![CDATA[$row['col_attribute']]]></code>
-      <code><![CDATA[$row['col_attribute']]]></code>
-      <code><![CDATA[$row['col_attribute']]]></code>
-      <code><![CDATA[$row['col_attribute']]]></code>
-      <code><![CDATA[$row['col_attribute']]]></code>
-      <code><![CDATA[$row['col_extra']]]></code>
     </MixedArrayAssignment>
     <MixedAssignment>
       <code><![CDATA[$columnDefault]]></code>
       <code><![CDATA[$columnDefault[$i]]]></code>
       <code><![CDATA[$columnExtra[$i]]]></code>
-      <code><![CDATA[$defaultValues[$rowNum]]]></code>
       <code><![CDATA[$length]]></code>
-      <code><![CDATA[$row]]></code>
-      <code><![CDATA[$row]]></code>
-      <code><![CDATA[$rowsMeta[$rowNum]['DefaultValue']]]></code>
       <code><![CDATA[$type]]></code>
     </MixedAssignment>
-    <MixedReturnTypeCoercion>
-      <code><![CDATA[$hasList]]></code>
-      <code><![CDATA[(string|null)[][]]]></code>
-    </MixedReturnTypeCoercion>
     <PossiblyInvalidArgument>
       <code><![CDATA[$tnPageNow]]></code>
     </PossiblyInvalidArgument>
     <PossiblyNullArgument>
       <code><![CDATA[$column['col_name']]]></code>
       <code><![CDATA[$field]]></code>
+      <code><![CDATA[$row['col_extra']]]></code>
     </PossiblyNullArgument>
     <PossiblyNullOperand>
       <code><![CDATA[$column['col_attribute']]]></code>
@@ -9770,7 +9736,6 @@
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
     <InvalidReturnStatement>
-      <code><![CDATA[$ret]]></code>
       <code><![CDATA[$tableAutoIncrement ?? '']]></code>
       <code><![CDATA[$this->getStatusInfo('TABLE_COLLATION') ?? '']]></code>
       <code><![CDATA[$this->getStatusInfo('TABLE_COMMENT') ?? '']]></code>
@@ -9779,7 +9744,6 @@
       <code><![CDATA[string]]></code>
       <code><![CDATA[string]]></code>
       <code><![CDATA[string]]></code>
-      <code><![CDATA[string[]]]></code>
     </InvalidReturnType>
     <MixedArgument>
       <code><![CDATA[$_POST['constraint_name'][$masterFieldMd5]]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3825,7 +3825,7 @@
     </MixedAssignment>
     <MixedReturnTypeCoercion>
       <code><![CDATA[$hasList]]></code>
-      <code><![CDATA[$this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser)]]></code>
+      <code><![CDATA[$this->dbi->fetchResultSimple($query, ConnectionType::ControlUser)]]></code>
       <code><![CDATA[(string|null)[][]]]></code>
       <code><![CDATA[string[]]]></code>
     </MixedReturnTypeCoercion>
@@ -4278,7 +4278,7 @@
       <code><![CDATA[reset($columns)]]></code>
     </MixedReturnStatement>
     <MixedReturnTypeCoercion>
-      <code><![CDATA[$this->fetchResultSimple($sql, null, $connectionType)]]></code>
+      <code><![CDATA[$this->fetchResultSimple($sql, $connectionType)]]></code>
       <code><![CDATA[array<int, array{
      *   Table: string,
      *   Non_unique: '0'|'1',

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -64,13 +64,8 @@
     <InvalidArgument>
       <code><![CDATA[$result]]></code>
       <code><![CDATA[$result]]></code>
+      <code><![CDATA[$row]]></code>
     </InvalidArgument>
-    <MixedArgument>
-      <code><![CDATA[$row]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$row]]></code>
-    </MixedAssignment>
     <PossiblyNullArgument>
       <code><![CDATA[$this->bookmarkFeature]]></code>
     </PossiblyNullArgument>
@@ -6189,17 +6184,15 @@
   </file>
   <file src="src/Navigation/Nodes/ObjectFetcher.php">
     <InvalidReturnStatement>
+      <code><![CDATA[$this->dbi->fetchResultSimple($query)]]></code>
       <code><![CDATA[$this->dbi->fetchSingleColumn($query)]]></code>
       <code><![CDATA[$this->dbi->fetchSingleColumn($query)]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
+      <code><![CDATA[array{name:string, type:string}[]]]></code>
       <code><![CDATA[string[]]]></code>
       <code><![CDATA[string[]]]></code>
     </InvalidReturnType>
-    <MixedReturnTypeCoercion>
-      <code><![CDATA[$this->dbi->fetchResultSimple($query)]]></code>
-      <code><![CDATA[array{name:string, type:string}[]]]></code>
-    </MixedReturnTypeCoercion>
   </file>
   <file src="src/Normalization.php">
     <DeprecatedMethod>
@@ -6443,28 +6436,12 @@
     </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Partitioning/Maintenance.php">
-    <MixedArrayAccess>
-      <code><![CDATA[$row['Table']]]></code>
-      <code><![CDATA[$row['Table']]]></code>
-      <code><![CDATA[$row['Table']]]></code>
-      <code><![CDATA[$row['Table']]]></code>
-    </MixedArrayAccess>
-    <MixedArrayOffset>
-      <code><![CDATA[$rows[$row['Table']]]]></code>
-      <code><![CDATA[$rows[$row['Table']]]]></code>
-      <code><![CDATA[$rows[$row['Table']]]]></code>
-      <code><![CDATA[$rows[$row['Table']]]]></code>
-    </MixedArrayOffset>
-    <MixedAssignment>
-      <code><![CDATA[$row]]></code>
-      <code><![CDATA[$row]]></code>
-      <code><![CDATA[$row]]></code>
-      <code><![CDATA[$row]]></code>
-      <code><![CDATA[$rows[$row['Table']][]]]></code>
-      <code><![CDATA[$rows[$row['Table']][]]]></code>
-      <code><![CDATA[$rows[$row['Table']][]]]></code>
-      <code><![CDATA[$rows[$row['Table']][]]]></code>
-    </MixedAssignment>
+    <PossiblyNullArrayOffset>
+      <code><![CDATA[$rows]]></code>
+      <code><![CDATA[$rows]]></code>
+      <code><![CDATA[$rows]]></code>
+      <code><![CDATA[$rows]]></code>
+    </PossiblyNullArrayOffset>
   </file>
   <file src="src/Partitioning/Partition.php">
     <DeprecatedMethod>
@@ -6473,29 +6450,16 @@
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
-    <MixedArgument>
-      <code><![CDATA[$row]]></code>
-    </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$row['PARTITION_NAME']]]></code>
-      <code><![CDATA[$row['PARTITION_NAME']]]></code>
-      <code><![CDATA[$value['Name']]]></code>
-    </MixedArrayAccess>
-    <MixedArrayOffset>
-      <code><![CDATA[$partitionMap[$row['PARTITION_NAME']]]]></code>
-      <code><![CDATA[$partitionMap[$row['PARTITION_NAME']]]]></code>
-      <code><![CDATA[$partitionMap[$row['PARTITION_NAME']]]]></code>
-    </MixedArrayOffset>
     <MixedAssignment>
       <code><![CDATA[$this->description]]></code>
       <code><![CDATA[$this->expression]]></code>
       <code><![CDATA[$this->method]]></code>
       <code><![CDATA[$this->name]]></code>
-      <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$row]]></code>
-    </PossiblyInvalidArgument>
+    <PossiblyNullArrayOffset>
+      <code><![CDATA[$partitionMap]]></code>
+      <code><![CDATA[$partitionMap]]></code>
+    </PossiblyNullArrayOffset>
     <PossiblyUnusedMethod>
       <code><![CDATA[getDescription]]></code>
       <code><![CDATA[getSubPartitions]]></code>
@@ -6503,6 +6467,7 @@
     </PossiblyUnusedMethod>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$dbi->fetchValue('SELECT @@have_partitioning;')]]></code>
+      <code><![CDATA[empty($row['SUBPARTITION_NAME'])]]></code>
     </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Partitioning/SubPartition.php">
@@ -7330,20 +7295,16 @@
     </InvalidArgument>
     <MixedArgument>
       <code><![CDATA[$colAs]]></code>
-      <code><![CDATA[$dbCharset]]></code>
-      <code><![CDATA[$dbCollation]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$result[$table][1]]]></code>
-      <code><![CDATA[$result[0]['DEFAULT_CHARACTER_SET_NAME']]]></code>
-      <code><![CDATA[$result[0]['DEFAULT_COLLATION_NAME']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code><![CDATA[$colAs]]></code>
-      <code><![CDATA[$dbCharset]]></code>
-      <code><![CDATA[$dbCollation]]></code>
     </MixedAssignment>
     <PossiblyNullArgument>
+      <code><![CDATA[$dbCharset]]></code>
+      <code><![CDATA[$dbCollation]]></code>
       <code><![CDATA[$record[$i]]]></code>
       <code><![CDATA[$tableAlias]]></code>
     </PossiblyNullArgument>
@@ -8842,26 +8803,20 @@
     </MixedArrayAssignment>
   </file>
   <file src="src/Replication/Replication.php">
+    <LessSpecificReturnStatement>
+      <code><![CDATA[$output]]></code>
+    </LessSpecificReturnStatement>
     <MixedArgument>
       <code><![CDATA[$pos['File']]]></code>
       <code><![CDATA[$pos['File']]]></code>
     </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$data[0]['File']]]></code>
-      <code><![CDATA[$data[0]['Position']]]></code>
-    </MixedArrayAccess>
-    <MixedAssignment>
-      <code><![CDATA[$output['File']]]></code>
-      <code><![CDATA[$output['Position']]]></code>
-    </MixedAssignment>
     <MixedOperand>
       <code><![CDATA[$pos['Position']]]></code>
       <code><![CDATA[$pos['Position']]]></code>
     </MixedOperand>
-    <MixedReturnTypeCoercion>
-      <code><![CDATA[$output]]></code>
+    <MoreSpecificReturnType>
       <code><![CDATA[array{'File'?: string, 'Position'?: string}]]></code>
-    </MixedReturnTypeCoercion>
+    </MoreSpecificReturnType>
   </file>
   <file src="src/Replication/ReplicationGui.php">
     <DeprecatedMethod>
@@ -9054,10 +9009,6 @@
       <code><![CDATA[$row['Table_priv']]]></code>
       <code><![CDATA[$sqlQuery[0]]]></code>
       <code><![CDATA[$sqlQuery[0]]]></code>
-      <code><![CDATA[$val['CHARACTER_MAXIMUM_LENGTH']]]></code>
-      <code><![CDATA[$val['CHARACTER_MAXIMUM_LENGTH']]]></code>
-      <code><![CDATA[$val['COLUMN_NAME']]]></code>
-      <code><![CDATA[$val['COLUMN_NAME']]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
       <code><![CDATA[$dbRights[$row['User']][$row['Host']]]]></code>
@@ -9073,7 +9024,6 @@
       <code><![CDATA[$foundRows[]]]></code>
       <code><![CDATA[$grantValue]]></code>
       <code><![CDATA[$host]]></code>
-      <code><![CDATA[$hostnameLength]]></code>
       <code><![CDATA[$name]]></code>
       <code><![CDATA[$name]]></code>
       <code><![CDATA[$name]]></code>
@@ -9088,8 +9038,6 @@
       <code><![CDATA[$sqlQuery]]></code>
       <code><![CDATA[$sqlQuery]]></code>
       <code><![CDATA[$user]]></code>
-      <code><![CDATA[$usernameLength]]></code>
-      <code><![CDATA[$val]]></code>
     </MixedAssignment>
     <MixedOperand>
       <code><![CDATA[$origValue]]></code>
@@ -9832,6 +9780,7 @@
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
     <InvalidReturnStatement>
+      <code><![CDATA[$ret]]></code>
       <code><![CDATA[$tableAutoIncrement ?? '']]></code>
       <code><![CDATA[$this->getStatusInfo('TABLE_COLLATION') ?? '']]></code>
       <code><![CDATA[$this->getStatusInfo('TABLE_COMMENT') ?? '']]></code>
@@ -9840,11 +9789,10 @@
       <code><![CDATA[string]]></code>
       <code><![CDATA[string]]></code>
       <code><![CDATA[string]]></code>
+      <code><![CDATA[string[]]]></code>
     </InvalidReturnType>
     <MixedArgument>
       <code><![CDATA[$_POST['constraint_name'][$masterFieldMd5]]]></code>
-      <code><![CDATA[$column['Extra']]]></code>
-      <code><![CDATA[$column['Extra']]]></code>
       <code><![CDATA[$fields[$column]['expr']]]></code>
       <code><![CDATA[$index]]></code>
       <code><![CDATA[$index[0]]]></code>
@@ -9852,7 +9800,6 @@
       <code><![CDATA[$row['Type']]]></code>
       <code><![CDATA[$this->uiprefs[$property->value]]]></code>
       <code><![CDATA[$this->uiprefs[$property->value]]]></code>
-      <code><![CDATA[$value]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$indexed]]></code>
@@ -9860,9 +9807,6 @@
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code><![CDATA[$_SESSION['tmpval']['table_uiprefs'][$serverId][$this->dbName][$this->name]]]></code>
-      <code><![CDATA[$column['Extra']]]></code>
-      <code><![CDATA[$column['Extra']]]></code>
-      <code><![CDATA[$column['Field']]]></code>
       <code><![CDATA[$existrel[$masterField]['foreign_db']]]></code>
       <code><![CDATA[$existrel[$masterField]['foreign_field']]]></code>
       <code><![CDATA[$existrel[$masterField]['foreign_table']]]></code>
@@ -9886,12 +9830,9 @@
       <code><![CDATA[$optionsArray[$_POST['on_update'][$masterFieldMd5]]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
-      <code><![CDATA[$column]]></code>
       <code><![CDATA[$columns[$row['Field']]]]></code>
       <code><![CDATA[$index]]></code>
-      <code><![CDATA[$ret[]]]></code>
       <code><![CDATA[$row]]></code>
-      <code><![CDATA[$value]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
       <code><![CDATA[mixed[]]]></code>
@@ -9904,9 +9845,7 @@
     </MixedReturnStatement>
     <MixedReturnTypeCoercion>
       <code><![CDATA[$columns]]></code>
-      <code><![CDATA[$ret]]></code>
       <code><![CDATA[array<string, string>]]></code>
-      <code><![CDATA[string[]]]></code>
     </MixedReturnTypeCoercion>
     <PossiblyInvalidArgument>
       <code><![CDATA[$_POST['constraint_name'][$masterFieldMd5]]]></code>
@@ -9920,6 +9859,8 @@
       <code><![CDATA[$_POST['on_update'][$masterFieldMd5]]]></code>
     </PossiblyInvalidArrayOffset>
     <PossiblyNullArgument>
+      <code><![CDATA[$column['Extra']]]></code>
+      <code><![CDATA[$column['Extra']]]></code>
       <code><![CDATA[$existrelForeign[$masterFieldMd5]->refDbName]]></code>
       <code><![CDATA[$existrelForeign[$masterFieldMd5]->refTableName]]></code>
     </PossiblyNullArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2309,9 +2309,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="src/Controllers/Server/Variables/GetVariableController.php">
-    <PossiblyNullArrayAccess>
-      <code><![CDATA[$varValue[1]]]></code>
-    </PossiblyNullArrayAccess>
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
@@ -2323,9 +2320,6 @@
     <PossiblyNullArgument>
       <code><![CDATA[$varValue[1]]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess>
-      <code><![CDATA[$varValue[1]]]></code>
-    </PossiblyNullArrayAccess>
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
@@ -9118,10 +9112,6 @@
       <code><![CDATA[$row['Table_name']]]></code>
       <code><![CDATA[$row['Table_priv']]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess>
-      <code><![CDATA[$row1['Type']]]></code>
-      <code><![CDATA[$row['@@old_passwords']]]></code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullArrayOffset>
       <code><![CDATA[$columns]]></code>
       <code><![CDATA[$columns]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4229,9 +4229,6 @@
       <code><![CDATA[$row['Max_data_length']]]></code>
       <code><![CDATA[$row['Rows']]]></code>
     </InvalidOperand>
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$this->fetchResultSimple($sql, 'Field', $connectionType)]]></code>
-    </LessSpecificReturnStatement>
     <MixedArgument>
       <code><![CDATA[$a]]></code>
       <code><![CDATA[$b]]></code>
@@ -4300,10 +4297,9 @@
      *   Visible?: string,
      *   Expression?: string|null
      * }>]]></code>
-    </MixedReturnTypeCoercion>
-    <MoreSpecificReturnType>
+      <code><![CDATA[array_column($result->fetchAllAssoc(), 'Field')]]></code>
       <code><![CDATA[list<string>]]></code>
-    </MoreSpecificReturnType>
+    </MixedReturnTypeCoercion>
     <NullableReturnStatement>
       <code><![CDATA[$user]]></code>
     </NullableReturnStatement>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3771,6 +3771,12 @@
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
+    <InvalidReturnStatement>
+      <code><![CDATA[$this->dbi->fetchSingleColumn($query, ConnectionType::ControlUser)]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code><![CDATA[string[]]]></code>
+    </InvalidReturnType>
     <MixedArgument>
       <code><![CDATA[$columnDefault[$i]]]></code>
       <code><![CDATA[$columnExtra[$i]]]></code>
@@ -3825,9 +3831,7 @@
     </MixedAssignment>
     <MixedReturnTypeCoercion>
       <code><![CDATA[$hasList]]></code>
-      <code><![CDATA[$this->dbi->fetchResultSimple($query, ConnectionType::ControlUser)]]></code>
       <code><![CDATA[(string|null)[][]]]></code>
-      <code><![CDATA[string[]]]></code>
     </MixedReturnTypeCoercion>
     <PossiblyInvalidArgument>
       <code><![CDATA[$tnPageNow]]></code>
@@ -6184,13 +6188,17 @@
     </PossiblyNullArgument>
   </file>
   <file src="src/Navigation/Nodes/ObjectFetcher.php">
+    <InvalidReturnStatement>
+      <code><![CDATA[$this->dbi->fetchSingleColumn($query)]]></code>
+      <code><![CDATA[$this->dbi->fetchSingleColumn($query)]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code><![CDATA[string[]]]></code>
+      <code><![CDATA[string[]]]></code>
+    </InvalidReturnType>
     <MixedReturnTypeCoercion>
       <code><![CDATA[$this->dbi->fetchResultSimple($query)]]></code>
-      <code><![CDATA[$this->dbi->fetchResultSimple($query)]]></code>
-      <code><![CDATA[$this->dbi->fetchResultSimple($query)]]></code>
       <code><![CDATA[array{name:string, type:string}[]]]></code>
-      <code><![CDATA[string[]]]></code>
-      <code><![CDATA[string[]]]></code>
     </MixedReturnTypeCoercion>
   </file>
   <file src="src/Normalization.php">
@@ -6469,7 +6477,12 @@
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
+    <MixedArgument>
+      <code><![CDATA[$row]]></code>
+    </MixedArgument>
     <MixedArrayAccess>
+      <code><![CDATA[$row['PARTITION_NAME']]]></code>
+      <code><![CDATA[$row['PARTITION_NAME']]]></code>
       <code><![CDATA[$value['Name']]]></code>
     </MixedArrayAccess>
     <MixedArrayOffset>
@@ -6490,6 +6503,9 @@
     <MixedReturnStatement>
       <code><![CDATA[$partitionMethod[0]]]></code>
     </MixedReturnStatement>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$row]]></code>
+    </PossiblyInvalidArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[getDescription]]></code>
       <code><![CDATA[getSubPartitions]]></code>
@@ -7173,8 +7189,6 @@
       <code><![CDATA[$colAlias]]></code>
       <code><![CDATA[$colAlias]]></code>
       <code><![CDATA[$colAs]]></code>
-      <code><![CDATA[$eventName]]></code>
-      <code><![CDATA[$eventName]]></code>
       <code><![CDATA[$relFieldAlias]]></code>
       <code><![CDATA[$relFieldAlias]]></code>
       <code><![CDATA[$rel['foreign_field']]]></code>
@@ -7196,7 +7210,6 @@
       <code><![CDATA[$colAs]]></code>
       <code><![CDATA[$columnAliases]]></code>
       <code><![CDATA[$definition]]></code>
-      <code><![CDATA[$eventName]]></code>
       <code><![CDATA[$field->name]]></code>
       <code><![CDATA[$field->references->table->table]]></code>
       <code><![CDATA[$newDatabase]]></code>
@@ -7220,6 +7233,7 @@
     <PossiblyNullArgument>
       <code><![CDATA[$createQuery]]></code>
       <code><![CDATA[$definition]]></code>
+      <code><![CDATA[$eventName]]></code>
       <code><![CDATA[$tableAlias]]></code>
       <code><![CDATA[$tableAlias]]></code>
       <code><![CDATA[$tableAlias]]></code>
@@ -7321,14 +7335,14 @@
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
+    <InvalidArgument>
+      <code><![CDATA[$events]]></code>
+    </InvalidArgument>
     <MixedArgument>
       <code><![CDATA[$colAs]]></code>
       <code><![CDATA[$dbCharset]]></code>
       <code><![CDATA[$dbCollation]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$events]]></code>
-    </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code><![CDATA[$result[$table][1]]]></code>
       <code><![CDATA[$result[0]['DEFAULT_CHARACTER_SET_NAME']]]></code>
@@ -9073,7 +9087,6 @@
       <code><![CDATA[$name]]></code>
       <code><![CDATA[$name]]></code>
       <code><![CDATA[$name]]></code>
-      <code><![CDATA[$oneGrant]]></code>
       <code><![CDATA[$onePrivilege['name']]]></code>
       <code><![CDATA[$paramDbName]]></code>
       <code><![CDATA[$paramRoutineName]]></code>
@@ -9089,7 +9102,6 @@
       <code><![CDATA[$val]]></code>
     </MixedAssignment>
     <MixedOperand>
-      <code><![CDATA[$oneGrant]]></code>
       <code><![CDATA[$origValue]]></code>
     </MixedOperand>
     <MixedReturnTypeCoercion>
@@ -9189,6 +9201,7 @@
       <code><![CDATA[$alterUserQuery]]></code>
       <code><![CDATA[$alterUserQuery]]></code>
       <code><![CDATA[$alterUserQuery]]></code>
+      <code><![CDATA[$oneGrant]]></code>
       <code><![CDATA[$privilege['Host']]]></code>
       <code><![CDATA[$privilege['User']]]></code>
     </PossiblyNullOperand>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6268,7 +6268,6 @@
       <code><![CDATA[$cols['pk']]]></code>
       <code><![CDATA[$dropCols['nonpk']]]></code>
       <code><![CDATA[$dropCols['pk']]]></code>
-      <code><![CDATA[$res[0][$column . '_cnt']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code><![CDATA[$arrDependson]]></code>

--- a/src/Bookmarks/BookmarkRepository.php
+++ b/src/Bookmarks/BookmarkRepository.php
@@ -95,7 +95,7 @@ final class BookmarkRepository
 
         $query .= ' ORDER BY label ASC';
 
-        $result = $this->dbi->fetchResult($query, null, null, ConnectionType::ControlUser);
+        $result = $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
 
         $bookmarks = [];
         foreach ($result as $row) {

--- a/src/Bookmarks/BookmarkRepository.php
+++ b/src/Bookmarks/BookmarkRepository.php
@@ -95,7 +95,7 @@ final class BookmarkRepository
 
         $query .= ' ORDER BY label ASC';
 
-        $result = $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
+        $result = $this->dbi->fetchResultSimple($query, ConnectionType::ControlUser);
 
         $bookmarks = [];
         foreach ($result as $row) {

--- a/src/Bookmarks/BookmarkRepository.php
+++ b/src/Bookmarks/BookmarkRepository.php
@@ -134,7 +134,7 @@ final class BookmarkRepository
         $query .= ' LIMIT 1';
 
         $result = $this->dbi->fetchSingleRow($query, DatabaseInterface::FETCH_ASSOC, ConnectionType::ControlUser);
-        if ($result !== null) {
+        if ($result !== []) {
             return $this->createFromRow($result);
         }
 
@@ -162,7 +162,7 @@ final class BookmarkRepository
             . ' LIMIT 1';
 
         $result = $this->dbi->fetchSingleRow($query, DatabaseInterface::FETCH_ASSOC, ConnectionType::ControlUser);
-        if ($result !== null) {
+        if ($result !== []) {
             return $this->createFromRow($result);
         }
 

--- a/src/ConfigStorage/Relation.php
+++ b/src/ConfigStorage/Relation.php
@@ -662,9 +662,9 @@ class Relation
      *
      * @param string $username the username
      *
-     * @return mixed[]|bool list of history items
+     * @return mixed[]|false list of history items
      */
-    public function getHistory(string $username): array|bool
+    public function getHistory(string $username): array|false
     {
         $sqlHistoryFeature = $this->getRelationParameters()->sqlHistoryFeature;
         if ($sqlHistoryFeature === null) {

--- a/src/ConfigStorage/Relation.php
+++ b/src/ConfigStorage/Relation.php
@@ -693,7 +693,7 @@ class Relation
               WHERE `username` = ' . $this->dbi->quoteString($username) . '
            ORDER BY `id` DESC';
 
-        return $this->dbi->fetchResultSimple($histQuery, null, ConnectionType::ControlUser);
+        return $this->dbi->fetchResultSimple($histQuery, ConnectionType::ControlUser);
     }
 
     /**

--- a/src/ConfigStorage/Relation.php
+++ b/src/ConfigStorage/Relation.php
@@ -478,7 +478,7 @@ class Relation
                     . ' AND `table_name` = ' . $this->dbi->quoteString($table);
 
             $row = $this->dbi->fetchSingleRow($dispQuery, DatabaseInterface::FETCH_ASSOC, ConnectionType::ControlUser);
-            if (isset($row['display_field'])) {
+            if ($row['display_field'] !== null) {
                 return $row['display_field'];
             }
         }

--- a/src/ConfigStorage/Relation.php
+++ b/src/ConfigStorage/Relation.php
@@ -693,7 +693,7 @@ class Relation
               WHERE `username` = ' . $this->dbi->quoteString($username) . '
            ORDER BY `id` DESC';
 
-        return $this->dbi->fetchResult($histQuery, null, null, ConnectionType::ControlUser);
+        return $this->dbi->fetchResultSimple($histQuery, null, ConnectionType::ControlUser);
     }
 
     /**

--- a/src/Controllers/Database/MultiTableQuery/TablesController.php
+++ b/src/Controllers/Database/MultiTableQuery/TablesController.php
@@ -29,7 +29,7 @@ final class TablesController implements InvocableController
 
         $tablesListForQuery = array_map($this->dbi->quoteString(...), $tables);
 
-        $constrains = $this->dbi->fetchResult(
+        $constrains = $this->dbi->fetchResultSimple(
             QueryGenerator::getInformationSchemaForeignKeyConstraintsRequest(
                 $this->dbi->quoteString($db),
                 implode(',', $tablesListForQuery),

--- a/src/Controllers/Table/SearchController.php
+++ b/src/Controllers/Table/SearchController.php
@@ -304,9 +304,9 @@ final class SearchController implements InvocableController
      *
      * @param string $column Column name
      *
-     * @return mixed[]|null
+     * @return array<string|null>
      */
-    private function getColumnMinMax(string $column): array|null
+    private function getColumnMinMax(string $column): array
     {
         $sqlQuery = 'SELECT MIN(' . Util::backquote($column) . ') AS `min`, '
             . 'MAX(' . Util::backquote($column) . ') AS `max` '

--- a/src/Database/CentralColumns.php
+++ b/src/Database/CentralColumns.php
@@ -122,7 +122,7 @@ class CentralColumns
                 . 'LIMIT ' . $from . ', ' . $num . ';';
         }
 
-        $hasList = $this->dbi->fetchResult($query, null, null, ConnectionType::ControlUser);
+        $hasList = $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
         $this->handleColumnExtra($hasList);
 
         return $hasList;
@@ -147,7 +147,7 @@ class CentralColumns
         $query = 'SELECT count(db_name) FROM '
             . Util::backquote($pmadb) . '.' . Util::backquote($centralListTable) . ' '
             . 'WHERE db_name = ' . $this->dbi->quoteString($db, ConnectionType::ControlUser) . ';';
-        $res = $this->dbi->fetchResult($query, null, null, ConnectionType::ControlUser);
+        $res = $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
         if (isset($res[0])) {
             return (int) $res[0];
         }
@@ -180,7 +180,7 @@ class CentralColumns
             . Util::backquote($pmadb) . '.' . Util::backquote($centralListTable) . ' WHERE db_name = '
             . $this->dbi->quoteString($db, ConnectionType::ControlUser) . ' AND col_name IN (' . $cols . ');';
 
-        return $this->dbi->fetchResult($query, null, null, ConnectionType::ControlUser);
+        return $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
     }
 
     /**
@@ -207,7 +207,7 @@ class CentralColumns
         $query = 'SELECT * FROM '
             . Util::backquote($pmadb) . '.' . Util::backquote($centralListTable) . ' WHERE db_name = '
             . $this->dbi->quoteString($db, ConnectionType::ControlUser) . ' AND col_name IN (' . $cols . ');';
-        $hasList = $this->dbi->fetchResult($query, null, null, ConnectionType::ControlUser);
+        $hasList = $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
         $this->handleColumnExtra($hasList);
 
         return $hasList;
@@ -692,7 +692,7 @@ class CentralColumns
             $query .= ';';
         }
 
-        $columnsList = $this->dbi->fetchResult($query, null, null, ConnectionType::ControlUser);
+        $columnsList = $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
         $this->handleColumnExtra($columnsList);
 
         return $columnsList;
@@ -771,7 +771,7 @@ class CentralColumns
         $query = 'SELECT COUNT(db_name) FROM ' . Util::backquote($pmadb) . '.' . Util::backquote($centralListTable)
             . ' WHERE db_name = ' . $this->dbi->quoteString($db, ConnectionType::ControlUser)
             . ($num === 0 ? '' : 'LIMIT ' . $from . ', ' . $num) . ';';
-        $result = $this->dbi->fetchResult($query, null, null, ConnectionType::ControlUser);
+        $result = $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
 
         if (isset($result[0])) {
             return (int) $result[0];

--- a/src/Database/CentralColumns.php
+++ b/src/Database/CentralColumns.php
@@ -31,6 +31,7 @@ use function implode;
 use function in_array;
 use function is_array;
 use function is_bool;
+use function is_string;
 use function mb_strtoupper;
 use function sprintf;
 use function trim;
@@ -767,10 +768,10 @@ class CentralColumns
         $query = 'SELECT COUNT(db_name) FROM ' . Util::backquote($pmadb) . '.' . Util::backquote($centralListTable)
             . ' WHERE db_name = ' . $this->dbi->quoteString($db, ConnectionType::ControlUser)
             . ($num === 0 ? '' : 'LIMIT ' . $from . ', ' . $num) . ';';
-        $result = $this->dbi->fetchResultSimple($query, ConnectionType::ControlUser);
+        $result = $this->dbi->fetchValue($query, 0, ConnectionType::ControlUser);
 
-        if (isset($result[0])) {
-            return (int) $result[0];
+        if (is_string($result)) {
+            return (int) $result;
         }
 
         return -1;

--- a/src/Database/CentralColumns.php
+++ b/src/Database/CentralColumns.php
@@ -122,7 +122,7 @@ class CentralColumns
                 . 'LIMIT ' . $from . ', ' . $num . ';';
         }
 
-        $hasList = $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
+        $hasList = $this->dbi->fetchResultSimple($query, ConnectionType::ControlUser);
         $this->handleColumnExtra($hasList);
 
         return $hasList;
@@ -147,7 +147,7 @@ class CentralColumns
         $query = 'SELECT count(db_name) FROM '
             . Util::backquote($pmadb) . '.' . Util::backquote($centralListTable) . ' '
             . 'WHERE db_name = ' . $this->dbi->quoteString($db, ConnectionType::ControlUser) . ';';
-        $res = $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
+        $res = $this->dbi->fetchResultSimple($query, ConnectionType::ControlUser);
         if (isset($res[0])) {
             return (int) $res[0];
         }
@@ -180,7 +180,7 @@ class CentralColumns
             . Util::backquote($pmadb) . '.' . Util::backquote($centralListTable) . ' WHERE db_name = '
             . $this->dbi->quoteString($db, ConnectionType::ControlUser) . ' AND col_name IN (' . $cols . ');';
 
-        return $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
+        return $this->dbi->fetchResultSimple($query, ConnectionType::ControlUser);
     }
 
     /**
@@ -207,7 +207,7 @@ class CentralColumns
         $query = 'SELECT * FROM '
             . Util::backquote($pmadb) . '.' . Util::backquote($centralListTable) . ' WHERE db_name = '
             . $this->dbi->quoteString($db, ConnectionType::ControlUser) . ' AND col_name IN (' . $cols . ');';
-        $hasList = $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
+        $hasList = $this->dbi->fetchResultSimple($query, ConnectionType::ControlUser);
         $this->handleColumnExtra($hasList);
 
         return $hasList;
@@ -692,7 +692,7 @@ class CentralColumns
             $query .= ';';
         }
 
-        $columnsList = $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
+        $columnsList = $this->dbi->fetchResultSimple($query, ConnectionType::ControlUser);
         $this->handleColumnExtra($columnsList);
 
         return $columnsList;
@@ -771,7 +771,7 @@ class CentralColumns
         $query = 'SELECT COUNT(db_name) FROM ' . Util::backquote($pmadb) . '.' . Util::backquote($centralListTable)
             . ' WHERE db_name = ' . $this->dbi->quoteString($db, ConnectionType::ControlUser)
             . ($num === 0 ? '' : 'LIMIT ' . $from . ', ' . $num) . ';';
-        $result = $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
+        $result = $this->dbi->fetchResultSimple($query, ConnectionType::ControlUser);
 
         if (isset($result[0])) {
             return (int) $result[0];

--- a/src/Database/CentralColumns.php
+++ b/src/Database/CentralColumns.php
@@ -177,7 +177,7 @@ class CentralColumns
             . Util::backquote($pmadb) . '.' . Util::backquote($centralListTable) . ' WHERE db_name = '
             . $this->dbi->quoteString($db, ConnectionType::ControlUser) . ' AND col_name IN (' . $cols . ');';
 
-        return $this->dbi->fetchResultSimple($query, ConnectionType::ControlUser);
+        return $this->dbi->fetchSingleColumn($query, ConnectionType::ControlUser);
     }
 
     /**

--- a/src/Database/CentralColumns.php
+++ b/src/Database/CentralColumns.php
@@ -101,7 +101,7 @@ class CentralColumns
      * @param int    $from starting offset of first result
      * @param int    $num  maximum number of results to return
      *
-     * @return mixed[] list of $num columns present in central columns list
+     * @return list<array<string|null>> list of $num columns present in central columns list
      * starting at offset $from for the given database
      */
     public function getColumnsList(string $db, int $from = 0, int $num = 25): array
@@ -124,9 +124,8 @@ class CentralColumns
         }
 
         $hasList = $this->dbi->fetchResultSimple($query, ConnectionType::ControlUser);
-        $this->handleColumnExtra($hasList);
 
-        return $hasList;
+        return $this->handleColumnExtra($hasList);
     }
 
     /**
@@ -205,9 +204,8 @@ class CentralColumns
             . Util::backquote($pmadb) . '.' . Util::backquote($centralListTable) . ' WHERE db_name = '
             . $this->dbi->quoteString($db, ConnectionType::ControlUser) . ' AND col_name IN (' . $cols . ');';
         $hasList = $this->dbi->fetchResultSimple($query, ConnectionType::ControlUser);
-        $this->handleColumnExtra($hasList);
 
-        return $hasList;
+        return $this->handleColumnExtra($hasList);
     }
 
     /**
@@ -664,7 +662,7 @@ class CentralColumns
      * @param string $db    selected database
      * @param string $table current table name
      *
-     * @return mixed[] encoded list of columns present in central list for the given database
+     * @return list<array<string|null>> encoded list of columns present in central list for the given database
      */
     public function getListRaw(string $db, string $table): array
     {
@@ -690,18 +688,19 @@ class CentralColumns
         }
 
         $columnsList = $this->dbi->fetchResultSimple($query, ConnectionType::ControlUser);
-        $this->handleColumnExtra($columnsList);
 
-        return $columnsList;
+        return $this->handleColumnExtra($columnsList);
     }
 
     /**
      * Column `col_extra` is used to store both extra and attributes for a column.
      * This method separates them.
      *
-     * @param mixed[] $columnsList columns list
+     * @param list<array<string|null>> $columnsList columns list
+     *
+     * @return list<array<string|null>>
      */
-    private function handleColumnExtra(array &$columnsList): void
+    private function handleColumnExtra(array $columnsList): array
     {
         foreach ($columnsList as &$row) {
             $vals = explode(',', $row['col_extra']);
@@ -720,6 +719,8 @@ class CentralColumns
 
             $row['col_extra'] = in_array('auto_increment', $vals, true) ? 'auto_increment' : '';
         }
+
+        return $columnsList;
     }
 
     /**

--- a/src/Database/CentralColumns.php
+++ b/src/Database/CentralColumns.php
@@ -147,12 +147,8 @@ class CentralColumns
         $query = 'SELECT count(db_name) FROM '
             . Util::backquote($pmadb) . '.' . Util::backquote($centralListTable) . ' '
             . 'WHERE db_name = ' . $this->dbi->quoteString($db, ConnectionType::ControlUser) . ';';
-        $res = $this->dbi->fetchResultSimple($query, ConnectionType::ControlUser);
-        if (isset($res[0])) {
-            return (int) $res[0];
-        }
 
-        return 0;
+        return (int) $this->dbi->fetchValue($query, 0, ConnectionType::ControlUser);
     }
 
     /**

--- a/src/Database/Designer.php
+++ b/src/Database/Designer.php
@@ -17,7 +17,6 @@ use PhpMyAdmin\Util;
 use stdClass;
 
 use function __;
-use function is_array;
 use function json_decode;
 use function str_contains;
 
@@ -146,7 +145,7 @@ class Designer
                 . ';';
 
             $result = $this->dbi->fetchSingleRow($query);
-            if (is_array($result)) {
+            if ($result !== []) {
                 $params = json_decode((string) $result['settings_data'], true);
             }
         }

--- a/src/Database/Designer/Common.php
+++ b/src/Database/Designer/Common.php
@@ -669,7 +669,7 @@ class Common
                 ConnectionType::ControlUser,
             );
 
-            if ($origData !== null && $origData !== []) {
+            if ($origData !== []) {
                 $origData = json_decode($origData['settings_data'], true);
                 $origData[$index] = $value;
                 $origData = json_encode($origData);

--- a/src/Database/Designer/Common.php
+++ b/src/Database/Designer/Common.php
@@ -330,7 +330,7 @@ class Common
             . ' FROM ' . Util::backquote($pdfFeature->database)
             . '.' . Util::backquote($pdfFeature->pdfPages)
             . ' WHERE `page_descr` = ' . $this->dbi->quoteString($pg, ConnectionType::ControlUser);
-        $pageNos = $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
+        $pageNos = $this->dbi->fetchResultSimple($query, ConnectionType::ControlUser);
 
         return $pageNos !== [];
     }

--- a/src/Database/Designer/Common.php
+++ b/src/Database/Designer/Common.php
@@ -330,7 +330,7 @@ class Common
             . ' FROM ' . Util::backquote($pdfFeature->database)
             . '.' . Util::backquote($pdfFeature->pdfPages)
             . ' WHERE `page_descr` = ' . $this->dbi->quoteString($pg, ConnectionType::ControlUser);
-        $pageNos = $this->dbi->fetchResult($query, null, null, ConnectionType::ControlUser);
+        $pageNos = $this->dbi->fetchResultSimple($query, null, ConnectionType::ControlUser);
 
         return $pageNos !== [];
     }

--- a/src/Database/Events.php
+++ b/src/Database/Events.php
@@ -223,7 +223,7 @@ class Events
                  . ' AND EVENT_NAME=' . $this->dbi->quoteString($name);
         $query = 'SELECT ' . $columns . ' FROM `INFORMATION_SCHEMA`.`EVENTS` WHERE ' . $where . ';';
         $item = $this->dbi->fetchSingleRow($query);
-        if ($item === null || $item === []) {
+        if ($item === []) {
             return null;
         }
 

--- a/src/Database/Events.php
+++ b/src/Database/Events.php
@@ -367,7 +367,7 @@ class Events
         }
 
         $result = [];
-        $events = $this->dbi->fetchResult($query);
+        $events = $this->dbi->fetchResultSimple($query);
 
         /** @var string[] $event */
         foreach ($events as $event) {

--- a/src/Database/Routines.php
+++ b/src/Database/Routines.php
@@ -1256,7 +1256,7 @@ class Routines
                 in_array($which, ['FUNCTION', 'PROCEDURE'], true) ? $which : null,
                 $name === '' ? null : $dbi->quoteString($name),
             );
-            $routines = $dbi->fetchResult($query);
+            $routines = $dbi->fetchResultSimple($query);
         } else {
             $routines = [];
 
@@ -1266,7 +1266,7 @@ class Routines
                     $query .= ' AND `Name` = ' . $dbi->quoteString($name);
                 }
 
-                $routines = $dbi->fetchResult($query);
+                $routines = $dbi->fetchResultSimple($query);
             }
 
             if ($which === 'PROCEDURE' || $which == null) {
@@ -1275,7 +1275,7 @@ class Routines
                     $query .= ' AND `Name` = ' . $dbi->quoteString($name);
                 }
 
-                $routines = array_merge($routines, $dbi->fetchResult($query));
+                $routines = array_merge($routines, $dbi->fetchResultSimple($query));
             }
         }
 
@@ -1319,7 +1319,7 @@ class Routines
     public static function getFunctionNames(DatabaseInterface $dbi, string $db): array
     {
         /** @psalm-var list<array{Db: string, Name: string, Type: string}> $functions */
-        $functions = $dbi->fetchResult('SHOW FUNCTION STATUS;');
+        $functions = $dbi->fetchResultSimple('SHOW FUNCTION STATUS;');
         $names = [];
         foreach ($functions as $function) {
             if ($function['Db'] !== $db || $function['Type'] !== 'FUNCTION' || $function['Name'] === '') {
@@ -1339,7 +1339,7 @@ class Routines
     public static function getProcedureNames(DatabaseInterface $dbi, string $db): array
     {
         /** @psalm-var list<array{Db: string, Name: string, Type: string}> $procedures */
-        $procedures = $dbi->fetchResult('SHOW PROCEDURE STATUS;');
+        $procedures = $dbi->fetchResultSimple('SHOW PROCEDURE STATUS;');
         $names = [];
         foreach ($procedures as $procedure) {
             if ($procedure['Db'] !== $db || $procedure['Type'] !== 'PROCEDURE' || $procedure['Name'] === '') {

--- a/src/Database/Routines.php
+++ b/src/Database/Routines.php
@@ -432,7 +432,7 @@ class Routines
 
         $routine = $this->dbi->fetchSingleRow($query);
 
-        if ($routine === null || $routine === []) {
+        if ($routine === []) {
             return null;
         }
 

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -1352,7 +1352,7 @@ class DatabaseInterface implements DbalInterface
         return $resultRows;
     }
 
-    /** @return array<mixed> */
+    /** @return list<array<string|null>> */
     public function fetchResultSimple(
         string $query,
         ConnectionType $connectionType = ConnectionType::User,
@@ -1361,10 +1361,6 @@ class DatabaseInterface implements DbalInterface
 
         if ($result === false) {
             return [];
-        }
-
-        if ($result->numFields() === 1) {
-            return $result->fetchAllColumn();
         }
 
         return $result->fetchAllAssoc();

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -303,12 +303,19 @@ class DatabaseInterface implements DbalInterface
             return [];
         }
 
-        /** @var array<int, string> $tables */
-        $tables = $this->fetchResultSimple(
+        $result = $this->tryQuery(
             'SHOW TABLES FROM ' . Util::backquote($database) . ';',
-            0,
             $connectionType,
+            cacheAffectedRows: false,
         );
+
+        if ($result === false) {
+            return [];
+        }
+
+        /** @var list<string> $tables */
+        $tables = $result->fetchAllColumn();
+
         if ($this->config->settings['NaturalOrder']) {
             usort($tables, strnatcasecmp(...));
         }

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -1095,7 +1095,7 @@ class DatabaseInterface implements DbalInterface
     {
         $version = $this->fetchSingleRow('SELECT @@version, @@version_comment');
 
-        if (is_array($version)) {
+        if ($version !== []) {
             $this->setVersion($version);
         }
 
@@ -1211,19 +1211,19 @@ class DatabaseInterface implements DbalInterface
      * @param string $type  NUM|ASSOC|BOTH returned array should either numeric associative or both
      * @psalm-param DatabaseInterface::FETCH_NUM|DatabaseInterface::FETCH_ASSOC $type
      *
-     * @return array<string|null>|null
+     * @return array<string|null>
      */
     public function fetchSingleRow(
         string $query,
         string $type = DbalInterface::FETCH_ASSOC,
         ConnectionType $connectionType = ConnectionType::User,
-    ): array|null {
+    ): array {
         $result = $this->tryQuery($query, $connectionType, cacheAffectedRows: false);
         if ($result === false) {
-            return null;
+            return [];
         }
 
-        return $this->fetchByMode($result, $type) ?: null;
+        return $this->fetchByMode($result, $type);
     }
 
     /**

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -1370,6 +1370,20 @@ class DatabaseInterface implements DbalInterface
         return $result->fetchAllAssoc();
     }
 
+    /** @return list<string|null> */
+    public function fetchSingleColumn(
+        string $query,
+        ConnectionType $connectionType = ConnectionType::User,
+    ): array {
+        $result = $this->tryQuery($query, $connectionType, cacheAffectedRows: false);
+
+        if ($result === false) {
+            return [];
+        }
+
+        return $result->fetchAllColumn();
+    }
+
     /**
      * Get supported SQL compatibility modes
      *
@@ -1586,7 +1600,7 @@ class DatabaseInterface implements DbalInterface
     private function getCurrentUserGrants(): array
     {
         /** @var string[] $grants */
-        $grants = $this->fetchResultSimple('SHOW GRANTS FOR CURRENT_USER();');
+        $grants = $this->fetchSingleColumn('SHOW GRANTS FOR CURRENT_USER();');
 
         return $grants;
     }

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -137,6 +137,9 @@ class DatabaseInterface implements DbalInterface
     private ListDatabase|null $databaseList = null;
     private readonly Config $config;
 
+    /** @var int|numeric-string */
+    private static int|string $cachedAffectedRows = -1;
+
     /** @param DbiExtension $extension Object to be used for database queries */
     public function __construct(private DbiExtension $extension)
     {
@@ -199,7 +202,7 @@ class DatabaseInterface implements DbalInterface
         }
 
         if ($cacheAffectedRows) {
-            $GLOBALS['cached_affected_rows'] = $this->affectedRows($connectionType, false);
+            self::$cachedAffectedRows = $this->affectedRows($connectionType, false);
         }
 
         if ($this->config->config->debug->sql) {
@@ -1785,7 +1788,7 @@ class DatabaseInterface implements DbalInterface
         }
 
         if ($getFromCache) {
-            return $GLOBALS['cached_affected_rows'];
+            return self::$cachedAffectedRows;
         }
 
         return $this->extension->affectedRows($this->connections[$connectionType->value]);

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -989,8 +989,14 @@ class DatabaseInterface implements DbalInterface
     ): array {
         $sql = QueryGenerator::getColumnsSql($database, $table);
 
+        $result = $this->tryQuery($sql, $connectionType, cacheAffectedRows: false);
+
+        if ($result === false) {
+            return [];
+        }
+
         // We only need the 'Field' column which contains the table's column names
-        return $this->fetchResultSimple($sql, 'Field', $connectionType);
+        return array_column($result->fetchAllAssoc(), 'Field');
     }
 
     /**

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -1032,7 +1032,7 @@ class DatabaseInterface implements DbalInterface
     ): array {
         $sql = QueryGenerator::getTableIndexesSql($database, $table);
 
-        return $this->fetchResultSimple($sql, null, $connectionType);
+        return $this->fetchResultSimple($sql, $connectionType);
     }
 
     /**
@@ -1355,7 +1355,6 @@ class DatabaseInterface implements DbalInterface
     /** @return array<mixed> */
     public function fetchResultSimple(
         string $query,
-        string|int|null $value = null,
         ConnectionType $connectionType = ConnectionType::User,
     ): array {
         $result = $this->tryQuery($query, $connectionType, cacheAffectedRows: false);
@@ -1364,11 +1363,11 @@ class DatabaseInterface implements DbalInterface
             return [];
         }
 
-        if ($value === 0 || $result->numFields() === 1) {
+        if ($result->numFields() === 1) {
             return $result->fetchAllColumn();
         }
 
-        return $value === null ? $result->fetchAllAssoc() : array_column($result->fetchAllAssoc(), $value);
+        return $result->fetchAllAssoc();
     }
 
     /**

--- a/src/Dbal/DbalInterface.php
+++ b/src/Dbal/DbalInterface.php
@@ -302,13 +302,13 @@ interface DbalInterface
      * @param string $type  NUM|ASSOC returned array should either numeric associative or both
      * @psalm-param self::FETCH_NUM|self::FETCH_ASSOC $type
      *
-     * @return array<string|null>|null
+     * @return array<string|null>
      */
     public function fetchSingleRow(
         string $query,
         string $type = DbalInterface::FETCH_ASSOC,
         ConnectionType $connectionType = ConnectionType::User,
-    ): array|null;
+    ): array;
 
     /**
      * returns all rows in the resultset in one array

--- a/src/Dbal/DbalInterface.php
+++ b/src/Dbal/DbalInterface.php
@@ -352,15 +352,15 @@ interface DbalInterface
      * // $users['admin']['John Doe'] = '123'
      * </code>
      *
-     * @param string                  $query query to execute
-     * @param string|int|mixed[]|null $key   field-name or offset used as key for array or array of those
-     * @param string|int|null         $value value-name or offset used as value for array
+     * @param string             $query query to execute
+     * @param string|int|mixed[] $key   field-name or offset used as key for array or array of those
+     * @param string|int|null    $value value-name or offset used as value for array
      *
      * @return mixed[] resultrows or values indexed by $key
      */
     public function fetchResult(
         string $query,
-        string|int|array|null $key = null,
+        string|int|array $key,
         string|int|null $value = null,
         ConnectionType $connectionType = ConnectionType::User,
     ): array;

--- a/src/ListDatabase.php
+++ b/src/ListDatabase.php
@@ -100,7 +100,7 @@ class ListDatabase extends ArrayObject
         }
 
         if ($command !== '') {
-            $databaseList = $this->dbi->fetchResult($command);
+            $databaseList = $this->dbi->fetchResultSimple($command);
         }
 
         if ($this->config->settings['NaturalOrder']) {

--- a/src/ListDatabase.php
+++ b/src/ListDatabase.php
@@ -100,7 +100,8 @@ class ListDatabase extends ArrayObject
         }
 
         if ($command !== '') {
-            $databaseList = $this->dbi->fetchResultSimple($command);
+            /** @var string[] $databaseList */
+            $databaseList = $this->dbi->fetchSingleColumn($command);
         }
 
         if ($this->config->settings['NaturalOrder']) {

--- a/src/Navigation/Nodes/Node.php
+++ b/src/Navigation/Nodes/Node.php
@@ -609,7 +609,7 @@ class Node
      * @param int    $pos          The offset of the list within the results.
      * @param string $searchClause A string used to filter the results of the query.
      *
-     * @return mixed[]
+     * @return list<string|null>
      */
     private function getDataFromInfoSchema(int $pos, string $searchClause): array
     {
@@ -650,7 +650,7 @@ class Node
      * @param int    $pos          The offset of the list within the results.
      * @param string $searchClause A string used to filter the results of the query.
      *
-     * @return mixed[]
+     * @return list<string|null>
      */
     private function getDataFromShowDatabases(int $pos, string $searchClause): array
     {
@@ -732,7 +732,7 @@ class Node
      * @param int    $pos          The offset of the list within the results.
      * @param string $searchClause A string used to filter the results of the query.
      *
-     * @return mixed[]
+     * @return list<string|null>
      */
     private function getDataFromShowDatabasesLike(UserPrivileges $userPrivileges, int $pos, string $searchClause): array
     {

--- a/src/Navigation/Nodes/Node.php
+++ b/src/Navigation/Nodes/Node.php
@@ -626,7 +626,7 @@ class Node
                 $maxItems,
             );
 
-            return $dbi->fetchResult($query);
+            return $dbi->fetchResultSimple($query);
         }
 
         $dbSeparator = $this->config->settings['NavigationTreeDbSeparator'];
@@ -643,7 +643,7 @@ class Node
             $maxItems,
         );
 
-        return $dbi->fetchResult($query);
+        return $dbi->fetchResultSimple($query);
     }
 
     /**
@@ -725,7 +725,7 @@ class Node
             implode('OR', $subClauses),
         );
 
-        return $dbi->fetchResult($query);
+        return $dbi->fetchResultSimple($query);
     }
 
     /**

--- a/src/Navigation/Nodes/Node.php
+++ b/src/Navigation/Nodes/Node.php
@@ -626,7 +626,7 @@ class Node
                 $maxItems,
             );
 
-            return $dbi->fetchResultSimple($query);
+            return $dbi->fetchSingleColumn($query);
         }
 
         $dbSeparator = $this->config->settings['NavigationTreeDbSeparator'];
@@ -643,7 +643,7 @@ class Node
             $maxItems,
         );
 
-        return $dbi->fetchResultSimple($query);
+        return $dbi->fetchSingleColumn($query);
     }
 
     /**
@@ -725,7 +725,7 @@ class Node
             implode('OR', $subClauses),
         );
 
-        return $dbi->fetchResultSimple($query);
+        return $dbi->fetchSingleColumn($query);
     }
 
     /**

--- a/src/Navigation/Nodes/NodeTable.php
+++ b/src/Navigation/Nodes/NodeTable.php
@@ -164,7 +164,7 @@ class NodeTable extends NodeDatabaseChild
                     $query .= 'AND `TABLE_SCHEMA`=' . $dbi->quoteString($db) . ' ';
                     $query .= 'ORDER BY `COLUMN_NAME` ASC ';
                     $query .= 'LIMIT ' . $pos . ', ' . $maxItems;
-                    $retval = $dbi->fetchResult($query);
+                    $retval = $dbi->fetchResultSimple($query);
                     break;
                 }
 
@@ -229,7 +229,7 @@ class NodeTable extends NodeDatabaseChild
                     . Util::getCollateForIS() . '=' . $dbi->quoteString($table) . ' ';
                     $query .= 'ORDER BY `TRIGGER_NAME` ASC ';
                     $query .= 'LIMIT ' . $pos . ', ' . $maxItems;
-                    $retval = $dbi->fetchResult($query);
+                    $retval = $dbi->fetchResultSimple($query);
                     break;
                 }
 

--- a/src/Navigation/Nodes/NodeTable.php
+++ b/src/Navigation/Nodes/NodeTable.php
@@ -229,7 +229,7 @@ class NodeTable extends NodeDatabaseChild
                     . Util::getCollateForIS() . '=' . $dbi->quoteString($table) . ' ';
                     $query .= 'ORDER BY `TRIGGER_NAME` ASC ';
                     $query .= 'LIMIT ' . $pos . ', ' . $maxItems;
-                    $retval = $dbi->fetchResultSimple($query);
+                    $retval = $dbi->fetchSingleColumn($query);
                     break;
                 }
 

--- a/src/Navigation/Nodes/ObjectFetcher.php
+++ b/src/Navigation/Nodes/ObjectFetcher.php
@@ -121,7 +121,7 @@ class ObjectFetcher
 
             $query .= ' ORDER BY `EVENT_NAME` ASC';
 
-            return $this->dbi->fetchResultSimple($query);
+            return $this->dbi->fetchSingleColumn($query);
         }
 
         $query = 'SHOW EVENTS FROM ' . Util::backquote($realName);
@@ -225,7 +225,7 @@ class ObjectFetcher
 
             $query .= ' ORDER BY `ROUTINE_NAME` ASC';
 
-            return $this->dbi->fetchResultSimple($query);
+            return $this->dbi->fetchSingleColumn($query);
         }
 
         $query = 'SHOW ' . $routineType . ' STATUS WHERE `Db`=' . $this->dbi->quoteString($realName);

--- a/src/Navigation/Nodes/ObjectFetcher.php
+++ b/src/Navigation/Nodes/ObjectFetcher.php
@@ -121,7 +121,7 @@ class ObjectFetcher
 
             $query .= ' ORDER BY `EVENT_NAME` ASC';
 
-            return $this->dbi->fetchResult($query);
+            return $this->dbi->fetchResultSimple($query);
         }
 
         $query = 'SHOW EVENTS FROM ' . Util::backquote($realName);
@@ -181,7 +181,7 @@ class ObjectFetcher
 
             $query .= ' ORDER BY `TABLE_NAME` ASC';
 
-            return $this->dbi->fetchResult($query);
+            return $this->dbi->fetchResultSimple($query);
         }
 
         $query = 'SHOW FULL TABLES FROM ';
@@ -225,7 +225,7 @@ class ObjectFetcher
 
             $query .= ' ORDER BY `ROUTINE_NAME` ASC';
 
-            return $this->dbi->fetchResult($query);
+            return $this->dbi->fetchResultSimple($query);
         }
 
         $query = 'SHOW ' . $routineType . ' STATUS WHERE `Db`=' . $this->dbi->quoteString($realName);

--- a/src/Normalization.php
+++ b/src/Normalization.php
@@ -899,7 +899,7 @@ class Normalization
             $columns[] = Util::backquote($column);
         }
 
-        $totalRowsRes = $this->dbi->fetchResult(
+        $totalRowsRes = $this->dbi->fetchResultSimple(
             'SELECT COUNT(*) FROM (SELECT * FROM '
             . Util::backquote($table) . ' LIMIT 500) as dt;',
         );
@@ -988,7 +988,7 @@ class Normalization
             . 'COUNT(DISTINCT ' . $partialKey . ',' . $column . ') as pkColCnt '
             . 'FROM (SELECT * FROM ' . Util::backquote($table)
             . ' LIMIT 500) as dt;';
-        $res = $this->dbi->fetchResult($query);
+        $res = $this->dbi->fetchResultSimple($query);
         $pkColCnt = $res[0];
         if ($pkCnt !== 0 && $pkCnt === $colCnt && $colCnt == $pkColCnt) {
             return true;
@@ -1023,7 +1023,7 @@ class Normalization
         $query = trim($query, ', ');
         $query .= ' FROM (SELECT * FROM ' . Util::backquote($table)
             . ' LIMIT 500) as dt;';
-        $res = $this->dbi->fetchResult($query);
+        $res = $this->dbi->fetchResultSimple($query);
         foreach ($columns as $column) {
             if ($column === '') {
                 continue;

--- a/src/Normalization.php
+++ b/src/Normalization.php
@@ -899,11 +899,10 @@ class Normalization
             $columns[] = Util::backquote($column);
         }
 
-        $totalRowsRes = $this->dbi->fetchResultSimple(
+        $totalRows = (int) $this->dbi->fetchValue(
             'SELECT COUNT(*) FROM (SELECT * FROM '
             . Util::backquote($table) . ' LIMIT 500) as dt;',
         );
-        $totalRows = $totalRowsRes[0];
         $primary = Index::getPrimary($this->dbi, $table, $db);
         $primarycols = $primary === null ? [] : $primary->getColumns();
         $pk = [];

--- a/src/Normalization.php
+++ b/src/Normalization.php
@@ -988,8 +988,7 @@ class Normalization
             . 'COUNT(DISTINCT ' . $partialKey . ',' . $column . ') as pkColCnt '
             . 'FROM (SELECT * FROM ' . Util::backquote($table)
             . ' LIMIT 500) as dt;';
-        $res = $this->dbi->fetchResultSimple($query);
-        $pkColCnt = $res[0];
+        $pkColCnt = $this->dbi->fetchValue($query);
         if ($pkCnt !== 0 && $pkCnt === $colCnt && $colCnt == $pkColCnt) {
             return true;
         }

--- a/src/Normalization.php
+++ b/src/Normalization.php
@@ -1016,20 +1016,19 @@ class Normalization
             }
 
             //each column is already backquoted
-            $query .= 'COUNT(DISTINCT ' . $column . ') as \''
-                . $column . '_cnt\', ';
+            $query .= 'COUNT(DISTINCT ' . $column . ') as \'' . $column . '_cnt\', ';
         }
 
         $query = trim($query, ', ');
         $query .= ' FROM (SELECT * FROM ' . Util::backquote($table)
             . ' LIMIT 500) as dt;';
-        $res = $this->dbi->fetchResultSimple($query);
+        $res = $this->dbi->fetchSingleRow($query) ?? [];
         foreach ($columns as $column) {
             if ($column === '') {
                 continue;
             }
 
-            $result[$column] = (int) ($res[0][$column . '_cnt'] ?? null);
+            $result[$column] = (int) $res[$column . '_cnt'];
         }
 
         return $result;

--- a/src/Normalization.php
+++ b/src/Normalization.php
@@ -1006,7 +1006,6 @@ class Normalization
      */
     private function findDistinctValuesCount(array $columns, string $table): array
     {
-        $result = [];
         $query = 'SELECT ';
         foreach ($columns as $column) {
             if ($column === '') {
@@ -1020,7 +1019,12 @@ class Normalization
         $query = trim($query, ', ');
         $query .= ' FROM (SELECT * FROM ' . Util::backquote($table)
             . ' LIMIT 500) as dt;';
-        $res = $this->dbi->fetchSingleRow($query) ?? [];
+        $res = $this->dbi->fetchSingleRow($query);
+        if ($res === []) {
+            return [];
+        }
+
+        $result = [];
         foreach ($columns as $column) {
             if ($column === '') {
                 continue;

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -247,7 +247,7 @@ class Operations
     public function runEventDefinitionsForDb(string $db, DatabaseName $newDatabaseName): void
     {
         /** @var string[] $eventNames */
-        $eventNames = $this->dbi->fetchResult(
+        $eventNames = $this->dbi->fetchResultSimple(
             'SELECT EVENT_NAME FROM information_schema.EVENTS WHERE EVENT_SCHEMA= '
             . $this->dbi->quoteString($db) . ';',
         );

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -247,7 +247,7 @@ class Operations
     public function runEventDefinitionsForDb(string $db, DatabaseName $newDatabaseName): void
     {
         /** @var string[] $eventNames */
-        $eventNames = $this->dbi->fetchResultSimple(
+        $eventNames = $this->dbi->fetchSingleColumn(
             'SELECT EVENT_NAME FROM information_schema.EVENTS WHERE EVENT_SCHEMA= '
             . $this->dbi->quoteString($db) . ';',
         );

--- a/src/Partitioning/Maintenance.php
+++ b/src/Partitioning/Maintenance.php
@@ -29,7 +29,7 @@ final class Maintenance
         );
 
         $this->dbi->selectDb($db);
-        $result = $this->dbi->fetchResult($query);
+        $result = $this->dbi->fetchResultSimple($query);
 
         $rows = [];
         foreach ($result as $row) {
@@ -49,7 +49,7 @@ final class Maintenance
         );
 
         $this->dbi->selectDb($db);
-        $result = $this->dbi->fetchResult($query);
+        $result = $this->dbi->fetchResultSimple($query);
 
         $rows = [];
         foreach ($result as $row) {
@@ -84,7 +84,7 @@ final class Maintenance
         );
 
         $this->dbi->selectDb($db);
-        $result = $this->dbi->fetchResult($query);
+        $result = $this->dbi->fetchResultSimple($query);
 
         $rows = [];
         foreach ($result as $row) {
@@ -122,7 +122,7 @@ final class Maintenance
         );
 
         $this->dbi->selectDb($db);
-        $result = $this->dbi->fetchResult($query);
+        $result = $this->dbi->fetchResultSimple($query);
 
         $rows = [];
         foreach ($result as $row) {

--- a/src/Partitioning/Maintenance.php
+++ b/src/Partitioning/Maintenance.php
@@ -19,7 +19,7 @@ final class Maintenance
     {
     }
 
-    /** @return mixed[] */
+    /** @return array{array<array<array<string|null>>>, string} */
     public function analyze(DatabaseName $db, TableName $table, string $partition): array
     {
         $query = sprintf(
@@ -39,7 +39,7 @@ final class Maintenance
         return [$rows, $query];
     }
 
-    /** @return mixed[] */
+    /** @return array{array<array<array<string|null>>>, string} */
     public function check(DatabaseName $db, TableName $table, string $partition): array
     {
         $query = sprintf(
@@ -59,7 +59,7 @@ final class Maintenance
         return [$rows, $query];
     }
 
-    /** @return mixed[] */
+    /** @return array{bool, string} */
     public function drop(DatabaseName $db, TableName $table, string $partition): array
     {
         $query = sprintf(
@@ -74,7 +74,7 @@ final class Maintenance
         return [(bool) $result, $query];
     }
 
-    /** @return mixed[] */
+    /** @return array{array<array<array<string|null>>>, string} */
     public function optimize(DatabaseName $db, TableName $table, string $partition): array
     {
         $query = sprintf(
@@ -94,10 +94,7 @@ final class Maintenance
         return [$rows, $query];
     }
 
-    /**
-     * @return array<int, bool|string>
-     * @psalm-return array{bool, string}
-     */
+    /** @return array{bool, string} */
     public function rebuild(DatabaseName $db, TableName $table, string $partition): array
     {
         $query = sprintf(
@@ -112,7 +109,7 @@ final class Maintenance
         return [(bool) $result, $query];
     }
 
-    /** @return mixed[] */
+    /** @return array{array<array<array<string|null>>>, string} */
     public function repair(DatabaseName $db, TableName $table, string $partition): array
     {
         $query = sprintf(
@@ -132,10 +129,7 @@ final class Maintenance
         return [$rows, $query];
     }
 
-    /**
-     * @return array<int, bool|string>
-     * @psalm-return array{bool, string}
-     */
+    /** @return array{bool, string} */
     public function truncate(DatabaseName $db, TableName $table, string $partition): array
     {
         if (Table::get($table->getName(), $db->getName(), $this->dbi)->isView()) {

--- a/src/Partitioning/Partition.php
+++ b/src/Partitioning/Partition.php
@@ -150,7 +150,6 @@ class Partition extends SubPartition
             );
             if ($result !== []) {
                 $partitionMap = [];
-                /** @var array $row */
                 foreach ($result as $row) {
                     if (isset($partitionMap[$row['PARTITION_NAME']])) {
                         $partition = $partitionMap[$row['PARTITION_NAME']];
@@ -186,7 +185,7 @@ class Partition extends SubPartition
         if (self::havePartitioning()) {
             $dbi = DatabaseInterface::getInstance();
 
-            return $dbi->fetchResultSimple(
+            return $dbi->fetchSingleColumn(
                 'SELECT DISTINCT `PARTITION_NAME` FROM `information_schema`.`PARTITIONS`'
                 . ' WHERE `TABLE_SCHEMA` = ' . $dbi->quoteString($db)
                 . ' AND `TABLE_NAME` = ' . $dbi->quoteString($table),

--- a/src/Partitioning/Partition.php
+++ b/src/Partitioning/Partition.php
@@ -178,7 +178,7 @@ class Partition extends SubPartition
      * @param string $db    database name
      * @param string $table table name
      *
-     * @return mixed[]   of partition names
+     * @return list<string|null>   of partition names
      */
     public static function getPartitionNames(string $db, string $table): array
     {

--- a/src/Partitioning/Partition.php
+++ b/src/Partitioning/Partition.php
@@ -143,7 +143,7 @@ class Partition extends SubPartition
     {
         if (self::havePartitioning()) {
             $dbi = DatabaseInterface::getInstance();
-            $result = $dbi->fetchResult(
+            $result = $dbi->fetchResultSimple(
                 'SELECT * FROM `information_schema`.`PARTITIONS`'
                 . ' WHERE `TABLE_SCHEMA` = ' . $dbi->quoteString($db)
                 . ' AND `TABLE_NAME` = ' . $dbi->quoteString($table),
@@ -186,7 +186,7 @@ class Partition extends SubPartition
         if (self::havePartitioning()) {
             $dbi = DatabaseInterface::getInstance();
 
-            return $dbi->fetchResult(
+            return $dbi->fetchResultSimple(
                 'SELECT DISTINCT `PARTITION_NAME` FROM `information_schema`.`PARTITIONS`'
                 . ' WHERE `TABLE_SCHEMA` = ' . $dbi->quoteString($db)
                 . ' AND `TABLE_NAME` = ' . $dbi->quoteString($table),
@@ -208,7 +208,7 @@ class Partition extends SubPartition
     {
         if (self::havePartitioning()) {
             $dbi = DatabaseInterface::getInstance();
-            $partitionMethod = $dbi->fetchResult(
+            $partitionMethod = $dbi->fetchResultSimple(
                 'SELECT `PARTITION_METHOD` FROM `information_schema`.`PARTITIONS`'
                 . ' WHERE `TABLE_SCHEMA` = ' . $dbi->quoteString($db)
                 . ' AND `TABLE_NAME` = ' . $dbi->quoteString($table)
@@ -237,7 +237,7 @@ class Partition extends SubPartition
                 self::$havePartitioning = true;
             } else {
                 // see https://dev.mysql.com/doc/refman/5.6/en/partitioning.html
-                $plugins = $dbi->fetchResult('SHOW PLUGINS');
+                $plugins = $dbi->fetchResultSimple('SHOW PLUGINS');
                 foreach ($plugins as $value) {
                     if ($value['Name'] === 'partition') {
                         self::$havePartitioning = true;

--- a/src/Partitioning/Partition.php
+++ b/src/Partitioning/Partition.php
@@ -207,14 +207,14 @@ class Partition extends SubPartition
     {
         if (self::havePartitioning()) {
             $dbi = DatabaseInterface::getInstance();
-            $partitionMethod = $dbi->fetchResultSimple(
+            $partitionMethod = $dbi->fetchValue(
                 'SELECT `PARTITION_METHOD` FROM `information_schema`.`PARTITIONS`'
                 . ' WHERE `TABLE_SCHEMA` = ' . $dbi->quoteString($db)
                 . ' AND `TABLE_NAME` = ' . $dbi->quoteString($table)
                 . ' LIMIT 1',
             );
-            if ($partitionMethod !== []) {
-                return $partitionMethod[0];
+            if ($partitionMethod !== false) {
+                return $partitionMethod;
             }
         }
 

--- a/src/Plugins/Export/ExportSql.php
+++ b/src/Plugins/Export/ExportSql.php
@@ -980,7 +980,7 @@ class ExportSql extends ExportPlugin
         $delimiter = '$$';
 
         $dbi = DatabaseInterface::getInstance();
-        $eventNames = $dbi->fetchResult(
+        $eventNames = $dbi->fetchResultSimple(
             'SELECT EVENT_NAME FROM information_schema.EVENTS WHERE'
             . ' EVENT_SCHEMA= ' . $dbi->quoteString($db),
         );

--- a/src/Plugins/Export/ExportSql.php
+++ b/src/Plugins/Export/ExportSql.php
@@ -980,7 +980,7 @@ class ExportSql extends ExportPlugin
         $delimiter = '$$';
 
         $dbi = DatabaseInterface::getInstance();
-        $eventNames = $dbi->fetchResultSimple(
+        $eventNames = $dbi->fetchSingleColumn(
             'SELECT EVENT_NAME FROM information_schema.EVENTS WHERE'
             . ' EVENT_SCHEMA= ' . $dbi->quoteString($db),
         );

--- a/src/Plugins/Export/ExportXml.php
+++ b/src/Plugins/Export/ExportXml.php
@@ -222,7 +222,7 @@ class ExportXml extends ExportPlugin
             . '>' . "\n";
 
         if ($exportStruct) {
-            $result = $dbi->fetchResult(
+            $result = $dbi->fetchResultSimple(
                 'SELECT `DEFAULT_CHARACTER_SET_NAME`, `DEFAULT_COLLATION_NAME`'
                 . ' FROM `information_schema`.`SCHEMATA` WHERE `SCHEMA_NAME`'
                 . ' = ' . $dbi->quoteString(Current::$database) . ' LIMIT 1',
@@ -320,7 +320,7 @@ class ExportXml extends ExportPlugin
 
             if ($this->exportEvents) {
                 // Export events
-                $events = $dbi->fetchResult(
+                $events = $dbi->fetchResultSimple(
                     'SELECT EVENT_NAME FROM information_schema.EVENTS '
                     . 'WHERE EVENT_SCHEMA=' . $dbi->quoteString(Current::$database),
                 );

--- a/src/Plugins/Export/ExportXml.php
+++ b/src/Plugins/Export/ExportXml.php
@@ -320,7 +320,7 @@ class ExportXml extends ExportPlugin
 
             if ($this->exportEvents) {
                 // Export events
-                $events = $dbi->fetchResultSimple(
+                $events = $dbi->fetchSingleColumn(
                     'SELECT EVENT_NAME FROM information_schema.EVENTS '
                     . 'WHERE EVENT_SCHEMA=' . $dbi->quoteString(Current::$database),
                 );

--- a/src/Plugins/Export/ExportXml.php
+++ b/src/Plugins/Export/ExportXml.php
@@ -222,13 +222,13 @@ class ExportXml extends ExportPlugin
             . '>' . "\n";
 
         if ($exportStruct) {
-            $result = $dbi->fetchResultSimple(
+            $result = $dbi->fetchSingleRow(
                 'SELECT `DEFAULT_CHARACTER_SET_NAME`, `DEFAULT_COLLATION_NAME`'
                 . ' FROM `information_schema`.`SCHEMATA` WHERE `SCHEMA_NAME`'
                 . ' = ' . $dbi->quoteString(Current::$database) . ' LIMIT 1',
             );
-            $dbCollation = $result[0]['DEFAULT_COLLATION_NAME'];
-            $dbCharset = $result[0]['DEFAULT_CHARACTER_SET_NAME'];
+            $dbCollation = $result['DEFAULT_COLLATION_NAME'];
+            $dbCharset = $result['DEFAULT_CHARACTER_SET_NAME'];
 
             $head .= '    <!--' . "\n";
             $head .= '    - Structure schemas' . "\n";
@@ -326,8 +326,6 @@ class ExportXml extends ExportPlugin
                 );
                 $head .= $this->exportDefinitions(Current::$database, 'event', $events);
             }
-
-            unset($result);
 
             $head .= '        </pma:database>' . "\n";
             $head .= '    </pma:structure_schemas>' . "\n";

--- a/src/Plugins/Import/ImportCsv.php
+++ b/src/Plugins/Import/ImportCsv.php
@@ -587,7 +587,7 @@ class ImportCsv extends AbstractImportCsv
             if ($this->newDatabaseName !== '') {
                 $newDb = $this->newDatabaseName;
             } else {
-                $result = $dbi->fetchResultSimple('SHOW DATABASES');
+                $result = $dbi->fetchSingleColumn('SHOW DATABASES');
 
                 $newDb = 'CSV_DB ' . (count($result) + 1);
             }

--- a/src/Plugins/Import/ImportCsv.php
+++ b/src/Plugins/Import/ImportCsv.php
@@ -587,7 +587,7 @@ class ImportCsv extends AbstractImportCsv
             if ($this->newDatabaseName !== '') {
                 $newDb = $this->newDatabaseName;
             } else {
-                $result = $dbi->fetchResult('SHOW DATABASES');
+                $result = $dbi->fetchResultSimple('SHOW DATABASES');
 
                 $newDb = 'CSV_DB ' . (count($result) + 1);
             }

--- a/src/Profiling.php
+++ b/src/Profiling.php
@@ -50,7 +50,7 @@ final class Profiling
         }
 
         /** @psalm-var list<array{Status: non-empty-string, Duration: numeric-string}> $profile */
-        $profile = $dbi->fetchResult('SHOW PROFILE;');
+        $profile = $dbi->fetchResultSimple('SHOW PROFILE;');
 
         return $profile;
     }

--- a/src/Replication/Replication.php
+++ b/src/Replication/Replication.php
@@ -177,7 +177,6 @@ class Replication
     {
         $data = $this->dbi->fetchResultSimple(
             Compatibility::getShowBinLogStatusStmt($this->dbi),
-            null,
             $connectionType,
         );
         $output = [];

--- a/src/Replication/Replication.php
+++ b/src/Replication/Replication.php
@@ -175,9 +175,8 @@ class Replication
      */
     public function replicaBinLogPrimary(ConnectionType $connectionType): array
     {
-        $data = $this->dbi->fetchResult(
+        $data = $this->dbi->fetchResultSimple(
             Compatibility::getShowBinLogStatusStmt($this->dbi),
-            null,
             null,
             $connectionType,
         );

--- a/src/Replication/ReplicationGui.php
+++ b/src/Replication/ReplicationGui.php
@@ -77,11 +77,11 @@ class ReplicationGui
             $primaryStatusTable = $this->getHtmlForReplicationStatusTable($connection, 'primary', true, false);
             $dbi = DatabaseInterface::getInstance();
             if ($dbi->isMySql() && $dbi->getVersion() >= 80022) {
-                $replicas = $dbi->fetchResult('SHOW REPLICAS', null, null);
+                $replicas = $dbi->fetchResultSimple('SHOW REPLICAS');
             } elseif ($dbi->isMariaDB() && $dbi->getVersion() >= 100501) {
-                $replicas = $dbi->fetchResult('SHOW REPLICA HOSTS', null, null);
+                $replicas = $dbi->fetchResultSimple('SHOW REPLICA HOSTS');
             } else {
-                $replicas = $dbi->fetchResult('SHOW SLAVE HOSTS');
+                $replicas = $dbi->fetchResultSimple('SHOW SLAVE HOSTS');
             }
 
             $urlParams = UrlParams::$params;
@@ -138,9 +138,9 @@ class ReplicationGui
 
         $serverReplicaMultiReplication = [];
         if ($dbi->isMariaDB() && $dbi->getVersion() >= 100501) {
-            $serverReplicaMultiReplication = $dbi->fetchResult('SHOW ALL REPLICAS STATUS');
+            $serverReplicaMultiReplication = $dbi->fetchResultSimple('SHOW ALL REPLICAS STATUS');
         } elseif ($dbi->isMariaDB()) {
-            $serverReplicaMultiReplication = $dbi->fetchResult('SHOW ALL SLAVES STATUS');
+            $serverReplicaMultiReplication = $dbi->fetchResultSimple('SHOW ALL SLAVES STATUS');
         }
 
         $isReplicaIoRunning = false;

--- a/src/Replication/ReplicationInfo.php
+++ b/src/Replication/ReplicationInfo.php
@@ -109,7 +109,7 @@ final class ReplicationInfo
 
     private function setPrimaryStatus(): void
     {
-        $this->primaryStatus = $this->dbi->fetchResult(Compatibility::getShowBinLogStatusStmt($this->dbi));
+        $this->primaryStatus = $this->dbi->fetchResultSimple(Compatibility::getShowBinLogStatusStmt($this->dbi));
     }
 
     /** @return mixed[] */
@@ -124,9 +124,9 @@ final class ReplicationInfo
             $this->dbi->isMySql() && $this->dbi->getVersion() >= 80022
             || $this->dbi->isMariaDB() && $this->dbi->getVersion() >= 100501
         ) {
-            $this->replicaStatus = $this->dbi->fetchResult('SHOW REPLICA STATUS');
+            $this->replicaStatus = $this->dbi->fetchResultSimple('SHOW REPLICA STATUS');
         } else {
-            $this->replicaStatus = $this->dbi->fetchResult('SHOW SLAVE STATUS');
+            $this->replicaStatus = $this->dbi->fetchResultSimple('SHOW SLAVE STATUS');
         }
     }
 
@@ -140,9 +140,9 @@ final class ReplicationInfo
     {
         $this->multiPrimaryStatus = [];
         if ($this->dbi->isMariaDB() && $this->dbi->getVersion() >= 100501) {
-            $this->multiPrimaryStatus = $this->dbi->fetchResult('SHOW ALL REPLICAS STATUS');
+            $this->multiPrimaryStatus = $this->dbi->fetchResultSimple('SHOW ALL REPLICAS STATUS');
         } elseif ($this->dbi->isMariaDB()) {
-            $this->multiPrimaryStatus = $this->dbi->fetchResult('SHOW ALL SLAVES STATUS');
+            $this->multiPrimaryStatus = $this->dbi->fetchResultSimple('SHOW ALL SLAVES STATUS');
         }
     }
 

--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -473,7 +473,7 @@ class Privileges
             $row = $this->dbi->fetchSingleRow($sqlQuery);
         }
 
-        if ($row === null || $row === []) {
+        if ($row === []) {
             if ($table === '*' && $this->dbi->isSuperUser()) {
                 $row = [];
                 $sqlQuery = 'SHOW COLUMNS FROM `mysql`.' . ($db === '*' ? '`user`' : '`db`') . ';';
@@ -2057,7 +2057,7 @@ class Privileges
         if (isset($_POST['change_copy'])) {
             $userHostCondition = $this->getUserHostCondition($oldUsername, $oldHostname);
             $row = $this->dbi->fetchSingleRow('SELECT * FROM `mysql`.`user` ' . $userHostCondition . ';');
-            if ($row === null || $row === []) {
+            if ($row === []) {
                 $response = ResponseRenderer::getInstance();
                 $response->addHTML(
                     Message::notice(__('No user found.'))->getDisplay(),

--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -659,7 +659,7 @@ class Privileges
     /**
      * Get username and hostname length
      *
-     * @return mixed[] username length and hostname length
+     * @return array{int|string|null, int|string|null} username length and hostname length
      */
     public function getUsernameAndHostnameLength(): array
     {

--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -668,7 +668,7 @@ class Privileges
         $hostnameLength = 41;
 
         /* Try to get real lengths from the database */
-        $fieldsInfo = $this->dbi->fetchResult(
+        $fieldsInfo = $this->dbi->fetchResultSimple(
             'SELECT COLUMN_NAME, CHARACTER_MAXIMUM_LENGTH '
             . 'FROM information_schema.columns '
             . "WHERE table_schema = 'mysql' AND table_name = 'user' "
@@ -734,7 +734,7 @@ class Privileges
      */
     public function getGrants(string $user, string $host): string
     {
-        $grants = $this->dbi->fetchResult(
+        $grants = $this->dbi->fetchResultSimple(
             'SHOW GRANTS FOR '
             . $this->dbi->quoteString($user) . '@'
             . $this->dbi->quoteString($host),
@@ -1456,7 +1456,7 @@ class Privileges
         }
 
         // we also want privileges for this user not in table `db` but in other table
-        $tables = $this->dbi->fetchResult('SHOW TABLES FROM `mysql`;');
+        $tables = $this->dbi->fetchResultSimple('SHOW TABLES FROM `mysql`;');
 
         $dbRightsSqls = [];
         foreach ($tablesToSearchForUsers as $tableSearchIn) {
@@ -1848,7 +1848,7 @@ class Privileges
     public function getDbRightsForUserOverview(string|null $initial): array
     {
         // we also want users not in table `user` but in other table
-        $mysqlTables = $this->dbi->fetchResult('SHOW TABLES FROM `mysql`');
+        $mysqlTables = $this->dbi->fetchResultSimple('SHOW TABLES FROM `mysql`');
         $userTables = ['user', 'db', 'tables_priv', 'columns_priv', 'procs_priv'];
         $whereUser = $this->rangeOfUsers($initial);
         $sqls = [];

--- a/src/Server/Privileges.php
+++ b/src/Server/Privileges.php
@@ -734,7 +734,7 @@ class Privileges
      */
     public function getGrants(string $user, string $host): string
     {
-        $grants = $this->dbi->fetchResultSimple(
+        $grants = $this->dbi->fetchSingleColumn(
             'SHOW GRANTS FOR '
             . $this->dbi->quoteString($user) . '@'
             . $this->dbi->quoteString($host),
@@ -1456,7 +1456,7 @@ class Privileges
         }
 
         // we also want privileges for this user not in table `db` but in other table
-        $tables = $this->dbi->fetchResultSimple('SHOW TABLES FROM `mysql`;');
+        $tables = $this->dbi->fetchSingleColumn('SHOW TABLES FROM `mysql`;');
 
         $dbRightsSqls = [];
         foreach ($tablesToSearchForUsers as $tableSearchIn) {
@@ -1848,7 +1848,7 @@ class Privileges
     public function getDbRightsForUserOverview(string|null $initial): array
     {
         // we also want users not in table `user` but in other table
-        $mysqlTables = $this->dbi->fetchResultSimple('SHOW TABLES FROM `mysql`');
+        $mysqlTables = $this->dbi->fetchSingleColumn('SHOW TABLES FROM `mysql`');
         $userTables = ['user', 'db', 'tables_priv', 'columns_priv', 'procs_priv'];
         $whereUser = $this->rangeOfUsers($initial);
         $sqls = [];

--- a/src/Server/Status/Monitor.php
+++ b/src/Server/Status/Monitor.php
@@ -485,8 +485,6 @@ class Monitor
         string $database,
         string $query,
     ): array {
-        $GLOBALS['cached_affected_rows'] ??= null;
-
         $return = [];
 
         if ($database !== '') {
@@ -503,7 +501,7 @@ class Monitor
         $sqlQuery = preg_replace('/^(\s*SELECT)/i', '\\1 SQL_NO_CACHE', $query);
 
         $this->dbi->tryQuery($sqlQuery);
-        $return['affectedRows'] = $GLOBALS['cached_affected_rows'];
+        $return['affectedRows'] = $this->dbi->affectedRows();
 
         $result = $this->dbi->tryQuery('EXPLAIN ' . $sqlQuery);
         if ($result !== false) {

--- a/src/Sql.php
+++ b/src/Sql.php
@@ -315,7 +315,7 @@ class Sql
             $whereClause,
         ));
 
-        if ($row === null) {
+        if ($row === []) {
             return '';
         }
 

--- a/src/StorageEngine.php
+++ b/src/StorageEngine.php
@@ -157,8 +157,8 @@ class StorageEngine
         $dbi->selectDb($dbName);// Needed for mroonga_command calls
 
         if (! Cache::has($cacheKey)) {
-            $result = $dbi->fetchSingleRow('SELECT mroonga_command(\'object_list\');', DatabaseInterface::FETCH_NUM);
-            $objectList = (array) json_decode($result[0] ?? '', true);
+            $result = $dbi->fetchValue('SELECT mroonga_command(\'object_list\');', 0);
+            $objectList = (array) json_decode((string) $result, true);
             foreach ($objectList as $mroongaName => $mroongaData) {
                 /**
                  * We only need the objects of table or column types, more info:
@@ -187,11 +187,8 @@ class StorageEngine
                 continue;
             }
 
-            $result = $dbi->fetchSingleRow(
-                'SELECT mroonga_command(\'object_inspect ' . $mroongaName . '\');',
-                DatabaseInterface::FETCH_NUM,
-            );
-            $decodedData = json_decode($result[0] ?? '', true);
+            $result = $dbi->fetchValue('SELECT mroonga_command(\'object_inspect ' . $mroongaName . '\');', 0);
+            $decodedData = json_decode((string) $result, true);
             if ($decodedData === null) {
                 // Invalid for some strange reason, maybe query failed
                 continue;

--- a/src/Table/Maintenance.php
+++ b/src/Table/Maintenance.php
@@ -39,7 +39,7 @@ final class Maintenance
 
         $this->dbi->selectDb($db);
         /** @var array<int, array<string, string>> $result */
-        $result = $this->dbi->fetchResult($query);
+        $result = $this->dbi->fetchResultSimple($query);
 
         $rows = [];
         foreach ($result as $row) {
@@ -67,7 +67,7 @@ final class Maintenance
 
         $this->dbi->selectDb($db);
         /** @var array<int, array<string, string>> $result */
-        $result = $this->dbi->fetchResult($query);
+        $result = $this->dbi->fetchResultSimple($query);
 
         $rows = [];
         foreach ($result as $row) {
@@ -95,7 +95,7 @@ final class Maintenance
 
         $this->dbi->selectDb($db);
         /** @var array<int, array<string, string|null>> $rows */
-        $rows = $this->dbi->fetchResult($query);
+        $rows = $this->dbi->fetchResultSimple($query);
         $warnings = $this->dbi->getWarnings();
 
         return [$rows, $query, $warnings];
@@ -137,7 +137,7 @@ final class Maintenance
 
         $this->dbi->selectDb($db);
         /** @var array<int, array<string, string>> $result */
-        $result = $this->dbi->fetchResult($query);
+        $result = $this->dbi->fetchResultSimple($query);
 
         $rows = [];
         foreach ($result as $row) {
@@ -165,7 +165,7 @@ final class Maintenance
 
         $this->dbi->selectDb($db);
         /** @var array<int, array<string, string>> $result */
-        $result = $this->dbi->fetchResult($query);
+        $result = $this->dbi->fetchResultSimple($query);
 
         $rows = [];
         foreach ($result as $row) {

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -1756,7 +1756,7 @@ class Table implements Stringable
             ),
         );
 
-        if (! is_array($result)) {
+        if ($result === []) {
             return null;
         }
 

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -1033,6 +1033,7 @@ class Table implements Stringable
         $columnsMetaQueryResult = $this->dbi->fetchResultSimple($columnsMetaQuery);
 
         foreach ($columnsMetaQueryResult as $column) {
+            /** @var string $value */
             $value = $column['Field'];
             if ($backquoted) {
                 $value = Util::backquote($value);

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -1030,7 +1030,7 @@ class Table implements Stringable
         $columnsMetaQuery = 'SHOW COLUMNS FROM ' . $this->getFullName(true);
         $ret = [];
 
-        $columnsMetaQueryResult = $this->dbi->fetchResult($columnsMetaQuery);
+        $columnsMetaQueryResult = $this->dbi->fetchResultSimple($columnsMetaQuery);
 
         foreach ($columnsMetaQueryResult as $column) {
             $value = $column['Field'];

--- a/src/Triggers/Triggers.php
+++ b/src/Triggers/Triggers.php
@@ -58,7 +58,7 @@ class Triggers
         }
 
         /** @var mixed[][] $triggers */
-        $triggers = $dbi->fetchResult($query);
+        $triggers = $dbi->fetchResultSimple($query);
 
         return $triggers;
     }
@@ -270,7 +270,7 @@ class Triggers
             . " AND `TABLE_TYPE` IN ('BASE TABLE', 'SYSTEM VERSIONED')",
             $this->dbi->quoteString($db),
         );
-        $tables = $this->dbi->fetchResult($query);
+        $tables = $this->dbi->fetchResultSimple($query);
         Assert::allStringNotEmpty($tables);
         Assert::isList($tables);
 

--- a/src/Triggers/Triggers.php
+++ b/src/Triggers/Triggers.php
@@ -270,9 +270,8 @@ class Triggers
             . " AND `TABLE_TYPE` IN ('BASE TABLE', 'SYSTEM VERSIONED')",
             $this->dbi->quoteString($db),
         );
-        $tables = $this->dbi->fetchResultSimple($query);
+        $tables = $this->dbi->fetchSingleColumn($query);
         Assert::allStringNotEmpty($tables);
-        Assert::isList($tables);
 
         return $tables;
     }

--- a/src/Triggers/Triggers.php
+++ b/src/Triggers/Triggers.php
@@ -42,7 +42,7 @@ class Triggers
     {
     }
 
-    /** @return mixed[][] */
+    /** @return list<array<string|null>> */
     private static function fetchTriggerInfo(DatabaseInterface $dbi, string $db, string $table): array
     {
         if (! Config::getInstance()->selectedServer['DisableIS']) {
@@ -57,10 +57,7 @@ class Triggers
             }
         }
 
-        /** @var mixed[][] $triggers */
-        $triggers = $dbi->fetchResultSimple($query);
-
-        return $triggers;
+        return $dbi->fetchResultSimple($query);
     }
 
     /**

--- a/src/UserPreferences.php
+++ b/src/UserPreferences.php
@@ -93,7 +93,7 @@ class UserPreferences
             . ' WHERE `username` = '
             . $this->dbi->quoteString((string) $relationParameters->user);
         $row = $this->dbi->fetchSingleRow($query, DatabaseInterface::FETCH_ASSOC, ConnectionType::ControlUser);
-        if (! is_array($row) || ! isset($row['config_data']) || ! isset($row['ts'])) {
+        if ($row === [] || ! isset($row['config_data']) || ! isset($row['ts'])) {
             return ['config_data' => [], 'mtime' => time(), 'type' => 'db'];
         }
 
@@ -189,7 +189,7 @@ class UserPreferences
                 );
         }
 
-        return (bool) $this->dbi->fetchSingleRow($query, 'ASSOC', ConnectionType::ControlUser);
+        return $this->dbi->fetchSingleRow($query, 'ASSOC', ConnectionType::ControlUser) !== [];
     }
 
     /**

--- a/tests/unit/Database/CentralColumnsTest.php
+++ b/tests/unit/Database/CentralColumnsTest.php
@@ -197,12 +197,13 @@ class CentralColumnsTest extends AbstractTestCase
     public function testGetCount(): void
     {
         $this->dbi->expects(self::once())
-            ->method('fetchResultSimple')
+            ->method('fetchValue')
             ->with(
                 'SELECT count(db_name) FROM `phpmyadmin`.`pma_central_columns` WHERE db_name = \'phpmyadmin\';',
+                0,
                 ConnectionType::ControlUser,
             )
-            ->willReturn([3]);
+            ->willReturn('3');
 
         self::assertSame(
             3,

--- a/tests/unit/Database/CentralColumnsTest.php
+++ b/tests/unit/Database/CentralColumnsTest.php
@@ -175,7 +175,7 @@ class CentralColumnsTest extends AbstractTestCase
     public function testGetColumnsList(): void
     {
         $this->dbi->expects(self::exactly(2))
-            ->method('fetchResult')
+            ->method('fetchResultSimple')
             ->willReturnOnConsecutiveCalls(
                 self::COLUMN_DATA,
                 array_slice(self::COLUMN_DATA, 1, 2),
@@ -197,10 +197,9 @@ class CentralColumnsTest extends AbstractTestCase
     public function testGetCount(): void
     {
         $this->dbi->expects(self::once())
-            ->method('fetchResult')
+            ->method('fetchResultSimple')
             ->with(
                 'SELECT count(db_name) FROM `phpmyadmin`.`pma_central_columns` WHERE db_name = \'phpmyadmin\';',
-                null,
                 null,
                 ConnectionType::ControlUser,
             )
@@ -305,11 +304,10 @@ class CentralColumnsTest extends AbstractTestCase
     public function testGetHtmlForEditingPage(): void
     {
         $this->dbi->expects(self::any())
-            ->method('fetchResult')
+            ->method('fetchResultSimple')
             ->with(
                 'SELECT * FROM `phpmyadmin`.`pma_central_columns` '
                 . "WHERE db_name = 'phpmyadmin' AND col_name IN ('col1','col2');",
-                null,
                 null,
                 ConnectionType::ControlUser,
             )
@@ -336,10 +334,9 @@ class CentralColumnsTest extends AbstractTestCase
     public function testGetListRaw(): void
     {
         $this->dbi->expects(self::once())
-            ->method('fetchResult')
+            ->method('fetchResultSimple')
             ->with(
                 'SELECT * FROM `phpmyadmin`.`pma_central_columns` WHERE db_name = \'phpmyadmin\';',
-                null,
                 null,
                 ConnectionType::ControlUser,
             )
@@ -359,12 +356,11 @@ class CentralColumnsTest extends AbstractTestCase
     public function testGetListRawWithTable(): void
     {
         $this->dbi->expects(self::once())
-            ->method('fetchResult')
+            ->method('fetchResultSimple')
             ->with(
                 'SELECT * FROM `phpmyadmin`.`pma_central_columns` '
                 . "WHERE db_name = 'phpmyadmin' AND col_name "
                 . "NOT IN ('id','col1','col2');",
-                null,
                 null,
                 ConnectionType::ControlUser,
             )
@@ -386,8 +382,8 @@ class CentralColumnsTest extends AbstractTestCase
         $expectedQuery = 'SELECT * FROM `phpmyadmin`.`pma_central_columns`'
             . ' WHERE db_name = \'phpmyadmin\' AND col_name IN (\'col1\');';
         $this->dbi->expects(self::once())
-            ->method('fetchResult')
-            ->with($expectedQuery, null, null, ConnectionType::ControlUser)
+            ->method('fetchResultSimple')
+            ->with($expectedQuery, null, ConnectionType::ControlUser)
             ->willReturn(array_slice(self::COLUMN_DATA, 1, 1));
         self::assertSame(
             array_slice(self::MODIFIED_COLUMN_DATA, 1, 1),

--- a/tests/unit/Database/CentralColumnsTest.php
+++ b/tests/unit/Database/CentralColumnsTest.php
@@ -200,7 +200,6 @@ class CentralColumnsTest extends AbstractTestCase
             ->method('fetchResultSimple')
             ->with(
                 'SELECT count(db_name) FROM `phpmyadmin`.`pma_central_columns` WHERE db_name = \'phpmyadmin\';',
-                null,
                 ConnectionType::ControlUser,
             )
             ->willReturn([3]);
@@ -308,7 +307,6 @@ class CentralColumnsTest extends AbstractTestCase
             ->with(
                 'SELECT * FROM `phpmyadmin`.`pma_central_columns` '
                 . "WHERE db_name = 'phpmyadmin' AND col_name IN ('col1','col2');",
-                null,
                 ConnectionType::ControlUser,
             )
             ->willReturn(self::COLUMN_DATA);
@@ -337,7 +335,6 @@ class CentralColumnsTest extends AbstractTestCase
             ->method('fetchResultSimple')
             ->with(
                 'SELECT * FROM `phpmyadmin`.`pma_central_columns` WHERE db_name = \'phpmyadmin\';',
-                null,
                 ConnectionType::ControlUser,
             )
             ->willReturn(self::COLUMN_DATA);
@@ -361,7 +358,6 @@ class CentralColumnsTest extends AbstractTestCase
                 'SELECT * FROM `phpmyadmin`.`pma_central_columns` '
                 . "WHERE db_name = 'phpmyadmin' AND col_name "
                 . "NOT IN ('id','col1','col2');",
-                null,
                 ConnectionType::ControlUser,
             )
             ->willReturn(self::COLUMN_DATA);
@@ -383,7 +379,7 @@ class CentralColumnsTest extends AbstractTestCase
             . ' WHERE db_name = \'phpmyadmin\' AND col_name IN (\'col1\');';
         $this->dbi->expects(self::once())
             ->method('fetchResultSimple')
-            ->with($expectedQuery, null, ConnectionType::ControlUser)
+            ->with($expectedQuery, ConnectionType::ControlUser)
             ->willReturn(array_slice(self::COLUMN_DATA, 1, 1));
         self::assertSame(
             array_slice(self::MODIFIED_COLUMN_DATA, 1, 1),

--- a/tests/unit/DatabaseInterfaceTest.php
+++ b/tests/unit/DatabaseInterfaceTest.php
@@ -185,7 +185,7 @@ class DatabaseInterfaceTest extends AbstractTestCase
 
         $mock->expects(self::once())
             ->method('fetchSingleRow')
-            ->willReturn(null);
+            ->willReturn([]);
 
         $mock->expects(self::never())->method('setVersion');
 

--- a/tests/unit/Navigation/Nodes/NodeTest.php
+++ b/tests/unit/Navigation/Nodes/NodeTest.php
@@ -357,7 +357,7 @@ final class NodeTest extends AbstractTestCase
         $node = new Node($config, 'node');
 
         $dbi = self::createMock(DatabaseInterface::class);
-        $dbi->expects(self::once())->method('fetchResultSimple')->with($expectedSql);
+        $dbi->expects(self::once())->method('fetchSingleColumn')->with($expectedSql);
         $dbi->expects(self::any())->method('quoteString')
             ->willReturnCallback(static fn (string $string): string => "'" . $string . "'");
         DatabaseInterface::$instance = $dbi;
@@ -389,7 +389,7 @@ final class NodeTest extends AbstractTestCase
         $node = new Node($config, 'node');
 
         $dbi = self::createMock(DatabaseInterface::class);
-        $dbi->expects(self::once())->method('fetchResultSimple')->with($expectedSql);
+        $dbi->expects(self::once())->method('fetchSingleColumn')->with($expectedSql);
 
         DatabaseInterface::$instance = $dbi;
         $node->getData(new UserPrivileges(), $relationParameters, '', 10);
@@ -426,7 +426,7 @@ final class NodeTest extends AbstractTestCase
             ->willReturn(['0' => 'db'], ['0' => 'aa_db'], []);
 
         $dbi->expects(self::once())
-            ->method('fetchResultSimple')
+            ->method('fetchSingleColumn')
             ->with(
                 "SHOW DATABASES WHERE TRUE AND `Database` LIKE '%db%' AND ("
                 . " LOCATE('db_', CONCAT(`Database`, '_')) = 1"

--- a/tests/unit/Navigation/Nodes/NodeTest.php
+++ b/tests/unit/Navigation/Nodes/NodeTest.php
@@ -357,7 +357,7 @@ final class NodeTest extends AbstractTestCase
         $node = new Node($config, 'node');
 
         $dbi = self::createMock(DatabaseInterface::class);
-        $dbi->expects(self::once())->method('fetchResult')->with($expectedSql);
+        $dbi->expects(self::once())->method('fetchResultSimple')->with($expectedSql);
         $dbi->expects(self::any())->method('quoteString')
             ->willReturnCallback(static fn (string $string): string => "'" . $string . "'");
         DatabaseInterface::$instance = $dbi;
@@ -389,7 +389,7 @@ final class NodeTest extends AbstractTestCase
         $node = new Node($config, 'node');
 
         $dbi = self::createMock(DatabaseInterface::class);
-        $dbi->expects(self::once())->method('fetchResult')->with($expectedSql);
+        $dbi->expects(self::once())->method('fetchResultSimple')->with($expectedSql);
 
         DatabaseInterface::$instance = $dbi;
         $node->getData(new UserPrivileges(), $relationParameters, '', 10);
@@ -426,7 +426,7 @@ final class NodeTest extends AbstractTestCase
             ->willReturn(['0' => 'db'], ['0' => 'aa_db'], []);
 
         $dbi->expects(self::once())
-            ->method('fetchResult')
+            ->method('fetchResultSimple')
             ->with(
                 "SHOW DATABASES WHERE TRUE AND `Database` LIKE '%db%' AND ("
                 . " LOCATE('db_', CONCAT(`Database`, '_')) = 1"

--- a/tests/unit/NormalizationTest.php
+++ b/tests/unit/NormalizationTest.php
@@ -96,6 +96,9 @@ class NormalizationTest extends AbstractTestCase
         $dbi->expects(self::any())
             ->method('fetchResultSimple')
             ->willReturn([0]);
+        $dbi->expects(self::any())
+            ->method('fetchSingleRow')
+            ->willReturn(['`id`_cnt' => 0, '`col1`_cnt' => 0, '`col2`_cnt' => 0]);
 
         $this->normalization = new Normalization($dbi, new Relation($dbi), new Transformations(), new Template());
     }

--- a/tests/unit/NormalizationTest.php
+++ b/tests/unit/NormalizationTest.php
@@ -94,7 +94,7 @@ class NormalizationTest extends AbstractTestCase
             ->method('tryQuery')
             ->willReturn(self::createStub(DummyResult::class));
         $dbi->expects(self::any())
-            ->method('fetchResult')
+            ->method('fetchResultSimple')
             ->willReturn([0]);
 
         $this->normalization = new Normalization($dbi, new Relation($dbi), new Transformations(), new Template());

--- a/tests/unit/NormalizationTest.php
+++ b/tests/unit/NormalizationTest.php
@@ -94,9 +94,6 @@ class NormalizationTest extends AbstractTestCase
             ->method('tryQuery')
             ->willReturn(self::createStub(DummyResult::class));
         $dbi->expects(self::any())
-            ->method('fetchResultSimple')
-            ->willReturn([0]);
-        $dbi->expects(self::any())
             ->method('fetchSingleRow')
             ->willReturn(['`id`_cnt' => 0, '`col1`_cnt' => 0, '`col2`_cnt' => 0]);
 

--- a/tests/unit/Partitioning/PartitionTest.php
+++ b/tests/unit/Partitioning/PartitionTest.php
@@ -43,7 +43,7 @@ class PartitionTest extends AbstractTestCase
         $mock = self::createStub(DatabaseInterface::class);
         $mock->method('getVersion')->willReturn($version);
         $mock->method('fetchValue')->willReturn($varValue);
-        $mock->method('fetchResult')->willReturn($pluginValue);
+        $mock->method('fetchResultSimple')->willReturn($pluginValue);
         DatabaseInterface::$instance = $mock;
         self::assertSame($expected, Partition::havePartitioning());
     }

--- a/tests/unit/Plugins/Export/ExportSqlTest.php
+++ b/tests/unit/Plugins/Export/ExportSqlTest.php
@@ -592,7 +592,7 @@ class ExportSqlTest extends AbstractTestCase
             ->getMock();
 
         $dbi->expects(self::once())
-            ->method('fetchResultSimple')
+            ->method('fetchSingleColumn')
             ->with('SELECT EVENT_NAME FROM information_schema.EVENTS WHERE EVENT_SCHEMA= \'db\'')
             ->willReturn(['f1', 'f2']);
 

--- a/tests/unit/Plugins/Export/ExportSqlTest.php
+++ b/tests/unit/Plugins/Export/ExportSqlTest.php
@@ -592,7 +592,7 @@ class ExportSqlTest extends AbstractTestCase
             ->getMock();
 
         $dbi->expects(self::once())
-            ->method('fetchResult')
+            ->method('fetchResultSimple')
             ->with('SELECT EVENT_NAME FROM information_schema.EVENTS WHERE EVENT_SCHEMA= \'db\'')
             ->willReturn(['f1', 'f2']);
 

--- a/tests/unit/Table/TableTest.php
+++ b/tests/unit/Table/TableTest.php
@@ -85,38 +85,15 @@ class TableTest extends AbstractTestCase
 
         $getUniqueColumnsSql = 'SHOW INDEXES FROM `PMA`.`PMA_BookMark`';
 
-        $fetchResult = [
+        $fetchResultSimple = [
             [
                 $sqlAnalyzeStructureTrue,
-                null,
                 null,
                 ConnectionType::User,
                 [['COLUMN_NAME' => 'COLUMN_NAME', 'DATA_TYPE' => 'DATA_TYPE']],
             ],
             [
-                $getUniqueColumnsSql . ' WHERE (Non_unique = 0)',
-                ['Key_name', null],
-                'Column_name',
-                ConnectionType::User,
-                [['index1'], ['index3'], ['index5']],
-            ],
-            [
-                $getUniqueColumnsSql,
-                'Column_name',
-                'Column_name',
-                ConnectionType::User,
-                ['column1', 'column3', 'column5', 'ACCESSIBLE', 'ADD', 'ALL'],
-            ],
-            [
                 'SHOW COLUMNS FROM `PMA`.`PMA_BookMark`',
-                'Field',
-                'Field',
-                ConnectionType::User,
-                ['column1', 'column3', 'column5', 'ACCESSIBLE', 'ADD', 'ALL'],
-            ],
-            [
-                'SHOW COLUMNS FROM `PMA`.`PMA_BookMark`',
-                null,
                 null,
                 ConnectionType::User,
                 [
@@ -140,7 +117,6 @@ class TableTest extends AbstractTestCase
             ],
             [
                 'SHOW TRIGGERS FROM `PMA` LIKE \'PMA_BookMark\';',
-                null,
                 null,
                 ConnectionType::User,
                 [
@@ -172,7 +148,6 @@ class TableTest extends AbstractTestCase
             ],
             [
                 'SHOW TRIGGERS FROM `PMA` LIKE \'PMA_.BookMark\';',
-                null,
                 null,
                 ConnectionType::User,
                 [
@@ -208,7 +183,6 @@ class TableTest extends AbstractTestCase
                     . "information_schema.TRIGGERS WHERE EVENT_OBJECT_SCHEMA COLLATE utf8_bin= 'PMA' "
                     . "AND EVENT_OBJECT_TABLE COLLATE utf8_bin = 'PMA_BookMark';",
                 null,
-                null,
                 ConnectionType::User,
                 [
                     [],
@@ -220,7 +194,6 @@ class TableTest extends AbstractTestCase
                     . "information_schema.TRIGGERS WHERE EVENT_OBJECT_SCHEMA COLLATE utf8_bin= 'aa' "
                     . "AND EVENT_OBJECT_TABLE COLLATE utf8_bin = 'ad';",
                 null,
-                null,
                 ConnectionType::User,
                 [
                     [],
@@ -229,9 +202,32 @@ class TableTest extends AbstractTestCase
             [
                 'SHOW COLUMNS FROM `aa`.`ad`',
                 null,
-                null,
                 ConnectionType::User,
                 [],
+            ],
+        ];
+
+        $fetchResult = [
+            [
+                $getUniqueColumnsSql . ' WHERE (Non_unique = 0)',
+                ['Key_name', null],
+                'Column_name',
+                ConnectionType::User,
+                [['index1'], ['index3'], ['index5']],
+            ],
+            [
+                $getUniqueColumnsSql,
+                'Column_name',
+                'Column_name',
+                ConnectionType::User,
+                ['column1', 'column3', 'column5', 'ACCESSIBLE', 'ADD', 'ALL'],
+            ],
+            [
+                'SHOW COLUMNS FROM `PMA`.`PMA_BookMark`',
+                'Field',
+                'Field',
+                ConnectionType::User,
+                ['column1', 'column3', 'column5', 'ACCESSIBLE', 'ADD', 'ALL'],
             ],
         ];
 
@@ -267,6 +263,9 @@ class TableTest extends AbstractTestCase
 
         $dbi->expects(self::any())->method('fetchResult')
             ->willReturnMap($fetchResult);
+
+            $dbi->expects(self::any())->method('fetchResultSimple')
+                ->willReturnMap($fetchResultSimple);
 
         $dbi->expects(self::any())->method('fetchValue')
             ->willReturnMap($fetchValue);

--- a/tests/unit/Table/TableTest.php
+++ b/tests/unit/Table/TableTest.php
@@ -88,13 +88,11 @@ class TableTest extends AbstractTestCase
         $fetchResultSimple = [
             [
                 $sqlAnalyzeStructureTrue,
-                null,
                 ConnectionType::User,
                 [['COLUMN_NAME' => 'COLUMN_NAME', 'DATA_TYPE' => 'DATA_TYPE']],
             ],
             [
                 'SHOW COLUMNS FROM `PMA`.`PMA_BookMark`',
-                null,
                 ConnectionType::User,
                 [
                     [
@@ -117,7 +115,6 @@ class TableTest extends AbstractTestCase
             ],
             [
                 'SHOW TRIGGERS FROM `PMA` LIKE \'PMA_BookMark\';',
-                null,
                 ConnectionType::User,
                 [
                     [
@@ -148,7 +145,6 @@ class TableTest extends AbstractTestCase
             ],
             [
                 'SHOW TRIGGERS FROM `PMA` LIKE \'PMA_.BookMark\';',
-                null,
                 ConnectionType::User,
                 [
                     [
@@ -182,7 +178,6 @@ class TableTest extends AbstractTestCase
                     . 'ACTION_STATEMENT, EVENT_OBJECT_SCHEMA, EVENT_OBJECT_TABLE, DEFINER FROM '
                     . "information_schema.TRIGGERS WHERE EVENT_OBJECT_SCHEMA COLLATE utf8_bin= 'PMA' "
                     . "AND EVENT_OBJECT_TABLE COLLATE utf8_bin = 'PMA_BookMark';",
-                null,
                 ConnectionType::User,
                 [
                     [],
@@ -193,7 +188,6 @@ class TableTest extends AbstractTestCase
                     . 'ACTION_STATEMENT, EVENT_OBJECT_SCHEMA, EVENT_OBJECT_TABLE, DEFINER FROM '
                     . "information_schema.TRIGGERS WHERE EVENT_OBJECT_SCHEMA COLLATE utf8_bin= 'aa' "
                     . "AND EVENT_OBJECT_TABLE COLLATE utf8_bin = 'ad';",
-                null,
                 ConnectionType::User,
                 [
                     [],
@@ -201,7 +195,6 @@ class TableTest extends AbstractTestCase
             ],
             [
                 'SHOW COLUMNS FROM `aa`.`ad`',
-                null,
                 ConnectionType::User,
                 [],
             ],


### PR DESCRIPTION
The method `fetchResult` was a complex method that could very easily be misused. Two new methods were created to more precisely express the intent. A number of related changes were made possible and even necessary after these changes. I believe it also fixes a bug in normalization which was introduced with native parameter types.