### PR TITLE
Update Composer dependencies

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -313,12 +313,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmyadmin/motranslator.git",
-                "reference": "37e080dfc684e2b55afc6dd4a88dafb2fb4a5903"
+                "reference": "0b0b2171de6b6eb7284106d3e17309527ed38810"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmyadmin/motranslator/zipball/37e080dfc684e2b55afc6dd4a88dafb2fb4a5903",
-                "reference": "37e080dfc684e2b55afc6dd4a88dafb2fb4a5903",
+                "url": "https://api.github.com/repos/phpmyadmin/motranslator/zipball/0b0b2171de6b6eb7284106d3e17309527ed38810",
+                "reference": "0b0b2171de6b6eb7284106d3e17309527ed38810",
                 "shasum": ""
             },
             "require": {
@@ -377,7 +377,7 @@
                 "issues": "https://github.com/phpmyadmin/motranslator/issues",
                 "source": "https://github.com/phpmyadmin/motranslator"
             },
-            "time": "2025-02-26T00:07:50+00:00"
+            "time": "2025-04-01T03:50:44+00:00"
         },
         {
             "name": "phpmyadmin/shapefile",
@@ -456,12 +456,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmyadmin/sql-parser.git",
-                "reference": "ebcca8b500b5edcda403a227ee6cb1fec40aece7"
+                "reference": "8fb3e83289abec9d13a6a3686b17495a2353bc28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmyadmin/sql-parser/zipball/ebcca8b500b5edcda403a227ee6cb1fec40aece7",
-                "reference": "ebcca8b500b5edcda403a227ee6cb1fec40aece7",
+                "url": "https://api.github.com/repos/phpmyadmin/sql-parser/zipball/8fb3e83289abec9d13a6a3686b17495a2353bc28",
+                "reference": "8fb3e83289abec9d13a6a3686b17495a2353bc28",
                 "shasum": ""
             },
             "require": {
@@ -539,7 +539,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2025-03-12T13:20:09+00:00"
+            "time": "2025-03-22T07:14:31+00:00"
         },
         {
             "name": "psr/cache",
@@ -1042,16 +1042,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v7.2.4",
+            "version": "v7.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "d33cd9e14326e14a4145c21e600602eaf17cc9e7"
+                "reference": "9131e3018872d2ebb6fe8a9a4d6631273513d42c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/d33cd9e14326e14a4145c21e600602eaf17cc9e7",
-                "reference": "d33cd9e14326e14a4145c21e600602eaf17cc9e7",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/9131e3018872d2ebb6fe8a9a4d6631273513d42c",
+                "reference": "9131e3018872d2ebb6fe8a9a4d6631273513d42c",
                 "shasum": ""
             },
             "require": {
@@ -1120,7 +1120,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v7.2.4"
+                "source": "https://github.com/symfony/cache/tree/v7.2.5"
             },
             "funding": [
                 {
@@ -1136,7 +1136,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-26T09:57:54+00:00"
+            "time": "2025-03-25T15:54:33+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -1291,16 +1291,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.2.4",
+            "version": "v7.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "f0a1614cccb4b8431a97076f9debc08ddca321ca"
+                "reference": "58ab71379f14a741755717cece2868bf41ed45d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f0a1614cccb4b8431a97076f9debc08ddca321ca",
-                "reference": "f0a1614cccb4b8431a97076f9debc08ddca321ca",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/58ab71379f14a741755717cece2868bf41ed45d8",
+                "reference": "58ab71379f14a741755717cece2868bf41ed45d8",
                 "shasum": ""
             },
             "require": {
@@ -1308,7 +1308,7 @@
                 "psr/container": "^1.1|^2.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/service-contracts": "^3.5",
-                "symfony/var-exporter": "^6.4|^7.0"
+                "symfony/var-exporter": "^6.4.20|^7.2.5"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2",
@@ -1351,7 +1351,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.2.4"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.2.5"
             },
             "funding": [
                 {
@@ -1367,7 +1367,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-21T09:47:16+00:00"
+            "time": "2025-03-13T12:21:46+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1890,16 +1890,16 @@
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.2.4",
+            "version": "v7.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "4ede73aa7a73d81506002d2caadbbdad1ef5b69a"
+                "reference": "c37b301818bd7288715d40de634f05781b686ace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/4ede73aa7a73d81506002d2caadbbdad1ef5b69a",
-                "reference": "4ede73aa7a73d81506002d2caadbbdad1ef5b69a",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/c37b301818bd7288715d40de634f05781b686ace",
+                "reference": "c37b301818bd7288715d40de634f05781b686ace",
                 "shasum": ""
             },
             "require": {
@@ -1946,7 +1946,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.2.4"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.2.5"
             },
             "funding": [
                 {
@@ -1962,7 +1962,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-13T10:27:23+00:00"
+            "time": "2025-03-13T12:21:46+00:00"
         },
         {
             "name": "twig/twig",
@@ -2257,16 +2257,16 @@
         },
         {
             "name": "amphp/byte-stream",
-            "version": "v2.1.1",
+            "version": "v2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/byte-stream.git",
-                "reference": "daa00f2efdbd71565bf64ffefa89e37542addf93"
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/daa00f2efdbd71565bf64ffefa89e37542addf93",
-                "reference": "daa00f2efdbd71565bf64ffefa89e37542addf93",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46",
                 "shasum": ""
             },
             "require": {
@@ -2320,7 +2320,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/byte-stream/issues",
-                "source": "https://github.com/amphp/byte-stream/tree/v2.1.1"
+                "source": "https://github.com/amphp/byte-stream/tree/v2.1.2"
             },
             "funding": [
                 {
@@ -2328,7 +2328,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-02-17T04:49:38+00:00"
+            "time": "2025-03-16T17:10:27+00:00"
         },
         {
             "name": "amphp/cache",
@@ -2632,16 +2632,16 @@
         },
         {
             "name": "amphp/pipeline",
-            "version": "v1.2.2",
+            "version": "v1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/pipeline.git",
-                "reference": "97cbf289f4d8877acfe58dd90ed5a4370a43caa4"
+                "reference": "7b52598c2e9105ebcddf247fc523161581930367"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/pipeline/zipball/97cbf289f4d8877acfe58dd90ed5a4370a43caa4",
-                "reference": "97cbf289f4d8877acfe58dd90ed5a4370a43caa4",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/7b52598c2e9105ebcddf247fc523161581930367",
+                "reference": "7b52598c2e9105ebcddf247fc523161581930367",
                 "shasum": ""
             },
             "require": {
@@ -2687,7 +2687,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/pipeline/issues",
-                "source": "https://github.com/amphp/pipeline/tree/v1.2.2"
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.3"
             },
             "funding": [
                 {
@@ -2695,7 +2695,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-19T15:42:46+00:00"
+            "time": "2025-03-16T16:33:53+00:00"
         },
         {
             "name": "amphp/process",
@@ -3147,79 +3147,6 @@
                 "source": "https://github.com/code-lts/U2F-php-server"
             },
             "time": "2024-07-24T15:01:10+00:00"
-        },
-        {
-            "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b4f54f74ef3453349c24a845d22392cd31e65f1d",
-                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1.0 || ^2.0",
-                "php": "^7 || ^8"
-            },
-            "replace": {
-                "ocramius/package-versions": "1.11.99"
-            },
-            "require-dev": {
-                "composer/composer": "^1.9.3 || ^2.0@dev",
-                "ext-zip": "^1.13",
-                "phpunit/phpunit": "^6.5 || ^7"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be"
-                }
-            ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "support": {
-                "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.5"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-17T14:14:24+00:00"
         },
         {
             "name": "composer/pcre",
@@ -3928,16 +3855,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201"
+                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
-                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16",
                 "shasum": ""
             },
             "require": {
@@ -4024,7 +3951,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.7.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.7.1"
             },
             "funding": [
                 {
@@ -4040,7 +3967,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-18T11:15:46+00:00"
+            "time": "2025-03-27T12:30:47+00:00"
         },
         {
             "name": "httpsoft/http-message",
@@ -5302,16 +5229,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.8",
+            "version": "2.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "f9adff3b87c03b12cc7e46a30a524648e497758f"
+                "reference": "8ca5f79a8f63c49b2359065832a654e1ec70ac30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f9adff3b87c03b12cc7e46a30a524648e497758f",
-                "reference": "f9adff3b87c03b12cc7e46a30a524648e497758f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8ca5f79a8f63c49b2359065832a654e1ec70ac30",
+                "reference": "8ca5f79a8f63c49b2359065832a654e1ec70ac30",
                 "shasum": ""
             },
             "require": {
@@ -5356,7 +5283,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-09T09:30:48+00:00"
+            "time": "2025-03-24T13:45:00+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -5407,16 +5334,16 @@
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "2.0.4",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "d09e152f403c843998d7a52b5d87040c937525dd"
+                "reference": "6b92469f8a7995e626da3aa487099617b8dfa260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/d09e152f403c843998d7a52b5d87040c937525dd",
-                "reference": "d09e152f403c843998d7a52b5d87040c937525dd",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/6b92469f8a7995e626da3aa487099617b8dfa260",
+                "reference": "6b92469f8a7995e626da3aa487099617b8dfa260",
                 "shasum": ""
             },
             "require": {
@@ -5427,7 +5354,9 @@
                 "phpunit/phpunit": "<7.0"
             },
             "require-dev": {
+                "nikic/php-parser": "^5",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
                 "phpstan/phpstan-strict-rules": "^2.0",
                 "phpunit/phpunit": "^9.6"
             },
@@ -5452,22 +5381,22 @@
             "description": "PHPUnit extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.4"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.6"
             },
-            "time": "2025-01-22T13:07:38+00:00"
+            "time": "2025-03-26T12:47:06+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-strict-rules.git",
-                "reference": "8b88b5f818bfa301e0c99154ab622dace071c3ba"
+                "reference": "3e139cbe67fafa3588e1dbe27ca50f31fdb6236a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/8b88b5f818bfa301e0c99154ab622dace071c3ba",
-                "reference": "8b88b5f818bfa301e0c99154ab622dace071c3ba",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/3e139cbe67fafa3588e1dbe27ca50f31fdb6236a",
+                "reference": "3e139cbe67fafa3588e1dbe27ca50f31fdb6236a",
                 "shasum": ""
             },
             "require": {
@@ -5500,9 +5429,9 @@
             "description": "Extra strict and opinionated rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.3"
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.4"
             },
-            "time": "2025-01-21T10:52:14+00:00"
+            "time": "2025-03-18T11:42:40+00:00"
         },
         {
             "name": "phpstan/phpstan-webmozart-assert",
@@ -5880,16 +5809,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.12",
+            "version": "11.5.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "d42785840519401ed2113292263795eb4c0f95da"
+                "reference": "4b6a4ee654e5e0c5e1f17e2f83c0f4c91dee1f9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d42785840519401ed2113292263795eb4c0f95da",
-                "reference": "d42785840519401ed2113292263795eb4c0f95da",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4b6a4ee654e5e0c5e1f17e2f83c0f4c91dee1f9c",
+                "reference": "4b6a4ee654e5e0c5e1f17e2f83c0f4c91dee1f9c",
                 "shasum": ""
             },
             "require": {
@@ -5909,14 +5838,14 @@
                 "phpunit/php-text-template": "^4.0.1",
                 "phpunit/php-timer": "^7.0.1",
                 "sebastian/cli-parser": "^3.0.2",
-                "sebastian/code-unit": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
                 "sebastian/comparator": "^6.3.1",
                 "sebastian/diff": "^6.0.2",
                 "sebastian/environment": "^7.2.0",
                 "sebastian/exporter": "^6.3.0",
                 "sebastian/global-state": "^7.0.2",
                 "sebastian/object-enumerator": "^6.0.1",
-                "sebastian/type": "^5.1.0",
+                "sebastian/type": "^5.1.2",
                 "sebastian/version": "^5.0.2",
                 "staabm/side-effects-detector": "^1.0.5"
             },
@@ -5961,7 +5890,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.12"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.15"
             },
             "funding": [
                 {
@@ -5977,7 +5906,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-07T07:31:03+00:00"
+            "time": "2025-03-23T16:02:11+00:00"
         },
         {
             "name": "pragmarx/google2fa",
@@ -6100,34 +6029,32 @@
         },
         {
             "name": "psalm/plugin-phpunit",
-            "version": "0.19.2",
+            "version": "0.19.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
-                "reference": "7b7a5cde988f83ccdbdf3ebaecd88192e01c5eb1"
+                "reference": "143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/7b7a5cde988f83ccdbdf3ebaecd88192e01c5eb1",
-                "reference": "7b7a5cde988f83ccdbdf3ebaecd88192e01c5eb1",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc",
+                "reference": "143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc",
                 "shasum": ""
             },
             "require": {
-                "composer/package-versions-deprecated": "^1.10",
-                "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "ext-simplexml": "*",
                 "php": ">=8.1",
-                "vimeo/psalm": "dev-master || ^6"
+                "vimeo/psalm": "dev-master || ^6.10.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<7.5"
+                "phpspec/prophecy": "<1.20.0",
+                "phpspec/prophecy-phpunit": "<2.3.0",
+                "phpunit/phpunit": "<8.5.1"
             },
             "require-dev": {
-                "codeception/codeception": "^4.0.3",
                 "php": "^7.3 || ^8.0",
-                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
+                "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
                 "squizlabs/php_codesniffer": "^3.3.1",
-                "weirdan/codeception-psalm-module": "^0.11.0",
                 "weirdan/prophecy-shim": "^1.0 || ^2.0"
             },
             "type": "psalm-plugin",
@@ -6154,9 +6081,9 @@
             "description": "Psalm plugin for PHPUnit",
             "support": {
                 "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
-                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.2"
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.5"
             },
-            "time": "2025-01-26T11:39:17+00:00"
+            "time": "2025-03-31T18:49:55+00:00"
         },
         {
             "name": "psr/clock",
@@ -6386,12 +6313,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "9e474e1c4987ea63445e2eaefed17e4a87acf2df"
+                "reference": "bd7c044c1ed8548dbfb9c4753be1c99a60809a41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/9e474e1c4987ea63445e2eaefed17e4a87acf2df",
-                "reference": "9e474e1c4987ea63445e2eaefed17e4a87acf2df",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/bd7c044c1ed8548dbfb9c4753be1c99a60809a41",
+                "reference": "bd7c044c1ed8548dbfb9c4753be1c99a60809a41",
                 "shasum": ""
             },
             "conflict": {
@@ -6420,7 +6347,7 @@
                 "andrewhaine/silverstripe-form-capture": ">=0.2,<=0.2.3|>=1,<1.0.2|>=2,<2.2.5",
                 "apache-solr-for-typo3/solr": "<2.8.3",
                 "apereo/phpcas": "<1.6",
-                "api-platform/core": ">=2.2,<2.2.10|>=2.3,<2.3.6|>=2.6,<2.7.10|>=3,<3.0.12|>=3.1,<3.1.3",
+                "api-platform/core": ">=2.2,<2.2.10|>=2.3,<2.3.6|>=2.6,<2.7.10|>=3,<3.0.12|>=3.1,<3.1.3|>=3.3.8,<3.3.15",
                 "appwrite/server-ce": "<=1.2.1",
                 "arc/web": "<3",
                 "area17/twill": "<1.2.5|>=2,<2.5.3",
@@ -6484,12 +6411,14 @@
                 "chriskacerguis/codeigniter-restserver": "<=2.7.1",
                 "civicrm/civicrm-core": ">=4.2,<4.2.9|>=4.3,<4.3.3",
                 "ckeditor/ckeditor": "<4.25",
+                "clickstorm/cs-seo": ">=6,<6.7|>=7,<7.4|>=8,<8.3|>=9,<9.2",
                 "cockpit-hq/cockpit": "<2.7|==2.7",
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
                 "codeigniter/framework": "<3.1.9",
                 "codeigniter4/framework": "<4.5.8",
                 "codeigniter4/shield": "<1.0.0.0-beta8",
                 "codiad/codiad": "<=2.8.4",
+                "codingms/additional-tca": ">=1.7,<1.15.17|>=1.16,<1.16.9",
                 "components/jquery": ">=1.0.3,<3.5",
                 "composer/composer": "<1.10.27|>=2,<2.2.24|>=2.3,<2.7.7",
                 "concrete5/concrete5": "<9.4.0.0-RC1-dev",
@@ -6498,7 +6427,7 @@
                 "contao/comments-bundle": ">=2,<4.13.40|>=5.0.0.0-RC1-dev,<5.3.4",
                 "contao/contao": "<=5.4.1",
                 "contao/core": "<3.5.39",
-                "contao/core-bundle": "<4.13.49|>=5,<5.3.15|>=5.4,<5.4.3",
+                "contao/core-bundle": "<4.13.54|>=5,<5.3.30|>=5.4,<5.5.6",
                 "contao/listing-bundle": ">=3,<=3.5.30|>=4,<4.4.8",
                 "contao/managed-edition": "<=1.5",
                 "corveda/phpsandbox": "<1.3.5",
@@ -6620,7 +6549,7 @@
                 "funadmin/funadmin": "<=5.0.2",
                 "gaoming13/wechat-php-sdk": "<=1.10.2",
                 "genix/cms": "<=1.1.11",
-                "getformwork/formwork": "<=2.0.0.0-beta3",
+                "getformwork/formwork": "<1.13.1|>=2.0.0.0-beta1,<2.0.0.0-beta4",
                 "getgrav/grav": "<1.7.46",
                 "getkirby/cms": "<=3.6.6.5|>=3.7,<=3.7.5.4|>=3.8,<=3.8.4.3|>=3.9,<=3.9.8.1|>=3.10,<=3.10.1|>=4,<=4.3",
                 "getkirby/kirby": "<=2.5.12",
@@ -6892,7 +6821,7 @@
                 "pimcore/ecommerce-framework-bundle": "<1.0.10",
                 "pimcore/perspective-editor": "<1.5.1",
                 "pimcore/pimcore": "<11.5.4",
-                "pixelfed/pixelfed": "<0.11.11",
+                "pixelfed/pixelfed": "<0.12.5",
                 "plotly/plotly.js": "<2.25.2",
                 "pocketmine/bedrock-protocol": "<8.0.2",
                 "pocketmine/pocketmine-mp": "<5.25.2",
@@ -6954,7 +6883,7 @@
                 "shopware/production": "<=6.3.5.2",
                 "shopware/shopware": "<=5.7.17",
                 "shopware/storefront": "<=6.4.8.1|>=6.5.8,<6.5.8.7-dev",
-                "shopxo/shopxo": "<=6.1",
+                "shopxo/shopxo": "<=6.4",
                 "showdoc/showdoc": "<2.10.4",
                 "shuchkin/simplexlsx": ">=1.0.12,<1.1.13",
                 "silverstripe-australia/advancedreports": ">=1,<=2",
@@ -7020,7 +6949,7 @@
                 "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
                 "sylius/grid": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
                 "sylius/grid-bundle": "<1.10.1",
-                "sylius/paypal-plugin": ">=1,<1.2.4|>=1.3,<1.3.1",
+                "sylius/paypal-plugin": "<1.6.2|>=1.7,<1.7.2|>=2,<2.0.2",
                 "sylius/resource-bundle": ">=1,<1.3.14|>=1.4,<1.4.7|>=1.5,<1.5.2|>=1.6,<1.6.4",
                 "sylius/sylius": "<1.12.19|>=1.13.0.0-alpha1,<1.13.4",
                 "symbiote/silverstripe-multivaluefield": ">=3,<3.1",
@@ -7066,7 +6995,7 @@
                 "t3/dce": "<0.11.5|>=2.2,<2.6.2",
                 "t3g/svg-sanitizer": "<1.0.3",
                 "t3s/content-consent": "<1.0.3|>=2,<2.0.2",
-                "tastyigniter/tastyigniter": "<3.3",
+                "tastyigniter/tastyigniter": "<4",
                 "tcg/voyager": "<=1.8",
                 "tecnickcom/tc-lib-pdf-font": "<2.6.4",
                 "tecnickcom/tcpdf": "<6.8",
@@ -7173,7 +7102,7 @@
                 "yiisoft/yii2": "<2.0.49.4-dev",
                 "yiisoft/yii2-authclient": "<2.2.15",
                 "yiisoft/yii2-bootstrap": "<2.0.4",
-                "yiisoft/yii2-dev": "<2.0.43",
+                "yiisoft/yii2-dev": "<=2.0.45",
                 "yiisoft/yii2-elasticsearch": "<2.0.5",
                 "yiisoft/yii2-gii": "<=2.2.4",
                 "yiisoft/yii2-jui": "<2.0.4",
@@ -7256,7 +7185,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-14T19:04:21+00:00"
+            "time": "2025-04-01T15:06:22+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -7317,16 +7246,16 @@
         },
         {
             "name": "sebastian/code-unit",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "ee88b0cdbe74cf8dd3b54940ff17643c0d6543ca"
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/ee88b0cdbe74cf8dd3b54940ff17643c0d6543ca",
-                "reference": "ee88b0cdbe74cf8dd3b54940ff17643c0d6543ca",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
                 "shasum": ""
             },
             "require": {
@@ -7362,7 +7291,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
                 "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
             },
             "funding": [
                 {
@@ -7370,7 +7299,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-12T09:59:06+00:00"
+            "time": "2025-03-19T07:56:08+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -8075,16 +8004,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "5.1.0",
+            "version": "5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "461b9c5da241511a2a0e8f240814fb23ce5c0aac"
+                "reference": "a8a7e30534b0eb0c77cd9d07e82de1a114389f5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/461b9c5da241511a2a0e8f240814fb23ce5c0aac",
-                "reference": "461b9c5da241511a2a0e8f240814fb23ce5c0aac",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/a8a7e30534b0eb0c77cd9d07e82de1a114389f5e",
+                "reference": "a8a7e30534b0eb0c77cd9d07e82de1a114389f5e",
                 "shasum": ""
             },
             "require": {
@@ -8120,7 +8049,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/5.1.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.2"
             },
             "funding": [
                 {
@@ -8128,7 +8057,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-17T13:12:04+00:00"
+            "time": "2025-03-18T13:35:50+00:00"
         },
         {
             "name": "sebastian/version",
@@ -8186,16 +8115,16 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.16.0",
+            "version": "8.16.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "7748a4282df19daf966fda1d8c60a8aec803c83a"
+                "reference": "8bf0408a9cf30687d87957d364de9a3d5d00d948"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/7748a4282df19daf966fda1d8c60a8aec803c83a",
-                "reference": "7748a4282df19daf966fda1d8c60a8aec803c83a",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/8bf0408a9cf30687d87957d364de9a3d5d00d948",
+                "reference": "8bf0408a9cf30687d87957d364de9a3d5d00d948",
                 "shasum": ""
             },
             "require": {
@@ -8207,11 +8136,11 @@
             "require-dev": {
                 "phing/phing": "3.0.1",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
-                "phpstan/phpstan": "2.1.6",
+                "phpstan/phpstan": "2.1.11",
                 "phpstan/phpstan-deprecation-rules": "2.0.1",
-                "phpstan/phpstan-phpunit": "2.0.4",
-                "phpstan/phpstan-strict-rules": "2.0.3",
-                "phpunit/phpunit": "9.6.8|10.5.45|11.4.4|11.5.9|12.0.4"
+                "phpstan/phpstan-phpunit": "2.0.6",
+                "phpstan/phpstan-strict-rules": "2.0.4",
+                "phpunit/phpunit": "9.6.8|10.5.45|11.4.4|11.5.15|12.0.10"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -8235,7 +8164,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.16.0"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.16.2"
             },
             "funding": [
                 {
@@ -8247,7 +8176,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-23T18:12:49+00:00"
+            "time": "2025-03-27T19:37:58+00:00"
         },
         {
             "name": "spatie/array-to-xml",
@@ -8511,16 +8440,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.11.3",
+            "version": "3.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10"
+                "reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
-                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
+                "reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
                 "shasum": ""
             },
             "require": {
@@ -8587,11 +8516,11 @@
                     "type": "open_collective"
                 },
                 {
-                    "url": "https://thanks.dev/phpcsstandards",
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-01-23T17:04:15+00:00"
+            "time": "2025-03-18T05:04:51+00:00"
         },
         {
             "name": "staabm/side-effects-detector",
@@ -8647,16 +8576,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.2.1",
+            "version": "v7.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3"
+                "reference": "e51498ea18570c062e7df29d05a7003585b19b88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
-                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e51498ea18570c062e7df29d05a7003585b19b88",
+                "reference": "e51498ea18570c062e7df29d05a7003585b19b88",
                 "shasum": ""
             },
             "require": {
@@ -8720,7 +8649,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.2.1"
+                "source": "https://github.com/symfony/console/tree/v7.2.5"
             },
             "funding": [
                 {
@@ -8736,7 +8665,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-11T03:49:26+00:00"
+            "time": "2025-03-12T08:11:12+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -9054,16 +8983,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.2.4",
+            "version": "v7.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "d8f411ff3c7ddc4ae9166fb388d1190a2df5b5cf"
+                "reference": "87b7c93e57df9d8e39a093d32587702380ff045d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/d8f411ff3c7ddc4ae9166fb388d1190a2df5b5cf",
-                "reference": "d8f411ff3c7ddc4ae9166fb388d1190a2df5b5cf",
+                "url": "https://api.github.com/repos/symfony/process/zipball/87b7c93e57df9d8e39a093d32587702380ff045d",
+                "reference": "87b7c93e57df9d8e39a093d32587702380ff045d",
                 "shasum": ""
             },
             "require": {
@@ -9095,7 +9024,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.2.4"
+                "source": "https://github.com/symfony/process/tree/v7.2.5"
             },
             "funding": [
                 {
@@ -9111,7 +9040,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-05T08:33:46+00:00"
+            "time": "2025-03-13T12:21:46+00:00"
         },
         {
             "name": "symfony/string",
@@ -9276,16 +9205,16 @@
         },
         {
             "name": "tecnickcom/tcpdf",
-            "version": "6.8.2",
+            "version": "6.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tecnickcom/TCPDF.git",
-                "reference": "f7a781073e1645062f163e058139e2f89355d420"
+                "reference": "f67b761b61f2370a9000d98c3b9111284544f722"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/f7a781073e1645062f163e058139e2f89355d420",
-                "reference": "f7a781073e1645062f163e058139e2f89355d420",
+                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/f67b761b61f2370a9000d98c3b9111284544f722",
+                "reference": "f67b761b61f2370a9000d98c3b9111284544f722",
                 "shasum": ""
             },
             "require": {
@@ -9298,8 +9227,6 @@
                     "config",
                     "include",
                     "tcpdf.php",
-                    "tcpdf_parser.php",
-                    "tcpdf_import.php",
                     "tcpdf_barcodes_1d.php",
                     "tcpdf_barcodes_2d.php",
                     "include/tcpdf_colors.php",
@@ -9337,7 +9264,7 @@
             ],
             "support": {
                 "issues": "https://github.com/tecnickcom/TCPDF/issues",
-                "source": "https://github.com/tecnickcom/TCPDF/tree/6.8.2"
+                "source": "https://github.com/tecnickcom/TCPDF/tree/6.9.0"
             },
             "funding": [
                 {
@@ -9345,7 +9272,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-01-26T14:03:12+00:00"
+            "time": "2025-03-30T16:56:09+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -9399,16 +9326,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.8.9",
+            "version": "6.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "e856423a5dc38d65e56b5792750c557277afe393"
+                "reference": "9c0add4eb88d4b169ac04acb7c679918cbb9c252"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e856423a5dc38d65e56b5792750c557277afe393",
-                "reference": "e856423a5dc38d65e56b5792750c557277afe393",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/9c0add4eb88d4b169ac04acb7c679918cbb9c252",
+                "reference": "9c0add4eb88d4b169ac04acb7c679918cbb9c252",
                 "shasum": ""
             },
             "require": {
@@ -9513,7 +9440,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-03-10T13:29:13+00:00"
+            "time": "2025-03-31T10:12:50+00:00"
         },
         {
             "name": "web-auth/cose-lib",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4399,12 +4399,6 @@ parameters:
 			path: src/Controllers/Table/Structure/SaveController.php
 
 		-
-			message: '#^Only booleans are allowed in an if condition, mixed given\.$#'
-			identifier: if.condNotBoolean
-			count: 1
-			path: src/Controllers/Table/Structure/SaveController.php
-
-		-
 			message: '#^Parameter \#1 \$identifier of static method PhpMyAdmin\\Util\:\:backquote\(\) expects string\|Stringable\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 3
@@ -10297,7 +10291,7 @@ parameters:
 			path: src/Plugins/Auth/AuthenticationSignon.php
 
 		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$selectedServer \(array\{host\: string, port\: string, socket\: string, ssl\: bool, ssl_key\: string\|null, ssl_cert\: string\|null, ssl_ca\: string\|null, ssl_ca_path\: string\|null, \.\.\.\}\) does not accept non\-empty\-array\<mixed, mixed\>\.$#'
+			message: '#^Property PhpMyAdmin\\Config\:\:\$selectedServer \(array\{host\: string, port\: string, socket\: string, ssl\: bool, ssl_key\: string\|null, ssl_cert\: string\|null, ssl_ca\: string\|null, ssl_ca_path\: string\|null, \.\.\.\}\) does not accept non\-empty\-array\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/Plugins/Auth/AuthenticationSignon.php
@@ -11814,12 +11808,6 @@ parameters:
 		-
 			message: '#^Cannot access property \$spreadsheet on SimpleXMLElement\|null\.$#'
 			identifier: property.nonObject
-			count: 1
-			path: src/Plugins/Import/ImportOds.php
-
-		-
-			message: '#^Cannot call method __toString\(\) on mixed\.$#'
-			identifier: method.nonObject
 			count: 1
 			path: src/Plugins/Import/ImportOds.php
 
@@ -18325,6 +18313,12 @@ parameters:
 			path: tests/unit/CoreTest.php
 
 		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertSame\(\) with array\{pos\: ''0'', db\: ''test_db'', table\: ''test_table''\} and array\{pos\: ''0'', eq\: string\} will always evaluate to false\.$#'
+			identifier: staticMethod.impossibleType
+			count: 2
+			path: tests/unit/CoreTest.php
+
+		-
 			message: '#^Cannot access offset ''arr1'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 5
@@ -18376,6 +18370,18 @@ parameters:
 			'''
 			identifier: staticMethod.deprecated
 			count: 4
+			path: tests/unit/Crypto/CryptoTest.php
+
+		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertArrayHasKey\(\) with ''URLQueryEncryptionS…'' and array\{URLQueryEncryptionSecretKey\: ''aaaaaaaaaaaaaaaaaaa…''\} will always evaluate to true\.$#'
+			identifier: staticMethod.alreadyNarrowedType
+			count: 1
+			path: tests/unit/Crypto/CryptoTest.php
+
+		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertArrayHasKey\(\) with ''URLQueryEncryptionS…'' and array\{\} will always evaluate to false\.$#'
+			identifier: staticMethod.impossibleType
+			count: 1
 			path: tests/unit/Crypto/CryptoTest.php
 
 		-
@@ -18567,23 +18573,11 @@ parameters:
 		-
 			message: '#^Cannot access offset ''display_binary'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
-			path: tests/unit/Display/ResultsTest.php
-
-		-
-			message: '#^Cannot access offset ''display_blob'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
-			path: tests/unit/Display/ResultsTest.php
-
-		-
-			message: '#^Cannot access offset ''geoOption'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
 			path: tests/unit/Display/ResultsTest.php
 
 		-
-			message: '#^Cannot access offset ''hide_transformation'' on mixed\.$#'
+			message: '#^Cannot access offset ''display_blob'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
 			path: tests/unit/Display/ResultsTest.php
@@ -18591,41 +18585,23 @@ parameters:
 		-
 			message: '#^Cannot access offset ''max_rows'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 6
+			count: 4
 			path: tests/unit/Display/ResultsTest.php
 
 		-
 			message: '#^Cannot access offset ''pftext'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
+			count: 2
 			path: tests/unit/Display/ResultsTest.php
 
 		-
 			message: '#^Cannot access offset ''pos'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
-			path: tests/unit/Display/ResultsTest.php
-
-		-
-			message: '#^Cannot access offset ''possible_as_geometry'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: tests/unit/Display/ResultsTest.php
-
-		-
-			message: '#^Cannot access offset ''query'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
+			count: 1
 			path: tests/unit/Display/ResultsTest.php
 
 		-
 			message: '#^Cannot access offset ''relational_display'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
-			path: tests/unit/Display/ResultsTest.php
-
-		-
-			message: '#^Cannot access offset ''repeat_cells'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
 			path: tests/unit/Display/ResultsTest.php
@@ -18728,6 +18704,12 @@ parameters:
 			identifier: staticMethod.deprecated
 			count: 3
 			path: tests/unit/FileListingTest.php
+
+		-
+			message: '#^Offset ''FlashMessenger'' does not exist on array\<mixed, mixed\>\.$#'
+			identifier: offsetAccess.notFound
+			count: 2
+			path: tests/unit/FlashMessengerTest.php
 
 		-
 			message: '#^@readonly property PhpMyAdmin\\Config\\Settings\\Debug\:\:\$sql is assigned outside of its declaring class\.$#'
@@ -18865,6 +18847,18 @@ parameters:
 			path: tests/unit/GitTest.php
 
 		-
+			message: '#^Cannot unset offset ''git_location'' on array\<mixed, mixed\>\.$#'
+			identifier: unset.offset
+			count: 2
+			path: tests/unit/GitTest.php
+
+		-
+			message: '#^Cannot unset offset ''is_git_revision'' on array\<mixed, mixed\>\.$#'
+			identifier: unset.offset
+			count: 2
+			path: tests/unit/GitTest.php
+
+		-
 			message: '''
 				#^Call to deprecated method getInstance\(\) of class PhpMyAdmin\\Config\:
 				Use dependency injection instead\.$#
@@ -18953,6 +18947,18 @@ parameters:
 			identifier: staticMethod.deprecated
 			count: 1
 			path: tests/unit/Html/MySQLDocumentationTest.php
+
+		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertArrayHasKey\(\) with ''test'' and array\{test\: ''test''\} will always evaluate to true\.$#'
+			identifier: staticMethod.alreadyNarrowedType
+			count: 1
+			path: tests/unit/Http/Middleware/TokenRequestParamCheckingTest.php
+
+		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertSame\(\) with ''test'' and ''test'' will always evaluate to true\.$#'
+			identifier: staticMethod.alreadyNarrowedType
+			count: 1
+			path: tests/unit/Http/Middleware/TokenRequestParamCheckingTest.php
 
 		-
 			message: '#^Binary operation "\." between mixed and ''/'' results in an error\.$#'
@@ -19393,6 +19399,12 @@ parameters:
 			path: tests/unit/Plugins/Auth/AuthenticationCookieTest.php
 
 		-
+			message: '#^Offset non\-falsy\-string does not exist on array\{\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: tests/unit/Plugins/Auth/AuthenticationCookieTest.php
+
+		-
 			message: '#^Property PhpMyAdmin\\Config\:\:\$selectedServer \(array\{host\: string, port\: string, socket\: string, ssl\: bool, ssl_key\: string\|null, ssl_cert\: string\|null, ssl_ca\: string\|null, ssl_ca_path\: string\|null, \.\.\.\}\) does not accept array\{auth_type\: ''cookie''\}\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -19450,6 +19462,12 @@ parameters:
 			'''
 			identifier: staticMethod.deprecated
 			count: 13
+			path: tests/unit/Plugins/Auth/AuthenticationSignonTest.php
+
+		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertSame\(\) with ''https\://example\.com…'' and ''https\://example\.com…'' will always evaluate to true\.$#'
+			identifier: staticMethod.alreadyNarrowedType
+			count: 1
 			path: tests/unit/Plugins/Auth/AuthenticationSignonTest.php
 
 		-
@@ -19585,12 +19603,6 @@ parameters:
 			'''
 			identifier: staticMethod.deprecated
 			count: 2
-			path: tests/unit/Plugins/Import/ImportLdiTest.php
-
-		-
-			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with ''auto'' will always evaluate to false\.$#'
-			identifier: staticMethod.impossibleType
-			count: 1
 			path: tests/unit/Plugins/Import/ImportLdiTest.php
 
 		-
@@ -19839,7 +19851,7 @@ parameters:
 		-
 			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertIsString\(\) with null will always evaluate to false\.$#'
 			identifier: staticMethod.impossibleType
-			count: 1
+			count: 2
 			path: tests/unit/SessionTest.php
 
 		-
@@ -19852,6 +19864,12 @@ parameters:
 			path: tests/unit/Setup/IndexTest.php
 
 		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertSame\(\) with array\{array\{array\{0\: ''foo'', fresh\: false, active\: false\}, array\{0\: ''bar'', fresh\: false, active\: false\}\}\} and array\{array\{array\{''foo''\}, array\{''bar''\}\}\} will always evaluate to false\.$#'
+			identifier: staticMethod.impossibleType
+			count: 1
+			path: tests/unit/Setup/IndexTest.php
+
+		-
 			message: '#^Cannot access offset ''123'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -19860,6 +19878,12 @@ parameters:
 		-
 			message: '#^Cannot access offset ''type'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/unit/Setup/IndexTest.php
+
+		-
+			message: '#^Offset ''messages'' does not exist on array\<mixed, mixed\>\.$#'
+			identifier: offsetAccess.notFound
 			count: 1
 			path: tests/unit/Setup/IndexTest.php
 
@@ -20077,6 +20101,12 @@ parameters:
 			path: tests/unit/TwoFactorTest.php
 
 		-
+			message: '#^Cannot unset offset ''2fa_code'' on array\<mixed, mixed\>\.$#'
+			identifier: unset.offset
+			count: 1
+			path: tests/unit/TwoFactorTest.php
+
+		-
 			message: '#^Method PhpMyAdmin\\Tests\\TwoFactorTest\:\:loadResultForConfig\(\) has parameter \$config with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -20155,9 +20185,15 @@ parameters:
 			path: tests/unit/UserPreferencesTest.php
 
 		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with false will always evaluate to false\.$#'
+			identifier: staticMethod.impossibleType
+			count: 1
+			path: tests/unit/UserPreferencesTest.php
+
+		-
 			message: '#^Cannot access offset ''db'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
+			count: 1
 			path: tests/unit/UserPreferencesTest.php
 
 		-
@@ -20176,6 +20212,12 @@ parameters:
 			message: '#^Cannot access offset ''userprefs'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
+			path: tests/unit/UserPreferencesTest.php
+
+		-
+			message: '#^Offset ''userconfig'' does not exist on array\<mixed, mixed\>\.$#'
+			identifier: offsetAccess.notFound
+			count: 3
 			path: tests/unit/UserPreferencesTest.php
 
 		-
@@ -20296,6 +20338,12 @@ parameters:
 			path: tests/unit/Utils/SessionCacheTest.php
 
 		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertArrayHasKey\(\) with ''cache'' and array\{\} will always evaluate to false\.$#'
+			identifier: staticMethod.impossibleType
+			count: 2
+			path: tests/unit/Utils/SessionCacheTest.php
+
+		-
 			message: '#^Cannot access offset ''server_2'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 4
@@ -20311,6 +20359,12 @@ parameters:
 			message: '#^Cannot access offset ''test_data_3'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
+			path: tests/unit/Utils/SessionCacheTest.php
+
+		-
+			message: '#^Offset ''cache'' does not exist on array\{\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 4
 			path: tests/unit/Utils/SessionCacheTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.8.9@e856423a5dc38d65e56b5792750c557277afe393">
+<files psalm-version="6.10.0@9c0add4eb88d4b169ac04acb7c679918cbb9c252">
   <file src="app/services_loader.php">
     <MixedArgument>
       <code><![CDATA[$argumentName]]></code>
@@ -9669,11 +9669,6 @@
       <code><![CDATA[$tempName]]></code>
     </PossiblyInvalidOperand>
   </file>
-  <file src="tests/end-to-end/ExportTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[exportDataProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="tests/end-to-end/TestBase.php">
     <DeprecatedConstant>
       <code><![CDATA[ChromeOptions::CAPABILITY_W3C]]></code>
@@ -9748,15 +9743,10 @@
     <DeprecatedMethod>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[advisorTimes]]></code>
-      <code><![CDATA[rulesProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Advisory/RulesTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestRules]]></code>
-    </PossiblyUnusedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testAdvisorBytime]]></code>
+      <code><![CDATA[testAdvisorBytime]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="tests/unit/BookmarkTest.php">
     <DeprecatedMethod>
@@ -9777,20 +9767,21 @@
     </MixedAssignment>
   </file>
   <file src="tests/unit/CacheTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[dataProviderCacheKeyValues]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Charsets/CollationTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerTestBuildDescription]]></code>
-    </PossiblyUnusedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testCacheGet]]></code>
+      <code><![CDATA[testCacheGetDefaultValue]]></code>
+      <code><![CDATA[testCacheHas]]></code>
+      <code><![CDATA[testCachePurge]]></code>
+      <code><![CDATA[testCacheRemove]]></code>
+      <code><![CDATA[testCacheSet]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="tests/unit/Command/SetVersionCommandTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[dataProviderBadVersions]]></code>
-      <code><![CDATA[dataProviderGoodVersions]]></code>
-    </PossiblyUnusedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testGetGeneratedClassInvalidVersion]]></code>
+      <code><![CDATA[testGetGeneratedClassValidVersion]]></code>
+      <code><![CDATA[testGetGeneratedClassValidVersion]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="tests/unit/Command/TwigLintCommandTest.php">
     <DeprecatedMethod>
@@ -9842,9 +9833,6 @@
     <PossiblyNullIterator>
       <code><![CDATA[$val]]></code>
     </PossiblyNullIterator>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[getValues]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Config/FormDisplayTemplateTest.php">
     <TypeDoesNotContainType>
@@ -9875,9 +9863,6 @@
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[formObjects]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Config/PageSettingsTest.php">
     <DeprecatedMethod>
@@ -9917,173 +9902,9 @@
       <code><![CDATA[$this->sessionID]]></code>
     </MixedAssignment>
   </file>
-  <file src="tests/unit/Config/Settings/ConsoleTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[booleanWithDefaultFalseProvider]]></code>
-      <code><![CDATA[booleanWithDefaultTrueProvider]]></code>
-      <code><![CDATA[valuesForHeightProvider]]></code>
-      <code><![CDATA[valuesForModeProvider]]></code>
-      <code><![CDATA[valuesForOrderByProvider]]></code>
-      <code><![CDATA[valuesForOrderProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Config/Settings/DebugTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[booleanWithDefaultFalseProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Config/Settings/ExportTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[booleanWithDefaultFalseProvider]]></code>
-      <code><![CDATA[booleanWithDefaultTrueProvider]]></code>
-      <code><![CDATA[structureOrDataWithDefaultDataProvider]]></code>
-      <code><![CDATA[structureOrDataWithDefaultStructureOrDataProvider]]></code>
-      <code><![CDATA[valuesForCharsetProvider]]></code>
-      <code><![CDATA[valuesForCodegenFormatProvider]]></code>
-      <code><![CDATA[valuesForCompressionProvider]]></code>
-      <code><![CDATA[valuesForCsvEnclosedProvider]]></code>
-      <code><![CDATA[valuesForCsvEscapedProvider]]></code>
-      <code><![CDATA[valuesForCsvNullProvider]]></code>
-      <code><![CDATA[valuesForCsvSeparatorProvider]]></code>
-      <code><![CDATA[valuesForCsvTerminatedProvider]]></code>
-      <code><![CDATA[valuesForExcelEditionProvider]]></code>
-      <code><![CDATA[valuesForExcelNullProvider]]></code>
-      <code><![CDATA[valuesForFileTemplateDatabaseProvider]]></code>
-      <code><![CDATA[valuesForFileTemplateServerProvider]]></code>
-      <code><![CDATA[valuesForFileTemplateTableProvider]]></code>
-      <code><![CDATA[valuesForFormatProvider]]></code>
-      <code><![CDATA[valuesForHtmlwordNullProvider]]></code>
-      <code><![CDATA[valuesForLatexDataCaptionProvider]]></code>
-      <code><![CDATA[valuesForLatexDataContinuedCaptionProvider]]></code>
-      <code><![CDATA[valuesForLatexDataLabelProvider]]></code>
-      <code><![CDATA[valuesForLatexNullProvider]]></code>
-      <code><![CDATA[valuesForLatexStructureCaptionProvider]]></code>
-      <code><![CDATA[valuesForLatexStructureContinuedCaptionProvider]]></code>
-      <code><![CDATA[valuesForLatexStructureLabelProvider]]></code>
-      <code><![CDATA[valuesForMethodProvider]]></code>
-      <code><![CDATA[valuesForOdsNullProvider]]></code>
-      <code><![CDATA[valuesForOdtNullProvider]]></code>
-      <code><![CDATA[valuesForPdfReportTitleProvider]]></code>
-      <code><![CDATA[valuesForSqlCompatibilityProvider]]></code>
-      <code><![CDATA[valuesForSqlHeaderCommentProvider]]></code>
-      <code><![CDATA[valuesForSqlInsertSyntaxProvider]]></code>
-      <code><![CDATA[valuesForSqlMaxQuerySizeProvider]]></code>
-      <code><![CDATA[valuesForSqlTypeProvider]]></code>
-      <code><![CDATA[valuesForTexytextNullProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Config/Settings/ImportTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[booleanWithDefaultFalseProvider]]></code>
-      <code><![CDATA[booleanWithDefaultTrueProvider]]></code>
-      <code><![CDATA[valuesForCharsetProvider]]></code>
-      <code><![CDATA[valuesForCsvColumnsProvider]]></code>
-      <code><![CDATA[valuesForCsvEnclosedProvider]]></code>
-      <code><![CDATA[valuesForCsvEscapedProvider]]></code>
-      <code><![CDATA[valuesForCsvNewLineProvider]]></code>
-      <code><![CDATA[valuesForCsvTerminatedProvider]]></code>
-      <code><![CDATA[valuesForFormatProvider]]></code>
-      <code><![CDATA[valuesForLdiColumnsProvider]]></code>
-      <code><![CDATA[valuesForLdiEnclosedProvider]]></code>
-      <code><![CDATA[valuesForLdiEscapedProvider]]></code>
-      <code><![CDATA[valuesForLdiLocalOptionProvider]]></code>
-      <code><![CDATA[valuesForLdiNewLineProvider]]></code>
-      <code><![CDATA[valuesForLdiTerminatedProvider]]></code>
-      <code><![CDATA[valuesForSkipQueriesProvider]]></code>
-      <code><![CDATA[valuesForSqlCompatibilityProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Config/Settings/SchemaTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestConstructor]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Config/Settings/ServerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[booleanWithDefaultFalseProvider]]></code>
-      <code><![CDATA[booleanWithDefaultTrueProvider]]></code>
-      <code><![CDATA[valuesForAllowDenyProvider]]></code>
-      <code><![CDATA[valuesForAuthHttpRealmProvider]]></code>
-      <code><![CDATA[valuesForAuthTypeProvider]]></code>
-      <code><![CDATA[valuesForConfigStorageTablesProvider]]></code>
-      <code><![CDATA[valuesForControlCompressProvider]]></code>
-      <code><![CDATA[valuesForControlHideConnectionErrorsProvider]]></code>
-      <code><![CDATA[valuesForControlHostProvider]]></code>
-      <code><![CDATA[valuesForControlPassProvider]]></code>
-      <code><![CDATA[valuesForControlPortProvider]]></code>
-      <code><![CDATA[valuesForControlSocketProvider]]></code>
-      <code><![CDATA[valuesForControlSslProvider]]></code>
-      <code><![CDATA[valuesForControlSslVerifyProvider]]></code>
-      <code><![CDATA[valuesForControlUserProvider]]></code>
-      <code><![CDATA[valuesForHideDbProvider]]></code>
-      <code><![CDATA[valuesForHostProvider]]></code>
-      <code><![CDATA[valuesForLogoutURLProvider]]></code>
-      <code><![CDATA[valuesForMaxTableUiPrefsProvider]]></code>
-      <code><![CDATA[valuesForOnlyDbProvider]]></code>
-      <code><![CDATA[valuesForPasswordProvider]]></code>
-      <code><![CDATA[valuesForPmaDbProvider]]></code>
-      <code><![CDATA[valuesForPortProvider]]></code>
-      <code><![CDATA[valuesForSessionTimeZoneProvider]]></code>
-      <code><![CDATA[valuesForSignonCookieParamsProvider]]></code>
-      <code><![CDATA[valuesForSignonScriptProvider]]></code>
-      <code><![CDATA[valuesForSignonSessionProvider]]></code>
-      <code><![CDATA[valuesForSignonURLProvider]]></code>
-      <code><![CDATA[valuesForSocketProvider]]></code>
-      <code><![CDATA[valuesForSslOptionsProvider]]></code>
-      <code><![CDATA[valuesForTrackingDefaultStatementsProvider]]></code>
-      <code><![CDATA[valuesForUserProvider]]></code>
-      <code><![CDATA[valuesForVerboseProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Config/Settings/SqlQueryBoxTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[booleanWithDefaultTrueProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Config/Settings/TransformationsTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[valuesForBool2TextProvider]]></code>
-      <code><![CDATA[valuesForDateFormatProvider]]></code>
-      <code><![CDATA[valuesForExternalProvider]]></code>
-      <code><![CDATA[valuesForHexProvider]]></code>
-      <code><![CDATA[valuesForInlineProvider]]></code>
-      <code><![CDATA[valuesForPreApPendProvider]]></code>
-      <code><![CDATA[valuesForSubstringProvider]]></code>
-      <code><![CDATA[valuesForTextImageLinkProvider]]></code>
-      <code><![CDATA[valuesForTextLinkProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="tests/unit/Config/SettingsTest.php">
     <PossiblyUnusedMethod>
-      <code><![CDATA[booleanWithDefaultFalseProvider]]></code>
-      <code><![CDATA[booleanWithDefaultTrueProvider]]></code>
-      <code><![CDATA[providerForTestConstructor]]></code>
-      <code><![CDATA[valuesForAllowThirdPartyFramingProvider]]></code>
-      <code><![CDATA[valuesForAuthLogProvider]]></code>
-      <code><![CDATA[valuesForBlowfishSecretProvider]]></code>
-      <code><![CDATA[valuesForDebugProvider]]></code>
-      <code><![CDATA[valuesForExecTimeLimitProvider]]></code>
-      <code><![CDATA[valuesForLimitCharsProvider]]></code>
-      <code><![CDATA[valuesForMaxCharactersInDisplayedSQLProvider]]></code>
-      <code><![CDATA[valuesForMaxDbListProvider]]></code>
-      <code><![CDATA[valuesForMaxRowsProvider]]></code>
-      <code><![CDATA[valuesForMaxTableListProvider]]></code>
-      <code><![CDATA[valuesForMysqlMinVersionProvider]]></code>
       <code><![CDATA[valuesForOBGzipProvider]]></code>
-      <code><![CDATA[valuesForPmaAbsoluteUriProvider]]></code>
-      <code><![CDATA[valuesForProxyPassProvider]]></code>
-      <code><![CDATA[valuesForProxyUrlProvider]]></code>
-      <code><![CDATA[valuesForProxyUserProvider]]></code>
-      <code><![CDATA[valuesForRepeatCellsProvider]]></code>
-      <code><![CDATA[valuesForServerDefaultProvider]]></code>
-      <code><![CDATA[valuesForServersProvider]]></code>
-      <code><![CDATA[valuesForSessionSavePathProvider]]></code>
-      <code><![CDATA[valuesForTranslationWarningThresholdProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/ConfigStorage/RelationParametersTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestToArray]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/ConfigStorage/RelationTest.php">
@@ -10220,9 +10041,6 @@
       <code><![CDATA[[]]]></code>
       <code><![CDATA[[]]]></code>
     </InvalidPropertyAssignmentValue>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestRenameTable]]></code>
-    </PossiblyUnusedMethod>
     <RedundantCondition>
       <code><![CDATA[assertSame]]></code>
       <code><![CDATA[assertSame]]></code>
@@ -10251,14 +10069,19 @@
     <MixedArgument>
       <code><![CDATA[$gdNfo['GD Version']]]></code>
     </MixedArgument>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[configPaths]]></code>
-      <code><![CDATA[connectionParams]]></code>
-      <code><![CDATA[connectionParamsWhenConnectionIsUserOrAuxiliaryProvider]]></code>
-      <code><![CDATA[httpsParams]]></code>
-      <code><![CDATA[rootUris]]></code>
-      <code><![CDATA[selectServerProvider]]></code>
-    </PossiblyUnusedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testIsHttps]]></code>
+      <code><![CDATA[testIsHttps]]></code>
+      <code><![CDATA[testIsHttps]]></code>
+      <code><![CDATA[testIsHttps]]></code>
+      <code><![CDATA[testIsHttps]]></code>
+      <code><![CDATA[testIsHttps]]></code>
+      <code><![CDATA[testIsHttps]]></code>
+      <code><![CDATA[testIsHttps]]></code>
+      <code><![CDATA[testIsHttps]]></code>
+      <code><![CDATA[testIsHttps]]></code>
+      <code><![CDATA[testIsHttps]]></code>
+    </PossiblyInvalidArgument>
     <RedundantConditionGivenDocblockType>
       <code><![CDATA[assertIsArray]]></code>
     </RedundantConditionGivenDocblockType>
@@ -10277,11 +10100,6 @@
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="tests/unit/Container/ContainerBuilderTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[servicesProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="tests/unit/Controllers/BrowseForeignersControllerTest.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
@@ -10291,9 +10109,6 @@
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[createConfigStorage]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Controllers/Console/Bookmark/AddControllerTest.php">
     <DeprecatedMethod>
@@ -10307,10 +10122,10 @@
     </DeprecatedMethod>
   </file>
   <file src="tests/unit/Controllers/Console/UpdateConfigControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[invalidParamsProvider]]></code>
-      <code><![CDATA[validParamsProvider]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[iterable<array{string, string, bool|int|string}>]]></code>
+      <code><![CDATA[iterable<array{string|string[], string|string[]}>]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="tests/unit/Controllers/Database/EventsControllerTest.php">
     <DeprecatedMethod>
@@ -10421,9 +10236,9 @@
     </DeprecatedMethod>
   </file>
   <file src="tests/unit/Controllers/GisDataEditorControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestValidateGisData]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[iterable<array{0:mixed,1:string,2:string|null,3:string}>]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="tests/unit/Controllers/Import/ImportControllerTest.php">
     <DeprecatedMethod>
@@ -10431,16 +10246,11 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="tests/unit/Controllers/Import/SimulateDmlControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestGetMatchedRows]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="tests/unit/Controllers/Navigation/UpdateNavWidthConfigControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[invalidParamsProvider]]></code>
-      <code><![CDATA[validParamsProvider]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[iterable<array{string, int}>]]></code>
+      <code><![CDATA[iterable<array{string|string[]}>]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="tests/unit/Controllers/NavigationControllerTest.php">
     <DeprecatedMethod>
@@ -10465,11 +10275,6 @@
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-  </file>
-  <file src="tests/unit/Controllers/Normalization/FirstNormalForm/FirstStepControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestDefault]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Controllers/Operations/TableControllerTest.php">
     <DeprecatedMethod>
@@ -10724,66 +10529,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="tests/unit/Controllers/Table/Maintenance/AnalyzeControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestNoTableSelected]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Controllers/Table/Maintenance/CheckControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestNoTableSelected]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Controllers/Table/Maintenance/ChecksumControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestNoTableSelected]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Controllers/Table/Maintenance/OptimizeControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestNoTableSelected]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Controllers/Table/Maintenance/RepairControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestNoTableSelected]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Controllers/Table/Partition/AnalyzeControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestInvalidDatabaseAndTable]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Controllers/Table/Partition/CheckControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestInvalidDatabaseAndTable]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Controllers/Table/Partition/DropControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestInvalidDatabaseAndTable]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Controllers/Table/Partition/OptimizeControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestInvalidDatabaseAndTable]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Controllers/Table/Partition/RebuildControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestInvalidDatabaseAndTable]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Controllers/Table/Partition/RepairControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestInvalidDatabaseAndTable]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Controllers/Table/Partition/TruncateControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestInvalidDatabaseAndTable]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="tests/unit/Controllers/Table/PrivilegesControllerTest.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
@@ -10811,11 +10556,6 @@
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-  </file>
-  <file src="tests/unit/Controllers/Table/Structure/MoveColumnsControllerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestGenerateAlterTableSql]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Controllers/Table/Structure/SpatialControllerTest.php">
     <DeprecatedMethod>
@@ -10854,18 +10594,15 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestWithoutTheme]]></code>
-    </PossiblyUnusedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testWithoutTheme]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="tests/unit/Controllers/Triggers/IndexControllerTest.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerGetDataFromRequest]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/CoreTest.php">
     <DeprecatedMethod>
@@ -10874,6 +10611,10 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
+    <InvalidArgument>
+      <code><![CDATA[testPopulateRequestWithEncryptedQueryParamsWithInvalidParam]]></code>
+      <code><![CDATA[testPopulateRequestWithEncryptedQueryParamsWithInvalidParam]]></code>
+    </InvalidArgument>
     <MixedArgument>
       <code><![CDATA[$arr['arr']]]></code>
       <code><![CDATA[$arr['arr']]]></code>
@@ -10913,15 +10654,6 @@
       <code><![CDATA[$arr['sarr'][0][1][0]]]></code>
       <code><![CDATA[$arr['sarr'][0][2]]]></code>
     </MixedArrayAccess>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[provideTestIsAllowedDomain]]></code>
-      <code><![CDATA[provideTestSafeUnserialize]]></code>
-      <code><![CDATA[provideTestSanitizeMySQLHost]]></code>
-      <code><![CDATA[providerForTestPopulateRequestWithEncryptedQueryParamsWithInvalidParam]]></code>
-      <code><![CDATA[providerTestGetRealSize]]></code>
-      <code><![CDATA[providerTestGotoNowhere]]></code>
-      <code><![CDATA[providerTestLinkURL]]></code>
-    </PossiblyUnusedMethod>
     <TypeDoesNotContainType>
       <code><![CDATA[assertSame]]></code>
       <code><![CDATA[assertSame]]></code>
@@ -10931,11 +10663,6 @@
     <DeprecatedMethod>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerGetColumnCreationQueryRequest]]></code>
-      <code><![CDATA[providerGetPartitionsDefinition]]></code>
-      <code><![CDATA[providerGetTableCreationQuery]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Crypto/CryptoTest.php">
     <DeprecatedMethod>
@@ -10999,10 +10726,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerGetDataFromRequest]]></code>
-      <code><![CDATA[providerGetQueryFromRequest]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Database/RoutinesTest.php">
     <DeprecatedMethod>
@@ -11016,18 +10739,11 @@
       <code><![CDATA[$_REQUEST[$key]]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerGetDataFromRequest]]></code>
-      <code><![CDATA[providerGetQueryFromRequest]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Database/SearchTest.php">
     <DeprecatedMethod>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[searchTypesAndOptions]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/DatabaseInterfaceTest.php">
     <ArgumentTypeCoercion>
@@ -11048,29 +10764,25 @@
       <code><![CDATA[$config->config->debug->sql]]></code>
       <code><![CDATA[$config->config->debug->sql]]></code>
     </InaccessibleProperty>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[currentRolesData]]></code>
-      <code><![CDATA[currentUserData]]></code>
-      <code><![CDATA[errorData]]></code>
-      <code><![CDATA[isAmazonRdsData]]></code>
-      <code><![CDATA[provideDatabaseVersionData]]></code>
-      <code><![CDATA[providerForTestGetLowerCaseNames]]></code>
-      <code><![CDATA[versionData]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testFormatError]]></code>
+      <code><![CDATA[testFormatError]]></code>
+      <code><![CDATA[testFormatError]]></code>
+      <code><![CDATA[testVersion]]></code>
+      <code><![CDATA[testVersion]]></code>
+      <code><![CDATA[testVersion]]></code>
+      <code><![CDATA[testVersion]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="tests/unit/Dbal/DbiDummyTest.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[errorData]]></code>
-      <code><![CDATA[schemaData]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Dbal/WarningTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestWarning]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Display/ResultsTest.php">
     <DeprecatedMethod>
@@ -11137,16 +10849,23 @@
       <code><![CDATA[$output]]></code>
       <code><![CDATA[$output]]></code>
     </MixedAssignment>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[dataProviderForTestGetDataCellForNonNumericColumns]]></code>
-      <code><![CDATA[dataProviderForTestGetPartialText]]></code>
-      <code><![CDATA[dataProviderForTestGetRowInfoForSpecialLinks]]></code>
-      <code><![CDATA[dataProviderForTestGetSpecialLinkUrl]]></code>
-      <code><![CDATA[dataProviderForTestHandleNonPrintableContents]]></code>
-      <code><![CDATA[dataProviderGetSortOrderHiddenInputs]]></code>
-      <code><![CDATA[dataProviderSortOrder]]></code>
-      <code><![CDATA[providerSetConfigParamsForDisplayTable]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testGetSortOrderHiddenInputs]]></code>
+      <code><![CDATA[testGetSortOrderHiddenInputs]]></code>
+      <code><![CDATA[testGetSortOrderHiddenInputs]]></code>
+      <code><![CDATA[testGetSortOrderHiddenInputs]]></code>
+      <code><![CDATA[testGetSortOrderHiddenInputs]]></code>
+      <code><![CDATA[testSetConfigParamsForDisplayTable]]></code>
+      <code><![CDATA[testSetConfigParamsForDisplayTable]]></code>
+      <code><![CDATA[testSetConfigParamsForDisplayTable]]></code>
+      <code><![CDATA[testSetConfigParamsForDisplayTable]]></code>
+      <code><![CDATA[testSetConfigParamsForDisplayTable]]></code>
+    </PossiblyInvalidArgument>
     <PropertyTypeCoercion>
       <code><![CDATA[$config->settings]]></code>
       <code><![CDATA[Config::getInstance()->settings]]></code>
