### PR TITLE
2FA: Decouple authenticator and qrcode, permanently add an authenticator library (#19014)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
         "ext-pcre": "*",
         "ext-sodium": "*",
         "ext-xml": "*",
+        "chillerlan/php-authenticator": "^5.2.1",
         "composer/ca-bundle": "^1.2",
         "fig/http-message-util": "^1.1",
         "google/recaptcha": "^1.3",
@@ -80,8 +81,6 @@
         "williamdes/mariadb-mysql-kbs": "^1.2"
     },
     "conflict": {
-        "bacon/bacon-qr-code": "<2.0",
-        "pragmarx/google2fa-qrcode": "<2.1",
         "tecnickcom/tcpdf": "<6.4.4"
     },
     "suggest": {
@@ -93,13 +92,12 @@
         "ext-gd2": "For image transformations",
         "ext-mbstring": "For best performance",
         "tecnickcom/tcpdf": "For PDF support",
-        "pragmarx/google2fa-qrcode": "^2.1 or ^3.0 - For 2FA authentication",
-        "bacon/bacon-qr-code": "^2.0 - For 2FA authentication",
+        "chillerlan/php-qrcode": "^5.0 or higher - For 2FA authentication setup via QR Code",
         "code-lts/u2f-php-server": "For FIDO U2F authentication",
         "web-auth/webauthn-lib": "For better WebAuthn/FIDO2 authentication support"
     },
     "require-dev": {
-        "bacon/bacon-qr-code": "^2.0",
+        "chillerlan/php-qrcode": "^5.0",
         "code-lts/u2f-php-server": "^1.2",
         "guzzlehttp/psr7": "^2.5",
         "httpsoft/http-message": "^1.1",
@@ -114,7 +112,6 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^10.4",
-        "pragmarx/google2fa-qrcode": "^3.0",
         "psalm/plugin-phpunit": "^0.18.4",
         "roave/security-advisories": "dev-latest",
         "symfony/console": "^7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,154 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ebd5f44fa6a26180c91fee67cdf7022a",
+    "content-hash": "3271c914b4083505f86bd460dfa47db2",
     "packages": [
+        {
+            "name": "chillerlan/php-authenticator",
+            "version": "5.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/chillerlan/php-authenticator.git",
+                "reference": "040318f0055421ff1ee52f6afa13e5f60a88ade9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/chillerlan/php-authenticator/zipball/040318f0055421ff1ee52f6afa13e5f60a88ade9",
+                "reference": "040318f0055421ff1ee52f6afa13e5f60a88ade9",
+                "shasum": ""
+            },
+            "require": {
+                "chillerlan/php-settings-container": "^3.2.1",
+                "paragonie/constant_time_encoding": "^3.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-sodium": "*",
+                "phpmd/phpmd": "^2.15",
+                "phpstan/phpstan": "^1.11",
+                "phpstan/phpstan-deprecation-rules": "^1.2",
+                "phpunit/phpunit": "^11.2",
+                "squizlabs/php_codesniffer": "^3.10"
+            },
+            "suggest": {
+                "chillerlan/php-qrcode": "Create QR Codes for use with an authenticator app."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "chillerlan\\Authenticator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Smiley",
+                    "email": "smiley@chillerlan.net",
+                    "homepage": "https://github.com/codemasher"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/chillerlan/php-authenticator/graphs/contributors"
+                }
+            ],
+            "description": "A generator for counter- and time based 2-factor authentication codes (Google Authenticator). PHP 8.2+",
+            "homepage": "https://github.com/chillerlan/php-authenticator",
+            "keywords": [
+                "2fa",
+                "MFA",
+                "authenticator",
+                "google2fa",
+                "hotp",
+                "otp",
+                "rfc4226",
+                "rfc6238",
+                "tfa",
+                "totp",
+                "two factor"
+            ],
+            "support": {
+                "issues": "https://github.com/chillerlan/php-authenticator/issues",
+                "source": "https://github.com/chillerlan/php-authenticator"
+            },
+            "funding": [
+                {
+                    "url": "https://ko-fi.com/codemasher",
+                    "type": "Ko-Fi"
+                }
+            ],
+            "time": "2024-07-16T23:53:16+00:00"
+        },
+        {
+            "name": "chillerlan/php-settings-container",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/chillerlan/php-settings-container.git",
+                "reference": "95ed3e9676a1d47cab2e3174d19b43f5dbf52681"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/chillerlan/php-settings-container/zipball/95ed3e9676a1d47cab2e3174d19b43f5dbf52681",
+                "reference": "95ed3e9676a1d47cab2e3174d19b43f5dbf52681",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phpmd/phpmd": "^2.15",
+                "phpstan/phpstan": "^1.11",
+                "phpstan/phpstan-deprecation-rules": "^1.2",
+                "phpunit/phpunit": "^10.5",
+                "squizlabs/php_codesniffer": "^3.10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "chillerlan\\Settings\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Smiley",
+                    "email": "smiley@chillerlan.net",
+                    "homepage": "https://github.com/codemasher"
+                }
+            ],
+            "description": "A container class for immutable settings objects. Not a DI container.",
+            "homepage": "https://github.com/chillerlan/php-settings-container",
+            "keywords": [
+                "Settings",
+                "configuration",
+                "container",
+                "helper"
+            ],
+            "support": {
+                "issues": "https://github.com/chillerlan/php-settings-container/issues",
+                "source": "https://github.com/chillerlan/php-settings-container"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/donate?hosted_button_id=WLYUNAT9ZTJZ4",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://ko-fi.com/codemasher",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2024-07-16T11:13:48+00:00"
+        },
         {
             "name": "composer/ca-bundle",
             "version": "1.5.4",
@@ -306,6 +452,73 @@
                 "source": "https://github.com/nikic/FastRoute/tree/master"
             },
             "time": "2018-02-13T20:26:39+00:00"
