### PR TITLE
Fix duplicate Set-Cookie

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13836,7 +13836,19 @@ parameters:
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 5
+			count: 3
+			path: src/Session.php
+
+		-
+			message: '#^Only booleans are allowed in &&, string\|false given on the left side\.$#'
+			identifier: booleanAnd.leftNotBoolean
+			count: 1
+			path: src/Session.php
+
+		-
+			message: '#^Only booleans are allowed in &&, string\|false given on the right side\.$#'
+			identifier: booleanAnd.rightNotBoolean
+			count: 1
 			path: src/Session.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8325,8 +8325,8 @@
       <code><![CDATA[$config->getCookie('phpMyAdmin')]]></code>
     </MixedArgument>
     <RiskyTruthyFalsyComparison>
-      <code><![CDATA[empty(ini_get('session.auto_start'))]]></code>
-      <code><![CDATA[empty(session_id())]]></code>
+      <code><![CDATA[ini_get('session.auto_start')]]></code>
+      <code><![CDATA[session_id()]]></code>
     </RiskyTruthyFalsyComparison>
     <UnusedFunctionCall>
       <code><![CDATA[session_save_path]]></code>

--- a/src/Sql.php
+++ b/src/Sql.php
@@ -740,8 +740,8 @@ class Sql
         $this->queryTime = $this->dbi->lastQueryExecutionTime;
 
         if (! defined('TESTSUITE')) {
-            // reopen session
-            session_start();
+            // reopen session but prevent PHP from sending the session cookie again
+            session_start(['use_cookies' => false]);
         }
 
         $errorMessage = '';


### PR DESCRIPTION
Fixes #19702

This should fix the linked issue, but in my opinion, this is a PHP bug. PHP should not resend the same header without changes. I have spent the whole day working on this and I still could not understand why PHP sessions behave this way. I raised an issue https://github.com/php/php-src/issues/18601

However, I believe I have found a workaround for this. Most of the session logic is in Session.php. The session is closed and then reopened to avoid blocking the user from opening another tab when a long-running query is executed. The code doesn't seem to be doing any session-related stuff after that. If we reopen the session without cookie support, then it will not set the header. **We cannot do it in Session.php** because the code will call `session_regenerate_id()` later and that needs to send a new cookie. I have added a comment explaining that. 

The actual fix for the issue is only the change in Sql.php and it can be backported to QA5_2. The rest is just code quality refactoring and removing dead code. 