### PR TITLE
Fix thecodingmachine/safe deprecations using a fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,11 @@
         {
             "type": "composer",
             "url": "https://www.phpmyadmin.net"
+        },
+        {
+            "type": "github",
+            "url":  "https://github.com/MauricioFauth/thecodingmachine-safe.git",
+            "no-api": true
         }
     ],
     "require": {
@@ -114,6 +119,7 @@
         "roave/security-advisories": "dev-latest",
         "symfony/console": "^5.2.3",
         "tecnickcom/tcpdf": "^6.4.4",
+        "thecodingmachine/safe": "1.3.3.1",
         "vimeo/psalm": "^4.30",
         "web-auth/webauthn-lib": "^3.3.2"
     },

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -563,7 +563,7 @@ composer update --no-interaction --no-dev
 
 # Parse the required versions from composer.json
 PACKAGES_VERSIONS=''
-PACKAGE_LIST='tecnickcom/tcpdf pragmarx/google2fa-qrcode bacon/bacon-qr-code code-lts/u2f-php-server web-auth/webauthn-lib'
+PACKAGE_LIST='tecnickcom/tcpdf pragmarx/google2fa-qrcode bacon/bacon-qr-code code-lts/u2f-php-server web-auth/webauthn-lib thecodingmachine/safe'
 
 for PACKAGES in $PACKAGE_LIST
 do


### PR DESCRIPTION
Forces Composer to use a fork of thecodingmachine/safe to fix its PHP 8.4 deprecations.

https://github.com/thecodingmachine/safe/compare/v1.3.3...1.x
https://github.com/MauricioFauth/thecodingmachine-safe/compare/v1.3.3...v1-php8.4

- Fixes https://github.com/phpmyadmin/phpmyadmin/issues/19404
