### PR TITLE
Add support for INSERT IGNORE into for non table imports

### DIFF
--- a/src/Import/Import.php
+++ b/src/Import/Import.php
@@ -729,6 +729,8 @@ class Import
      * @param AnalysedColumn[][]|null $analyses      Analyses of the tables
      * @param string[]|null           $additionalSql Additional SQL to be executed
      * @param string[]                $sqlData       List of SQL to be executed
+     * @param string                  $insertMode    The insert mode you can use
+     * @phpstan-param 'INSERT'|'REPLACE'|'INSERT IGNORE' $insertMode
      */
     public function buildSql(
         string $dbName,
@@ -736,6 +738,7 @@ class Import
         array|null $analyses = null,
         array|null $additionalSql = null,
         array &$sqlData = [],
+        string $insertMode = 'INSERT',
     ): void {
         /* Needed to quell the beast that is Message */
         ImportSettings::$importNotice = '';
@@ -828,7 +831,7 @@ class Import
                 break;
             }
 
-            $tempSQLStr = 'INSERT INTO ' . Util::backquote($dbName) . '.'
+            $tempSQLStr = $insertMode . ' INTO ' . Util::backquote($dbName) . '.'
                 . Util::backquote($table->tableName) . ' (';
 
             $tempSQLStr .= implode(', ', array_map(Util::backquote(...), $table->columns));

--- a/src/Plugins/Import/ImportCsv.php
+++ b/src/Plugins/Import/ImportCsv.php
@@ -597,7 +597,13 @@ class ImportCsv extends AbstractImportCsv
                 $sqlStatements = $this->import->createDatabase($dbName, 'utf8', 'utf8_general_ci', $sqlStatements);
             }
 
-            $this->import->buildSql($dbName, [$table], [$analysis], sqlData: $sqlStatements);
+            $this->import->buildSql(
+                $dbName,
+                [$table],
+                [$analysis],
+                sqlData: $sqlStatements,
+                insertMode: $this->ignore ? 'INSERT IGNORE' : 'INSERT',
+            );
         }
 
         // Commit any possible data in buffers


### PR DESCRIPTION
### Description

Until this PR, the option does exist but does nothing.
But after this PR the option does work, as you can see in my test an user can import the CSV file version 1.
Then add a primary key to the structure. And import version 2 with more rows to update the table.

Anyway, this first version prepares for more support of different modes. `REPLACE INTO` can now be used by plugins

Mentioned on https://github.com/phpmyadmin/phpmyadmin/issues/19369#issuecomment-2594050476
