### PR TITLE
Remove the fields_meta global variable

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13474,36 +13474,6 @@ parameters:
 			path: src/Plugins/Transformations/Abs/DateFormatTransformationsPlugin.php
 
 		-
-			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: src/Plugins/Transformations/Abs/DownloadTransformationsPlugin.php
-
-		-
-			message: '#^Cannot access property \$name on mixed\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: src/Plugins/Transformations/Abs/DownloadTransformationsPlugin.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 3
-			path: src/Plugins/Transformations/Abs/DownloadTransformationsPlugin.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 1
-			path: src/Plugins/Transformations/Abs/DownloadTransformationsPlugin.php
-
-		-
-			message: '#^Parameter \#1 \$string of function htmlspecialchars expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Plugins/Transformations/Abs/DownloadTransformationsPlugin.php
-
-		-
 			message: '#^Parameter \#1 \.\.\.\$arrays of function array_merge expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8060,25 +8060,8 @@
   </file>
   <file src="src/Plugins/Transformations/Abs/DownloadTransformationsPlugin.php">
     <MixedArgument>
-      <code><![CDATA[$cn]]></code>
       <code><![CDATA[$options['wrapper_params']]]></code>
     </MixedArgument>
-    <MixedArrayOffset>
-      <code><![CDATA[Results::$row[$pos]]]></code>
-    </MixedArrayOffset>
-    <MixedAssignment>
-      <code><![CDATA[$GLOBALS['fields_meta']]]></code>
-      <code><![CDATA[$cn]]></code>
-      <code><![CDATA[$key]]></code>
-      <code><![CDATA[$pos]]></code>
-      <code><![CDATA[$val]]></code>
-    </MixedAssignment>
-    <MixedPropertyFetch>
-      <code><![CDATA[$val->name]]></code>
-    </MixedPropertyFetch>
-    <PossiblyNullIterator>
-      <code><![CDATA[$GLOBALS['fields_meta']]]></code>
-    </PossiblyNullIterator>
   </file>
   <file src="src/Plugins/Transformations/Abs/ExternalTransformationsPlugin.php">
     <DeprecatedMethod>

--- a/src/Plugins/Transformations/Abs/DownloadTransformationsPlugin.php
+++ b/src/Plugins/Transformations/Abs/DownloadTransformationsPlugin.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Plugins\Transformations\Abs;
 
-use PhpMyAdmin\Display\Results;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Plugins\TransformationsPlugin;
 use PhpMyAdmin\Url;
@@ -15,6 +14,7 @@ use PhpMyAdmin\Url;
 use function __;
 use function array_merge;
 use function htmlspecialchars;
+use function is_string;
 
 /**
  * Provides common methods for all of the download transformations plugins.
@@ -27,11 +27,8 @@ abstract class DownloadTransformationsPlugin extends TransformationsPlugin
     public static function getInfo(): string
     {
         return __(
-            'Displays a link to download the binary data of the column. You can'
-            . ' use the first option to specify the filename, or use the second'
-            . ' option as the name of a column which contains the filename. If'
-            . ' you use the second option, you need to set the first option to'
-            . ' the empty string.',
+            'Displays a link to download the binary data of the column.'
+            . ' You can use the option to specify the filename.',
         );
     }
 
@@ -44,27 +41,9 @@ abstract class DownloadTransformationsPlugin extends TransformationsPlugin
      */
     public function applyTransformation(string $buffer, array $options = [], FieldMetadata|null $meta = null): string
     {
-        $GLOBALS['fields_meta'] ??= null;
-
-        if (! empty($options[0])) {
-            $cn = $options[0]; // filename
-        } else {
-            if (! empty($options[1])) {
-                foreach ($GLOBALS['fields_meta'] as $key => $val) {
-                    if ($val->name == $options[1]) {
-                        $pos = $key;
-                        break;
-                    }
-                }
-
-                if (isset($pos)) {
-                    $cn = Results::$row[$pos];
-                }
-            }
-
-            if (empty($cn)) {
-                $cn = 'binary_file.dat';
-            }
+        $cn = 'binary_file.dat';
+        if (isset($options[0]) && is_string($options[0]) && $options[0] !== '') {
+            $cn = $options[0];
         }
 
         $link = '<a href="' . Url::getFromRoute(

--- a/tests/unit/Plugins/Transformations/TransformationPluginsTest.php
+++ b/tests/unit/Plugins/Transformations/TransformationPluginsTest.php
@@ -110,7 +110,6 @@ class TransformationPluginsTest extends AbstractTestCase
 
         // For Application Octetstream Download plugin
 
-        $GLOBALS['fields_meta'] = [];
         Results::$row = ['pma' => 'aaa', 'pca' => 'bbb'];
 
         // For Image_*_Inline plugin
@@ -206,11 +205,8 @@ class TransformationPluginsTest extends AbstractTestCase
             [
                 new Application_Octetstream_Download(),
                 'getInfo',
-                'Displays a link to download the binary data of the column. You can'
-                . ' use the first option to specify the filename, or use the second'
-                . ' option as the name of a column which contains the filename. If'
-                . ' you use the second option, you need to set the first option to'
-                . ' the empty string.',
+                'Displays a link to download the binary data of the column.'
+                . ' You can use the option to specify the filename.',
             ],
             [new Application_Octetstream_Download(), 'getMIMEType', 'Application'],
             [new Application_Octetstream_Download(), 'getMIMESubtype', 'OctetStream'],


### PR DESCRIPTION
This feature is broken since phpMyAdmin 4.1.0, so it's better to remove that option for now.