+        },
+        {
+            "name": "paragonie/constant_time_encoding",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/constant_time_encoding.git",
+                "reference": "df1e7fde177501eee2037dd159cf04f5f301a512"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/df1e7fde177501eee2037dd159cf04f5f301a512",
+                "reference": "df1e7fde177501eee2037dd159cf04f5f301a512",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9",
+                "vimeo/psalm": "^4|^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\ConstantTime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve 'Sc00bz' Thomas",
+                    "email": "steve@tobtu.com",
+                    "homepage": "https://www.tobtu.com",
+                    "role": "Original Developer"
+                }
+            ],
+            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
+            "keywords": [
+                "base16",
+                "base32",
+                "base32_decode",
+                "base32_encode",
+                "base64",
+                "base64_decode",
+                "base64_encode",
+                "bin2hex",
+                "encoding",
+                "hex",
+                "hex2bin",
+                "rfc4648"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
+            "time": "2024-05-08T12:36:18+00:00"
         },
         {
             "name": "phpmyadmin/motranslator",
@@ -2412,60 +2625,6 @@
             "time": "2024-04-13T18:00:56+00:00"
         },
         {
-            "name": "bacon/bacon-qr-code",
-            "version": "2.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Bacon/BaconQrCode.git",
-                "reference": "8674e51bb65af933a5ffaf1c308a660387c35c22"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/8674e51bb65af933a5ffaf1c308a660387c35c22",
-                "reference": "8674e51bb65af933a5ffaf1c308a660387c35c22",
-                "shasum": ""
-            },
-            "require": {
-                "dasprid/enum": "^1.0.3",
-                "ext-iconv": "*",
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "phly/keep-a-changelog": "^2.1",
-                "phpunit/phpunit": "^7 | ^8 | ^9",
-                "spatie/phpunit-snapshot-assertions": "^4.2.9",
-                "squizlabs/php_codesniffer": "^3.4"
-            },
-            "suggest": {
-                "ext-imagick": "to generate QR code images"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "BaconQrCode\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Ben Scholzen 'DASPRiD'",
-                    "email": "mail@dasprids.de",
-                    "homepage": "https://dasprids.de/",
-                    "role": "Developer"
-                }
-            ],
-            "description": "BaconQrCode is a QR code generator for PHP.",
-            "homepage": "https://github.com/Bacon/BaconQrCode",
-            "support": {
-                "issues": "https://github.com/Bacon/BaconQrCode/issues",
-                "source": "https://github.com/Bacon/BaconQrCode/tree/2.0.8"
-            },
-            "time": "2022-12-07T17:46:57+00:00"
-        },
-        {
             "name": "brick/math",
             "version": "0.12.1",
             "source": {
@@ -2524,6 +2683,99 @@
                 }
             ],
             "time": "2023-11-29T23:19:16+00:00"
