### PR TITLE
Optimization: Memoize SpecialSchemaLinks

### DIFF
--- a/src/Config/SpecialSchemaLinks.php
+++ b/src/Config/SpecialSchemaLinks.php
@@ -12,7 +12,7 @@ use PhpMyAdmin\Url;
 
 class SpecialSchemaLinks
 {
-    /** @var array<string,
+    /** @var array<'mysql'|'information_schema',
      *   array<string,
      *    array<string,
      *     array{
@@ -33,6 +33,8 @@ class SpecialSchemaLinks
      * special schemas like mysql, information_schema etc.
      * Major element represent a schema.
      * All the strings in this array represented in lower case
+     *
+     * @param 'mysql'|'information_schema' $database
      *
      * @return array{
      *   'link_param': string,

--- a/src/Config/SpecialSchemaLinks.php
+++ b/src/Config/SpecialSchemaLinks.php
@@ -12,63 +12,53 @@ use PhpMyAdmin\Url;
 
 class SpecialSchemaLinks
 {
+    /** @var array<string,
+     *   array<string,
+     *    array<string,
+     *     array{
+     *      'link_param': string,
+     *      'link_dependancy_params'?: array<
+     *       int,
+     *       array{'param_info': string, 'column_name': string}
+     *      >,
+     *      'default_page': string
+     *     }
+     *    >
+     *   >
+     *  > */
+    private static array $specialSchemaLinks = [];
+
     /**
      * This array represent the details for generating links inside
      * special schemas like mysql, information_schema etc.
      * Major element represent a schema.
      * All the strings in this array represented in lower case
      *
-     * Array structure ex:
-     * array(
-     *     // Database name is the major element
-     *     'mysql' => array(
-     *         // Table name
-     *         'db' => array(
-     *             // Column name
-     *             'user' => array(
-     *                 // Main url param (can be an array where represent sql)
-     *                 'link_param' => 'username',
-     *                 // Other url params
-     *                 'link_dependancy_params' => array(
-     *                     0 => array(
-     *                         // URL parameter name
-     *                         // (can be array where url param has static value)
-     *                         'param_info' => 'hostname',
-     *                         // Column name related to url param
-     *                         'column_name' => 'host'
-     *                     )
-     *                 ),
-     *                 // Page to link
-     *                 'default_page' => './' . Url::getFromRoute('/server/privileges')
-     *             )
-     *         )
-     *     )
-     * );
-     *
-     * @return array<string,array<string,array<string,array<string,array<int,array<string,string>>|string>>>>
-     * @phpstan-return array<
-     *              string, array<
-     *                  string, array<
-     *                      string,
-     *                      array{
-     *                          'link_param': string,
-     *                          'link_dependancy_params'?: array<
-     *                                                      int,
-     *                                                      array{'param_info': string, 'column_name': string}
-     *                                                     >,
-     *                          'default_page': string
-     *                      }>
-     *                  >
-     *             >
-     * }
+     * @return array{
+     *   'link_param': string,
+     *   'link_dependancy_params'?: array<
+     *     int,
+     *     array{'param_info': string, 'column_name': string}
+     *   >,
+     *   'default_page': string
+     * }|null
      */
-    public static function get(): array
+    public static function get(string $database, string $table, string $column): array|null
+    {
+        if (self::$specialSchemaLinks === []) {
+            self::setSpecialSchemaLinks();
+        }
+
+        return self::$specialSchemaLinks[$database][$table][$column] ?? null;
+    }
+
+    private static function setSpecialSchemaLinks(): void
     {
         $config = Config::getInstance();
         $defaultPageDatabase = './' . Url::getFromRoute($config->settings['DefaultTabDatabase']);
         $defaultPageTable = './' . Url::getFromRoute($config->settings['DefaultTabTable']);
 
-        return [
+        self::$specialSchemaLinks = [
             'mysql' => [
                 'columns_priv' => [
                     'user' => [

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -2084,8 +2084,6 @@ class Results
 
         $rowInfo = $this->getRowInfoForSpecialLinks($row);
 
-        // Load SpecialSchemaLinks for all rows
-        $specialSchemaLinks = SpecialSchemaLinks::get();
         $relationParameters = $this->relation->getRelationParameters();
 
         $columnCount = count($this->fieldsMeta);
@@ -2170,9 +2168,10 @@ class Results
             }
 
             // Check for the predefined fields need to show as link in schemas
-            if (isset($specialSchemaLinks[$dbLower][$tblLower][$nameLower])) {
+            $specialSchemaLink = SpecialSchemaLinks::get($dbLower, $tblLower, $nameLower);
+            if ($specialSchemaLink !== null) {
                 $linkingUrl = $this->getSpecialLinkUrl(
-                    $specialSchemaLinks[$dbLower][$tblLower][$nameLower],
+                    $specialSchemaLink,
                     $row[$i],
                     $rowInfo,
                 );

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -2167,19 +2167,17 @@ class Results
                     . '_' . $this->transformationInfo[$dbLower][$orgTable][$orgName]::getMIMESubtype();
             }
 
-            // Check for the predefined fields need to show as link in schemas
-            $specialSchemaLink = SpecialSchemaLinks::get($dbLower, $tblLower, $nameLower);
-            if ($specialSchemaLink !== null) {
-                $linkingUrl = $this->getSpecialLinkUrl(
-                    $specialSchemaLink,
-                    $row[$i],
-                    $rowInfo,
-                );
-                $transformationPlugin = new Text_Plain_Link();
+            if ($dbLower === 'mysql' || $dbLower === 'information_schema') {
+                // Check for the predefined fields need to show as link in schemas
+                $specialSchemaLink = SpecialSchemaLinks::get($dbLower, $tblLower, $nameLower);
+                if ($specialSchemaLink !== null) {
+                    $linkingUrl = $this->getSpecialLinkUrl($specialSchemaLink, $row[$i], $rowInfo);
+                    $transformationPlugin = new Text_Plain_Link();
 
-                $transformOptions = [0 => $linkingUrl, 2 => true];
+                    $transformOptions = [0 => $linkingUrl, 2 => true];
 
-                $meta->internalMediaType = 'Text_Plain';
+                    $meta->internalMediaType = 'Text_Plain';
+                }
             }
 
             $expressions = [];


### PR DESCRIPTION
Assuming that the Config doesn't change during the execution of `getRowValues()` the values should remain constant. There's no need to compile the list again and again for every row. This should improve the performance of the `route=/sql` by up to 10%. 