@@ -11161,9 +10880,9 @@
     </DeprecatedMethod>
   </file>
   <file src="tests/unit/Engines/PbxtTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerFortTestResolveTypeSize]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="tests/unit/Error/ErrorHandlerTest.php">
     <DeprecatedMethod>
@@ -11175,31 +10894,20 @@
     <InvalidScalarArgument>
       <code><![CDATA[$_SESSION]]></code>
     </InvalidScalarArgument>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[addErrorProvider]]></code>
-      <code><![CDATA[providerForTestHandleError]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Error/ErrorReportTest.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testSanitizeUrl]]></code>
+      <code><![CDATA[testSanitizeUrl]]></code>
+    </PossiblyInvalidArgument>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$_SERVER['SERVER_SOFTWARE']]]></code>
       <code><![CDATA[$_SERVER['SERVER_SOFTWARE']]]></code>
     </PossiblyUndefinedArrayOffset>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[urlsToSanitize]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Error/ErrorTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[errorLevelProvider]]></code>
-      <code><![CDATA[errorTypeProvider]]></code>
-      <code><![CDATA[invalidFilePathsProvider]]></code>
-      <code><![CDATA[validFilePathsProvider]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Export/ExportTest.php">
     <DeprecatedMethod>
@@ -11225,11 +10933,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-  </file>
-  <file src="tests/unit/FileTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[compressedFiles]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/FooterTest.php">
     <DeprecatedMethod>
@@ -11262,105 +10965,26 @@
       <code><![CDATA[$temp['POLYGON'][0]['data_length']]]></code>
       <code><![CDATA[$temp['POLYGON'][1]['data_length']]]></code>
     </MixedArrayAccess>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForIsOuterRing]]></code>