+        },
+        {
+            "name": "chillerlan/php-qrcode",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/chillerlan/php-qrcode.git",
+                "reference": "42e215640e9ebdd857570c9e4e52245d1ee51de2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/chillerlan/php-qrcode/zipball/42e215640e9ebdd857570c9e4e52245d1ee51de2",
+                "reference": "42e215640e9ebdd857570c9e4e52245d1ee51de2",
+                "shasum": ""
+            },
+            "require": {
+                "chillerlan/php-settings-container": "^2.1.6 || ^3.2.1",
+                "ext-mbstring": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "chillerlan/php-authenticator": "^4.3.1 || ^5.2.1",
+                "ext-fileinfo": "*",
+                "phan/phan": "^5.4.5",
+                "phpcompatibility/php-compatibility": "10.x-dev",
+                "phpmd/phpmd": "^2.15",
+                "phpunit/phpunit": "^9.6",
+                "setasign/fpdf": "^1.8.2",
+                "slevomat/coding-standard": "^8.15",
+                "squizlabs/php_codesniffer": "^3.11"
+            },
+            "suggest": {
+                "chillerlan/php-authenticator": "Yet another Google authenticator! Also creates URIs for mobile apps.",
+                "setasign/fpdf": "Required to use the QR FPDF output.",
+                "simple-icons/simple-icons": "SVG icons that you can use to embed as logos in the QR Code"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "chillerlan\\QRCode\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT",
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Kazuhiko Arase",
+                    "homepage": "https://github.com/kazuhikoarase/qrcode-generator"
+                },
+                {
+                    "name": "ZXing Authors",
+                    "homepage": "https://github.com/zxing/zxing"
+                },
+                {
+                    "name": "Ashot Khanamiryan",
+                    "homepage": "https://github.com/khanamiryan/php-qrcode-detector-decoder"
+                },
+                {
+                    "name": "Smiley",
+                    "email": "smiley@chillerlan.net",
+                    "homepage": "https://github.com/codemasher"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/chillerlan/php-qrcode/graphs/contributors"
+                }
+            ],
+            "description": "A QR Code generator and reader with a user-friendly API. PHP 7.4+",
+            "homepage": "https://github.com/chillerlan/php-qrcode",
+            "keywords": [
+                "phpqrcode",
+                "qr",
+                "qr code",
+                "qr-reader",
+                "qrcode",
+                "qrcode-generator",
+                "qrcode-reader"
+            ],
+            "support": {
+                "docs": "https://php-qrcode.readthedocs.io",
+                "issues": "https://github.com/chillerlan/php-qrcode/issues",
+                "source": "https://github.com/chillerlan/php-qrcode"
+            },
+            "funding": [
+                {
+                    "url": "https://ko-fi.com/codemasher",
+                    "type": "Ko-Fi"
+                }
+            ],
+            "time": "2024-11-21T16:12:34+00:00"
         },
         {
             "name": "code-lts/u2f-php-server",
@@ -2875,56 +3127,6 @@
                 }
             ],
             "time": "2024-05-06T16:37:16+00:00"
