### PR TITLE
Implement getValuesForCsvTable for CSV table type

### DIFF
--- a/libraries/classes/Controllers/Database/StructureController.php
+++ b/libraries/classes/Controllers/Database/StructureController.php
@@ -893,6 +893,11 @@ class StructureController extends AbstractController
      * Get values for CSV table
      *
      * https://bugs.mysql.com/bug.php?id=53929
+     *
+     * @param array $currentTable current table
+     * @param int   $sumSize      sum size
+     *
+     * @return array
      */
     protected function getValuesForCsvTable(
         array $currentTable,

--- a/libraries/classes/Controllers/Database/StructureController.php
+++ b/libraries/classes/Controllers/Database/StructureController.php
@@ -563,7 +563,7 @@ class StructureController extends AbstractController
         if (isset($currentTable['TABLE_ROWS']) && ($currentTable['ENGINE'] != null || $tableIsView)) {
             // InnoDB/TokuDB table: we did not get an accurate row count
             $approxRows = ! $tableIsView
-                && in_array($currentTable['ENGINE'], ['InnoDB', 'TokuDB'])
+                && in_array($currentTable['ENGINE'], ['CSV', 'InnoDB', 'TokuDB'])
                 && ! $currentTable['COUNTED'];
 
             if ($tableIsView && $currentTable['TABLE_ROWS'] >= $GLOBALS['cfg']['MaxExactCountViews']) {
@@ -900,11 +900,7 @@ class StructureController extends AbstractController
     ) {
         $formattedSize = $unit = '';
 
-        if (
-            ($currentTable['ENGINE'] === 'CSV'
-            && $currentTable['TABLE_ROWS'] < $GLOBALS['cfg']['MaxExactCount'])
-            || ! isset($currentTable['TABLE_ROWS'])
-        ) {
+        if ($currentTable['ENGINE'] === 'CSV') {
             $currentTable['COUNTED'] = true;
             $currentTable['TABLE_ROWS'] = $this->dbi
                 ->getTable($this->db, $currentTable['TABLE_NAME'])

--- a/libraries/classes/Controllers/Database/StructureController.php
+++ b/libraries/classes/Controllers/Database/StructureController.php
@@ -726,6 +726,12 @@ class StructureController extends AbstractController
                     $sumSize
                 );
                 break;
+            case 'CSV':
+                [$currentTable, $formattedSize, $unit, $sumSize] = $this->getValuesForCsvTable(
+                    $currentTable,
+                    $sumSize
+                );
+                break;
             // Mysql 5.0.x (and lower) uses MRG_MyISAM
             // and MySQL 5.1.x (and higher) uses MRG_MYISAM
             // Both are aliases for MERGE
@@ -881,6 +887,74 @@ class StructureController extends AbstractController
             $unit,
             $sumSize,
         ];
+    }
+
+    /**
+     * Get values for CSV table
+     *
+     * https://bugs.mysql.com/bug.php?id=53929
+     *
+     * @param array $currentTable current table
+     * @param int   $sumSize      sum size
+     *
+     * @return array
+     */
+    protected function getValuesForCsvTable(
+        array $currentTable,
+        $sumSize
+    ) {
+        $formattedSize = $unit = '';
+
+        if (
+            (in_array($currentTable['ENGINE'], ['CSV'], true)
+            && $currentTable['TABLE_ROWS'] < $GLOBALS['cfg']['MaxExactCount'])
+            || ! isset($currentTable['TABLE_ROWS'])
+        ) {
+            $currentTable['COUNTED'] = true;
+            $currentTable['TABLE_ROWS'] = $this->dbi
+                ->getTable($this->db, $currentTable['TABLE_NAME'])
+                ->countRecords(true);
+        } else {
+            $currentTable['COUNTED'] = false;
+        }
+
+        if ($this->isShowStats) {
+            // Only count columns that have double quotes
+            $columnCount = (int) $this->dbi->fetchValue(
+                'SELECT COUNT(COLUMN_NAME) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = \''
+                . $this->dbi->escapeString($this->db) . '\' AND TABLE_NAME = \''
+                . $this->dbi->escapeString($currentTable['TABLE_NAME']) . '\' AND NUMERIC_SCALE IS NULL;'
+            );
+
+            // Get column names
+            $columnNames = $this->dbi->fetchValue(
+                'SELECT GROUP_CONCAT(COLUMN_NAME) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = \''
+                . $this->dbi->escapeString($this->db) . '\' AND TABLE_NAME = \''
+                . $this->dbi->escapeString($currentTable['TABLE_NAME']) . '\';'
+            );
+
+            // 10Mb buffer for CONCAT_WS
+            // not sure if is needed
+            $this->dbi->query('SET SESSION group_concat_max_len = 10 * 1024 * 1024');
+
+            // Calculate data length
+            $dataLength = (int) $this->dbi->fetchValue('
+                SELECT SUM(CHAR_LENGTH(REPLACE(REPLACE(REPLACE(
+                    CONCAT_WS(\',\', ' . $columnNames . '),
+                    UNHEX(\'0A\'), \'nn\'), UNHEX(\'22\'), \'nn\'), UNHEX(\'5C\'), \'nn\'
+                ))) FROM ' . Util::backquote($this->db) . '.' . Util::backquote($currentTable['TABLE_NAME']));
+
+            // Calculate quotes length
+            $quotesLength = $currentTable['TABLE_ROWS'] * $columnCount * 2;
+
+            /** @var int $tblsize */
+            $tblsize = $dataLength + $quotesLength + $currentTable['TABLE_ROWS'];
+
+            $sumSize += $tblsize;
+            [$formattedSize, $unit] = Util::formatByteDown($tblsize, 3, $tblsize > 0 ? 1 : 0);
+        }
+
+        return [$currentTable, $formattedSize, $unit, $sumSize];
     }
 
     /**

--- a/libraries/classes/Controllers/Database/StructureController.php
+++ b/libraries/classes/Controllers/Database/StructureController.php
@@ -893,11 +893,6 @@ class StructureController extends AbstractController
      * Get values for CSV table
      *
      * https://bugs.mysql.com/bug.php?id=53929
-     *
-     * @param array $currentTable current table
-     * @param int   $sumSize      sum size
-     *
-     * @return array
      */
     protected function getValuesForCsvTable(
         array $currentTable,
@@ -906,7 +901,7 @@ class StructureController extends AbstractController
         $formattedSize = $unit = '';
 
         if (
-            (in_array($currentTable['ENGINE'], ['CSV'], true)
+            ($currentTable['ENGINE'] === 'CSV'
             && $currentTable['TABLE_ROWS'] < $GLOBALS['cfg']['MaxExactCount'])
             || ! isset($currentTable['TABLE_ROWS'])
         ) {


### PR DESCRIPTION
### Description

If table type is CSV, the row count always shows 2 and the size is unknown, even if there are rows in it. It will only count the rows, if the table name is clicked, and then go back to database.

Based on https://bugs.mysql.com/bug.php?id=53929

Before:

![csv0](https://github.com/user-attachments/assets/a574c34b-1070-4c15-ae3d-4611f4b43a3d)

After:

![csv1](https://github.com/user-attachments/assets/a676f9da-32d3-4a05-bc50-c57a3a3c7d42)

![csv2](https://github.com/user-attachments/assets/fb0bdd36-8005-4a49-9660-69b33321fff4)

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
