### PR TITLE
hide unwanted input depending on choosen op type

### DIFF
--- a/resources/templates/database/multi_table_query/form.twig
+++ b/resources/templates/database/multi_table_query/form.twig
@@ -119,7 +119,7 @@
                           </td>
                         </tr>
 
-                        <tr>
+                        <tr class="rhs_table" style="display: none;">
                           <td></td>
                           <td>
                             <select class="tableNameSelect">


### PR DESCRIPTION
### Description

Hello :wave:

In this PR I hide the inputs that's shown even they are not necessary, depending on op type.

#### Before
The table and column fields are shown even we don't need them in case of `text` .

![image](https://github.com/user-attachments/assets/60bbd30c-86b3-4b43-912c-ccb9683014e4)

#### After
Text field shows only when text is chosen.

![image](https://github.com/user-attachments/assets/a9e73494-54f4-44be-8a17-a7b4b137f5f7)

When `Another column` is chosen, table and column fields shows up.
![image](https://github.com/user-attachments/assets/eb16731d-5278-4b45-bed8-18a657bc1697)


### Server configuration

- phpMyAdmin version: 6.0.0-dev