### PR TITLE
Fix column move

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4225,12 +4225,6 @@ parameters:
 			path: src/Controllers/Table/Structure/ChangeController.php
 
 		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 1
-			path: src/Controllers/Table/Structure/MoveColumnsController.php
-
-		-
 			message: '#^PHPDoc tag @var with type int is not subtype of type int\<0, max\>\|false\.$#'
 			identifier: varTag.type
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4237,6 +4237,12 @@ parameters:
 			path: src/Controllers/Table/Structure/MoveColumnsController.php
 
 		-
+			message: '#^Parameter \#2 \$moveColumns of method PhpMyAdmin\\Controllers\\Table\\Structure\\MoveColumnsController\:\:generateAlterTableSql\(\) expects list\<string\>, list given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Controllers/Table/Structure/MoveColumnsController.php
+
+		-
 			message: '#^Cannot call method get\(\) on PhpMyAdmin\\SqlParser\\Components\\OptionsArray\|null\.$#'
 			identifier: method.nonObject
 			count: 16

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2808,6 +2808,11 @@
       <code><![CDATA[[$request->getParam('field')]]]></code>
     </MixedArgumentTypeCoercion>
   </file>
+  <file src="src/Controllers/Table/Structure/MoveColumnsController.php">
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$moveColumns]]></code>
+    </MixedArgumentTypeCoercion>
+  </file>
   <file src="src/Controllers/Table/Structure/PartitioningController.php">
     <PossiblyNullArgument>
       <code><![CDATA[$stmt->partitions]]></code>

--- a/resources/js/src/table/structure.ts
+++ b/resources/js/src/table/structure.ts
@@ -405,7 +405,7 @@ AJAX.registerOnload('table/structure.js', function () {
                     for (var i in data.columns) {
                         var theColumn = data.columns[i];
                         var $theRow = $rows
-                            .find('input:checkbox[value=\'' + theColumn + '\']')
+                            .find('input:checkbox[value="' + escapeJsString(theColumn) + '"]')
                             .closest('tr');
                         // append the row for this column to the table
                         $fieldsTable.append($theRow);

--- a/src/Controllers/Table/Structure/MoveColumnsController.php
+++ b/src/Controllers/Table/Structure/MoveColumnsController.php
@@ -20,7 +20,6 @@ use PhpMyAdmin\Util;
 use function __;
 use function array_diff;
 use function array_is_list;
-use function array_keys;
 use function array_search;
 use function array_splice;
 use function assert;
@@ -95,15 +94,16 @@ final class MoveColumnsController implements InvocableController
         /** @var CreateDefinition[] $fields */
         $fields = $statement->fields;
         $columns = [];
+        $columnNames = [];
         foreach ($fields as $field) {
             if ($field->name === null) {
                 continue;
             }
 
             $columns[$field->name] = $field;
+            $columnNames[] = $field->name;
         }
 
-        $columnNames = array_keys($columns);
         // Ensure the columns from client match the columns from the table
         if (
             count($columnNames) !== count($moveColumns) ||
@@ -117,7 +117,7 @@ final class MoveColumnsController implements InvocableController
         // move columns from first to last
         foreach ($moveColumns as $i => $columnName) {
             // is this column already correctly placed?
-            if ($columnNames[$i] == $columnName) {
+            if ($columnNames[$i] === $columnName) {
                 continue;
             }
 
@@ -126,7 +126,10 @@ final class MoveColumnsController implements InvocableController
                 ($i === 0 ? ' FIRST' : ' AFTER ' . Util::backquote($columnNames[$i - 1]));
 
             // Move column to its new position
-            /** @var int $j */
+            /**
+             * @var int $j
+             * We are sure that the value exists because we checked it with array_diff and the type of both is string
+             */
             $j = array_search($columnName, $columnNames, true);
             array_splice($columnNames, $j, 1);
             array_splice($columnNames, $i, 0, $columnName);


### PR DESCRIPTION
This should fix at least 3 issues:
- When the UI goes out of sync with the table structure, e.g. you change the structure in another tab
- When your column names are numerical
- When your column names are quoted
It should probably be fixed in 5.2 but I don't feel like working on 5.2 anymore. If someone wants to fix it there too, feel free to do it.