### PR TITLE
Fix missing tooltip in status monitor log table

### DIFF
--- a/js/src/server/status/monitor.js
+++ b/js/src/server/status/monitor.js
@@ -2083,19 +2083,16 @@ AJAX.registerOnload('server/status/monitor.js', function () {
                     '</span></th><th class="text-end">' + data.sum.TOTAL + '</th></tr></tfoot>');
 
         // Append a tooltip to the count column, if there exist one
-        if ($('#logTable').find('tr').first().find('th').last().text().indexOf('#') > -1) {
-            $('#logTable').find('tr').first().find('th').last().append('&nbsp;' + Functions.getImage('b_help', '', { 'class': 'qroupedQueryInfoIcon' }));
+        const amountColumn = $('#logTable').find('tr').first().find('th').last();
+        if (amountColumn.text().indexOf('#') > -1) {
+            amountColumn.append('&nbsp;' + Functions.getImage('b_help'));
 
-            var tooltipContent = Messages.strCountColumnExplanation;
+            let tooltipContent = Messages.strCountColumnExplanation;
             if (groupInserts) {
-                tooltipContent += '<p>' + Messages.strMoreCountColumnExplanation + '</p>';
+                tooltipContent += '<br>' + Messages.strMoreCountColumnExplanation;
             }
 
-            Functions.tooltip(
-                $('img.qroupedQueryInfoIcon'),
-                'img',
-                tooltipContent
-            );
+            Functions.tooltip(amountColumn, 'th', tooltipContent);
         }
 
         $('#logTable').find('table').tablesorter({


### PR DESCRIPTION
Before:
![Screenshot From 2025-01-22 22-23-00](https://github.com/user-attachments/assets/76cfc9bc-0ade-4166-9d70-4db9f3d46f9d)

After:
![Screenshot From 2025-01-22 22-24-34](https://github.com/user-attachments/assets/e319e76b-66f0-41f1-88d7-6e7b418a65d1)
