### PR TITLE
Disable Search input on unary operators

### DIFF
--- a/resources/js/src/table/select.ts
+++ b/resources/js/src/table/select.ts
@@ -310,11 +310,7 @@ AJAX.registerOnload('table/select.js', function () {
         const $targetField = $(this).closest('tr').find('[name*="criteriaValues"]')
 
         $targetField.prop('disabled', opIsUnary(operator));
-        if (opIsUnary(operator)) {
-            $targetField.siblings('.ui-datepicker-trigger').eq(0).hide();
-        } else {
-            $targetField.siblings('.ui-datepicker-trigger').eq(0).show();
-        }
+        $targetField.siblings('.ui-datepicker-trigger').eq(0).toggle(!opIsUnary(operator));
 
         if ((operator === 'BETWEEN' || operator === 'NOT BETWEEN') && dataType) {
             var $msgbox = ajaxShowMessage();

--- a/resources/js/src/table/select.ts
+++ b/resources/js/src/table/select.ts
@@ -44,6 +44,14 @@ const checkIfDataTypeNumericOrDate = function (dataType) {
 const TableSelect = {
     checkIfDataTypeNumericOrDate: checkIfDataTypeNumericOrDate,
 };
+const UNARY_OPERATORS = [
+    'IS NULL',
+    'IS NOT NULL',
+    '= \'\'',
+    '!= \'\''
+];
+
+const opIsUnary = (op) => UNARY_OPERATORS.includes(op);
 
 /**
  * Unbind all event handlers before tearing down a page
@@ -298,7 +306,15 @@ AJAX.registerOnload('table/select.js', function () {
         dataType = TableSelect.checkIfDataTypeNumericOrDate(dataType);
 
         // Get the operator.
-        var operator = ($(this).val() as string);
+        const operator = ($(this).val() as string);
+        const $targetField = $(this).closest('tr').find('[name*="criteriaValues"]')
+
+        $targetField.prop('disabled', opIsUnary(operator));
+        if (opIsUnary(operator)) {
+            $targetField.siblings('.ui-datepicker-trigger').eq(0).hide();
+        } else {
+            $targetField.siblings('.ui-datepicker-trigger').eq(0).show();
+        }
 
         if ((operator === 'BETWEEN' || operator === 'NOT BETWEEN') && dataType) {
             var $msgbox = ajaxShowMessage();
@@ -344,9 +360,6 @@ AJAX.registerOnload('table/select.js', function () {
                                 finalValue = minValue + ', ' +
                                     maxValue;
                             }
-
-                            var $targetField = $sourceSelect.closest('tr')
-                                .find('[name*="criteriaValues"]');
 
                             // If target field is a select list.
                             if ($targetField.is('select')) {

--- a/resources/js/src/table/select.ts
+++ b/resources/js/src/table/select.ts
@@ -290,7 +290,6 @@ AJAX.registerOnload('table/select.js', function () {
      * Ajax event handler for Range-Search.
      */
     $('body').on('change', 'select[name*="criteriaColumnOperators"]', function () { // Fix for bug #13778, changed 'click' to 'change'
-        var $sourceSelect = $(this);
         // Get the column name.
         var columnName = $(this)
             .closest('tr')


### PR DESCRIPTION
In this PR I made the inputs enabled/disabled depending on the chosen operator.

In case of unary operator the input will be disabled since it's not needed.
In case it's a date the calendar icon gonna disappear too.

https://github.com/user-attachments/assets/c1c2acb9-486a-46ac-8142-f5026094fbab

