### PR TITLE
Update column_row.twig

### DIFF
--- a/resources/templates/table/insert/column_row.twig
+++ b/resources/templates/table/insert/column_row.twig
@@ -17,7 +17,7 @@
       <td class="text-center">--</td>
     {% else %}
       <td>
-        <select name="funcs[multi_edit][{{ row_id }}][{{ column.md5 }}]" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')" id="field_{{ id_index }}_1">
+        <select name="funcs[multi_edit][{{ row_id }}][{{ column.md5 }}]" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.trueType }}')" id="field_{{ id_index }}_1">
           {{ function_options|raw }}
         </select>
       </td>
@@ -44,18 +44,18 @@
       {% if is_value_foreign_link %}
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="foreign">
-        <input type="text" name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" tabindex="{{ id_index }}" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')" id="field_{{ id_index }}_3" value="{{ data }}">
+        <input type="text" name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" tabindex="{{ id_index }}" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.trueType }}')" id="field_{{ id_index }}_3" value="{{ data }}">
         <a class="ajax browse_foreign" href="{{ url('/browse-foreigners') }}" data-post="{{ get_common({'db': db, 'table': table, 'field': column.field, 'rownumber': row_id, 'data': data}) }}">{{ get_icon('b_browse', t('Browse foreign values')) }}</a>
       {% elseif foreign_dropdown is not empty %}
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="{{ column.isBinary ? 'hex' : 'foreign' }}">
-        <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" tabindex="{{ id_index }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')">
+        <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" tabindex="{{ id_index }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.trueType }}')">
           {{ foreign_dropdown|raw }}
         </select>
       {% elseif (longtext_double_textarea and 'longtext' in column.trueType) or 'json' in column.trueType or 'text' in column.trueType %}
         {{ backup_field|raw }}
         <textarea name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" id="field_{{ id_index }}_3" data-type="{{ data_type }}" dir="{{ pma.text_dir }}" rows="{{ textarea_rows }}" cols="{{ textarea_cols }}" tabindex="{{ id_index }}"
-          {{- max_length ? ' data-maxlength="' ~ max_length ~ '"' }}{{ column.isChar ? ' class="charField"' }} onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')">
+          {{- max_length ? ' data-maxlength="' ~ max_length ~ '"' }}{{ column.isChar ? ' class="charField"' }} onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.trueType }}')">
           {#- We need to duplicate the first \n or otherwise we will lose the first newline entered in a VARCHAR or TEXT column -#}
           {{- special_chars starts with "\r\n" ? "\n" }}{{ special_chars|raw -}}
         </textarea>
@@ -68,7 +68,7 @@
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="enum">
         {% if column.type|length > 20 %}
-          <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" tabindex="{{ id_index }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')">
+          <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" tabindex="{{ id_index }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.trueType }}')">
             <option value=""></option>
             {% for enum_value in enum_values %}
               <option value="{{ enum_value }}"{{ enum_value == enum_selected_value ? ' selected' }}>{{ enum_value }}</option>
@@ -76,14 +76,14 @@
           </select>
         {% else %}
           {% for enum_value in enum_values %}
-            <input type="radio" name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="{{ enum_value }}" class="textfield" tabindex="{{ id_index }}" id="field_{{ id_index }}_3_{{ loop.index0 }}" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')"{{ enum_value == enum_selected_value ? ' checked' }}>
+            <input type="radio" name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="{{ enum_value }}" class="textfield" tabindex="{{ id_index }}" id="field_{{ id_index }}_3_{{ loop.index0 }}" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.trueType }}')"{{ enum_value == enum_selected_value ? ' checked' }}>
             <label for="field_{{ id_index }}_3_{{ loop.index0 }}">{{ enum_value }}</label>
           {% endfor %}
         {% endif %}
       {% elseif column.trueType == 'set' %}
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="set">
-        <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}][]" class="textfield" tabindex="{{ id_index }}" size="{{ set_select_size }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')" multiple>
+        <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}][]" class="textfield" tabindex="{{ id_index }}" size="{{ set_select_size }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.trueType }}')" multiple>
           {% for set_value in set_values %}
             <option value="{{ set_value }}"{{ set_value in data|split(',') ? ' selected' }}>{{ set_value }}</option>
           {% endfor %}
@@ -98,7 +98,7 @@
           {{ backup_field|raw }}
           <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="hex">
           <textarea name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" id="field_{{ id_index }}_3" data-type="HEX" dir="{{ pma.text_dir }}" rows="{{ textarea_rows }}" cols="{{ textarea_cols }}" tabindex="{{ id_index }}"
-            {{- max_length ? ' data-maxlength="' ~ max_length ~ '"' }}{{ column.isChar ? ' class="charField"' }} onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')">
+            {{- max_length ? ' data-maxlength="' ~ max_length ~ '"' }}{{ column.isChar ? ' class="charField"' }} onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.trueType }}')">
             {#- We need to duplicate the first \n or otherwise we will lose the first newline entered in a VARCHAR or TEXT column -#}
             {{- special_chars starts with "\r\n" ? "\n" }}{{ special_chars|raw -}}
           </textarea>
@@ -110,7 +110,7 @@
         {% if is_upload and column.isBlob %}
           <br>
           {# We don't want to prevent users from using browser's default drag-drop feature on some page(s), so we add noDragDrop class to the input #}
-          <input type="file" name="fields_upload[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield noDragDrop" id="field_{{ id_index }}_3" size="10" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.type }}')">
+          <input type="file" name="fields_upload[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield noDragDrop" id="field_{{ id_index }}_3" size="10" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.trueType }}')">
           {{ max_upload_size }}
         {% endif %}
         {{ select_option_for_upload|raw }}


### PR DESCRIPTION
Fixes #19582

Enum and set are the only types that can have quotes in their definition. I didn't pay attention to what the previous code was doing but it had code that handled these two types specifically instead of using the true type in the JS call. 