### PR TITLE
Fix #19109 - Do not enforce character encoding when checking roles

### DIFF
--- a/libraries/classes/Query/Generator.php
+++ b/libraries/classes/Query/Generator.php
@@ -229,7 +229,7 @@ class Generator
             . "'''" . $user . "''@''" . $host . "''' LIKE `GRANTEE`"
             . ' UNION '
             . 'SELECT 1 FROM mysql.user '
-            . "WHERE `create_user_priv` = 'Y' COLLATE utf8mb4_general_ci AND "
+            . "WHERE `create_user_priv` = 'Y' AND "
             . "'" . $user . "' LIKE `User` AND '' LIKE `Host`"
             . ' LIMIT 1';
     }
@@ -250,7 +250,7 @@ class Generator
             . "'''" . $user . "''@''" . $host . "''' LIKE `GRANTEE` "
             . ' UNION '
             . 'SELECT 1 FROM mysql.user '
-            . "WHERE `create_user_priv` = 'Y' COLLATE utf8mb4_general_ci AND "
+            . "WHERE `create_user_priv` = 'Y' AND "
             . "'" . $user . "' LIKE `User` AND '' LIKE `Host`"
             . ' LIMIT 1';
     }

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -583,7 +583,7 @@ class DbiDummy implements DbiExtension
                 'query' => 'SELECT 1 FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES`'
                     . " WHERE `PRIVILEGE_TYPE` = 'CREATE USER'"
                     . " AND '''pma_test''@''localhost''' LIKE `GRANTEE`"
-                    . " UNION SELECT 1 FROM mysql.user WHERE `create_user_priv` = 'Y' COLLATE utf8mb4_general_ci"
+                    . " UNION SELECT 1 FROM mysql.user WHERE `create_user_priv` = 'Y'"
                     . " AND 'pma_test' LIKE `User` AND '' LIKE `Host` LIMIT 1",
                 'result' => [['1']],
             ],
@@ -598,7 +598,7 @@ class DbiDummy implements DbiExtension
                     . ' FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES`) t'
                     . " WHERE `IS_GRANTABLE` = 'YES'"
                     . " AND '''pma_test''@''localhost''' LIKE `GRANTEE`"
-                    . " UNION SELECT 1 FROM mysql.user WHERE `create_user_priv` = 'Y' COLLATE utf8mb4_general_ci"
+                    . " UNION SELECT 1 FROM mysql.user WHERE `create_user_priv` = 'Y'"
                     . " AND 'pma_test' LIKE `User` AND '' LIKE `Host` LIMIT 1",
                 'result' => [['1']],
             ],


### PR DESCRIPTION
### Description

The functions `getInformationSchemaDataForCreateRequest()` and `getInformationSchemaDataForGranteeRequest()` generate a query that fails with the error `COLLATION 'utf8mb4_general_ci' is not valid for CHARACTER SET 'utf8mb3'` on some servers that got migrated from MySql 5.7. This lead to admin users not being able to create new users via PhpMyAdmin's UI. Instead, the error message "You do not have the privileges to administrate the users!" is being shown. When not forcing the encoding to `utf8mb4_general_ci` in the query, everything works fine.

Fixes #19109
