### PR TITLE
Fix #18980 - Escape table name when counting rows

### DIFF
--- a/js/src/database/structure.js
+++ b/js/src/database/structure.js
@@ -161,7 +161,7 @@ DatabaseStructure.fetchRealRowCount = function ($target) {
                     $.each(response.real_row_count_all,
                         function (index, table) {
                             // Update each table row count.
-                            $('table.data td[data-table*="' + table.table + '"]')
+                            $('table.data td[data-table*="' + Functions.escapeJsString(table.table) + '"]')
                                 .text(table.row_count);
                         }
                     );


### PR DESCRIPTION
### Description

Escape table name when counting rows.

https://github.com/user-attachments/assets/38a18a3f-f610-42bd-808c-5e4e621bf67a

Fixes #18980

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
