### PR TITLE
Fix mysql default value insert

### DIFF
--- a/src/InsertEdit.php
+++ b/src/InsertEdit.php
@@ -1865,7 +1865,11 @@ class InsertEdit
     /** @return array<string|null> */
     public function getColumnDefaultValues(string $database, string $table): array
     {
-        $sql = 'SELECT COLUMN_NAME, COLUMN_DEFAULT FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '
+        $sql = 'SELECT COLUMN_NAME, CASE WHEN INSTR(EXTRA, \'DEFAULT_GENERATED\')'
+            . ' THEN COLUMN_DEFAULT '
+            . ' ELSE CONCAT(\'\'\'\', COLUMN_DEFAULT, \'\'\'\')'
+            . ' END AS COLUMN_DEFAULT'
+            . ' FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '
             . $this->dbi->quoteString($table)
             . ' AND TABLE_SCHEMA = ' . $this->dbi->quoteString($database);
 

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -34,7 +34,6 @@ use function array_merge;
 use function count;
 use function end;
 use function explode;
-use function htmlspecialchars;
 use function implode;
 use function in_array;
 use function intval;

--- a/tests/unit/Controllers/Table/ReplaceControllerTest.php
+++ b/tests/unit/Controllers/Table/ReplaceControllerTest.php
@@ -133,7 +133,8 @@ class ReplaceControllerTest extends AbstractTestCase
         $dummyDbi->addSelectDb('my_db');
         $dummyDbi->addSelectDb('my_db');
         $dummyDbi->addResult(
-            'SELECT COLUMN_NAME, COLUMN_DEFAULT FROM INFORMATION_SCHEMA.COLUMNS '
+            "SELECT COLUMN_NAME, CASE WHEN INSTR(EXTRA, 'DEFAULT_GENERATED') THEN COLUMN_DEFAULT "
+                . "ELSE CONCAT('''', COLUMN_DEFAULT, '''') END AS COLUMN_DEFAULT FROM INFORMATION_SCHEMA.COLUMNS "
                 . "WHERE TABLE_NAME = 'test_tbl' AND TABLE_SCHEMA = 'my_db'",
             [],
         );


### PR DESCRIPTION
This should fix #19623 without affecting MariaDB since it doesn't set the flag. It doesn't fix the issue with escaped quotes on MySQL. 

@faissaloux Can you please check if it fixes the issue for you?