### PR TITLE
Fix new table name CSS

### DIFF
--- a/public/themes/bootstrap/scss/_common.scss
+++ b/public/themes/bootstrap/scss/_common.scss
@@ -1107,7 +1107,8 @@ input#auto_increment_opt {
 }
 
 #table_name_col_no_outer {
-  margin-top: 45px;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 #table_name_col_no {

--- a/public/themes/original/scss/_common.scss
+++ b/public/themes/original/scss/_common.scss
@@ -1110,7 +1110,8 @@ input#auto_increment_opt {
 }
 
 #table_name_col_no_outer {
-  margin-top: 45px;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 #table_name_col_no {

--- a/public/themes/pmahomme/scss/_common.scss
+++ b/public/themes/pmahomme/scss/_common.scss
@@ -1313,7 +1313,8 @@ input#auto_increment_opt {
 }
 
 #table_name_col_no_outer {
-  margin-top: 45px;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 #table_name_col_no {

--- a/resources/templates/columns_definitions/column_definitions_form.twig
+++ b/resources/templates/columns_definitions/column_definitions_form.twig
@@ -17,32 +17,29 @@
 
     {% if action == '/table/create' %}
         <div id="table_name_col_no_outer">
-            <table id="table_name_col_no" class="table table-borderless tdblock">
-                <tr class="align-middle float-start">
-                    <td>{{ t('Table name') }}:
-                    <input type="text"
-                        name="table"
-                        size="40"
-                        maxlength="64"
-                        value="{{ table is defined ? table }}"
-                        class="textfield" autofocus required>
-                    </td>
-                    <td>
-                        {{ t('Add') }}
-                        <input type="number"
-                            id="added_fields"
-                            name="added_fields"
-                            size="2"
-                            value="1"
-                            min="1"
-                            onfocus="this.select()">
-                        {{ t('column(s)') }}
-                        <input class="btn btn-secondary" type="button"
-                            name="submit_num_fields"
-                            value="{{ t('Go') }}">
-                    </td>
-                </tr>
-            </table>
+            <span>
+                {{ t('Table name') }}:
+                <input type="text"
+                    name="table"
+                    size="40"
+                    maxlength="64"
+                    value="{{ table is defined ? table }}"
+                    class="textfield" autofocus required>
+            </span>
+            <span>
+                {{ t('Add') }}
+                <input type="number"
+                    id="added_fields"
+                    name="added_fields"
+                    size="2"
+                    value="1"
+                    min="1"
+                    onfocus="this.select()">
+                {{ t('column(s)') }}
+                <input class="btn btn-secondary" type="button"
+                    name="submit_num_fields"
+                    value="{{ t('Go') }}">
+            </span>
         </div>
     {% endif %}
     {% if content_cells is iterable %}


### PR DESCRIPTION
### Before:
![image](https://github.com/user-attachments/assets/1c8807c9-a3ec-48f8-bb94-f3084a5ced80)
![image](https://github.com/user-attachments/assets/969742fb-bc8e-4d67-9493-d57a5938b34a)

### After: 
![image](https://github.com/user-attachments/assets/e5acb5c6-d71b-49c5-9b60-ed6be90f10f0)

The table name input box is no longer in a fixed position but that's better because it created a nasty visual effect. It's also more responsive now. 