### PR TITLE
Fix enum editor with empty values

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -3145,7 +3145,10 @@ AJAX.registerOnload('functions.js', function () {
             var valueArray = [];
             $('#enumEditorModal').find('.values input').each(function (index, elm) {
                 var val = elm.value.replace(/\\/g, '\\\\').replace(/'/g, '\'\'');
-                valueArray.push('\'' + val + '\'');
+
+                if (val.length) {
+                    valueArray.push('\'' + val + '\'');
+                }
             });
             // get the Length/Values text field where this value belongs
             var valuesId = $('#enumEditorModal').find('input[type=\'hidden\']').val();


### PR DESCRIPTION
When I submit enum values from the `ENUM/SET` editor with empty fields, it generates empty strings as enum values. I have fixed this on this PR.

![image](https://github.com/user-attachments/assets/9635446e-63f4-4e88-a1bd-eddb92724e95)

### Current
![image](https://github.com/user-attachments/assets/0415b645-e989-4ba6-b244-c48cfc0d6ee6)

### After
![image](https://github.com/user-attachments/assets/c395f2e3-0468-4ee9-b98f-ac45ca727ead)
