### PR TITLE
Fix badge text color

### DIFF
--- a/templates/server/collations/index.twig
+++ b/templates/server/collations/index.twig
@@ -20,7 +20,7 @@
               </div>
               <div class="col align-self-center text-end">
                 {% if collation.is_default %}
-                  <span class="badge bg-secondary text-dark">{% trans %}default{% context %}The collation is the default one{% endtrans %}</span>
+                  <span class="badge bg-secondary">{% trans %}default{% context %}The collation is the default one{% endtrans %}</span>
                 {% endif %}
               </div>
             </div>

--- a/templates/table/maintenance/analyze.twig
+++ b/templates/table/maintenance/analyze.twig
@@ -14,7 +14,7 @@
         {% for row in table %}
           <li class="list-group-item">
             {% if row.operation|lower != 'analyze' %}
-              <span class="badge bg-secondary text-dark">{{ row.operation|title }}</span>
+              <span class="badge bg-secondary">{{ row.operation|title }}</span>
             {% endif %}
 
             {% set badge_variation %}
@@ -28,7 +28,7 @@
                 bg-secondary
               {%- endif -%}
             {% endset %}
-            <span class="badge {{ badge_variation }} text-dark">{{ row.type|title }}</span>
+            <span class="badge {{ badge_variation }}">{{ row.type|title }}</span>
 
             {{ row.text }}
           </li>

--- a/templates/table/maintenance/check.twig
+++ b/templates/table/maintenance/check.twig
@@ -14,7 +14,7 @@
         {% for row in table %}
           <li class="list-group-item">
             {% if row.operation|lower != 'check' %}
-              <span class="badge bg-secondary text-dark">{{ row.operation|title }}</span>
+              <span class="badge bg-secondary">{{ row.operation|title }}</span>
             {% endif %}
 
             {% set badge_variation %}
@@ -28,7 +28,7 @@
                 bg-secondary
               {%- endif -%}
             {% endset %}
-            <span class="badge {{ badge_variation }} text-dark">{{ row.type|title }}</span>
+            <span class="badge {{ badge_variation }}">{{ row.type|title }}</span>
 
             {{ row.text }}
           </li>

--- a/templates/table/maintenance/optimize.twig
+++ b/templates/table/maintenance/optimize.twig
@@ -14,7 +14,7 @@
         {% for row in table %}
           <li class="list-group-item">
             {% if row.operation|lower != 'optimize' %}
-              <span class="badge bg-secondary text-dark">{{ row.operation|title }}</span>
+              <span class="badge bg-secondary">{{ row.operation|title }}</span>
             {% endif %}
 
             {% set badge_variation %}
@@ -28,7 +28,7 @@
                 bg-secondary
               {%- endif -%}
             {% endset %}
-            <span class="badge {{ badge_variation }} text-dark">{{ row.type|title }}</span>
+            <span class="badge {{ badge_variation }}">{{ row.type|title }}</span>
 
             {{ row.text }}
           </li>

--- a/templates/table/maintenance/repair.twig
+++ b/templates/table/maintenance/repair.twig
@@ -14,7 +14,7 @@
         {% for row in table %}
           <li class="list-group-item">
             {% if row.operation|lower != 'repair' %}
-              <span class="badge bg-secondary text-dark">{{ row.operation|title }}</span>
+              <span class="badge bg-secondary">{{ row.operation|title }}</span>
             {% endif %}
 
             {% set badge_variation %}
@@ -28,7 +28,7 @@
                 bg-secondary
               {%- endif -%}
             {% endset %}
-            <span class="badge {{ badge_variation }} text-dark">{{ row.type|title }}</span>
+            <span class="badge {{ badge_variation }}">{{ row.type|title }}</span>
 
             {{ row.text }}
           </li>

--- a/templates/table/partition/analyze.twig
+++ b/templates/table/partition/analyze.twig
@@ -11,7 +11,7 @@
         {% for row in table %}
           <li class="list-group-item">
             {% if row.Op|lower != 'analyze' %}
-              <span class="badge bg-secondary text-dark">{{ row.Op|title }}</span>
+              <span class="badge bg-secondary">{{ row.Op|title }}</span>
             {% endif %}
 
             {% set badge_variation %}
@@ -25,7 +25,7 @@
                 bg-secondary
               {%- endif -%}
             {% endset %}
-            <span class="badge {{ badge_variation }} text-dark">{{ row.Msg_type|title }}</span>
+            <span class="badge {{ badge_variation }}">{{ row.Msg_type|title }}</span>
 
             {{ row.Msg_text }}
           </li>

