### PR TITLE
Fix blowfish_secret validation: support 64-character hex format and update documentation

### DIFF
--- a/config.sample.inc.php
+++ b/config.sample.inc.php
@@ -10,8 +10,9 @@
 declare(strict_types=1);
 
 /**
- * This is needed for cookie based authentication to encrypt the cookie.
- * Needs to be a 32-bytes long string of random bytes. See FAQ 2.10.
+ * This is needed for cookie-based authentication to encrypt the cookie.
+ * Needs to be a 32-byte long binary string (use `random_bytes(32)`)
+ * or a 64-character hexadecimal string (use `bin2hex(random_bytes(32))`).
  */
 $cfg['blowfish_secret'] = ''; /* YOU MUST FILL IN THIS FOR COOKIE AUTH! */
 
@@ -27,7 +28,7 @@ $i++;
 /* Authentication type */
 $cfg['Servers'][$i]['auth_type'] = 'cookie';
 /* Server parameters */
-$cfg['Servers'][$i]['host'] = 'localhost';
+$cfg['Servers'][$i]['host'] = '';
 $cfg['Servers'][$i]['compress'] = false;
 $cfg['Servers'][$i]['AllowNoPassword'] = false;
 

--- a/config.sample.inc.php
+++ b/config.sample.inc.php
@@ -28,7 +28,7 @@ $i++;
 /* Authentication type */
 $cfg['Servers'][$i]['auth_type'] = 'cookie';
 /* Server parameters */
-$cfg['Servers'][$i]['host'] = '';
+$cfg['Servers'][$i]['host'] = 'localhost';
 $cfg['Servers'][$i]['compress'] = false;
 $cfg['Servers'][$i]['AllowNoPassword'] = false;
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1924,7 +1924,8 @@ Cookie authentication options
     will be used internally by the :term:`Sodium` extension: you won't be prompted for this encryption key.
 
     Since a binary string is usually not printable, it can be converted into a hexadecimal representation (using a
-    function like `sodium_bin2hex <https://www.php.net/sodium_bin2hex>`_) and then used in the configuration file. For
+    function like `sodium_bin2hex <https://www.php.net/sodium_bin2hex>`_) and then used in the configuration file.  
+    If a 64-character hexadecimal string is provided, phpMyAdmin will automatically convert it into a 32-byte binary string. For
     example:
 
     .. code-block:: php
@@ -1932,9 +1933,9 @@ Cookie authentication options
         // The string is a hexadecimal representation of a 32-bytes long string of random bytes.
         $cfg['blowfish_secret'] = sodium_hex2bin('f16ce59f45714194371b48fe362072dc3b019da7861558cd4ad29e4d6fb13851');
 
-    Using a binary string is recommended. However, if all 32 bytes of the string are visible
-    characters, then a function like `sodium_bin2hex <https://www.php.net/sodium_bin2hex>`_ is not required. For
-    example:
+        Using a binary string is recommended. However, if all 32 bytes of the string are visible
+        characters, then a function like `sodium_bin2hex <https://www.php.net/sodium_bin2hex>`_ is not required. For
+        example:
 
     .. code-block:: php
 
@@ -1943,9 +1944,9 @@ Cookie authentication options
 
     .. warning::
 
-        The encryption key must be 32 bytes long. If it is longer than the length of bytes, only the first 32 bytes will
-        be used, and if it is shorter, a new temporary key will be automatically generated for you. However, this
-        temporary key will only last for the duration of the session.
+        The encryption key must be 32 bytes long. If it is a 64-character hexadecimal string, it will be automatically converted to a 32-byte binary string.  
+        If it is longer than 32 bytes (excluding hex format), only the first 32 bytes will be used.  
+        If it is shorter, a new temporary key will be automatically generated for you. However, this temporary key will only last for the duration of the session.
 
     .. note::
 

--- a/src/Controllers/HomeController.php
+++ b/src/Controllers/HomeController.php
@@ -314,6 +314,26 @@ final class HomeController implements InvocableController
             // This can happen if the user did use getenv() to set blowfish_secret
             $encryptionKeyLength = mb_strlen($config->settings['blowfish_secret'], '8bit');
 
+            // If the key is in hexadecimal and has a length of 64 characters (i.e., 32 bytes), then convert it to binary.
+            if ($encryptionKeyLength === 64 && ctype_xdigit($config->settings['blowfish_secret'])) {
+                // Convert the hexadecimal string to binary and override the original blowfish_secret
+                $binaryKey = hex2bin($config->settings['blowfish_secret']);
+                if ($binaryKey !== false) { // Ensure conversion is successful
+                    $config->settings['blowfish_secret'] = $binaryKey;
+                    $encryptionKeyLength = SODIUM_CRYPTO_SECRETBOX_KEYBYTES; // Update length
+                } else {
+                     // If hex2bin conversion fails, log an error or warning
+                    $this->errors[] = [
+                        'message' => __(
+                            'Invalid blowfish_secret format: Unable to convert hex string to binary.'
+                            . ' Please ensure it is a valid 64-character hexadecimal string.'
+                            . ' Refer to the [doc@cfg_blowfish_secret]documentation[/doc].',
+                        ),
+                        'severity' => 'error',
+                    ];
+                }
+            }
+
             if ($encryptionKeyLength < SODIUM_CRYPTO_SECRETBOX_KEYBYTES) {
                 $this->errors[] = [
                     'message' => __(


### PR DESCRIPTION
### What Changed

- **Validation Update:**  
  The `blowfish_secret` validation in HomeController.php has been enhanced to support a 64-character hexadecimal string.  
  When a valid 64-character hex string is detected, it is automatically converted to a 32-byte binary string using `hex2bin()`.  
  This conversion ensures that the encryption key meets the required length defined by `SODIUM_CRYPTO_SECRETBOX_KEYBYTES`.

- **Error Handling:**  
  If the conversion fails (i.e. the provided hex string is invalid), an error is logged to inform the user that the key format is invalid.  
  Warnings are issued if the key is shorter than 32 bytes or longer than 32 bytes (after conversion), so users are aware of the proper key length requirements.

- **Documentation Update:**  
  The configuration documentation (in `config.sample.inc.php` and related docs) has been updated to explain:
    - That the key can be provided as either a 32-byte binary string or a 64-character hexadecimal string.
    - If a 64-character hexadecimal string is provided, phpMyAdmin will automatically convert it into a 32-byte binary string.
    - The key must ultimately be exactly 32 bytes long; if it is too short, a temporary key is generated (which only lasts for the session), and if it is too long (non-hex), only the first 32 bytes are used.
  
### Why This Change?

- **User Convenience:**  
  Many users set the `blowfish_secret` using environment variables or external tools that may produce a 64-character hex string.  
  This change allows such keys to be accepted automatically, reducing configuration errors.

- **Improved Robustness:**  
  By supporting both binary and hex formats, the configuration process becomes more flexible while ensuring that the encryption key meets the security requirements of the Sodium extension.

- **Clearer Documentation:**  
  The documentation now clearly states the acceptable formats and the behavior when using different key lengths, which should help prevent misconfiguration.

### Testing

- Verified that providing a 32-byte binary string works as expected.
- Verified that a 64-character hexadecimal string is correctly converted to a 32-byte binary string.
- Verified that invalid key lengths result in appropriate error/warning messages.

Closes: #19096 