-      <code><![CDATA[providerForTestArea]]></code>
-      <code><![CDATA[providerForTestGetPointOnSurface]]></code>
-      <code><![CDATA[providerForTestIsPointInsidePolygon]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Gis/GisFactoryTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestFromType]]></code>
-      <code><![CDATA[providerForTestFromWkt]]></code>
-    </PossiblyUnusedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testGetPointOnSurface]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="tests/unit/Gis/GisGeometryCollectionTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForPrepareRowAsOl]]></code>
-      <code><![CDATA[providerForPrepareRowAsPdf]]></code>
-      <code><![CDATA[providerForPrepareRowAsSvg]]></code>
-      <code><![CDATA[providerForTestGenerateParams]]></code>
-      <code><![CDATA[providerForTestGenerateWkt]]></code>
-      <code><![CDATA[providerForTestGetExtent]]></code>
-    </PossiblyUnusedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testGenerateWkt]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="tests/unit/Gis/GisGeometryTest.php">
     <MixedAssignment>
       <code><![CDATA[$extent]]></code>
       <code><![CDATA[$points]]></code>
     </MixedAssignment>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestExtractPointsInternal]]></code>
-      <code><![CDATA[providerForTestGetCoordinatesExtent]]></code>
-      <code><![CDATA[providerForTestParseWktAndSrid]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Gis/GisLineStringTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForPrepareRowAsOl]]></code>
-      <code><![CDATA[providerForPrepareRowAsPdf]]></code>
-      <code><![CDATA[providerForPrepareRowAsSvg]]></code>
-      <code><![CDATA[providerForTestGenerateParams]]></code>
-      <code><![CDATA[providerForTestGenerateWkt]]></code>
-      <code><![CDATA[providerForTestGetExtent]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Gis/GisMultiLineStringTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForPrepareRowAsOl]]></code>
-      <code><![CDATA[providerForPrepareRowAsPdf]]></code>
-      <code><![CDATA[providerForPrepareRowAsSvg]]></code>
-      <code><![CDATA[providerForTestGenerateParams]]></code>
-      <code><![CDATA[providerForTestGenerateWkt]]></code>
-      <code><![CDATA[providerForTestGetExtent]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Gis/GisMultiPointTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForPrepareRowAsOl]]></code>
-      <code><![CDATA[providerForPrepareRowAsPdf]]></code>
-      <code><![CDATA[providerForPrepareRowAsSvg]]></code>
-      <code><![CDATA[providerForTestGenerateParams]]></code>
-      <code><![CDATA[providerForTestGenerateWkt]]></code>
-      <code><![CDATA[providerForTestGetExtent]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Gis/GisMultiPolygonTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForPrepareRowAsOl]]></code>
-      <code><![CDATA[providerForPrepareRowAsPdf]]></code>
-      <code><![CDATA[providerForPrepareRowAsSvg]]></code>
-      <code><![CDATA[providerForTestGenerateParams]]></code>
-      <code><![CDATA[providerForTestGenerateWkt]]></code>
-      <code><![CDATA[providerForTestGetExtent]]></code>
-      <code><![CDATA[providerForTestGetShape]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Gis/GisPointTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForPrepareRowAsOl]]></code>
-      <code><![CDATA[providerForPrepareRowAsPdf]]></code>
-      <code><![CDATA[providerForPrepareRowAsSvg]]></code>
-      <code><![CDATA[providerForTestGenerateParams]]></code>
-      <code><![CDATA[providerForTestGenerateWkt]]></code>
-      <code><![CDATA[providerForTestGetExtent]]></code>
-      <code><![CDATA[providerForTestGetShape]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Gis/GisPolygonTest.php">
     <MixedArrayAccess>
       <code><![CDATA[$temp1[0]['POLYGON'][1][3]]]></code>
       <code><![CDATA[$temp1[0]['POLYGON'][1][3]['y']]]></code>
     </MixedArrayAccess>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForPrepareRowAsOl]]></code>
