### PR TITLE
Fix #17730 - Make LIKE %...% as default search operator

### DIFF
--- a/libraries/classes/Types.php
+++ b/libraries/classes/Types.php
@@ -96,8 +96,8 @@ class Types
     public function getTextOperators()
     {
         return [
-            'LIKE',
             'LIKE %...%',
+            'LIKE',
             'NOT LIKE',
             'NOT LIKE %...%',
             '=',

--- a/test/classes/TypesTest.php
+++ b/test/classes/TypesTest.php
@@ -74,8 +74,8 @@ class TypesTest extends AbstractTestCase
     public function testgetTextOperators(): void
     {
         self::assertSame([
-            'LIKE',
             'LIKE %...%',
+            'LIKE',
             'NOT LIKE',
             'NOT LIKE %...%',
             '=',
@@ -166,8 +166,8 @@ class TypesTest extends AbstractTestCase
                 'CHAR',
                 true,
                 [
-                    'LIKE',
                     'LIKE %...%',
+                    'LIKE',
                     'NOT LIKE',
                     'NOT LIKE %...%',
                     '=',


### PR DESCRIPTION
### Description

Make `LIKE %...%` as default search operator. As it can be seen in the issue, this can cause confusion.

Fixes #17730 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
