### PR TITLE
Show small note in export stating about invalid export files

### DIFF
--- a/resources/templates/export.twig
+++ b/resources/templates/export.twig
@@ -422,7 +422,10 @@
                 <li class="list-group-item">
                   <div class="row">
                     <div class="col-auto">
-                      <label for="compression" class="col-form-label">{{ t('Compression:') }}</label>
+                      <label for="compression" class="col-form-label">
+                        {{ t('Compression:') }}
+                        {{ show_hint('Compressing big tables requires PHP memory. Be aware that this might produce invalid files %s'|format(get_formatted_maximum_upload_size(export_memory_limit))) }}
+                      </label>
                     </div>
                     <div class="col-auto">
                       <select class="form-select" id="compression" name="compression">

--- a/src/Controllers/Database/ExportController.php
+++ b/src/Controllers/Database/ExportController.php
@@ -145,6 +145,7 @@ final class ExportController implements InvocableController
         );
 
         $this->response->render('database/export/index', array_merge($options, [
+            'export_memory_limit' => $this->export->getMemoryLimit(),
             'page_settings_error_html' => $pageSettingsErrorHtml,
             'page_settings_html' => $pageSettingsHtml,
             'structure_or_data_forced' => $request->getParsedBodyParam('structure_or_data_forced', 0),


### PR DESCRIPTION
### Description

While exporting tables using compression, we would sometimes get invalid files. We turned out to be hitting PHP maximum memory limit.
This commit will add a small non-obstrusive hint about that.

![Screenshot_2025-04-22_15-14-01](https://github.com/user-attachments/assets/18037681-4af0-4681-b656-2eae0b58b488)

Fixes # -> (no issue made for it)

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.

I did not create a test for this, since the change is purely cosmetic and doesn't fix anything.