-      <code><![CDATA[providerForPrepareRowAsPdf]]></code>
-      <code><![CDATA[providerForPrepareRowAsSvg]]></code>
-      <code><![CDATA[providerForTestGenerateParams]]></code>
-      <code><![CDATA[providerForTestGenerateWkt]]></code>
-      <code><![CDATA[providerForTestGetExtent]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Gis/GisVisualizationTest.php">
     <MixedAssignment>
@@ -11393,9 +11017,17 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestGetHttpHeaders]]></code>
-    </PossiblyUnusedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testGetHttpHeaders]]></code>
+      <code><![CDATA[testGetHttpHeaders]]></code>
+      <code><![CDATA[testGetHttpHeaders]]></code>
+      <code><![CDATA[testGetHttpHeaders]]></code>
+      <code><![CDATA[testGetHttpHeaders]]></code>
+      <code><![CDATA[testGetHttpHeaders]]></code>
+      <code><![CDATA[testGetHttpHeaders]]></code>
+      <code><![CDATA[testGetHttpHeaders]]></code>
+      <code><![CDATA[testGetHttpHeaders]]></code>
+    </PossiblyInvalidArgument>
     <PropertyTypeCoercion>
       <code><![CDATA[$config->settings]]></code>
       <code><![CDATA[$config->settings]]></code>
