### PR TITLE
Fix bugs in relations tab

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15226,6 +15226,12 @@ parameters:
 			path: src/Table/Table.php
 
 		-
+			message: '#^Parameter \#2 \$field of method PhpMyAdmin\\Table\\Table\:\:getSQLToCreateForeignKey\(\) expects array\<string\>, array\<int\|string\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Table/Table.php
+
+		-
 			message: '#^Parameter \#2 \$string of function explode expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15132,7 +15132,7 @@ parameters:
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 13
+			count: 2
 			path: src/Table/Table.php
 
 		-
@@ -15227,12 +15227,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#2 \$string of function explode expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Table/Table.php
-
-		-
-			message: '#^Parameter \#3 \$foreignDb of method PhpMyAdmin\\Table\\Table\:\:getSQLToCreateForeignKey\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Table/Table.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8937,6 +8937,9 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
+    <InvalidArgument>
+      <code><![CDATA[$existrelForeign[$masterFieldMd5]->indexList]]></code>
+    </InvalidArgument>
     <InvalidReturnStatement>
       <code><![CDATA[$tableAutoIncrement ?? '']]></code>
       <code><![CDATA[$this->getStatusInfo('TABLE_COLLATION') ?? '']]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8997,7 +8997,6 @@
     <PossiblyNullArgument>
       <code><![CDATA[$column['Extra']]]></code>
       <code><![CDATA[$column['Extra']]]></code>
-      <code><![CDATA[$existrelForeign[$masterFieldMd5]->refDbName]]></code>
       <code><![CDATA[$existrelForeign[$masterFieldMd5]->refTableName]]></code>
     </PossiblyNullArgument>
     <PossiblyNullOperand>
@@ -9010,11 +9009,6 @@
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($existrelForeign[$masterFieldMd5]->onDelete)]]></code>
       <code><![CDATA[empty($existrelForeign[$masterFieldMd5]->onUpdate)]]></code>
-      <code><![CDATA[empty($foreignField)]]></code>
-      <code><![CDATA[empty($foreignField[$key])]]></code>
-      <code><![CDATA[empty($foreignField[$key])]]></code>
-      <code><![CDATA[empty($foreignField[$key])]]></code>
-      <code><![CDATA[empty($foreignTable)]]></code>
     </RiskyTruthyFalsyComparison>
     <UnsupportedPropertyReferenceUsage>
       <code><![CDATA[$this->uiprefs =& $_SESSION['tmpval']['table_uiprefs'][$serverId][$this->dbName][$this->name]]]></code>

--- a/resources/templates/table/relation/foreign_key_row.twig
+++ b/resources/templates/table/relation/foreign_key_row.twig
@@ -107,7 +107,7 @@
         </span>
     </td>
     <td>
