### PR TITLE
Avoid passing null to synchronizeFavoriteTables

### DIFF
--- a/libraries/classes/Controllers/Database/Structure/FavoriteTableController.php
+++ b/libraries/classes/Controllers/Database/Structure/FavoriteTableController.php
@@ -14,6 +14,7 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function count;
+use function is_array;
 use function json_decode;
 use function json_encode;
 use function md5;
@@ -52,6 +53,9 @@ final class FavoriteTableController extends AbstractController
         $favoriteInstance = RecentFavoriteTable::getInstance('favorite');
         if (isset($parameters['favoriteTables'])) {
             $favoriteTables = json_decode($parameters['favoriteTables'], true);
+            if (! is_array($favoriteTables)) {
+                $favoriteTables = [];
+            }
         } else {
             $favoriteTables = [];
         }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4856,11 +4856,6 @@ parameters:
 			path: libraries/classes/Controllers/Database/Structure/FavoriteTableController.php
 
 		-
-			message: "#^Cannot access offset non\\-falsy\\-string on mixed\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Database/Structure/FavoriteTableController.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/Structure/FavoriteTableController.php
@@ -4917,11 +4912,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$table of method PhpMyAdmin\\\\RecentFavoriteTable\\:\\:remove\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Database/Structure/FavoriteTableController.php
-
-		-
-			message: "#^Parameter \\#3 \\$favoriteTables of method PhpMyAdmin\\\\Controllers\\\\Database\\\\Structure\\\\FavoriteTableController\\:\\:synchronizeFavoriteTables\\(\\) expects array, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/Structure/FavoriteTableController.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1686,8 +1686,7 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="libraries/classes/Controllers/Database/Structure/FavoriteTableController.php">
-    <MixedArgument occurrences="3">
-      <code>$favoriteTables</code>
+    <MixedArgument occurrences="2">
       <code>$value['db']</code>
       <code>$value['table']</code>
     </MixedArgument>
@@ -1700,9 +1699,8 @@
       <code>$value['table']</code>
       <code>$value['table']</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="2">
+    <MixedArrayAssignment occurrences="1">
       <code>$_SESSION['tmpval']['favorites_synced']</code>
-      <code>$favoriteTables[$user]</code>
     </MixedArrayAssignment>
     <MixedAssignment occurrences="3">
       <code>$favoriteTables</code>


### PR DESCRIPTION
Fixes #18530 This PR DOES NOT invalidate the other one. 