### PR TITLE
Fix #14542 - Show query if no results found

### DIFF
--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -1048,7 +1048,7 @@ class Sql
             $message = $this->getMessageForNoRowsReturned($messageToShow, $analyzedSqlResults, $numRows);
         }
 
-        $queryMessage = Generator::getMessage($message, $GLOBALS['sql_query'], 'success');
+        $queryMessage = Generator::getMessage($message, $sqlQuery, 'success');
 
         if (isset($GLOBALS['show_as_php'])) {
             return $queryMessage;


### PR DESCRIPTION
### Description

Show query if no results found. I think this bug was introduced when the code was refactored, just looking at the param name case. Did not look in the past commits.

Glad that this is fixed. It annoyed me too.

Before:

![before](https://github.com/user-attachments/assets/89ce4d04-4dbd-41b2-80e2-4c54c5a6db87)

After:

![after](https://github.com/user-attachments/assets/c8238f44-0104-4369-8263-f5defa5f607d)

Fixes #14542

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