--- a/templates/table/partition/check.twig
+++ b/templates/table/partition/check.twig
@@ -11,7 +11,7 @@
         {% for row in table %}
           <li class="list-group-item">
             {% if row.Op|lower != 'check' %}
-              <span class="badge bg-secondary text-dark">{{ row.Op|title }}</span>
+              <span class="badge bg-secondary">{{ row.Op|title }}</span>
             {% endif %}
 
             {% set badge_variation %}
@@ -25,7 +25,7 @@
                 bg-secondary
               {%- endif -%}
             {% endset %}
-            <span class="badge {{ badge_variation }} text-dark">{{ row.Msg_type|title }}</span>
+            <span class="badge {{ badge_variation }}">{{ row.Msg_type|title }}</span>
 
             {{ row.Msg_text }}
           </li>

--- a/templates/table/partition/optimize.twig
+++ b/templates/table/partition/optimize.twig
@@ -11,7 +11,7 @@
         {% for row in table %}
           <li class="list-group-item">
             {% if row.Op|lower != 'optimize' %}
-              <span class="badge bg-secondary text-dark">{{ row.Op|title }}</span>
+              <span class="badge bg-secondary">{{ row.Op|title }}</span>
             {% endif %}
 
             {% set badge_variation %}
@@ -25,7 +25,7 @@
                 bg-secondary
               {%- endif -%}
             {% endset %}
-            <span class="badge {{ badge_variation }} text-dark">{{ row.Msg_type|title }}</span>
+            <span class="badge {{ badge_variation }}">{{ row.Msg_type|title }}</span>
 
             {{ row.Msg_text }}
           </li>

--- a/templates/table/partition/repair.twig
+++ b/templates/table/partition/repair.twig
@@ -11,7 +11,7 @@
         {% for row in table %}
           <li class="list-group-item">
             {% if row.Op|lower != 'repair' %}
-              <span class="badge bg-secondary text-dark">{{ row.Op|title }}</span>
+              <span class="badge bg-secondary">{{ row.Op|title }}</span>
             {% endif %}
 
             {% set badge_variation %}
@@ -25,7 +25,7 @@
                 bg-secondary
               {%- endif -%}
             {% endset %}
-            <span class="badge {{ badge_variation }} text-dark">{{ row.Msg_type|title }}</span>
+            <span class="badge {{ badge_variation }}">{{ row.Msg_type|title }}</span>
 
             {{ row.Msg_text }}
           </li>

--- a/test/classes/Controllers/Server/CollationsControllerTest.php
+++ b/test/classes/Controllers/Server/CollationsControllerTest.php
@@ -46,7 +46,7 @@ class CollationsControllerTest extends AbstractTestCase
         self::assertStringContainsString('<div>cp1252 West European</div>', $actual);
         self::assertStringContainsString('<div><strong>latin1_swedish_ci</strong></div>', $actual);
         self::assertStringContainsString('<div>Swedish, case-insensitive</div>', $actual);
-        self::assertStringContainsString('<span class="badge bg-secondary text-dark">default</span>', $actual);
+        self::assertStringContainsString('<span class="badge bg-secondary">default</span>', $actual);
         self::assertStringContainsString('<div><strong>utf8</strong></div>', $actual);
         self::assertStringContainsString('<div>UTF-8 Unicode</div>', $actual);
         self::assertStringContainsString('<div><strong>utf8_bin</strong></div>', $actual);

--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -2865,3 +2865,7 @@ body .ui-dialog {
 .table-responsive-md .data {
   z-index: 9;
 }
+
+.bg-secondary {
+  color: #333;
+}


### PR DESCRIPTION
### Description

I fixed the badge text color. On `/index.php?route=/server/plugins` is not used, and it looks much better.

![ok](https://github.com/user-attachments/assets/7b15a465-72ae-438e-ba38-f3ffb932bf3a)

Before:

![before1](https://github.com/user-attachments/assets/0a83a149-9cb7-4f97-aedf-245bf4f99859)

![before2](https://github.com/user-attachments/assets/39a51ffd-0cce-4270-a628-e58812441da3)

![before3](https://github.com/user-attachments/assets/9de3b106-eb75-4e06-9bb1-8122a9442433)

After:

![after1](https://github.com/user-attachments/assets/7824417e-2c34-40ef-8550-71612264417e)

![after2](https://github.com/user-attachments/assets/30ff951e-34ac-43a5-8b10-4bc1bf847f62)

![after3](https://github.com/user-attachments/assets/0f36eaf5-e5c4-4026-983f-fee53ce6fa2a)

Fixes #

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
