### PR TITLE
Improve error template

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7692,7 +7692,7 @@ parameters:
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 11
+			count: 7
 			path: src/Html/Generator.php
 
 		-
@@ -14070,7 +14070,7 @@ parameters:
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 11
+			count: 10
 			path: src/Sql.php
 
 		-

--- a/public/themes/bootstrap/scss/_common.scss
+++ b/public/themes/bootstrap/scss/_common.scss
@@ -1225,15 +1225,6 @@ input#auto_increment_opt {
     position: static;
   }
 
-  tbody td span {
-    display: block;
-    overflow: hidden;
-
-    code span {
-      display: inline;
-    }
-  }
-
   th.draggable {
     span {
       margin-right: 10px;
@@ -2399,4 +2390,8 @@ body .ui-dialog {
 
 .table-responsive-md .data {
   z-index: 9;
+}
+
+pre {
+  margin: 0;
 }

--- a/public/themes/metro/scss/_common.scss
+++ b/public/themes/metro/scss/_common.scss
@@ -1489,15 +1489,6 @@ input#auto_increment_opt {
   td {
     position: static;
   }
-
-  tbody td span {
-    display: block;
-    overflow: hidden;
-
-    code span {
-      display: inline;
-    }
-  }
 }
 
 .modal-copy input {
@@ -2576,4 +2567,8 @@ body {
 
 .table-responsive-md .data {
   z-index: 9;
+}
+
+pre {
+  margin: 0;
 }

--- a/public/themes/original/scss/_common.scss
+++ b/public/themes/original/scss/_common.scss
@@ -1229,15 +1229,6 @@ input#auto_increment_opt {
   td {
     position: static;
   }
-
-  tbody td span {
-    display: block;
-    overflow: hidden;
-
-    code span {
-      display: inline;
-    }
-  }
 }
 
 .modal-copy input {
@@ -2401,4 +2392,8 @@ body {
 
 .table-responsive-md .data {
   z-index: 9;
+}
+
+pre {
+  margin: 0;
 }

--- a/public/themes/pmahomme/scss/_common.scss
+++ b/public/themes/pmahomme/scss/_common.scss
@@ -1432,15 +1432,6 @@ input#auto_increment_opt {
     position: static;
   }
 
-  tbody td span {
-    display: block;
-    overflow: hidden;
-
-    code span {
-      display: inline;
-    }
-  }
-
   th.draggable {
     span {
       margin-right: 10px;
@@ -2552,4 +2543,8 @@ body .ui-dialog {
 
 .bg-secondary {
   color: #333;
+}
+
+pre {
+  margin: 0;
 }

--- a/resources/js/src/modules/sql-highlight.ts
+++ b/resources/js/src/modules/sql-highlight.ts
@@ -459,15 +459,15 @@ export default function highlightSql ($base) {
     var $elm = $base.find('code.sql');
     $elm.each(function () {
         var $sql = $(this);
-        var $pre = $sql.find('pre');
+        var $pre = $sql.closest('pre');
         /* We only care about visible elements to avoid double processing */
-        if ($pre.is(':visible')) {
+        if ($sql.is(':visible')) {
             var $highlight = $('<div class="sql-highlight cm-s-default"></div>');
-            $sql.append($highlight);
+            $pre.append($highlight);
             if (typeof window.CodeMirror !== 'undefined') {
                 // @ts-ignore
                 window.CodeMirror.runMode($sql.text(), 'text/x-mysql', $highlight[0]);
-                $pre.hide();
+                $sql.hide();
                 $highlight.find('.cm-keyword').each(documentationKeyword);
                 $highlight.find('.cm-builtin').each(documentationBuiltin);
             }

--- a/resources/js/src/transformations/json.ts
+++ b/resources/js/src/transformations/json.ts
@@ -8,14 +8,14 @@ AJAX.registerOnload('transformations/json.js', function () {
     var $elm = $('#page_content').find('code.json');
     $elm.each(function () {
         var $json = $(this);
-        var $pre = $json.find('pre');
+        var $pre = $json.closest('pre');
         /* We only care about visible elements to avoid double processing */
-        if ($pre.is(':visible')) {
+        if ($json.is(':visible')) {
             var $highlight = $('<div class="json-highlight cm-s-default"></div>');
-            $json.append($highlight);
+            $pre.append($highlight);
             // @ts-ignore
             window.CodeMirror.runMode($json.text(), 'application/json', $highlight[0]);
-            $pre.hide();
+            $json.hide();
         }
     });
 });

--- a/resources/js/src/transformations/xml.ts
+++ b/resources/js/src/transformations/xml.ts
@@ -8,14 +8,14 @@ AJAX.registerOnload('transformations/xml.js', function () {
     var $elm = $('#page_content').find('code.xml');
     $elm.each(function () {
         var $json = $(this);
-        var $pre = $json.find('pre');
+        var $pre = $json.closest('pre');
         /* We only care about visible elements to avoid double processing */
-        if ($pre.is(':visible')) {
+        if ($json.is(':visible')) {
             var $highlight = $('<div class="xml-highlight cm-s-default"></div>');
-            $json.append($highlight);
+            $pre.append($highlight);
             // @ts-ignore
             window.CodeMirror.runMode($json.text(), 'application/xml', $highlight[0]);
-            $pre.hide();
+            $json.hide();
         }
     });
 });

--- a/resources/templates/error/generic.twig
+++ b/resources/templates/error/generic.twig
@@ -25,16 +25,20 @@
             color: #ffffff;
             background-color: #ff0000;
         }
+        .errormessage {
+            border: 0.1em solid red;
+            background-color: #ffeeee;
+        }
         p {
             margin: 0;
             padding: 0.5em;
-            border: 0.1em solid red;
-            background-color: #ffeeee;
         }
     </style>
 </head>
 <body>
 <h1>phpMyAdmin - {{ t('Error') }}</h1>
+<div class="errormessage">
 <p>{{ error_message|raw }}</p>
+</div>
 </body>
 </html>

--- a/src/Controllers/Import/ImportController.php
+++ b/src/Controllers/Import/ImportController.php
@@ -331,7 +331,7 @@ final readonly class ImportController implements InvocableController
         }
 
         // Do no run query if we show PHP code
-        if (isset(Sql::$showAsPhp)) {
+        if (Sql::$showAsPhp !== null) {
             ImportSettings::$runQuery = false;
             ImportSettings::$goSql = true;
         }

--- a/src/Html/Generator.php
+++ b/src/Html/Generator.php
@@ -450,12 +450,12 @@ class Generator
         /* SQL-Parser-Analyzer */
 
         if (Sql::$showAsPhp === true) {
-            $newLine = '\\n"<br>' . "\n" . '&nbsp;&nbsp;&nbsp;&nbsp;. "';
+            $newLine = '\\n"' . "\n" . '    . "';
             $queryBase = htmlspecialchars(addslashes($sqlQuery));
             $queryBase = preg_replace('/((\015\012)|(\015)|(\012))/', $newLine, $queryBase);
-            $queryBase = '<code class="php" dir="ltr"><pre>' . "\n"
-                . '$sql = "' . $queryBase . '";' . "\n"
-                . '</pre></code>';
+            $queryBase = '<pre><code class="php" dir="ltr">'
+                . '$sql = "' . $queryBase . '";'
+                . '</code></pre>';
         } else {
             $queryBase = self::formatSql($sqlQuery, true);
         }
@@ -1072,9 +1072,9 @@ class Generator
             $sqlQuery = mb_substr($sqlQuery, 0, $config->settings['MaxCharactersInDisplayedSQL']) . '[...]';
         }
 
-        return '<code class="sql" dir="ltr"><pre>' . "\n"
-            . htmlspecialchars($sqlQuery, ENT_COMPAT) . "\n"
-            . '</pre></code>';
+        return '<pre><code class="sql" dir="ltr">'
+            . htmlspecialchars($sqlQuery, ENT_COMPAT)
+            . '</code></pre>';
     }
 
     /**

--- a/src/Html/Generator.php
+++ b/src/Html/Generator.php
@@ -449,7 +449,7 @@ class Generator
         // If we want to show some sql code it is easiest to create it here
         /* SQL-Parser-Analyzer */
 
-        if (! empty(Sql::$showAsPhp)) {
+        if (Sql::$showAsPhp === true) {
             $newLine = '\\n"<br>' . "\n" . '&nbsp;&nbsp;&nbsp;&nbsp;. "';
             $queryBase = htmlspecialchars(addslashes($sqlQuery));
             $queryBase = preg_replace('/((\015\012)|(\015)|(\012))/', $newLine, $queryBase);
@@ -512,7 +512,7 @@ class Generator
 
         // even if the query is big and was truncated, offer the chance
         // to edit it (unless it's enormous, see linkOrButton() )
-        if (! empty($config->settings['SQLQuery']['Edit']) && empty(Sql::$showAsPhp)) {
+        if (! empty($config->settings['SQLQuery']['Edit']) && Sql::$showAsPhp !== true) {
             $editLink = '<div class="col-auto">'
                 . self::linkOrButton(
                     Url::getFromRoute($editLinkRoute, $urlParams),
@@ -528,7 +528,7 @@ class Generator
         // Also we would like to get the SQL formed in some nice
         // php-code
         if (! empty($config->settings['SQLQuery']['ShowAsPHP']) && ! $queryTooBig) {
-            if (! empty(Sql::$showAsPhp)) {
+            if (Sql::$showAsPhp === true) {
                 $phpLink = '<div class="col-auto">'
                     . self::linkOrButton(
                         Url::getFromRoute('/import', $urlParams),
@@ -565,7 +565,7 @@ class Generator
         // Refresh query
         if (
             ! empty($config->settings['SQLQuery']['Refresh'])
-            && ! isset(Sql::$showAsPhp) // 'Submit query' does the same
+            && Sql::$showAsPhp === null // 'Submit query' does the same
             && preg_match('@^(SELECT|SHOW)[[:space:]]+@i', $sqlQuery) === 1
         ) {
             $refreshLink = Url::getFromRoute('/sql', $urlParams);
@@ -613,7 +613,7 @@ class Generator
         /**
          * TODO: Should we have $cfg['SQLQuery']['InlineEdit']?
          */
-        if (! empty($config->settings['SQLQuery']['Edit']) && ! $queryTooBig && empty(Sql::$showAsPhp)) {
+        if (! empty($config->settings['SQLQuery']['Edit']) && ! $queryTooBig && Sql::$showAsPhp !== true) {
             $inlineEditLink = '<div class="col-auto">'
                 . self::linkOrButton(
                     '#',

--- a/src/Plugins/Transformations/Output/Text_Plain_Json.php
+++ b/src/Plugins/Transformations/Output/Text_Plain_Json.php
@@ -52,9 +52,7 @@ class Text_Plain_Json extends TransformationsPlugin
      */
     public function applyTransformation(string $buffer, array $options = [], FieldMetadata|null $meta = null): string
     {
-        return '<code class="json"><pre>' . "\n"
-        . htmlspecialchars($buffer) . "\n"
-        . '</pre></code>';
+        return '<pre><code class="json">' . htmlspecialchars($buffer) . '</code></pre>';
     }
 
     /* ~~~~~~~~~~~~~~~~~~~~ Getters and Setters ~~~~~~~~~~~~~~~~~~~~ */

--- a/src/Plugins/Transformations/Output/Text_Plain_Xml.php
+++ b/src/Plugins/Transformations/Output/Text_Plain_Xml.php
@@ -52,9 +52,7 @@ class Text_Plain_Xml extends TransformationsPlugin
      */
     public function applyTransformation(string $buffer, array $options = [], FieldMetadata|null $meta = null): string
     {
-        return '<code class="xml"><pre>' . "\n"
-        . htmlspecialchars($buffer) . "\n"
-        . '</pre></code>';
+        return '<pre><code class="xml">' . htmlspecialchars($buffer) . '</code></pre>';
     }
 
     /* ~~~~~~~~~~~~~~~~~~~~ Getters and Setters ~~~~~~~~~~~~~~~~~~~~ */

--- a/src/Session.php
+++ b/src/Session.php
@@ -106,8 +106,8 @@ class Session
             . 'webserver log file and configure your PHP '
             . 'installation properly. Also ensure that cookies are enabled '
             . 'in your browser.'
-            . '<br><br>'
-            . implode('<br><br>', $messages);
+            . '<p>'
+            . implode('<p>', $messages);
 
         throw new SessionHandlerException($errorMessage);
     }

--- a/src/Sql.php
+++ b/src/Sql.php
@@ -854,9 +854,9 @@ class Sql
             // the form should not have priority over errors
         } elseif ($messageToShow !== '' && $statementInfo->flags->queryType !== StatementType::Select) {
             $message = Message::rawSuccess(htmlspecialchars($messageToShow));
-        } elseif (! empty(self::$showAsPhp)) {
+        } elseif (self::$showAsPhp === true) {
             $message = Message::success(__('Showing as PHP code'));
-        } elseif (isset(self::$showAsPhp)) {
+        } elseif (self::$showAsPhp === false) {
             /* User disable showing as PHP, query is only displayed */
             $message = Message::notice(__('Showing SQL query'));
         } else {
@@ -931,7 +931,7 @@ class Sql
 
         $queryMessage = Generator::getMessage($message, $sqlQuery, MessageType::Success);
 
-        if (isset(self::$showAsPhp)) {
+        if (self::$showAsPhp !== null) {
             return $queryMessage;
         }
 
@@ -1533,7 +1533,7 @@ class Sql
         ResponseRenderer::$reload = $this->hasCurrentDbChanged($db);
         $this->dbi->selectDb($db);
 
-        if (isset(self::$showAsPhp)) {
+        if (self::$showAsPhp !== null) {
             // Only if we ask to see the php code
             // The following was copied from getQueryResponseForNoResultsReturned()
             // Delete if it's not needed in this context

--- a/tests/unit/Controllers/Server/PrivilegesControllerTest.php
+++ b/tests/unit/Controllers/Server/PrivilegesControllerTest.php
@@ -148,10 +148,10 @@ class PrivilegesControllerTest extends AbstractTestCase
         self::assertStringContainsString("You have updated the privileges for 'pma_test'@'localhost'.", $output);
 
         // phpcs:disable Generic.Files.LineLength.TooLong
-        $expectedSql = '<pre>' . "\n"
+        $expectedSql = '<pre><code class="sql" dir="ltr">'
             . "REVOKE ALL PRIVILEGES ON  `test_db_1`.* FROM 'pma_test'@'localhost'; REVOKE GRANT OPTION ON  `test_db_1`.* FROM 'pma_test'@'localhost'; GRANT SELECT ON  `test_db_1`.* TO 'pma_test'@'localhost'; \n"
-            . "REVOKE ALL PRIVILEGES ON  `test_db_2`.* FROM 'pma_test'@'localhost'; REVOKE GRANT OPTION ON  `test_db_2`.* FROM 'pma_test'@'localhost'; GRANT SELECT ON  `test_db_2`.* TO 'pma_test'@'localhost'; \n"
-            . '</pre>';
+            . "REVOKE ALL PRIVILEGES ON  `test_db_2`.* FROM 'pma_test'@'localhost'; REVOKE GRANT OPTION ON  `test_db_2`.* FROM 'pma_test'@'localhost'; GRANT SELECT ON  `test_db_2`.* TO 'pma_test'@'localhost'; "
+            . '</code></pre>';
         // phpcs:enable
         self::assertStringContainsString($expectedSql, $output);
 

--- a/tests/unit/Controllers/Table/FindReplaceControllerTest.php
+++ b/tests/unit/Controllers/Table/FindReplaceControllerTest.php
@@ -54,10 +54,10 @@ final class FindReplaceControllerTest extends AbstractTestCase
         $controller($request);
 
         self::assertStringContainsString(
-            '<pre>' . "\n"
+            '<pre><code class="sql" dir="ltr">'
             . 'UPDATE `test_table` SET `id` = REPLACE(`id`, \'Field\', \'Column\')'
             . ' WHERE `id` LIKE \'%Field%\' COLLATE utf8mb4_bin'
-            . "\n" . '</pre>',
+            . '</code></pre>',
             $responseRenderer->getHTMLResult(),
         );
         self::assertSame([], $responseRenderer->getJSONResult());
@@ -102,9 +102,9 @@ final class FindReplaceControllerTest extends AbstractTestCase
         $controller($request);
 
         self::assertStringContainsString(
-            '<pre>' . "\n"
+            '<pre><code class="sql" dir="ltr">'
             . 'UPDATE `test_table` SET `id` = `id` WHERE `id` RLIKE \'Field\' COLLATE utf8mb4_bin'
-            . "\n" . '</pre>',
+            . '</code></pre>',
             $responseRenderer->getHTMLResult(),
         );
         self::assertSame([], $responseRenderer->getJSONResult());

--- a/tests/unit/Controllers/Table/IndexRenameControllerTest.php
+++ b/tests/unit/Controllers/Table/IndexRenameControllerTest.php
@@ -87,14 +87,14 @@ class IndexRenameControllerTest extends AbstractTestCase
         $dbi->setVersion(['@@version' => '5.5.0']);
         DatabaseInterface::$instance = $dbi;
 
+        // phpcs:disable Generic.Files.LineLength.TooLong
         $expected = <<<'HTML'
-<div class="preview_sql">
-            <code class="sql" dir="ltr"><pre>
-ALTER TABLE `test_db`.`test_table_index_rename` DROP INDEX `old_name`, ADD INDEX `new_name` (`name`) USING BTREE;
-</pre></code>
-    </div>
+        <div class="preview_sql">
+                    <pre><code class="sql" dir="ltr">ALTER TABLE `test_db`.`test_table_index_rename` DROP INDEX `old_name`, ADD INDEX `new_name` (`name`) USING BTREE;</code></pre>
+            </div>
 
-HTML;
+        HTML;
+        // phpcs:enable
 
         $request = ServerRequestFactory::create()->createServerRequest('GET', 'http://example.com/')
             ->withQueryParams(['db' => 'test_db', 'table' => 'test_table_index_rename'])

--- a/tests/unit/Html/GeneratorTest.php
+++ b/tests/unit/Html/GeneratorTest.php
@@ -277,18 +277,18 @@ class GeneratorTest extends AbstractTestCase
     public function testFormatSql(): void
     {
         self::assertSame(
-            '<code class="sql" dir="ltr"><pre>' . "\n"
-            . 'SELECT 1 &lt; 2' . "\n"
-            . '</pre></code>',
+            '<pre><code class="sql" dir="ltr">'
+            . 'SELECT 1 &lt; 2'
+            . '</code></pre>',
             Generator::formatSql('SELECT 1 < 2'),
         );
 
         Config::getInstance()->settings['MaxCharactersInDisplayedSQL'] = 6;
 
         self::assertSame(
-            '<code class="sql" dir="ltr"><pre>' . "\n"
-            . 'SELECT[...]' . "\n"
-            . '</pre></code>',
+            '<pre><code class="sql" dir="ltr">'
+            . 'SELECT[...]'
+            . '</code></pre>',
             Generator::formatSql('SELECT 1 < 2', true),
         );
     }
@@ -486,9 +486,7 @@ class GeneratorTest extends AbstractTestCase
 <div class="alert alert-primary border-top-0 border-start-0 border-end-0 rounded-bottom-0 mb-0" role="alert">
   <img src="themes/dot.gif" title="" alt="" class="icon ic_s_notice"> Message <em>one</em>.
 </div>
-<div class="card-body sqlOuter"><code class="sql" dir="ltr"><pre>
-SELECT 1;
-</pre></code></div>
+<div class="card-body sqlOuter"><pre><code class="sql" dir="ltr">SELECT 1;</code></pre></div>
 <div class="card-footer tools d-print-none">
 <div class="row align-items-center">
 <div class="col-auto">
@@ -535,9 +533,7 @@ HTML;
 <div class="alert alert-success border-top-0 border-start-0 border-end-0 rounded-bottom-0 mb-0" role="alert">
   <img src="themes/dot.gif" title="" alt="" class="icon ic_s_success"> Message <em>one</em>.
 </div>
-<div class="card-body sqlOuter"><code class="php" dir="ltr"><pre>
-$sql = "EXPLAIN SELECT 1;";
-</pre></code></div>
+<div class="card-body sqlOuter"><pre><code class="php" dir="ltr">$sql = "EXPLAIN SELECT 1;";</code></pre></div>
 <div class="card-footer tools d-print-none">
 <div class="row align-items-center">
 <div class="col-auto">

--- a/tests/unit/Plugins/Transformations/TransformationPluginsTest.php
+++ b/tests/unit/Plugins/Transformations/TransformationPluginsTest.php
@@ -564,9 +564,9 @@ class TransformationPluginsTest extends AbstractTestCase
             [
                 new Text_Plain_Sql(),
                 ['select *', ['option1', 'option2']],
-                '<code class="sql" dir="ltr"><pre>' . "\n"
-                . 'select *' . "\n"
-                . '</pre></code>',
+                '<pre><code class="sql" dir="ltr">'
+                . 'select *'
+                . '</code></pre>',
             ],
             [new Text_Plain_Link(), ['PMA_TXT_LINK', ['./php/', 'text_name']], './php/PMA_TXT_LINK'],
             [new Text_Plain_Link(), ['PMA_TXT_LINK', []], 'PMA_TXT_LINK'],


### PR DESCRIPTION
The `<pre>` element is block display while `<code>` is an inline element. Block elements should not be within inline elements. Semantically, it also makes sense for `<code>` to be inside of `<pre>` and not the other way around. I believe that the CSS I removed was an attempt to fix a problem caused by this issue. 

The `<pre>` by default has a bottom margin which looks odd IMHO and existing PMA users are probably not used to it, so I have removed it. 

As a side effect, the text inside `<code>` is now more readable. 

The error message template has been updated to make it possible to use `<p>` for delimiting paragraphs instead of `<br>`.