@@ -11442,10 +11074,9 @@
       <code><![CDATA[$params]]></code>
       <code><![CDATA[$params]]></code>
     </MixedArgument>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[linksOrButtons]]></code>
-      <code><![CDATA[providerForTestGetDefaultFunctionForField]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
     <PropertyTypeCoercion>
       <code><![CDATA[$config->settings]]></code>
     </PropertyTypeCoercion>
@@ -11455,12 +11086,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="tests/unit/Http/Factory/ResponseFactoryTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestCreate]]></code>
-      <code><![CDATA[providerForTestCreateResponse]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="tests/unit/Http/Factory/ServerRequestFactoryTest.php">
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$_SERVER['PHP_SELF']]]></code>
@@ -11469,57 +11094,11 @@
       <code><![CDATA[$_SERVER['SCRIPT_NAME']]]></code>
       <code><![CDATA[$_SERVER['argv']]]></code>
     </PossiblyUndefinedArrayOffset>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestCreate]]></code>
-      <code><![CDATA[providerForTestCreateServerRequest]]></code>
-      <code><![CDATA[providerForTestFromGlobals]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Http/Factory/UriFactoryTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestCreateUri]]></code>
-      <code><![CDATA[uriFactoryProviders]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Http/Middleware/TokenRequestParamCheckingTest.php">
     <RedundantCondition>
       <code><![CDATA[assertSame]]></code>
     </RedundantCondition>
-  </file>
-  <file src="tests/unit/Http/ResponseTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[responseFactoryProviders]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Http/ServerRequestTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[isAjaxProvider]]></code>
-      <code><![CDATA[providerForTestGetRoute]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/I18n/LanguageManagerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[availableLocalesProvider]]></code>
-      <code><![CDATA[selectDataProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Identifiers/DatabaseNameTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestInvalidNames]]></code>
-      <code><![CDATA[providerForTestValidNames]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Identifiers/TableNameTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestInvalidNames]]></code>
-      <code><![CDATA[providerForTestValidNames]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Identifiers/TriggerNameTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestInvalidNames]]></code>
-      <code><![CDATA[providerForTestValidNames]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Import/ImportTest.php">
     <DeprecatedMethod>
@@ -11536,15 +11115,14 @@
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[Config::getInstance()->settings]]></code>
     </InvalidPropertyAssignmentValue>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[provDetectType]]></code>