-        },
-        {
-            "name": "dasprid/enum",
-            "version": "1.0.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/DASPRiD/Enum.git",
-                "reference": "8dfd07c6d2cf31c8da90c53b83c026c7696dda90"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/8dfd07c6d2cf31c8da90c53b83c026c7696dda90",
-                "reference": "8dfd07c6d2cf31c8da90c53b83c026c7696dda90",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1 <9.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
-                "squizlabs/php_codesniffer": "*"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "DASPRiD\\Enum\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Ben Scholzen 'DASPRiD'",
-                    "email": "mail@dasprids.de",
-                    "homepage": "https://dasprids.de/",
-                    "role": "Developer"
-                }
-            ],
-            "description": "PHP 7.1 enum implementation",
-            "keywords": [
-                "enum",
-                "map"
-            ],
-            "support": {
-                "issues": "https://github.com/DASPRiD/Enum/issues",
-                "source": "https://github.com/DASPRiD/Enum/tree/1.0.6"
-            },
-            "time": "2024-08-09T14:30:48+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -3879,73 +4081,6 @@
                 }
             ],
             "time": "2024-09-09T07:06:30+00:00"
-        },
-        {
-            "name": "paragonie/constant_time_encoding",
-            "version": "v3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paragonie/constant_time_encoding.git",
-                "reference": "df1e7fde177501eee2037dd159cf04f5f301a512"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/df1e7fde177501eee2037dd159cf04f5f301a512",
-                "reference": "df1e7fde177501eee2037dd159cf04f5f301a512",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9",
-                "vimeo/psalm": "^4|^5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "ParagonIE\\ConstantTime\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com",
-                    "homepage": "https://paragonie.com",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "Steve 'Sc00bz' Thomas",
-                    "email": "steve@tobtu.com",
-                    "homepage": "https://www.tobtu.com",
-                    "role": "Original Developer"
-                }
-            ],
-            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
-            "keywords": [
-                "base16",
-                "base32",
-                "base32_decode",
-                "base32_encode",
-                "base64",
-                "base64_decode",
-                "base64_encode",
-                "bin2hex",
-                "encoding",
-                "hex",
-                "hex2bin",
-                "rfc4648"
-            ],
-            "support": {
-                "email": "info@paragonie.com",
-                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
-                "source": "https://github.com/paragonie/constant_time_encoding"
-            },
-            "time": "2024-05-08T12:36:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -5120,125 +5255,6 @@
                 }
             ],
             "time": "2024-12-21T05:49:06+00:00"