-        {% if foreign_db and foreign_table %}
+        {% if foreign_table is not same as ( '' ) %}
             {% for foreign_column in one_key.refIndexList %}
                 <span class="clearfloat">
                     {% include 'table/relation/relational_dropdown.twig' with {

--- a/src/Controllers/Table/RelationController.php
+++ b/src/Controllers/Table/RelationController.php
@@ -185,16 +185,16 @@ final class RelationController implements InvocableController
 
         foreach ($relationsForeign as $oneKey) {
             $foreignDb = $oneKey->refDbName ?? Current::$database;
-            $foreignTable = false;
+            $foreignTable = '';
             if ($foreignDb !== '') {
-                $foreignTable = $oneKey->refTableName ?? false;
+                $foreignTable = $oneKey->refTableName ?? '';
                 $tables = $this->relation->getTables($foreignDb, $storageEngine);
             } else {
                 $tables = $this->relation->getTables(Current::$database, $storageEngine);
             }
 
             $uniqueColumns = [];
-            if ($foreignDb !== '' && $foreignTable !== false && $foreignTable !== '') {
+            if ($foreignDb !== '' && $foreignTable !== '') {
                 $tableObject = new Table($foreignTable, $foreignDb, $this->dbi);
                 $uniqueColumns = $tableObject->getUniqueColumns(false, false);
             }
@@ -228,8 +228,8 @@ final class RelationController implements InvocableController
             'table' => Current::$table,
             'url_params' => UrlParams::$params,
             'databases' => $this->dbi->getDatabaseList(),
-            'foreign_db' => false,
-            'foreign_table' => false,
+            'foreign_db' => '',
+            'foreign_table' => '',
             'unique_columns' => [],
             'tables' => $tables,
         ]);
@@ -240,7 +240,7 @@ final class RelationController implements InvocableController
             // (see bug https://github.com/phpmyadmin/phpmyadmin/issues/8827)
             $fieldHash = md5($column->field);
 
-            $foreignTable = false;
+            $foreignTable = '';
             $foreignColumn = false;
 
             // Database dropdown
@@ -264,7 +264,7 @@ final class RelationController implements InvocableController
 
             // Column dropdown
             $uniqueColumns = [];
-            if ($foreignDb !== '' && $foreignTable !== false && $foreignTable !== '') {
+            if ($foreignDb !== '' && $foreignTable !== '') {
                 if (isset($relations[$column->field])) {
                     /** @var string $foreignColumn */
                     $foreignColumn = $relations[$column->field]['foreign_field'];

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -1598,7 +1598,7 @@ class Table implements Stringable
             $sqlQueryRecreate = '# Restoring the dropped constraint...' . "\n";
             $sqlQueryRecreate .= $this->getSQLToCreateForeignKey(
                 $table,
-                $masterField,
+                $existrelForeign[$masterFieldMd5]->indexList,
                 $existrelForeign[$masterFieldMd5]->refDbName ?? Current::$database,
                 $existrelForeign[$masterFieldMd5]->refTableName,
                 $existrelForeign[$masterFieldMd5]->refIndexList,

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -1377,7 +1377,11 @@ class Table implements Stringable
             $masterField = $multiEditColumnsName[$masterFieldMd5];
             $foreignTable = $destinationTable[$masterFieldMd5];
             $foreignField = $destinationColumn[$masterFieldMd5];
-            if (! empty($foreignDb) && ! empty($foreignTable) && ! empty($foreignField)) {
+            if (
+                $foreignDb !== ''
+                && $foreignTable !== '' && $foreignTable !== null
+                && $foreignField !== '' && $foreignField !== null
+            ) {
                 if (! isset($existrel[$masterField])) {
                     $updQuery = 'INSERT INTO '
                         . Util::backquote($relationFeature->database)
@@ -1477,20 +1481,20 @@ class Table implements Stringable
             $emptyFields = false;
             foreach ($masterField as $key => $oneField) {
                 if (
-                    (! empty($oneField) && empty($foreignField[$key]))
-                    || (empty($oneField) && ! empty($foreignField[$key]))
+                    ($oneField !== '' && (! isset($foreignField[$key]) || $foreignField[$key] === ''))
+                    || ($oneField === '' && (isset($foreignField[$key]) && $foreignField[$key] !== ''))
                 ) {
                     $emptyFields = true;
                 }
 
-                if (! empty($oneField) || ! empty($foreignField[$key])) {
+                if ($oneField !== '' || (isset($foreignField[$key]) && $foreignField[$key] !== '')) {
                     continue;
                 }
 
                 unset($masterField[$key], $foreignField[$key]);
             }
 
-            if (! empty($foreignDb) && ! empty($foreignTable) && ! $emptyFields) {
+            if ($foreignDb !== '' && $foreignTable !== '' && ! $emptyFields) {
                 if (isset($existrelForeign[$masterFieldMd5])) {
                     $constraintName = $existrelForeign[$masterFieldMd5]->constraint;
                     $onDelete = ! empty($existrelForeign[$masterFieldMd5]->onDelete)
@@ -1595,7 +1599,7 @@ class Table implements Stringable
             $sqlQueryRecreate .= $this->getSQLToCreateForeignKey(
                 $table,
                 $masterField,
-                $existrelForeign[$masterFieldMd5]->refDbName,
+                $existrelForeign[$masterFieldMd5]->refDbName ?? Current::$database,
                 $existrelForeign[$masterFieldMd5]->refTableName,
                 $existrelForeign[$masterFieldMd5]->refIndexList,
                 $existrelForeign[$masterFieldMd5]->constraint,


### PR DESCRIPTION
I don't know if they have been reported but they annoyed me. Fixed issues:
- Using a database/table/column name which is zero-string
- Replacing an existing relation with an invalid exception which causes a rollback to happen (passing null to string parameter error)