### PR TITLE
Fix #19118 - update table comment field to textarea

### DIFF
--- a/resources/templates/columns_definitions/column_definitions_form.twig
+++ b/resources/templates/columns_definitions/column_definitions_form.twig
@@ -84,12 +84,12 @@
             </tr>
             <tr>
                 <td>
-                    <input type="text"
-                        name="comment"
-                        size="40"
-                        maxlength="60"
-                        value="{{ comment is defined ? comment }}"
-                        class="textfield">
+                  <textarea 
+                    name="comment" 
+                    maxlength="2048" 
+                    class="textfield" 
+                    rows="1"
+                    cols="30">{{ comment is defined ? comment }}</textarea>
                 </td>
                 <td width="25">&nbsp;</td>
                 <td>

--- a/resources/templates/table/operations/index.twig
+++ b/resources/templates/table/operations/index.twig
@@ -124,7 +124,14 @@
           <label for="tableCommentsInput">{{ t('Table comments') }}</label>
         </div>
         <div class="col-6">
-          <input class="form-control" id="tableCommentsInput" type="text" name="comment" maxlength="2048" value="{{ table_comment }}">
+          <textarea 
+            id="tableCommentsInput"
+            class="form-control"
+            name="comment" 
+            maxlength="2048" 
+            class="textfield" 
+            rows="1"
+            cols="30">{{ table_comment }}</textarea>
         </div>
       </div>
 


### PR DESCRIPTION
### Description
- Changed the table comment field from a textfield to a textarea to support longer comments.
- Updated the maximum character limit to 2048 to align with MySQL and MariaDB documentation.
- Ensured the textarea allows multi-line input for improved user experience when adding comments.

#### Screenshots:
![image](https://github.com/user-attachments/assets/65f7545b-cb0a-4ec9-8d51-26279ffdd6f7)

----

![image](https://github.com/user-attachments/assets/d8d2b54b-6069-490d-aeee-89f5b43fa0a8)

Fixes #19118 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
