### PR TITLE
Change link to tutorial from http to https to avoid redirect

### DIFF
--- a/docs/other.rst
+++ b/docs/other.rst
@@ -24,7 +24,7 @@ English
 +++++++
 
 - `Having fun with phpMyAdmin's MIME-transformations & PDF-features <https://garv.in/tops/texte/mimetutorial>`_
-- `Learning SQL Using phpMyAdmin (old tutorial) <http://www.php-editors.com/articles/sql_phpmyadmin.php>`_
+- `Learning SQL Using phpMyAdmin (old tutorial) <https://www.php-editors.com/articles/sql_phpmyadmin.php>`_
 
 Русский (Russian)
 +++++++++++++++++


### PR DESCRIPTION
### Description

This changes an old link to an http:// url to use https:// (the target URL already redirects).

(Retry with correct signed-off-by line.)