### PR TITLE
Fix #17535 - ajax class is required for confirmation modal to show

### DIFF
--- a/templates/display/results/checkbox_and_links.twig
+++ b/templates/display/results/checkbox_and_links.twig
@@ -32,7 +32,7 @@
   {% if delete.url is not empty %}
     <td class="text-center d-print-none{{ is_ajax ? ' ajax' }}">
       <span class="text-nowrap">
-        {{ link_or_button(delete.url, delete.params, delete.string, {'class': 'delete_row requireConfirm' ~ (is_ajax ? ' ajax') }) }}
+        {{ link_or_button(delete.url, delete.params, delete.string, {'class': 'delete_row requireConfirm ajax'}) }}
         {% if js_conf is not empty %}
           <div class="hide">{{ js_conf }}</div>
         {% endif %}
@@ -43,7 +43,7 @@
   {% if delete.url is not empty %}
     <td class="text-center d-print-none{{ is_ajax ? ' ajax' }}">
       <span class="text-nowrap">
-        {{ link_or_button(delete.url, delete.params, delete.string, {'class': 'delete_row requireConfirm' ~ (is_ajax ? ' ajax') }) }}
+        {{ link_or_button(delete.url, delete.params, delete.string, {'class': 'delete_row requireConfirm ajax'}) }}
         {% if js_conf is not empty %}
           <div class="hide">{{ js_conf }}</div>
         {% endif %}


### PR DESCRIPTION
### Description

Before:

https://github.com/user-attachments/assets/ddc16a7f-1989-466b-9ce8-8d5ab7f20526

After:

https://github.com/user-attachments/assets/9c68100f-c149-4518-9831-50602cb481a2

Fixes #17535

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