-      <code><![CDATA[provGetColumnAlphaName]]></code>
-      <code><![CDATA[provGetColumnNumberFromName]]></code>
-      <code><![CDATA[provGetDecimalSize]]></code>
-      <code><![CDATA[provPMACheckIfRollbackPossibleNegative]]></code>
-      <code><![CDATA[provPMACheckIfRollbackPossiblePositive]]></code>
-      <code><![CDATA[providerContentWithByteOrderMarks]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testSkipByteOrderMarksFromContents]]></code>
+      <code><![CDATA[testSkipByteOrderMarksFromContents]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="tests/unit/Indexes/IndexTest.php">
     <MixedArgument>
@@ -11634,10 +11212,6 @@
     <PossiblyInvalidCast>
       <code><![CDATA[$value]]></code>
     </PossiblyInvalidCast>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[dataProviderConfigValueInsertRows]]></code>
-      <code><![CDATA[providerForTestGetSpecialCharsForInsertingMode]]></code>
-    </PossiblyUnusedMethod>
     <PropertyTypeCoercion>
       <code><![CDATA[Config::getInstance()->settings]]></code>
     </PropertyTypeCoercion>
@@ -11652,34 +11226,24 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
     <PossiblyNullArrayOffset>
       <code><![CDATA[$config->settings['TrustedProxies']]]></code>
     </PossiblyNullArrayOffset>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[proxyIPs]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/LinterTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[lintProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/ListDatabaseTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestGetList]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/MessageTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerAffectedRows]]></code>
