### PR TITLE
Use native MySQL paging

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5664,7 +5664,7 @@ parameters:
 				Use dependency injection instead\.$#
 			'''
 			identifier: staticMethod.deprecated
-			count: 3
+			count: 2
 			path: src/Database/Routines.php
 
 		-
@@ -5730,7 +5730,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 3
+			count: 1
 			path: src/Database/Routines.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3645,7 +3645,6 @@
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
-      <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$itemParamDir]]></code>

--- a/src/Controllers/Database/RoutinesController.php
+++ b/src/Controllers/Database/RoutinesController.php
@@ -25,8 +25,6 @@ use PhpMyAdmin\UserPrivilegesFactory;
 use PhpMyAdmin\Util;
 
 use function __;
-use function array_slice;
-use function count;
 use function htmlentities;
 use function htmlspecialchars;
 use function in_array;
@@ -457,8 +455,7 @@ final class RoutinesController implements InvocableController
             $type = null;
         }
 
-        $items = Routines::getDetails($this->dbi, Current::$database, $type);
-        $totalNumRoutines = count($items);
+        $totalNumRoutines = Routines::getRoutineCount($this->dbi, Current::$database, $type);
         $pageSize = $config->settings['MaxRoutineList'];
         $pos = (int) $request->getParam('pos');
 
@@ -481,7 +478,7 @@ final class RoutinesController implements InvocableController
             return $this->response->response();
         }
 
-        $items = array_slice($items, $pos, $pageSize);
+        $items = Routines::getDetails($this->dbi, Current::$database, $type, limit: $pageSize, offset: $pos);
 
         $isAjax = $request->isAjax() && empty($_REQUEST['ajax_page_request']);
 

--- a/src/Query/Generator.php
+++ b/src/Query/Generator.php
@@ -177,20 +177,44 @@ class Generator
         string $quotedDbName,
         string|null $routineType,
         string|null $quotedRoutineName,
+        int $limit = 0,
+        int $offset = 0,
     ): string {
         $query = 'SELECT'
-            . ' `ROUTINE_SCHEMA` AS `Db`,'
             . ' `SPECIFIC_NAME` AS `Name`,'
             . ' `ROUTINE_TYPE` AS `Type`,'
             . ' `DEFINER` AS `Definer`,'
-            . ' `LAST_ALTERED` AS `Modified`,'
-            . ' `CREATED` AS `Created`,'
-            . ' `SECURITY_TYPE` AS `Security_type`,'
-            . ' `ROUTINE_COMMENT` AS `Comment`,'
-            . ' `CHARACTER_SET_CLIENT` AS `character_set_client`,'
-            . ' `COLLATION_CONNECTION` AS `collation_connection`,'
-            . ' `DATABASE_COLLATION` AS `Database Collation`,'
             . ' `DTD_IDENTIFIER`'
+            . ' FROM `information_schema`.`ROUTINES`'
+            . ' WHERE `ROUTINE_SCHEMA` ' . Util::getCollateForIS()
+            . ' = ' . $quotedDbName;
+        if ($routineType !== null) {
+            $query .= " AND `ROUTINE_TYPE` = '" . $routineType . "'";
+        }
+
+        if ($quotedRoutineName !== null) {
+            $query .= ' AND `SPECIFIC_NAME` = ' . $quotedRoutineName;
+        }
+
+        $query .= ' ORDER BY `SPECIFIC_NAME`';
+
+        if ($limit > 0) {
+            $query .= ' LIMIT ' . $limit;
+        }
+
+        if ($offset > 0) {
+            $query .= ' OFFSET ' . $offset;
+        }
+
+        return $query;
+    }
+
+    public static function getInformationSchemaRoutinesCountRequest(
+        string $quotedDbName,
+        string|null $routineType,
+        string|null $quotedRoutineName = null,
+    ): string {
+        $query = 'SELECT COUNT(*) AS `count`'
             . ' FROM `information_schema`.`ROUTINES`'
             . ' WHERE `ROUTINE_SCHEMA` ' . Util::getCollateForIS()
             . ' = ' . $quotedDbName;

--- a/tests/unit/Controllers/Database/RoutinesControllerTest.php
+++ b/tests/unit/Controllers/Database/RoutinesControllerTest.php
@@ -38,20 +38,20 @@ final class RoutinesControllerTest extends AbstractTestCase
             ['Grants for definer@localhost'],
         );
         $dummyDbi->addResult(
-            'SHOW FUNCTION STATUS WHERE `Db` = \'test_db\'',
-            [['test_db', 'test_func', 'FUNCTION', 'definer@localhost']],
-            ['Db', 'Name', 'Type', 'Definer'],
-        );
-        $dummyDbi->addResult(
-            'SHOW PROCEDURE STATUS WHERE `Db` = \'test_db\'',
-            [['test_db', 'test_proc', 'PROCEDURE', 'definer@localhost']],
-            ['Db', 'Name', 'Type', 'Definer'],
+            "SELECT `SPECIFIC_NAME` AS `Name`, `ROUTINE_TYPE` AS `Type`, `DEFINER` AS `Definer`, `DTD_IDENTIFIER` FROM `information_schema`.`ROUTINES` WHERE `ROUTINE_SCHEMA` COLLATE utf8_bin = 'test_db' ORDER BY `SPECIFIC_NAME` LIMIT 250",
+            [['test_db', 'test_func', 'FUNCTION', 'definer@localhost', null], ['test_db', 'test_proc', 'PROCEDURE', 'definer@localhost', null]],
+            ['Db', 'Name', 'Type', 'Definer', 'DTD_IDENTIFIER'],
         );
         $dummyDbi->addResult('SELECT @@lower_case_table_names', []);
         $dummyDbi->addResult(
-            "SELECT `DEFINER` FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_SCHEMA COLLATE utf8_bin='test_db' AND SPECIFIC_NAME='test_func' AND ROUTINE_TYPE='FUNCTION';",
-            [['definer@localhost']],
-            ['DEFINER'],
+            "SELECT `PRIVILEGE_TYPE` FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES` WHERE GRANTEE='''definer''@''localhost''' AND PRIVILEGE_TYPE='CREATE ROUTINE'",
+            [['CREATE ROUTINE']],
+            ['PRIVILEGE_TYPE'],
+        );
+        $dummyDbi->addResult(
+            "SELECT `PRIVILEGE_TYPE` FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES` WHERE GRANTEE='''definer''@''localhost''' AND PRIVILEGE_TYPE='EXECUTE'",
+            [['EXECUTE']],
+            ['PRIVILEGE_TYPE'],
         );
         $dummyDbi->addResult(
             "SELECT `PRIVILEGE_TYPE` FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES` WHERE GRANTEE='''definer''@''localhost''' AND PRIVILEGE_TYPE='CREATE ROUTINE'",
@@ -64,34 +64,14 @@ final class RoutinesControllerTest extends AbstractTestCase
             ['PRIVILEGE_TYPE'],
         );
         $dummyDbi->addResult(
-            'SHOW CREATE FUNCTION `test_db`.`test_func`',
-            [['test_func', 'CREATE FUNCTION `test_func` (p INT) RETURNS int(11) BEGIN END']],
-            ['Function', 'Create Function'],
-        );
-        $dummyDbi->addResult(
-            "SELECT `DEFINER` FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_SCHEMA COLLATE utf8_bin='test_db' AND SPECIFIC_NAME='test_proc' AND ROUTINE_TYPE='PROCEDURE';",
-            [['definer@localhost']],
-            ['DEFINER'],
-        );
-        $dummyDbi->addResult(
             "SELECT `PRIVILEGE_TYPE` FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES` WHERE GRANTEE='''definer''@''localhost''' AND PRIVILEGE_TYPE='CREATE ROUTINE'",
             [['CREATE ROUTINE']],
             ['PRIVILEGE_TYPE'],
         );
         $dummyDbi->addResult(
-            "SELECT `PRIVILEGE_TYPE` FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES` WHERE GRANTEE='''definer''@''localhost''' AND PRIVILEGE_TYPE='EXECUTE'",
-            [['EXECUTE']],
-            ['PRIVILEGE_TYPE'],
-        );
-        $dummyDbi->addResult(
-            'SHOW CREATE PROCEDURE `test_db`.`test_proc`',
-            [['test_proc2', 'CREATE PROCEDURE `test_proc2` (p INT) BEGIN END']],
-            ['Procedure', 'Create Procedure'],
-        );
-        $dummyDbi->addResult(
-            "SELECT `PRIVILEGE_TYPE` FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES` WHERE GRANTEE='''definer''@''localhost''' AND PRIVILEGE_TYPE='CREATE ROUTINE'",
-            [['CREATE ROUTINE']],
-            ['PRIVILEGE_TYPE'],
+            "SELECT COUNT(*) AS `count` FROM `information_schema`.`ROUTINES` WHERE `ROUTINE_SCHEMA` COLLATE utf8_bin = 'test_db'",
+            [[2]],
+            ['count'],
         );
         // phpcs:enable
 
@@ -291,6 +271,8 @@ HTML;
         // phpcs:enable
 
         self::assertSame($expected, $actual);
+        $dummyDbi->assertAllQueriesConsumed();
+        $dummyDbi->assertAllSelectsConsumed();
     }
 
     public function testWithoutRoutines(): void
@@ -309,12 +291,21 @@ HTML;
             [['GRANT ALL PRIVILEGES ON *.* TO `definer`@`localhost`']],
             ['Grants for definer@localhost'],
         );
-        $dummyDbi->addResult('SHOW FUNCTION STATUS WHERE `Db` = \'test_db\'', [], ['Db', 'Name', 'Type', 'Definer']);
-        $dummyDbi->addResult('SHOW PROCEDURE STATUS WHERE `Db` = \'test_db\'', [], ['Db', 'Name', 'Type', 'Definer']);
         $dummyDbi->addResult(
             "SELECT `PRIVILEGE_TYPE` FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES` WHERE GRANTEE='''definer''@''localhost''' AND PRIVILEGE_TYPE='CREATE ROUTINE'",
             [['CREATE ROUTINE']],
             ['PRIVILEGE_TYPE'],
+        );
+        $dummyDbi->addResult('SELECT @@lower_case_table_names', []);
+        $dummyDbi->addResult(
+            "SELECT COUNT(*) AS `count` FROM `information_schema`.`ROUTINES` WHERE `ROUTINE_SCHEMA` COLLATE utf8_bin = 'test_db'",
+            [[1]],
+            ['count'],
+        );
+        $dummyDbi->addResult(
+            "SELECT `SPECIFIC_NAME` AS `Name`, `ROUTINE_TYPE` AS `Type`, `DEFINER` AS `Definer`, `DTD_IDENTIFIER` FROM `information_schema`.`ROUTINES` WHERE `ROUTINE_SCHEMA` COLLATE utf8_bin = 'test_db' ORDER BY `SPECIFIC_NAME` LIMIT 250",
+            [],
+            ['Db', 'Name', 'Type', 'Definer', 'DTD_IDENTIFIER'],
         );
         // phpcs:enable
 
@@ -434,5 +425,7 @@ HTML;
         // phpcs:enable
 
         self::assertSame($expected, $actual);
+        $dummyDbi->assertAllQueriesConsumed();
+        $dummyDbi->assertAllSelectsConsumed();
     }
 }


### PR DESCRIPTION
https://github.com/phpmyadmin/phpmyadmin/issues/16487#issuecomment-2814048056

This PR changes how Routines are fetched from DB. The MySQL shorthand commands are dropped and all information is fetched from IS, which allows us to limit and sort the results. I was not able to observe any performance impact but the page opens pretty fast for me either way with 1000 routines. Maybe someone on a worse DB connection with more routines can test the performance. In theory the performance should remain more or less the same. 