-        },
-        {
-            "name": "pragmarx/google2fa",
-            "version": "v8.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/antonioribeiro/google2fa.git",
-                "reference": "6f8d87ebd5afbf7790bde1ffc7579c7c705e0fad"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/antonioribeiro/google2fa/zipball/6f8d87ebd5afbf7790bde1ffc7579c7c705e0fad",
-                "reference": "6f8d87ebd5afbf7790bde1ffc7579c7c705e0fad",
-                "shasum": ""
-            },
-            "require": {
-                "paragonie/constant_time_encoding": "^1.0|^2.0|^3.0",
-                "php": "^7.1|^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.9",
-                "phpunit/phpunit": "^7.5.15|^8.5|^9.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PragmaRX\\Google2FA\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Antonio Carlos Ribeiro",
-                    "email": "acr@antoniocarlosribeiro.com",
-                    "role": "Creator & Designer"
-                }
-            ],
-            "description": "A One Time Password Authentication package, compatible with Google Authenticator.",
-            "keywords": [
-                "2fa",
-                "Authentication",
-                "Two Factor Authentication",
-                "google2fa"
-            ],
-            "support": {
-                "issues": "https://github.com/antonioribeiro/google2fa/issues",
-                "source": "https://github.com/antonioribeiro/google2fa/tree/v8.0.3"
-            },
-            "time": "2024-09-05T11:56:40+00:00"
-        },
-        {
-            "name": "pragmarx/google2fa-qrcode",
-            "version": "v3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/antonioribeiro/google2fa-qrcode.git",
-                "reference": "ce4d8a729b6c93741c607cfb2217acfffb5bf76b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/antonioribeiro/google2fa-qrcode/zipball/ce4d8a729b6c93741c607cfb2217acfffb5bf76b",
-                "reference": "ce4d8a729b6c93741c607cfb2217acfffb5bf76b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1",
-                "pragmarx/google2fa": ">=4.0"
-            },
-            "require-dev": {
-                "bacon/bacon-qr-code": "^2.0",
-                "chillerlan/php-qrcode": "^1.0|^2.0|^3.0|^4.0",
-                "khanamiryan/qrcode-detector-decoder": "^1.0",
-                "phpunit/phpunit": "~4|~5|~6|~7|~8|~9"
-            },
-            "suggest": {
-                "bacon/bacon-qr-code": "For QR Code generation, requires imagick",
-                "chillerlan/php-qrcode": "For QR Code generation"
-            },
-            "type": "library",
-            "extra": {
-                "component": "package",
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PragmaRX\\Google2FAQRCode\\": "src/",
-                    "PragmaRX\\Google2FAQRCode\\Tests\\": "tests/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Antonio Carlos Ribeiro",
-                    "email": "acr@antoniocarlosribeiro.com",
-                    "role": "Creator & Designer"
-                }
-            ],
-            "description": "QR Code package for Google2FA",
-            "keywords": [
-                "2fa",
-                "Authentication",
-                "Two Factor Authentication",
-                "google2fa",
-                "qr code",
-                "qrcode"
-            ],
-            "support": {
-                "issues": "https://github.com/antonioribeiro/google2fa-qrcode/issues",
-                "source": "https://github.com/antonioribeiro/google2fa-qrcode/tree/v3.0.0"
-            },
-            "time": "2021-08-15T12:53:48+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",

--- a/resources/templates/login/twofactor/application_configure.twig
+++ b/resources/templates/login/twofactor/application_configure.twig
@@ -1,17 +1,45 @@
 {{ get_hidden_inputs() }}
+<div class="config-form">
+<fieldset>
+
+<div class="2fa-setup-qrcode">
+  {% if qrcode %}
+      {{ qrcode|raw }}
+  {% else %}
+      {{ uri }}
+  {% endif %}
+</div>
+
+<table class="table table-borderless">
+
+  <tr>
+    <th class="w-75"><label for="2fa-setup-secret">{{ t('Secret/key:') }}</label></th>
+    <td class="w-25">
+      <input id="2fa-setup-secret" class="w-100" type="text" readonly="readonly" onclick="this.select();" value="{{ secret }}"/>
+    </td>
+  </tr>
+
+  <tr>
+    <th class="w-75">
+      <label for="2fa-setup-backup">{{ t('Backup code:') }}</label>
+      <br/>
+      <span class="text-danger">{{ t('Please write this backup code down and store in a safe place. You can use it to access your account in case you lost access to your mobile authenticator.') }}</span>
+    </th>
+    <td class="w-25">
+      <input id="2fa-setup-backup" class="w-100" type="text" readonly="readonly" onclick="this.select();" value="{{ backup }}"/>
+    </td>
+  </tr>
+
+</table>
+
 <p>
-    {{ t('Please scan following QR code into the two-factor authentication app on your device and enter authentication code it generates.') }}
+  {{ t('Please scan the QR code or copy the secret key into the two-factor authentication app on your device and enter authentication code it generates.') }}
 </p>
+
 <p>
-    {% if has_imagick %}
-        <img src="{{ image }}">
-    {% else %}
-        {{ image|raw }}
-    {% endif %}
+  <label for="2fa-setup-confirm">{{ t('Authentication code:') }}</label>
+  <input id="2fa-setup-confirm" type="text" name="2fa_code" autocomplete="off" />
 </p>
