### PR TITLE
fix: misspell on 'nevegador' to 'navegador'

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7269,7 +7269,7 @@ msgid ""
 "the browser."
 msgstr ""
 "Você realmente quer ver todas as linhas? Para uma tabela grande isto poderia "
-"travar o nevegador."
+"travar o navegador."
 
 #: libraries/classes/Controllers/JavaScriptMessagesController.php:571
 msgid "Original length"


### PR DESCRIPTION
### Description

When I was using phpmyadm I saw a misspell on show all lines. Using the PT-BR version.

On the translation we have the word 'navegador' writed properly, just missing place.

'nevegador' > 'navegador'

Fixes #19473

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.