-      <code><![CDATA[providerDeletedRows]]></code>
-      <code><![CDATA[providerInsertedRows]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="tests/unit/MimeTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestDetect]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="tests/unit/Navigation/NavigationTest.php">
     <DeprecatedMethod>
@@ -11711,9 +11275,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestIcon]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Navigation/Nodes/NodeTest.php">
     <DeprecatedMethod>
@@ -11759,23 +11320,9 @@
     </InvalidPropertyAssignmentValue>
   </file>
   <file src="tests/unit/OperationsTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerGetPartitionMaintenanceChoices]]></code>
-    </PossiblyUnusedMethod>
     <TypeDoesNotContainType>
       <code><![CDATA[assertSame]]></code>
     </TypeDoesNotContainType>
-  </file>
-  <file src="tests/unit/Partitioning/PartitionTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestHavePartitioning]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Partitioning/TablePartitionDefinitionTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerGetDetails]]></code>
-      <code><![CDATA[providerGetDetailsWithMaxPartitions]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/PdfTest.php">
     <MixedArgument>
@@ -11865,10 +11412,10 @@
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$config->selectedServer]]></code>
     </MixedPropertyTypeCoercion>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[checkRulesProvider]]></code>
-      <code><![CDATA[dataProviderPasswordLength]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
     <PropertyTypeCoercion>
       <code><![CDATA[$config->settings]]></code>
       <code><![CDATA[$config->settings]]></code>
@@ -11897,9 +11444,9 @@
       <code><![CDATA[['host' => 'a', 'user' => 'user2']]]></code>
       <code><![CDATA[['host' => 'a', 'user' => 'user2']]]></code>
     </InvalidPropertyAssignmentValue>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[readCredentialsProvider]]></code>
-    </PossiblyUnusedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testAuthCheck]]></code>
+    </PossiblyInvalidArgument>
     <RedundantCondition>
       <code><![CDATA[assertSame]]></code>
       <code><![CDATA[assertSame]]></code>
@@ -11947,9 +11494,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestValidPlugins]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Plugins/Export/ExportHtmlwordTest.php">
     <DeprecatedMethod>
@@ -11972,9 +11516,9 @@
       <code><![CDATA[$config->selectedServer]]></code>
       <code><![CDATA[$config->selectedServer]]></code>
     </InvalidPropertyAssignmentValue>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForGetTranslatedText]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[iterable<array{string, string}>]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="tests/unit/Plugins/Export/ExportOdtTest.php">
     <DeprecatedMethod>
@@ -12027,12 +11571,12 @@
     </InvalidPropertyAssignmentValue>
   </file>
   <file src="tests/unit/Plugins/Export/Helpers/TablePropertyTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[getDotNetObjectTypeProvider]]></code>
-      <code><![CDATA[getDotNetPrimitiveTypeProvider]]></code>
-      <code><![CDATA[isNotNullProvider]]></code>
-      <code><![CDATA[isUniqueProvider]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="tests/unit/Plugins/Import/ImportLdiTest.php">
     <DeprecatedMethod>
@@ -12047,9 +11591,6 @@
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[dataProviderOdsEmptyRows]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Plugins/Import/ImportShpTest.php">
     <RedundantCondition>
@@ -12081,10 +11622,12 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[multiDataProvider]]></code>
-      <code><![CDATA[transformationDataProvider]]></code>
-    </PossiblyUnusedMethod>
+    <InvalidArgument>
+      <code><![CDATA[testTransformation]]></code>
+    </InvalidArgument>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testTransformation]]></code>
+    </PossiblyInvalidArgument>
     <PropertyTypeCoercion>
       <code><![CDATA[['pma' => 'aaa', 'pca' => 'bbb']]]></code>
     </PropertyTypeCoercion>
@@ -12094,19 +11637,9 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestGetDefault]]></code>
-    </PossiblyUnusedMethod>
     <PropertyTypeCoercion>
       <code><![CDATA[Config::getInstance()->settings]]></code>
     </PropertyTypeCoercion>
-  </file>
-  <file src="tests/unit/Query/CompatibilityTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestHasAccountLocking]]></code>
-      <code><![CDATA[providerForTestIsUUIDSupported]]></code>
-      <code><![CDATA[showBinLogStatusProvider]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Replication/ReplicationGuiTest.php">
     <DeprecatedMethod>
@@ -12132,16 +11665,13 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestCleanupPathInfo]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/SanitizeTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[dataProviderCheckLinks]]></code>
-      <code><![CDATA[docLinks]]></code>
-      <code><![CDATA[variables]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="tests/unit/Server/PluginsTest.php">
     <DeprecatedMethod>
@@ -12166,10 +11696,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerGetHostname]]></code>
-      <code><![CDATA[providerUnEscapeMysqlWildcards]]></code>
-    </PossiblyUnusedMethod>
     <UnusedVariable>
       <code><![CDATA[$password]]></code>
     </UnusedVariable>
@@ -12196,18 +11722,11 @@
     </InvalidPropertyAssignmentValue>
     <PossiblyInvalidArgument>
       <code><![CDATA[$server['only_db']]]></code>
+      <code><![CDATA[testRender]]></code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast>
       <code><![CDATA[$server['only_db']]]></code>
     </PossiblyInvalidCast>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[renderDataProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Server/SysInfo/SysInfoTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[sysInfoOsProvider]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Setup/ConfigGeneratorTest.php">
     <MixedAssignment>
@@ -12257,14 +11776,19 @@
       <code><![CDATA[$_SESSION['tmpval']['max_rows']]]></code>
       <code><![CDATA[$_SESSION['tmpval']['pos']]]></code>
     </MixedArrayAssignment>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[dataProviderCountQueryResults]]></code>