-<p>
-    {{ t('Secret/key:') }} <strong>{{ secret }}</strong>
-</p>
-<p>
-    <label>{{ t('Authentication code:') }} <input type="text" name="2fa_code" autocomplete="off"></label>
-</p>
+
+</fieldset>
+</div>

--- a/src/Plugins/TwoFactor/PmaQrCodeSVG.php
+++ b/src/Plugins/TwoFactor/PmaQrCodeSVG.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * SVG QR Code renderer
+ */
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Plugins\TwoFactor;
+
+use chillerlan\QRCode\Common\EccLevel;
+use chillerlan\QRCode\Data\QRMatrix;
+use chillerlan\QRCode\Output\QRMarkupSVG;
+
+use function abs;
+use function ceil;
+use function pow;
+use function sprintf;
+
+/**
+ * a bit messy proof-of-concept for a PMA themed QR Code
+ */
+class PmaQrCodeSVG extends QRMarkupSVG
+{
+    // logo from https://simpleicons.org/?q=phpmyadmin
+    // @todo: put logo in separate file perhaps?
+    // phpcs:disable
+    protected const LOGO = '
+    <svg class="pma-qrcode-logo" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>phpMyAdmin</title>
+        <path class="sail-dark" d="M5.463 3.476C6.69 5.225 7.497 7.399 7.68 9.798a12.9 12.9 0 0 1-.672 5.254 4.29 4.29 0 0 1 2.969-1.523c.05-.004.099-.006.148-.008.08-.491.47-3.45-.977-6.68-1.068-2.386-3-3.16-3.685-3.365Z"/>
+        <path class="sail-light" d="M7.24 3.513s2.406 1.066 3.326 5.547c.607 2.955.049 4.836-.402 5.773a7.347 7.347 0 0 1 4.506-1.994c.86-.065 1.695.02 2.482.233-.1-.741-.593-3.414-2.732-5.92-3.263-3.823-7.18-3.64-7.18-3.64Z"/>
+        <path class="boat" d="M22.057 13.214l-17.92 3.049a2.284 2.284 0 0 1 1.535 2.254 2.31 2.31 0 0 1-.106.61c.055-.027 2.689-1.275 6.342-2.034 3.238-.673 5.723-.36 6.285-.273a6.46 6.46 0 0 1 3.864-3.606Z"/>
+        <path class="water" d="M15.844 17.292c-2.318 0-4.641.495-6.614 1.166-2.868.976-2.951 1.348-5.55 1.043C1.844 19.286 0 18.386 0 18.386s2.406 1.97 4.914 2.127c1.986.125 3.505-.822 5.315-1.414 2.661-.871 4.511-.97 6.253-.975C19.361 18.116 24 19.353 24 19.353s-2.11-1.044-5.033-1.72a13.885 13.885 0 0 0-3.123-.34Z"/>
+    </svg>';
+    // phpcs:enable
+
+    protected const LOGOSCALE = 0.2;
+
+    /**
+     * We're going to set some options here that we don't want or need to bother with in the 2fa module
+     */
+    protected function setOptions(): void
+    {
+        $this->options->eccLevel = EccLevel::H;
+        $this->options->svgAddXmlHeader = false;
+        $this->options->svgUseFillAttributes = false;
+        // css -> theme stylesheets
+        $this->options->svgDefs = '
+    <style><![CDATA[
+        .pma-2fa-qrcode { min-width: 200px; max-width: 500px; height: auto; }
+
+        .qr-finder-dark, .qr-alignment-dark, .qr-finder-dot { fill: #669; }
+        .qr-data-dark{ fill: #f90; }
+
+        .pma-qrcode-logo > .sail-dark{ fill: #669; }
+        .pma-qrcode-logo > .sail-light{ fill: #f90; }
+        .pma-qrcode-logo > .boat{ fill: #999; }
+        .pma-qrcode-logo > .water{ fill: #ccc; }
+    ]]></style>';
+
+        $this->options->drawLightModules = false;
+        $this->options->drawCircularModules = true;
+        $this->options->circleRadius = 0.4;
+        $this->options->keepAsSquare = [
+            QRMatrix::M_FINDER_DARK,
+            QRMatrix::M_FINDER_DOT,
+            QRMatrix::M_ALIGNMENT_DARK,
+        ];
+
+        $this->options->connectPaths = true;
+        $this->options->excludeFromConnect = [
+            QRMatrix::M_FINDER_DARK,
+            QRMatrix::M_FINDER_DOT,
+            QRMatrix::M_ALIGNMENT_DARK,
+            QRMatrix::M_LOGO,
+        ];
+
+        $this->copyVars();
+    }
+
+    protected function createMarkup(bool $saveToFile): string
+    {
+        $this->setOptions();
+        $this->clearLogoSpace();
+
+        $svg = $this->header();
+        $svg .= sprintf('<defs>%1$s%2$s</defs>%2$s', $this->options->svgDefs, $this->eol);
+        $svg .= $this->paths();
+        $svg .= $this->getLogo();
+        // close svg
+        $svg .= sprintf('%1$s</svg>%1$s', $this->eol);
+
+        // we're putting out the raw SVG here, the base64 URI option is ignored
+        return $svg;
+    }
+
+    protected function clearLogoSpace(): void
+    {
+        $r = (int) ceil(($this->moduleCount * $this::LOGOSCALE + 2) / 2);
+        $c = $this->moduleCount / 2;
+
+        for ($y = 0; $y < $this->moduleCount; $y++) {
+            for ($x = 0; $x < $this->moduleCount; $x++) {
+                if (! $this->checkIfInsideCircle($x + 0.5, $y + 0.5, $c, $c, $r)) {
+                    continue;
+                }
+
+                $this->matrix->set($x, $y, false, QRMatrix::M_LOGO);
+            }
+        }
+    }
+
+    /**
+     * @see https://stackoverflow.com/a/7227057
+     */
+    protected function checkIfInsideCircle(float $x, float $y, float $centerX, float $centerY, float $radius): bool
+    {
+        $dx = abs($x - $centerX);
+        $dy = abs($y - $centerY);
+
+        if ($dx + $dy <= $radius) {
+            return true;
+        }
+
+        if ($dx > $radius || $dy > $radius) {
+            return false;
+        }
+
+        return pow($dx, 2) + pow($dy, 2) <= pow($radius, 2);
+    }
+
+    /**
+     * returns a <g> element that contains the SVG logo and positions it properly within the QR Code
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g
+     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform
+     */
+    protected function getLogo(): string
+    {
+        // phpcs:ignore
+        $template = '<g transform="translate(%1$s %1$s) scale(%2$s)" class="pma-qrcode-logo-transform">%4$s%3$s%4$s</g>';
+        $translate = ($this->moduleCount - $this->moduleCount * $this::LOGOSCALE) / 2;
+
+        return sprintf($template, $translate, $this::LOGOSCALE, $this::LOGO, $this->eol);
+    }
+}

--- a/src/TwoFactor.php
+++ b/src/TwoFactor.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
-use BaconQrCode\Renderer\ImageRenderer;
+use chillerlan\QRCode\QRCode;
 use CodeLts\U2F\U2FServer\U2FServer;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Dbal\DatabaseInterface;
@@ -16,12 +16,9 @@ use PhpMyAdmin\Plugins\TwoFactor\Application;
 use PhpMyAdmin\Plugins\TwoFactor\Invalid;
 use PhpMyAdmin\Plugins\TwoFactor\Key;
 use PhpMyAdmin\Plugins\TwoFactorPlugin;
-use PragmaRX\Google2FAQRCode\Google2FA;
-use XMLWriter;
 
 use function array_merge;
 use function class_exists;
-use function extension_loaded;
 use function in_array;
 use function is_array;
 use function is_bool;
@@ -124,14 +121,7 @@ class TwoFactor
             $result[] = 'simple';
         }
 
-        if (
-            class_exists(Google2FA::class)
-            && class_exists(ImageRenderer::class)
-            && (class_exists(XMLWriter::class) || extension_loaded('imagick'))
-        ) {
-            $result[] = 'application';
-        }
-
+        $result[] = 'application';
         $result[] = 'WebAuthn';
 
         if (class_exists(U2FServer::class)) {
@@ -149,12 +139,9 @@ class TwoFactor
     public function getMissingDeps(): array
     {
         $result = [];
-        if (! class_exists(Google2FA::class)) {
-            $result[] = ['class' => Application::getName(), 'dep' => 'pragmarx/google2fa-qrcode'];
-        }
 
-        if (! class_exists(ImageRenderer::class)) {
-            $result[] = ['class' => Application::getName(), 'dep' => 'bacon/bacon-qr-code'];
+        if (! class_exists(QRCode::class)) {
+            $result[] = ['class' => Application::getName(), 'dep' => 'chillerlan/php-qrcode'];
         }
 
         if (! class_exists(U2FServer::class)) {


### PR DESCRIPTION
## Description

**Implements #19014**

- Decouples the 2FA and QR Code libraries in order to permanently add a 2FA ("Google Authenticator") dependency, so that baseline security is guaranteed - no matter how PMA was installed  (i.e. #16779, #17567, among others).
- Introduces a backup-code functionality, so that users who have lost their authenticator can regain access. (WIP)
- The QR Code dependency becomes optional and can even be moved to the frontend Javascript and be used for other purposes, as it has only very little use in the backend (no requirements for image generating PHP extensions anymore).
- Removes an outdated, possibly abandoned dependency in the process.

## Open questions

### Authenticator

- Extract into an interface to ease switching 3rd party libraries? (With that said, I'd extract all 3rd party functionality in the subclasses of `PhpMyAdmin\Plugins\TwoFactorPlugin` into interfaces, so that they remain untouched in case a library changes)
- Offer global options for secret length and number of allowed adjacent codes (grace period), and maybe time offset?
- Backup code functionality (currently WIP without function aside of being displayed in the setup screen):
  - I'm not exactly sure what whould be the best course of action in case a backup code was used. Just redirect to the setup screen, so that the user can scan/enter the secret once again? Provide a new secret? Unknown third thing??
  - I'm unsure how to faciliate a redirect in that case, and I might a little help/pointing into the right direction here.
  - Does PMA have functionality to rate limit certain endpoints (to avoid the 2FA endpoint being brute forced), or do we just use a good ol' internal counter (via settings)?

Suggested library: [chillerlan/php-authenticator](https://github.com/chillerlan/php-authenticator)

### QR Code

- Leave in backend?
  - if kept:
    - Extract into an interface to ease switching 3rd party libraries and allow enhanced configuration and/or user defined classes?
      - Add an option for a user-defined class, provide one by default, with an optional composer dependency.
    - Maybe move the "missing qrcode library" message to the setup page, so that a user knows why no QR Code is shown.
  - if not:
    - Figure out possible issues frontend QR Codes could cause (e.g. mobile compatibility: SVG, HTML Canvas, performance, package size).
    - Explore other possible uses, e.g. display of queries and field values (up to ~3kb).

Suggestes libraries: [chillerlan/php-qrcode](https://github.com/chillerlan/php-qrcode), [chillerlan/js-qrcode](https://github.com/chillerlan/js-qrcode)


*I'm going to submit this as a draft for now as there are several open questions that need to be discussed.*


Before submitting the pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] ~~Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.~~ (see https://github.com/phpmyadmin/phpmyadmin/issues/19014#issuecomment-2573927213)
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