-    </PossiblyUnusedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testCountQueryResults]]></code>
+      <code><![CDATA[testCountQueryResults]]></code>
+      <code><![CDATA[testCountQueryResults]]></code>
+      <code><![CDATA[testCountQueryResults]]></code>
+      <code><![CDATA[testCountQueryResults]]></code>
+      <code><![CDATA[testCountQueryResults]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="tests/unit/StorageEngineTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerGetEngine]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="tests/unit/Stubs/DummyResult.php">
     <InvalidReturnStatement>
@@ -12303,14 +11827,6 @@
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerColumnMetaDefault]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Table/Maintenance/MessageTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForTestFromArray]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/Table/SearchTest.php">
     <DeprecatedMethod>
@@ -12326,16 +11842,13 @@
       <code><![CDATA[$isDefineProperty]]></code>
       <code><![CDATA[$sql]]></code>
     </MixedAssignment>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[dataValidateName]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/TemplateTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerTestDynamicRender]]></code>
-      <code><![CDATA[providerTestRender]]></code>
-      <code><![CDATA[providerTestSet]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="tests/unit/Theme/ThemeManagerTest.php">
     <DeprecatedMethod>
@@ -12343,9 +11856,9 @@
     </DeprecatedMethod>
   </file>
   <file src="tests/unit/Theme/ThemeTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForGetImgPath]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="tests/unit/Tracking/TrackerTest.php">
     <DeprecatedMethod>
@@ -12362,9 +11875,9 @@
       <code><![CDATA[$config->selectedServer]]></code>
       <code><![CDATA[$config->selectedServer]]></code>
     </InvalidPropertyAssignmentValue>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[parseQueryData]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="tests/unit/Tracking/TrackingTest.php">
     <DeprecatedMethod>
@@ -12379,13 +11892,13 @@
       <code><![CDATA[$ret[0]['statement']]]></code>
       <code><![CDATA[$ret[0]['username']]]></code>
     </MixedArrayAccess>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$data[0]]]></code>
       <code><![CDATA[$fetchArrayReturn[0]]]></code>
     </PossiblyUndefinedArrayOffset>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[getTrackedDataProvider]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/TransformationsTest.php">
     <DeprecatedMethod>
@@ -12394,18 +11907,16 @@
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[['ServerDefault' => 1, 'ActionLinksMode' => 'icons']]]></code>
     </InvalidPropertyAssignmentValue>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[fixupData]]></code>
-      <code><![CDATA[getOptionsData]]></code>
-      <code><![CDATA[providerGetDescription]]></code>
-      <code><![CDATA[providerGetName]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Triggers/TriggerTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[arrayWithInvalidValuesProvider]]></code>
-      <code><![CDATA[arrayWithValidValuesProvider]]></code>
-    </PossiblyUnusedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testFixup]]></code>
+      <code><![CDATA[testFixup]]></code>
+      <code><![CDATA[testGetDescription]]></code>
+      <code><![CDATA[testGetDescription]]></code>
+      <code><![CDATA[testGetName]]></code>
+      <code><![CDATA[testGetName]]></code>
+      <code><![CDATA[testGetOptions]]></code>
+      <code><![CDATA[testGetOptions]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="tests/unit/Triggers/TriggersTest.php">
     <DeprecatedMethod>
@@ -12416,15 +11927,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerGetQueryFromRequest]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/Twig/Node/Expression/TransExpressionTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[transExpressionsProvider]]></code>
-      <code><![CDATA[transExpressionsWithErrorProvider]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/TwoFactorTest.php">
     <DeprecatedMethod>
@@ -12448,32 +11950,15 @@
       <code><![CDATA[$object->config['settings']['secret']]]></code>
     </MixedArgument>
   </file>
-  <file src="tests/unit/TypesByDatabaseVersionTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerFortTestGetAllFunctions]]></code>
-      <code><![CDATA[providerFortTestGetColumns]]></code>
-      <code><![CDATA[providerFortTestGetFunctionsClass]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="tests/unit/TypesTest.php">
     <DeprecatedMethod>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerForGetTypeOperators]]></code>
-      <code><![CDATA[providerForTestGetTypeDescription]]></code>
-      <code><![CDATA[providerForTestGetTypeOperatorsHtml]]></code>
-      <code><![CDATA[providerFortTestGetFunctionsClass]]></code>
-      <code><![CDATA[providerFortTestGetTypeClass]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/UniqueConditionTest.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerGetUniqueConditionForGroupFlag]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/UrlRedirectorTest.php">
     <DeprecatedMethod>
@@ -12491,14 +11976,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[getArgSeparatorProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/UserPasswordTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerSetChangePasswordMsg]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="tests/unit/UserPreferencesTest.php">
     <DeprecatedMethod>
@@ -12559,55 +12036,60 @@
       <code><![CDATA[$_SESSION['cache']['server_2']['is_superuser']]]></code>
       <code><![CDATA[$_SESSION['cache']['server_2']['mysql_cur_user']]]></code>
     </MixedArrayAccess>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[charsetQueryData]]></code>
-      <code><![CDATA[provideForTestIsUUIDSupported]]></code>
-      <code><![CDATA[providerConvertBitDefaultValue]]></code>
-      <code><![CDATA[providerDuplicateFirstNewline]]></code>
-      <code><![CDATA[providerExpandUserString]]></code>
-      <code><![CDATA[providerExtractColumnSpec]]></code>
-      <code><![CDATA[providerExtractValueFromFormattedSize]]></code>
-      <code><![CDATA[providerForTestBackquote]]></code>
-      <code><![CDATA[providerForTestGetLowerCaseNames]]></code>
-      <code><![CDATA[providerForTestGetMySQLDocuURL]]></code>
-      <code><![CDATA[providerForTestGetValueByKey]]></code>
-      <code><![CDATA[providerFormatByteDown]]></code>
-      <code><![CDATA[providerFormatNumber]]></code>
-      <code><![CDATA[providerForwardedHeaders]]></code>
-      <code><![CDATA[providerGetFormattedMaximumUploadSize]]></code>
-      <code><![CDATA[providerGetTitleForTarget]]></code>
-      <code><![CDATA[providerIsInteger]]></code>
-      <code><![CDATA[providerLocalisedDate]]></code>
-      <code><![CDATA[providerParseEnumSetValues]]></code>
-      <code><![CDATA[providerPrintableBitValue]]></code>
-      <code><![CDATA[providerTimespanFormat]]></code>
-      <code><![CDATA[providerUnQuote]]></code>
-      <code><![CDATA[providerUnQuoteSelectedChar]]></code>
-      <code><![CDATA[providerUserDir]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testBackquote]]></code>
+      <code><![CDATA[testBackquote]]></code>
+      <code><![CDATA[testBackquote]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="tests/unit/Utils/ForeignKeyTest.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerCheckCleanup]]></code>
-      <code><![CDATA[providerCheckInit]]></code>
-      <code><![CDATA[providerIsSupported]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testHandleDisableCheckCleanup]]></code>
+      <code><![CDATA[testHandleDisableCheckCleanup]]></code>
+      <code><![CDATA[testHandleDisableCheckInit]]></code>
+      <code><![CDATA[testHandleDisableCheckInit]]></code>
+      <code><![CDATA[testHandleDisableCheckInitVarFalse]]></code>
+      <code><![CDATA[testHandleDisableCheckInitVarFalse]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="tests/unit/Utils/FormatConverterTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerBinaryToIp]]></code>
-      <code><![CDATA[providerIpToBinary]]></code>
-      <code><![CDATA[providerIpToLong]]></code>
-      <code><![CDATA[providerLongToIp]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="tests/unit/Utils/GisTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[providerConvertToWellKnownText]]></code>
-    </PossiblyUnusedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[testConvertToWellKnownText]]></code>
+      <code><![CDATA[testConvertToWellKnownText]]></code>
+      <code><![CDATA[testConvertToWellKnownText]]></code>
+      <code><![CDATA[testConvertToWellKnownText]]></code>
+      <code><![CDATA[testConvertToWellKnownText]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="tests/unit/Utils/HttpRequestTest.php">
     <MixedArgument>
@@ -12625,9 +12107,6 @@
     <MixedOperand>
       <code><![CDATA[$curl !== false ? $curl['ssl_version'] : '?']]></code>
     </MixedOperand>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[httpRequests]]></code>
-    </PossiblyUnusedMethod>
     <RedundantCondition>
       <code><![CDATA[$curl !== false]]></code>
       <code><![CDATA[$curl !== false]]></code>
@@ -12675,11 +12154,6 @@
       <code><![CDATA[$_SESSION['cache']['server_2']['test_data_3']]]></code>
     </MixedArrayAccess>
   </file>
-  <file src="tests/unit/Utils/UserAgentParserTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[userAgentProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="tests/unit/VersionInformationTest.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
@@ -12696,21 +12170,8 @@
     <MixedArrayAccess>
       <code><![CDATA[$_SESSION['cache']['version_check']]]></code>
     </MixedArrayAccess>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[dataProviderVersionConditions]]></code>
-      <code><![CDATA[dataVersions]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/WebAuthn/CBORDecoderTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[dataProviderForTestDecode]]></code>
-      <code><![CDATA[indefiniteLengthValuesProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="tests/unit/ZipExtensionTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[provideTestFindFile]]></code>
-      <code><![CDATA[provideTestGetContents]]></code>
-    </PossiblyUnusedMethod>
+    <MixedReturnStatement>
+      <code><![CDATA[mixed[]]]></code>
+    </MixedReturnStatement>
   </file>
 </files>


### PR DESCRIPTION
  - Removing composer/package-versions-deprecated (1.11.99.5)
  - Upgrading amphp/byte-stream (v2.1.1 => v2.1.2)
  - Upgrading amphp/pipeline (v1.2.2 => v1.2.3)
  - Upgrading guzzlehttp/psr7 (2.7.0 => 2.7.1)
  - Upgrading phpmyadmin/motranslator (dev-master 37e080d => dev-master 0b0b217)
  - Upgrading phpmyadmin/sql-parser (dev-master ebcca8b => dev-master 8fb3e83)
  - Upgrading phpstan/phpstan (2.1.8 => 2.1.11)
  - Upgrading phpstan/phpstan-phpunit (2.0.4 => 2.0.6)
  - Upgrading phpstan/phpstan-strict-rules (2.0.3 => 2.0.4)
  - Upgrading phpunit/phpunit (11.5.12 => 11.5.15)
  - Upgrading psalm/plugin-phpunit (0.19.2 => 0.19.5)
  - Upgrading roave/security-advisories (dev-latest 9e474e1 => dev-latest bd7c044)
  - Upgrading sebastian/code-unit (3.0.2 => 3.0.3)
  - Upgrading sebastian/type (5.1.0 => 5.1.2)
  - Upgrading slevomat/coding-standard (8.16.0 => 8.16.2)
  - Upgrading squizlabs/php_codesniffer (3.11.3 => 3.12.0)
  - Upgrading symfony/cache (v7.2.4 => v7.2.5)
  - Upgrading symfony/console (v7.2.1 => v7.2.5)
  - Upgrading symfony/dependency-injection (v7.2.4 => v7.2.5)
  - Upgrading symfony/process (v7.2.4 => v7.2.5)
  - Upgrading symfony/var-exporter (v7.2.4 => v7.2.5)
  - Upgrading tecnickcom/tcpdf (6.8.2 => 6.9.0)
  - Upgrading vimeo/psalm (6.8.9 => 6.10.0)


