### PR TITLE
Fix to Renaming Timestamp issue #19367

### DIFF
--- a/app/services.php
+++ b/app/services.php
@@ -219,7 +219,8 @@ return [
             'class' => TrackingChecker::class,
             'arguments' => ['$dbi' => '@dbi', '$relation' => '@relation'],
         ],
-        'transformations' => ['class' => Transformations::class],
+        'transformations' => ['class' => Transformations::class, 'arguments' => ['@dbi', '@relation']],
+        Transformations::class => 'transformations',
         'triggers' => ['class' => Triggers::class, 'arguments' => ['@dbi']],
         'user_password' => [
             'class' => UserPassword::class,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -14968,15 +14968,6 @@ parameters:
 			path: src/Tracking/Tracking.php
 
 		-
-			message: '''
-				#^Call to deprecated method getInstance\(\) of class PhpMyAdmin\\Dbal\\DatabaseInterface\:
-				Use dependency injection instead\.$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 3
-			path: src/Transformations.php
-
-		-
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
 			count: 1

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8990,11 +8990,6 @@
     </PossiblyNullArgument>
   </file>
   <file src="src/Transformations.php">
-    <DeprecatedMethod>
-      <code><![CDATA[DatabaseInterface::getInstance()]]></code>
-      <code><![CDATA[DatabaseInterface::getInstance()]]></code>
-      <code><![CDATA[DatabaseInterface::getInstance()]]></code>
-    </DeprecatedMethod>
     <LessSpecificReturnStatement>
       <code><![CDATA['PhpMyAdmin\\Plugins\\Transformations\\' . str_replace('/', '\\', explode('.php', $filename)[0])]]></code>
     </LessSpecificReturnStatement>

--- a/resources/po/af.po
+++ b/resources/po/af.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-12-06 00:47+0000\n"
 "Last-Translator: MP-van-Niekerk <manie@wedoweb.co.za>\n"
 "Language-Team: Afrikaans <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -304,7 +304,7 @@ msgstr "Gaan voort"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 #, fuzzy
 #| msgid "Table comments"
 msgid "Table comments:"
@@ -508,9 +508,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kolom naam"
 
@@ -653,7 +653,7 @@ msgstr "Struktuur"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Naam"
 
@@ -684,9 +684,9 @@ msgstr "Naam"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tipe"
 
@@ -729,9 +729,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Verstekwaarde (default)"
 
@@ -767,8 +767,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Kenmerke"
 
@@ -791,9 +791,9 @@ msgstr "Kenmerke"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -817,9 +817,9 @@ msgstr "Verander Regte"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Kommentaar"
 
@@ -839,7 +839,7 @@ msgstr "Voeg By/Verwyder Veld Kolomme"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Display Features"
 msgid "Media type"
@@ -974,7 +974,7 @@ msgstr "Onbeskikbaar"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ja"
 
@@ -1010,7 +1010,7 @@ msgstr "Ja"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Nee"
 
@@ -1543,9 +1543,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Skakels na"
 
@@ -1991,7 +1991,7 @@ msgstr "Einde"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 msgid "Definition"
 msgstr "geen Beskrywing"
@@ -3033,7 +3033,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4187,8 +4187,8 @@ msgstr "Naspeur verslag"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Bladsy nommer:"
 
@@ -4328,7 +4328,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -6892,7 +6892,7 @@ msgstr "Sa"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -7792,8 +7792,8 @@ msgstr "Drukker mooi (print view)"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Ekstra"
 
@@ -8061,7 +8061,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -17935,17 +17935,17 @@ msgid "Error reading data for table %s:"
 msgstr "Stort data vir tabel"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Skepping:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Vorige opdatering:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Vorige inspeksie:"
 
@@ -17962,7 +17962,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18125,18 +18125,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Verkeerde uitvoer tipe"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database"
 msgstr "Skema van die \"%s\" databasis - Bladsy %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 #, fuzzy
 msgid "Table of contents"
 msgstr "Tabel kommentaar"

--- a/resources/po/am.po
+++ b/resources/po/am.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Amharic <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -283,7 +283,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "የቴብል ኮሜንት"
 
@@ -479,9 +479,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "ኮለመን"
 
@@ -600,7 +600,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -631,9 +631,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "ዓይነት"
 
@@ -666,9 +666,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -704,8 +704,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -728,9 +728,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "ባዶ"
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "ኮሜንት"
 
@@ -772,7 +772,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Bad type!"
 msgid "Media type"
@@ -898,7 +898,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "አዎ"
 
@@ -934,7 +934,7 @@ msgstr "አዎ"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "አይደለም"
 
@@ -1408,9 +1408,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "አገናኝ ከ"
 
@@ -1784,7 +1784,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2710,7 +2710,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3713,8 +3713,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3848,7 +3848,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -6924,8 +6924,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7158,7 +7158,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16225,17 +16225,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16252,7 +16252,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16405,17 +16405,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/ar.po
+++ b/resources/po/ar.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2024-02-01 15:01+0000\n"
 "Last-Translator: Mohammed Al Otaibi <mopes.03.belle@icloud.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -290,7 +290,7 @@ msgstr "إنطلق"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "تعليقات الجدول:"
 
@@ -488,9 +488,9 @@ msgstr "هو مفتاح خارجي."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "عمود"
 
@@ -619,7 +619,7 @@ msgstr "بناء"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "الاسم"
 
@@ -650,9 +650,9 @@ msgstr "الاسم"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "نوع"
 
@@ -690,9 +690,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "إفتراضي"
 
@@ -730,8 +730,8 @@ msgstr "الترتيب"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "الخواص"
 
@@ -754,9 +754,9 @@ msgstr "الخواص"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "لا شيء"
 
@@ -779,9 +779,9 @@ msgstr "تحرير الامتيازات"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "التعليقات"
 
@@ -800,7 +800,7 @@ msgstr "إضافه/حذف عمود حقل"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 msgid "Media type"
 msgstr "نوع MIME"
@@ -934,7 +934,7 @@ msgstr "معطل"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "نعم"
 
@@ -970,7 +970,7 @@ msgstr "نعم"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "لا"
 
@@ -1469,9 +1469,9 @@ msgstr "طباعة"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "مرتبط بـ"
 
@@ -1877,7 +1877,7 @@ msgstr "نهاية"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 msgid "Definition"
 msgstr "الوصف"
@@ -2866,7 +2866,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "قاعدة بيانات:"
 
@@ -3903,8 +3903,8 @@ msgstr "يأخذك إلى الموقع المستهدف."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "رقم الصفحة:"
 
@@ -4040,7 +4040,7 @@ msgstr ""
 msgid "View:"
 msgstr "عرض :"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "جدول:"
 
@@ -6474,7 +6474,7 @@ msgstr "حالة"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "وقت"
 
@@ -7292,8 +7292,8 @@ msgstr "إزالة التقسيم"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "إضافي"
 
@@ -7540,7 +7540,7 @@ msgstr "وقت"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "حدث"
 
@@ -17033,17 +17033,17 @@ msgid "Error reading data for table %s:"
 msgstr "خطأ في قراءة بيانات الجدول %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "الإنشاء:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "آخر تحديث:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "آخر فحص:"
 
@@ -17060,7 +17060,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -17215,17 +17215,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr "نوع التصدير غير صحيح"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "مخطط قاعدة البيانات %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "بناء الارتباطات"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "جدول المحتويات"
 

--- a/resources/po/ar_LY.po
+++ b/resources/po/ar_LY.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Arabic (Libya) <https://hosted.weblate.org/projects/"
@@ -284,7 +284,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -480,9 +480,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr "هيكل"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -633,9 +633,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr ""
 
@@ -668,9 +668,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -706,8 +706,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -730,9 +730,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr ""
 
@@ -754,9 +754,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -774,7 +774,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Bad type!"
 msgid "Media type"
@@ -900,7 +900,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr ""
 
@@ -936,7 +936,7 @@ msgstr ""
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr ""
 
@@ -1410,9 +1410,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1786,7 +1786,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2724,7 +2724,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3727,8 +3727,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3862,7 +3862,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6163,7 +6163,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -6940,8 +6940,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7174,7 +7174,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16280,17 +16280,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16307,7 +16307,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16460,17 +16460,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/ast.po
+++ b/resources/po/ast.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-02-27 16:44+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@mfauth.net>\n"
 "Language-Team: Asturian <https://hosted.weblate.org/projects/phpmyadmin/5-2/"
@@ -283,7 +283,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -479,9 +479,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -631,9 +631,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr ""
 
@@ -666,9 +666,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -704,8 +704,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -728,9 +728,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr ""
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr ""
 
@@ -1406,9 +1406,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1782,7 +1782,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2708,7 +2708,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3711,8 +3711,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3846,7 +3846,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6139,7 +6139,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -6910,8 +6910,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7142,7 +7142,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16198,17 +16198,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16225,7 +16225,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16378,17 +16378,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/az.po
+++ b/resources/po/az.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2024-06-13 15:09+0000\n"
 "Last-Translator: Ricky From Hong Kong <lamricky11@hotmail.com>\n"
 "Language-Team: Azerbaijani <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -297,7 +297,7 @@ msgstr "Davam"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Cədvəl şərhləri:"
 
@@ -501,9 +501,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Sütun"
 
@@ -653,7 +653,7 @@ msgstr "Quruluş"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Adı"
 
@@ -684,9 +684,9 @@ msgstr "Adı"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tip"
 
@@ -729,9 +729,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "İlkin vəziyyət"
 
@@ -769,8 +769,8 @@ msgstr "Qarşılaşdırma"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Xüsusiyyətlər"
 
@@ -793,9 +793,9 @@ msgstr "Xüsusiyyətlər"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -819,9 +819,9 @@ msgstr "Səlahiyyətləri Dəyişdir"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Şərhlər"
 
@@ -839,7 +839,7 @@ msgstr "Sütunları daşı"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -983,7 +983,7 @@ msgstr "Söndürülüb"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Bəli"
 
@@ -1019,7 +1019,7 @@ msgstr "Bəli"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Xeyr"
 
@@ -1538,9 +1538,9 @@ msgstr "Çap et"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Əlaqələr"
 
@@ -1944,7 +1944,7 @@ msgstr "Son"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Tərif"
 
@@ -2949,7 +2949,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Verilənlər Bazası:"
 
@@ -4046,8 +4046,8 @@ msgstr "Sizi növbəti addıma aparır…"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Sehife Nömresi:"
 
@@ -4189,7 +4189,7 @@ msgstr ""
 msgid "View:"
 msgstr "Görünüş"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Cədvəl:"
 
@@ -6779,7 +6779,7 @@ msgstr "Status"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Müddət"
 
@@ -7635,8 +7635,8 @@ msgstr "bölündü"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Əlavə"
 
@@ -7887,7 +7887,7 @@ msgstr "Müddət"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Hadisə"
 
@@ -17796,17 +17796,17 @@ msgid "Error reading data for table %s:"
 msgstr "Verilənlərin oxunması xətası:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Yaradılma:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Ən son yenilənmə:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Ən son yoxlama:"
 
@@ -17823,7 +17823,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -17982,18 +17982,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Etibarsız eksport tipi"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the %s database - Page %s"
 msgid "Schema of the %s database"
 msgstr "%s Bazasının sxemi - Səhifə %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "İçindəkilər Cədvəli"
 

--- a/resources/po/be.po
+++ b/resources/po/be.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Belarusian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -293,7 +293,7 @@ msgstr "Панеслася"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Камэнтар да табліцы:"
 
@@ -495,9 +495,9 @@ msgstr "Гэта знешні ключ."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Калонка"
 
@@ -616,7 +616,7 @@ msgstr "Структура"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Назва"
 
@@ -647,9 +647,9 @@ msgstr "Назва"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Тып"
 
@@ -692,9 +692,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Па змоўчаньні"
 
@@ -732,8 +732,8 @@ msgstr "Параўноўванне"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Атрыбуты"
 
@@ -756,9 +756,9 @@ msgstr "Атрыбуты"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Нуль"
 
@@ -780,9 +780,9 @@ msgstr "Наладзіць прывілеі"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Камэнтары"
 
@@ -800,7 +800,7 @@ msgstr "Перамясціць слупок"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -936,7 +936,7 @@ msgstr "Адключана"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Так"
 
@@ -972,7 +972,7 @@ msgstr "Так"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Не"
 
@@ -1460,9 +1460,9 @@ msgstr "Друк"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Зьвязаная з"
 
@@ -1840,7 +1840,7 @@ msgstr "Канец"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Азначэнне"
 
@@ -2811,7 +2811,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "База даных:"
 
@@ -3875,8 +3875,8 @@ msgstr "Прымаючы вас на мэтавы сайт."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Старонка:"
 
@@ -4016,7 +4016,7 @@ msgstr ""
 msgid "View:"
 msgstr "Прадстаўленні:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Табліца:"
 
@@ -6491,7 +6491,7 @@ msgstr "Стан"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Час"
 
@@ -7305,8 +7305,8 @@ msgstr "Рэдагаваць падзяленне"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Дадаткова"
 
@@ -7548,7 +7548,7 @@ msgstr "Час"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Падзея"
 
@@ -17106,17 +17106,17 @@ msgid "Error reading data for table %s:"
 msgstr "Памылка чытання даных табліц %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Створаная:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Апошняе абнаўленьне:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Апошняя праверка:"
 
@@ -17133,7 +17133,7 @@ msgstr ""
 msgid "Export contents"
 msgstr "Экспартаваць змест"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -17289,17 +17289,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Старонка экспарту PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Схема базы даных «%s»"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Рэляцыйная схема"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Зьмест"
 

--- a/resources/po/be@latin.po
+++ b/resources/po/be@latin.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Belarusian (latin) <https://hosted.weblate.org/projects/"
@@ -307,7 +307,7 @@ msgstr "Paniesłasia"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 #, fuzzy
 #| msgid "Table comments"
 msgid "Table comments:"
@@ -522,9 +522,9 @@ msgstr "Vybierycie źniešni kluč"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 #, fuzzy
 #| msgid "Column names"
 msgid "Column"
@@ -677,7 +677,7 @@ msgstr "Struktura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nazva"
 
@@ -708,9 +708,9 @@ msgstr "Nazva"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Typ"
 
@@ -753,9 +753,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Pa zmoŭčańni"
 
@@ -793,8 +793,8 @@ msgstr "Supastaŭleńnie"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atrybuty"
 
@@ -817,9 +817,9 @@ msgstr "Atrybuty"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Nul"
 
@@ -843,9 +843,9 @@ msgstr "Redagavać pryvilei"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Kamentary"
 
@@ -865,7 +865,7 @@ msgstr "Dadać/vydalić kalonku kryteru"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -1011,7 +1011,7 @@ msgstr "Adklučana"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Tak"
 
@@ -1047,7 +1047,7 @@ msgstr "Tak"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Nie"
 
@@ -1595,9 +1595,9 @@ msgstr "Druk"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Źviazanaja z"
 
@@ -2050,7 +2050,7 @@ msgstr "Apošniaja staronka"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3134,7 +3134,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4341,8 +4341,8 @@ msgstr "Źmianić"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Staronka:"
 
@@ -4484,7 +4484,7 @@ msgstr ""
 msgid "View:"
 msgstr "Vyhlad"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7177,7 +7177,7 @@ msgstr "Sub"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Čas"
 
@@ -8122,8 +8122,8 @@ msgstr "Skasavać padzieł na častki"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Dadatkova"
 
@@ -8401,7 +8401,7 @@ msgstr "Čas"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Padzieja"
 
@@ -19040,21 +19040,21 @@ msgid "Error reading data for table %s:"
 msgstr "Dazvalaje čytać dadzienyja."
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "Stvoranaja"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 #, fuzzy
 #| msgid "Last update"
 msgid "Last update:"
 msgstr "Apošniaje abnaŭleńnie"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 #, fuzzy
 #| msgid "Last check"
 msgid "Last check:"
@@ -19073,7 +19073,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -19244,18 +19244,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Ekspart"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database"
 msgstr "Struktura bazy \"%s\" — staronka %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Relacyjnaja schiema"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Źmiest"
 

--- a/resources/po/ber.po
+++ b/resources/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2020-08-16 22:12+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -283,7 +283,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -479,9 +479,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -631,9 +631,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr ""
 
@@ -666,9 +666,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -704,8 +704,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -728,9 +728,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr ""
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr ""
 
@@ -1406,9 +1406,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1782,7 +1782,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2708,7 +2708,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3711,8 +3711,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3846,7 +3846,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6139,7 +6139,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -6910,8 +6910,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7142,7 +7142,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16198,17 +16198,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16225,7 +16225,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16378,17 +16378,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/bg.po
+++ b/resources/po/bg.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-06-02 19:01+0000\n"
 "Last-Translator: Мария Рангелова <rangelova1186@gmail.com>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -281,7 +281,7 @@ msgstr "Изпълнение"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Коментари към таблицата:"
 
@@ -479,9 +479,9 @@ msgstr "Външен ключ е."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kолона"
 
@@ -600,7 +600,7 @@ msgstr "Структура"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Име"
 
@@ -631,9 +631,9 @@ msgstr "Име"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Тип"
 
@@ -670,9 +670,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "По подразбиране"
 
@@ -710,8 +710,8 @@ msgstr "Колация"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Атрибути"
 
@@ -734,9 +734,9 @@ msgstr "Атрибути"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Празно"
 
@@ -758,9 +758,9 @@ msgstr "Коригиране на привилегиите"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Коментари"
 
@@ -778,7 +778,7 @@ msgstr "Преместване колона"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Тип медия"
 
@@ -907,7 +907,7 @@ msgstr "Забранено"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Да"
 
@@ -943,7 +943,7 @@ msgstr "Да"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Не"
 
@@ -1417,9 +1417,9 @@ msgstr "Печат"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Свързана към"
 
@@ -1801,7 +1801,7 @@ msgstr "Край"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Описание"
 
@@ -2776,7 +2776,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "База данни:"
 
@@ -3817,8 +3817,8 @@ msgstr "Към целевата страница."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Страница:"
 
@@ -3953,7 +3953,7 @@ msgstr ""
 msgid "View:"
 msgstr "Изглед:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Таблица:"
 
@@ -6464,7 +6464,7 @@ msgstr "Начало"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Време"
 
@@ -7291,8 +7291,8 @@ msgstr "Редактиране"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Допълнително"
 
@@ -7537,7 +7537,7 @@ msgstr "Време"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Действие"
 
@@ -17268,17 +17268,17 @@ msgid "Error reading data for table %s:"
 msgstr "Грешка при четене на данните за таблица %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Създаване:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Последно обновяване:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Последна проверка:"
 
@@ -17295,7 +17295,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -17449,17 +17449,17 @@ msgstr "ГРЕШКА В СХЕМАТА: "
 msgid "PDF export page"
 msgstr "Невалиден тип експорт"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Схема на базата данни %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Релационна схема"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Съдържание"
 

--- a/resources/po/bn.po
+++ b/resources/po/bn.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Bengali <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -299,7 +299,7 @@ msgstr "যাও"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "টেবিলের মন্তব্য সমূহ:"
 
@@ -508,9 +508,9 @@ msgstr "ফরেন কী নির্বাচন করুন"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "স্তম্ভ"
 
@@ -661,7 +661,7 @@ msgstr "গঠন"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "নাম"
 
@@ -692,9 +692,9 @@ msgstr "নাম"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "ধরণ"
 
@@ -730,9 +730,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "ডিফল্ট"
 
@@ -768,8 +768,8 @@ msgstr "ভাষা"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "গুনাবলী"
 
@@ -792,9 +792,9 @@ msgstr "গুনাবলী"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "নাল"
 
@@ -818,9 +818,9 @@ msgstr "অধিকারসমূহ সম্পাদনা"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "মন্তব্য"
 
@@ -838,7 +838,7 @@ msgstr "স্বম্ভ সরাও"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -981,7 +981,7 @@ msgstr "অকার্যকর"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "হ্যাঁ"
 
@@ -1017,7 +1017,7 @@ msgstr "হ্যাঁ"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "না"
 
@@ -1569,9 +1569,9 @@ msgstr "প্রিন্ট"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "এর সংযোগ"
 
@@ -1990,7 +1990,7 @@ msgstr "শেষ"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "সংজ্ঞা"
 
@@ -3010,7 +3010,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "ডাটাবেইজ:"
 
@@ -4160,8 +4160,8 @@ msgstr "ট্রেকিং প্রতিবেদন"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "পাতার সংখ্যা:"
 
@@ -4306,7 +4306,7 @@ msgstr ""
 msgid "View:"
 msgstr "ভিউসমূহ:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "টেবিল:"
 
@@ -6986,7 +6986,7 @@ msgstr "অবস্থা"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "সময়"
 
@@ -7867,8 +7867,8 @@ msgstr "খন্ড মুছ"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "বেশতী"
 
@@ -8123,7 +8123,7 @@ msgstr "সময়"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "ইভেন্ট"
 
@@ -18626,17 +18626,17 @@ msgid "Error reading data for table %s:"
 msgstr "তথ্য পড়ার ভুল:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "প্রস্তুত:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "সর্বশেষ আপডেট:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "সর্বশেষ যাচাই:"
 
@@ -18653,7 +18653,7 @@ msgstr "ওবজেক্ট তৈরীর অপশন (সবগুলো �
 msgid "Export contents"
 msgstr "তথ্য রফতানী কর"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18819,18 +18819,18 @@ msgstr "রূপরেখায় ভুল : "
 msgid "PDF export page"
 msgstr "রফতানীর ধরন সঠিক নয়"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the %s database - Page %s"
 msgid "Schema of the %s database"
 msgstr "%s ডাটাবেইজের রূপরেখা - পাতা %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "সর্ম্পকের রূপরেখা"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "সুচিপত্র"
 

--- a/resources/po/br.po
+++ b/resources/po/br.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-03-17 19:29+0000\n"
 "Last-Translator: Fulup Jakez <fulup.jakez@gmail.com>\n"
 "Language-Team: Breton <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -291,7 +291,7 @@ msgstr "Mont"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Evezhiadennoù diwar-benn an daolenn :"
 
@@ -489,9 +489,9 @@ msgstr "Zo un alc'hwez estren."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Bann"
 
@@ -634,7 +634,7 @@ msgstr "Framm"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -665,9 +665,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Seurt"
 
@@ -700,9 +700,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Dre ziouer"
 
@@ -738,8 +738,8 @@ msgstr "Etrerummadiñ"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -762,9 +762,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -788,9 +788,9 @@ msgstr "Oc'h adkargañ an dreistgwirioù"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Evezhiadennoù"
 
@@ -810,7 +810,7 @@ msgstr "Er bann :"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -943,7 +943,7 @@ msgstr "Diweredekaet"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ya"
 
@@ -979,7 +979,7 @@ msgstr "Ya"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Ket"
 
@@ -1528,9 +1528,9 @@ msgstr "Moullañ"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Liammet ouzh"
 
@@ -1959,7 +1959,7 @@ msgstr "Fin"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2963,7 +2963,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4110,8 +4110,8 @@ msgstr "Danevell heuliañ"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Pajenn niv. : "
 
@@ -4261,7 +4261,7 @@ msgstr ""
 msgid "View:"
 msgstr "Gwelet"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -6830,7 +6830,7 @@ msgstr "Pajenn deraouiñ"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -7738,8 +7738,8 @@ msgstr "Mod aozañ"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -8004,7 +8004,7 @@ msgstr "Tem"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -18285,17 +18285,17 @@ msgid "Error reading data for table %s:"
 msgstr "Roadennoù a vank evit %s"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Krouiñ :"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Hizivadenn ziwezhañ :"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Gwiriet da ziwezhañ :"
 
@@ -18312,7 +18312,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18474,18 +18474,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Seurt ezporzhiadenn direizh"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Search in database"
 msgid "Schema of the %s database"
 msgstr "Klask en diaz roadennoù"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/brx.po
+++ b/resources/po/brx.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2015-09-04 09:33+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Bodo <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -283,7 +283,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -479,9 +479,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -631,9 +631,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr ""
 
@@ -666,9 +666,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -704,8 +704,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -728,9 +728,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr ""
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr ""
 
@@ -1406,9 +1406,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1782,7 +1782,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2708,7 +2708,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3711,8 +3711,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3846,7 +3846,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6139,7 +6139,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -6910,8 +6910,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7142,7 +7142,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16198,17 +16198,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16225,7 +16225,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16378,17 +16378,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/bs.po
+++ b/resources/po/bs.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Bosnian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -307,7 +307,7 @@ msgstr "Kreni"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 #, fuzzy
 #| msgid "Table comments"
 msgid "Table comments:"
@@ -512,9 +512,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kolona"
 
@@ -663,7 +663,7 @@ msgstr "Struktura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Ime"
 
@@ -694,9 +694,9 @@ msgstr "Ime"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tip"
 
@@ -739,9 +739,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Podrazumjevano"
 
@@ -779,8 +779,8 @@ msgstr "Sortiranje"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atributi"
 
@@ -803,9 +803,9 @@ msgstr "Atributi"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -829,9 +829,9 @@ msgstr "Promijeni privilegije"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Komentari"
 
@@ -851,7 +851,7 @@ msgstr "Dodaj/obriši kolonu"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -991,7 +991,7 @@ msgstr "Onemogućeno"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Da"
 
@@ -1027,7 +1027,7 @@ msgstr "Da"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Ne"
 
@@ -1565,9 +1565,9 @@ msgstr "Štampaj"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Veze ka"
 
@@ -2017,7 +2017,7 @@ msgstr "Kraj"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3076,7 +3076,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4245,8 +4245,8 @@ msgstr "Promijeni"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Broj strane:"
 
@@ -4385,7 +4385,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7019,7 +7019,7 @@ msgstr "Status"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Vrijeme"
 
@@ -7939,8 +7939,8 @@ msgstr "Dodaj novo polje"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Dodatno"
 
@@ -8212,7 +8212,7 @@ msgstr "Vrijeme"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 #, fuzzy
 msgid "Event"
 msgstr "Poslato"
@@ -18276,21 +18276,21 @@ msgid "Error reading data for table %s:"
 msgstr "Dozvoljava čitanje podataka."
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "Napravljeno"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 #, fuzzy
 #| msgid "Last update"
 msgid "Last update:"
 msgstr "Posljednja izmjena"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 #, fuzzy
 #| msgid "Last check"
 msgid "Last check:"
@@ -18309,7 +18309,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18473,18 +18473,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Nema tabela"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database"
 msgstr "Shema baze \"%s\" - Strana %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Relaciona shema"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Sadržaj"
 

--- a/resources/po/ca.po
+++ b/resources/po/ca.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -291,7 +291,7 @@ msgstr "Executa"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Comentaris de la taula:"
 
@@ -493,9 +493,9 @@ msgstr "És una clau forana."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Columna"
 
@@ -614,7 +614,7 @@ msgstr "Estructura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nom"
 
@@ -645,9 +645,9 @@ msgstr "Nom"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tipus"
 
@@ -690,9 +690,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Per defecte"
 
@@ -730,8 +730,8 @@ msgstr "Col·lació"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atributs"
 
@@ -754,9 +754,9 @@ msgstr "Atributs"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Nul"
 
@@ -778,9 +778,9 @@ msgstr "Ajusta els privilegis"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Comentaris"
 
@@ -798,7 +798,7 @@ msgstr "Mou la columna"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -929,7 +929,7 @@ msgstr "Desactivat"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Sí"
 
@@ -965,7 +965,7 @@ msgstr "Sí"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "No"
 
@@ -1455,9 +1455,9 @@ msgstr "Imprimeix"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Enllaços a"
 
@@ -1834,7 +1834,7 @@ msgstr "Final"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definició"
 
@@ -2804,7 +2804,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Base de dades:"
 
@@ -3891,8 +3891,8 @@ msgstr "Se us està portant al lloc destí."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Número de pàgina:"
 
@@ -4060,7 +4060,7 @@ msgstr ""
 msgid "View:"
 msgstr "Vistes:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Taula:"
 
@@ -6741,7 +6741,7 @@ msgstr "Estat"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Temps"
 
@@ -7565,8 +7565,8 @@ msgstr "Edició de les particions"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -7808,7 +7808,7 @@ msgstr "Temps"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Esdeveniment"
 
@@ -18346,17 +18346,17 @@ msgid "Error reading data for table %s:"
 msgstr "Error en llegir les dades per a la taula %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Creació:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Última actualització:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Última comprovació:"
 
@@ -18375,7 +18375,7 @@ msgstr "Opcions de creació d'objectes (es recomanen totes)"
 msgid "Export contents"
 msgstr "Exporta el contingut"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Propòsit:"
 
@@ -18544,17 +18544,17 @@ msgstr "ERROR D'ESQUEMA: "
 msgid "PDF export page"
 msgstr "Pàgina d'exportació PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Esquema de la base de dades %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Esquema relacional"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Taula de continguts"
 

--- a/resources/po/ckb.po
+++ b/resources/po/ckb.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Kurdish (Central) <https://hosted.weblate.org/projects/"
@@ -292,7 +292,7 @@ msgstr "بڕۆ"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "تێبینیەکانی خشتە:"
 
@@ -492,9 +492,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "ستون"
 
@@ -613,7 +613,7 @@ msgstr "پێکهاتە"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "ناو"
 
@@ -644,9 +644,9 @@ msgstr "ناو"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "جۆر"
 
@@ -679,9 +679,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "بنەڕەت"
 
@@ -717,8 +717,8 @@ msgstr "ڕێکخستن"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "تایبەتمەندی"
 
@@ -741,9 +741,9 @@ msgstr "تایبەتمەندی"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "بەتاڵ"
 
@@ -765,9 +765,9 @@ msgstr "تایبەتمەندێتیەکان"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "بۆچوون"
 
@@ -785,7 +785,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "جۆری میدیا"
 
@@ -909,7 +909,7 @@ msgstr "ناچالاککراوە"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "بەڵێ"
 
@@ -945,7 +945,7 @@ msgstr "بەڵێ"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "نەخێر"
 
@@ -1427,9 +1427,9 @@ msgstr "چاپکردن"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "بەستەر بۆ"
 
@@ -1807,7 +1807,7 @@ msgstr "کۆتایی"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "پێناسە"
 
@@ -2753,7 +2753,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "بنکەی دراو"
 
@@ -3779,8 +3779,8 @@ msgstr "هەنگاوی داهاتووت…"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "ژمارەی پەڕە:"
 
@@ -3920,7 +3920,7 @@ msgstr ""
 msgid "View:"
 msgstr "نیشاندان"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "خشتە"
 
@@ -6338,7 +6338,7 @@ msgstr "شەممە"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "کات"
 
@@ -7143,8 +7143,8 @@ msgstr "چاکردنی نیشاندەر"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "زیادە"
 
@@ -7381,7 +7381,7 @@ msgstr "کات"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "ڕووداو"
 
@@ -16666,17 +16666,17 @@ msgid "Error reading data for table %s:"
 msgstr "سڕینەوە داتا شوێنکەوتووەکانی ئەم خشانە؟"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "درووستکردن:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "دواترین نوێکردنەوە:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "دواین پشکنین:"
 
@@ -16693,7 +16693,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16846,17 +16846,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr "هەناردنی ئەم جۆرە ڕێگەپێدراو نییە"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 msgid "Schema of the %s database"
 msgstr "گەڕان لە بنکەی دراو"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "خشتەی ناوەڕۆک"
 

--- a/resources/po/cs.po
+++ b/resources/po/cs.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2024-03-29 10:58+0000\n"
 "Last-Translator: Vaniron CZ <vanironcz@gmail.com>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -291,7 +291,7 @@ msgstr "Proveď"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Komentář k tabulce:"
 
@@ -489,9 +489,9 @@ msgstr "Jedná se o cizí klíč."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Sloupec"
 
@@ -610,7 +610,7 @@ msgstr "Struktura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Název"
 
@@ -641,9 +641,9 @@ msgstr "Název"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Typ"
 
@@ -680,9 +680,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Výchozí"
 
@@ -720,8 +720,8 @@ msgstr "Porovnávání"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Vlastnosti"
 
@@ -744,9 +744,9 @@ msgstr "Vlastnosti"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Prázdný"
 
@@ -768,9 +768,9 @@ msgstr "Upravit oprávnění"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Komentáře"
 
@@ -788,7 +788,7 @@ msgstr "Přesunout sloupec"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Typ média"
 
@@ -916,7 +916,7 @@ msgstr "Vypnuto"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ano"
 
@@ -952,7 +952,7 @@ msgstr "Ano"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Ne"
 
@@ -1430,9 +1430,9 @@ msgstr "Vytisknout"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Odkazuje na"
 
@@ -1808,7 +1808,7 @@ msgstr "Konec"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definice"
 
@@ -2756,7 +2756,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Databáze:"
 
@@ -3783,8 +3783,8 @@ msgstr "Probíhá přesměrování na cílový web."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Strana číslo:"
 
@@ -3938,7 +3938,7 @@ msgstr "Připojte zařízení WebAuthn/FIDO2. Poté v zařízení potvrďte při
 msgid "View:"
 msgstr "Pohled:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabulka:"
 
@@ -6380,7 +6380,7 @@ msgstr "Stav"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Čas"
 
@@ -7165,8 +7165,8 @@ msgstr "Upravit rozdělení"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Další"
 
@@ -7398,7 +7398,7 @@ msgstr "Spouštění"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Událost"
 
@@ -17380,17 +17380,17 @@ msgid "Error reading data for table %s:"
 msgstr "Chyba při čtení dat pro tabulku %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Vytvořeno:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Poslední změna:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Poslední kontrola:"
 
@@ -17409,7 +17409,7 @@ msgstr "Nastavení vytváření objektů (všechna jsou doporučena)"
 msgid "Export contents"
 msgstr "Exportovat obsah"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Účel:"
 
@@ -17574,17 +17574,17 @@ msgstr "Chyba při vytváření schématu: "
 msgid "PDF export page"
 msgstr "Stránka exportu PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Schéma databáze %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Relační schéma"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Obsah"
 

--- a/resources/po/cy.po
+++ b/resources/po/cy.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Welsh <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -307,7 +307,7 @@ msgstr "Ewch"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Sylwadau tabl:"
 
@@ -519,9 +519,9 @@ msgstr "Dewis Allwedd Estron"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Colofn"
 
@@ -672,7 +672,7 @@ msgstr "Strwythur"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Enw"
 
@@ -703,9 +703,9 @@ msgstr "Enw"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Math"
 
@@ -738,9 +738,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Diofyn"
 
@@ -776,8 +776,8 @@ msgstr "Coladiad"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -800,9 +800,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Nyl"
 
@@ -826,9 +826,9 @@ msgstr "Breintiau"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Sylwadau"
 
@@ -848,7 +848,7 @@ msgstr "Ychwanegu/Dileu colofnau"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -982,7 +982,7 @@ msgstr "Analluogwyd"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ie"
 
@@ -1018,7 +1018,7 @@ msgstr "Ie"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Na"
 
@@ -1557,9 +1557,9 @@ msgstr "Argraffu"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Yn cysylltu gyda"
 
@@ -2008,7 +2008,7 @@ msgstr "Diwedd"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3071,7 +3071,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4254,8 +4254,8 @@ msgstr "Adroddiad tracio"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Rhif tudalen:"
 
@@ -4399,7 +4399,7 @@ msgstr ""
 msgid "View:"
 msgstr "Dangos"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7026,7 +7026,7 @@ msgstr "Sad"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Amser"
 
@@ -7956,8 +7956,8 @@ msgstr "Tynnu'r ymraniadu"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Ychwanegol"
 
@@ -8232,7 +8232,7 @@ msgstr "Amser"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Digwyddiad"
 
@@ -18638,21 +18638,21 @@ msgid "Error reading data for table %s:"
 msgstr "Data ar goll ar gyfer %s"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "Cread"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 #, fuzzy
 #| msgid "Last update"
 msgid "Last update:"
 msgstr "Diweddariad diwethaf"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 #, fuzzy
 #| msgid "Last check"
 msgid "Last check:"
@@ -18671,7 +18671,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18837,18 +18837,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Allforio"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Search in database"
 msgid "Schema of the %s database"
 msgstr "Chwilio yn y gronfa ddata"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Sgema perthynol"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Tabl cynnwys"
 

--- a/resources/po/da.po
+++ b/resources/po/da.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2021-01-22 17:26+0000\n"
 "Last-Translator: William Desportes <williamdes@wdes.fr>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -291,7 +291,7 @@ msgstr "Udfør"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Tabelkommentarer:"
 
@@ -493,9 +493,9 @@ msgstr "Vælg fremmednøgle."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kolonne"
 
@@ -614,7 +614,7 @@ msgstr "Struktur"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Navn"
 
@@ -645,9 +645,9 @@ msgstr "Navn"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Datatype"
 
@@ -684,9 +684,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Standardværdi"
 
@@ -724,8 +724,8 @@ msgstr "Tegnsæt (sortering)"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Attributter"
 
@@ -748,9 +748,9 @@ msgstr "Attributter"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Nulværdi"
 
@@ -772,9 +772,9 @@ msgstr "Ret privilegier"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Kommentarer"
 
@@ -792,7 +792,7 @@ msgstr "Fjern kolonne"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -924,7 +924,7 @@ msgstr "Slået fra"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ja"
 
@@ -960,7 +960,7 @@ msgstr "Ja"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Nej"
 
@@ -1454,9 +1454,9 @@ msgstr "Udskriv"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Linker til"
 
@@ -1833,7 +1833,7 @@ msgstr "Slut"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definition"
 
@@ -2825,7 +2825,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Database:"
 
@@ -3919,8 +3919,8 @@ msgstr "Tager dig til målstedet."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Side nummer:"
 
@@ -4074,7 +4074,7 @@ msgstr ""
 msgid "View:"
 msgstr "Views:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabel:"
 
@@ -6722,7 +6722,7 @@ msgstr "Tilstand"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Tid"
 
@@ -7543,8 +7543,8 @@ msgstr "Rediger partitionering"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Ekstra"
 
@@ -7788,7 +7788,7 @@ msgstr "Tid"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Hændelse"
 
@@ -18131,17 +18131,17 @@ msgid "Error reading data for table %s:"
 msgstr "Fejl ved læsning af data i tabel %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Oprettelse:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Seneste opdatering:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Seneste tjek:"
 
@@ -18160,7 +18160,7 @@ msgstr "Indstillinger for oprettelse af objekter (alle anbefales)"
 msgid "Export contents"
 msgstr "Eksport indhold"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Formål:"
 
@@ -18326,17 +18326,17 @@ msgstr "SCHEMA ERROR: "
 msgid "PDF export page"
 msgstr "PDF-eksportside"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Skema for databasen \"%s\""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Relationel skematik"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Indholdsfortegnelse"
 

--- a/resources/po/de.po
+++ b/resources/po/de.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin-docs 4.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-05-01 11:02+0000\n"
 "Last-Translator: M393 <maximilian.kroeg@geocept.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -281,7 +281,7 @@ msgstr "OK"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Tabellenkommentar:"
 
@@ -479,9 +479,9 @@ msgstr "Ist ein Fremdschlüssel."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Spalte"
 
@@ -600,7 +600,7 @@ msgstr "Struktur"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Name"
 
@@ -631,9 +631,9 @@ msgstr "Name"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Typ"
 
@@ -670,9 +670,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Standard"
 
@@ -710,8 +710,8 @@ msgstr "Kollation"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Attribute"
 
@@ -734,9 +734,9 @@ msgstr "Attribute"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -758,9 +758,9 @@ msgstr "Rechte anpassen"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Kommentare"
 
@@ -778,7 +778,7 @@ msgstr "Spalte verschieben"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Medientyp"
 
@@ -906,7 +906,7 @@ msgstr "Deaktiviert"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ja"
 
@@ -942,7 +942,7 @@ msgstr "Ja"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Nein"
 
@@ -1418,9 +1418,9 @@ msgstr "Drucken"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Verweise"
 
@@ -1794,7 +1794,7 @@ msgstr "Ende"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definition"
 
@@ -2732,7 +2732,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Datenbank:"
 
@@ -3767,8 +3767,8 @@ msgstr "Führt Sie zur Zielsite."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Seite:"
 
@@ -3930,7 +3930,7 @@ msgstr ""
 msgid "View:"
 msgstr "Ansicht:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabelle:"
 
@@ -6398,7 +6398,7 @@ msgstr "Status"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Zeit"
 
@@ -7186,8 +7186,8 @@ msgstr "Bearbeite die Partitionierung"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -7420,7 +7420,7 @@ msgstr "Zeit"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Ereignis"
 
@@ -17666,17 +17666,17 @@ msgid "Error reading data for table %s:"
 msgstr "Fehler beim Lesen der Daten von Tabelle %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Erstellt am:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Zuletzt aktualisiert:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Letzte Prüfung:"
 
@@ -17695,7 +17695,7 @@ msgstr "Optionen zum Anlegen von Objekten (alle werden empfohlen)"
 msgid "Export contents"
 msgstr "Export-Inhalte"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Zweck:"
 
@@ -17865,17 +17865,17 @@ msgstr "SCHEMA-FEHLER: "
 msgid "PDF export page"
 msgstr "PDF-Export-Seite"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Schema der Datenbank %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Beziehungsschema"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Inhalt"
 

--- a/resources/po/el.po
+++ b/resources/po/el.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-05-14 19:50+0000\n"
 "Last-Translator: Spyridon Eftychios Kokotos <spiroskoeu@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -285,7 +285,7 @@ msgstr "Εκτέλεση"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Σχόλια πίνακα:"
 
@@ -487,9 +487,9 @@ msgstr "Είναι ένα foreign key."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Στήλη"
 
@@ -608,7 +608,7 @@ msgstr "Δομή"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Όνομα"
 
@@ -639,9 +639,9 @@ msgstr "Όνομα"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Τύπος"
 
@@ -678,9 +678,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Προεπιλογή"
 
@@ -718,8 +718,8 @@ msgstr "Σύνθεση"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Χαρακτηριστικά"
 
@@ -742,9 +742,9 @@ msgstr "Χαρακτηριστικά"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Κενό"
 
@@ -766,9 +766,9 @@ msgstr "Προσαρμογή δικαιωμάτων"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Σχόλια"
 
@@ -786,7 +786,7 @@ msgstr "Απομάκρυνση στήλης"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Τύπος μέσου"
 
@@ -916,7 +916,7 @@ msgstr "Απενεργοποιημένη"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ναι"
 
@@ -952,7 +952,7 @@ msgstr "Ναι"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Όχι"
 
@@ -1436,9 +1436,9 @@ msgstr "Εκτύπωση"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Σύνδεση με"
 
@@ -1814,7 +1814,7 @@ msgstr "Λήξη"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Προσδιορισμός"
 
@@ -2757,7 +2757,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Βάση δεδομένων:"
 
@@ -3845,8 +3845,8 @@ msgstr "Μεταφέροντάς σας στη σελίδα προορισμού
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Σελίδα:"
 
@@ -4021,7 +4021,7 @@ msgstr ""
 msgid "View:"
 msgstr "Προβολές:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Πίνακας:"
 
@@ -6717,7 +6717,7 @@ msgstr "Κατάσταση"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Χρόνος"
 
@@ -7542,8 +7542,8 @@ msgstr "Επεξεργασία κατάτμησης"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Πρόσθετα"
 
@@ -7785,7 +7785,7 @@ msgstr "Χρόνος"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Συμβάν"
 
@@ -18338,17 +18338,17 @@ msgid "Error reading data for table %s:"
 msgstr "Σφάλμα ανάγνωσης δεδομένων για τον πίνακα %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Δημιουργία:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Τελευταία ενημέρωση:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Tελευταίος έλεγχος:"
 
@@ -18367,7 +18367,7 @@ msgstr "Επιλογές δημιουργίας αντικειμένου (όλε
 msgid "Export contents"
 msgstr "Εξαγωγή περιεχομένων"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Σκοπός:"
 
@@ -18533,17 +18533,17 @@ msgstr "ΣΦΑΛΜΑ ΣΧΗΜΑΤΟΣ: "
 msgid "PDF export page"
 msgstr "Σελίδα εξαγωγής PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Σχήμα της βάσης δεδομένων %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Σχεσιακό σχήμα"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Πίνακας περιεχομένων"
 

--- a/resources/po/en_GB.po
+++ b/resources/po/en_GB.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-04-24 14:25+0000\n"
 "Last-Translator: Andi Chandler <andi@gowling.com>\n"
 "Language-Team: English (United Kingdom) <https://hosted.weblate.org/projects/"
@@ -283,7 +283,7 @@ msgstr "Go"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Table comments:"
 
@@ -481,9 +481,9 @@ msgstr "Is a foreign key."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Column"
 
@@ -602,7 +602,7 @@ msgstr "Structure"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Name"
 
@@ -633,9 +633,9 @@ msgstr "Name"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Type"
 
@@ -672,9 +672,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Default"
 
@@ -712,8 +712,8 @@ msgstr "Collation"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Attributes"
 
@@ -736,9 +736,9 @@ msgstr "Attributes"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -760,9 +760,9 @@ msgstr "Adjust privileges"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Comments"
 
@@ -780,7 +780,7 @@ msgstr "Move column"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Media type"
 
@@ -909,7 +909,7 @@ msgstr "Disabled"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Yes"
 
@@ -945,7 +945,7 @@ msgstr "Yes"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "No"
 
@@ -1421,9 +1421,9 @@ msgstr "Print"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Links to"
 
@@ -1797,7 +1797,7 @@ msgstr "End"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definition"
 
@@ -2735,7 +2735,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Database:"
 
@@ -3760,8 +3760,8 @@ msgstr "Taking you to the target site."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Page number:"
 
@@ -3918,7 +3918,7 @@ msgstr ""
 msgid "View:"
 msgstr "View:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Table:"
 
@@ -6334,7 +6334,7 @@ msgstr "State"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Time"
 
@@ -7117,8 +7117,8 @@ msgstr "Edit partitioning"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -7349,7 +7349,7 @@ msgstr "Time"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Event"
 
@@ -17273,17 +17273,17 @@ msgid "Error reading data for table %s:"
 msgstr "Error reading data for table %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Creation:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Last update:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Last check:"
 
@@ -17301,7 +17301,7 @@ msgstr "Object creation options (all are recommended)"
 msgid "Export contents"
 msgstr "Export contents"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Purpose:"
 
@@ -17464,17 +17464,17 @@ msgstr "SCHEMA ERROR: "
 msgid "PDF export page"
 msgstr "PDF export page"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Schema of the %s database"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Relational schema"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Table of contents"
 

--- a/resources/po/enm.po
+++ b/resources/po/enm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-20 13:11+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: English (Middle) <https://hosted.weblate.org/projects/"
@@ -283,7 +283,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -479,9 +479,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -631,9 +631,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr ""
 
@@ -666,9 +666,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -704,8 +704,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -728,9 +728,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr ""
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr ""
 
@@ -1406,9 +1406,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1782,7 +1782,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2708,7 +2708,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3711,8 +3711,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3846,7 +3846,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6139,7 +6139,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -6910,8 +6910,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7142,7 +7142,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16197,17 +16197,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16224,7 +16224,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16377,17 +16377,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/eo.po
+++ b/resources/po/eo.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -292,7 +292,7 @@ msgstr "Ek"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -488,9 +488,9 @@ msgstr "Estas fremda ŝlosilo."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kolumno"
 
@@ -609,7 +609,7 @@ msgstr "Strukturo"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nomo"
 
@@ -640,9 +640,9 @@ msgstr "Nomo"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tipo"
 
@@ -675,9 +675,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Defaŭlta"
 
@@ -713,8 +713,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atributoj"
 
@@ -737,9 +737,9 @@ msgstr "Atributoj"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Senvalora"
 
@@ -761,9 +761,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Komentoj"
 
@@ -781,7 +781,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -907,7 +907,7 @@ msgstr "Malŝaltita"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Jes"
 
@@ -943,7 +943,7 @@ msgstr "Jes"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Ne"
 
@@ -1421,9 +1421,9 @@ msgstr "Presi"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1808,7 +1808,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2768,7 +2768,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Datumbazo:"
 
@@ -3805,8 +3805,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3946,7 +3946,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabelo:"
 
@@ -6324,7 +6324,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Tempo"
 
@@ -7109,8 +7109,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7347,7 +7347,7 @@ msgstr "Tempo"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Evento"
 
@@ -16648,17 +16648,17 @@ msgid "Error reading data for table %s:"
 msgstr "Limigoj por tabelo"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16675,7 +16675,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16830,17 +16830,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Tabelo de enhavo"
 

--- a/resources/po/es.po
+++ b/resources/po/es.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-02-24 01:46+0000\n"
 "Last-Translator: Salvador Peña <salvadorp74@hotmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -284,7 +284,7 @@ msgstr "Continuar"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Comentarios de la tabla:"
 
@@ -482,9 +482,9 @@ msgstr "Es una clave foránea."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Columna"
 
@@ -603,7 +603,7 @@ msgstr "Estructura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nombre"
 
@@ -634,9 +634,9 @@ msgstr "Nombre"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tipo"
 
@@ -673,9 +673,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Predeterminado"
 
@@ -713,8 +713,8 @@ msgstr "Cotejamiento"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atributos"
 
@@ -737,9 +737,9 @@ msgstr "Atributos"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Nulo"
 
@@ -761,9 +761,9 @@ msgstr "Ajustar privilegios"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Comentarios"
 
@@ -781,7 +781,7 @@ msgstr "Mover columna"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Tipo de medio"
 
@@ -909,7 +909,7 @@ msgstr "Deshabilitado"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Sí"
 
@@ -945,7 +945,7 @@ msgstr "Sí"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "No"
 
@@ -1421,9 +1421,9 @@ msgstr "Imprimir"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Enlaces a"
 
@@ -1800,7 +1800,7 @@ msgstr "Fin"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definición"
 
@@ -2754,7 +2754,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Base de datos:"
 
@@ -3792,8 +3792,8 @@ msgstr "Llevándolo a la página web destino."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Número de página:"
 
@@ -3953,7 +3953,7 @@ msgstr ""
 msgid "View:"
 msgstr "Vista:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabla:"
 
@@ -6424,7 +6424,7 @@ msgstr "Estado"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Tiempo"
 
@@ -7210,8 +7210,8 @@ msgstr "Editar partición"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -7444,7 +7444,7 @@ msgstr "Tiempo"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Evento"
 
@@ -17657,17 +17657,17 @@ msgid "Error reading data for table %s:"
 msgstr "Error leyendo datos de la tabla %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Creación:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Última actualización:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Última revisión:"
 
@@ -17686,7 +17686,7 @@ msgstr "Opciones de creación de objetos (todas son recomendadas)"
 msgid "Export contents"
 msgstr "Exportar contenidos"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Propósito:"
 
@@ -17858,17 +17858,17 @@ msgstr "ERROR DE ESQUEMA: "
 msgid "PDF export page"
 msgstr "Página de exportación PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Esquema de la base de datos %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Esquema relacionado"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Tabla de contenidos"
 

--- a/resources/po/et.po
+++ b/resources/po/et.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2023-11-25 02:27+0000\n"
 "Last-Translator: Kristjan Räts <kristjanrats@gmail.com>\n"
 "Language-Team: Estonian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -291,7 +291,7 @@ msgstr "Mine"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Tabeli kommentaarid:"
 
@@ -489,9 +489,9 @@ msgstr "On välisvõti."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Veerg"
 
@@ -610,7 +610,7 @@ msgstr "Struktuur"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nimi"
 
@@ -641,9 +641,9 @@ msgstr "Nimi"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tüüp"
 
@@ -680,9 +680,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Vaikimisi"
 
@@ -720,8 +720,8 @@ msgstr "Kodeering"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atribuudid"
 
@@ -744,9 +744,9 @@ msgstr "Atribuudid"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -768,9 +768,9 @@ msgstr "Kohanda õiguseid"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Kommentaarid"
 
@@ -788,7 +788,7 @@ msgstr "Liiguta veergu"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Meedia tüüp"
 
@@ -916,7 +916,7 @@ msgstr "Keelatud"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Jah"
 
@@ -952,7 +952,7 @@ msgstr "Jah"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Ei"
 
@@ -1430,9 +1430,9 @@ msgstr "Prindi"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Viitab aadressile"
 
@@ -1806,7 +1806,7 @@ msgstr "Lõpp"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definitsioon"
 
@@ -2752,7 +2752,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Andmebaas:"
 
@@ -3778,8 +3778,8 @@ msgstr "Sind viiakse sihtsaidile."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Leht:"
 
@@ -3935,7 +3935,7 @@ msgstr ""
 msgid "View:"
 msgstr "Vaade:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabel:"
 
@@ -6366,7 +6366,7 @@ msgstr "Olek"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Aeg"
 
@@ -7147,8 +7147,8 @@ msgstr "Muuda partitsioneerimist"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Lisaks"
 
@@ -7380,7 +7380,7 @@ msgstr "Aeg"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Sündmus"
 
@@ -17354,17 +17354,17 @@ msgid "Error reading data for table %s:"
 msgstr "Viga tabeli %s andmete lugemisel:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Loodud:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Viimati uuendatud:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Viimane kontroll:"
 
@@ -17383,7 +17383,7 @@ msgstr "Objekti loomise valikud (soovitatav on valida kõik)"
 msgid "Export contents"
 msgstr "Ekspordi sisu"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Eesmärk:"
 
@@ -17547,17 +17547,17 @@ msgstr "SKEEMI VIGA: "
 msgid "PDF export page"
 msgstr "PDF ekspordi leht"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Andmebaasi %s skeem"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Seoseskeem"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Sisu tabel"
 

--- a/resources/po/eu.po
+++ b/resources/po/eu.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Basque <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -306,7 +306,7 @@ msgstr "Joan"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Taularen iruzkinak:"
 
@@ -509,9 +509,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Zutabea"
 
@@ -660,7 +660,7 @@ msgstr "Egitura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Izena"
 
@@ -691,9 +691,9 @@ msgstr "Izena"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Mota"
 
@@ -736,9 +736,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Lehenetsia"
 
@@ -776,8 +776,8 @@ msgstr "Ordenamendua"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atributuak"
 
@@ -800,9 +800,9 @@ msgstr "Atributuak"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Nulua"
 
@@ -826,9 +826,9 @@ msgstr "Editatu Pribilegioak"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Iruzkinak"
 
@@ -848,7 +848,7 @@ msgstr "Gehitu/ezabatu irizpide-zutabea"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -994,7 +994,7 @@ msgstr "Ezgaituta"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Bai"
 
@@ -1030,7 +1030,7 @@ msgstr "Bai"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Ez"
 
@@ -1576,9 +1576,9 @@ msgstr "Inprimatu"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Esteka"
 
@@ -2026,7 +2026,7 @@ msgstr "Amaiera"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3070,7 +3070,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4238,8 +4238,8 @@ msgstr "Jarraipen informea"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Orri zenbakia:"
 
@@ -4380,7 +4380,7 @@ msgstr ""
 msgid "View:"
 msgstr "Ikusipegia"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7039,7 +7039,7 @@ msgstr "Egoera"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Denbora"
 
@@ -7970,8 +7970,8 @@ msgstr "Inprimatzeko ikuspegia"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -8249,7 +8249,7 @@ msgstr "Denbora"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 #, fuzzy
 msgid "Event"
 msgstr "Bidalita"
@@ -18338,21 +18338,21 @@ msgid "Error reading data for table %s:"
 msgstr "Datuak irakurtzea baimentzen du."
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "Sortzea"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 #, fuzzy
 #| msgid "Last update"
 msgid "Last update:"
 msgstr "Azken eguneraketa"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 #, fuzzy
 #| msgid "Last check"
 msgid "Last check:"
@@ -18371,7 +18371,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18536,18 +18536,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Esportatze mota baliogabea"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database"
 msgstr "\"%s\" datu-basearen eskema- Orria %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Erlazio-eskema"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Edukinen taula"
 

--- a/resources/po/fa.po
+++ b/resources/po/fa.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2024-08-09 14:09+0000\n"
 "Last-Translator: Hojat Ghanad <hojat.ghanad@gmail.com>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -282,7 +282,7 @@ msgstr "برو"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "توضيحات جدول:"
 
@@ -480,9 +480,9 @@ msgstr "یک کلید خارجی است."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "ستون"
 
@@ -615,7 +615,7 @@ msgstr "ساختار"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "اسم"
 
@@ -646,9 +646,9 @@ msgstr "اسم"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "نوع"
 
@@ -692,9 +692,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "پيش‌ فرض"
 
@@ -730,8 +730,8 @@ msgstr "مقایسه"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "ويژگيها"
 
@@ -754,9 +754,9 @@ msgstr "ويژگيها"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "تهی"
 
@@ -778,9 +778,9 @@ msgstr "تنظیم امتیازات"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "توضيحات"
 
@@ -800,7 +800,7 @@ msgstr "اضافه يا حذف ستونها"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Display Features"
 msgid "Media type"
@@ -937,7 +937,7 @@ msgstr "غيرفعال"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "بلي"
 
@@ -973,7 +973,7 @@ msgstr "بلي"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "خير"
 
@@ -1523,9 +1523,9 @@ msgstr "چاپ"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "پيوند به"
 
@@ -1959,7 +1959,7 @@ msgstr "انتها"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -2991,7 +2991,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4132,8 +4132,8 @@ msgstr "گزارشات دنبال شده"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "شماره صفحه:"
 
@@ -4277,7 +4277,7 @@ msgstr ""
 msgid "View:"
 msgstr "مشاهده ها:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -6886,7 +6886,7 @@ msgstr "شنبه"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "زمان"
 
@@ -7809,8 +7809,8 @@ msgstr "نماي چاپ"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "اضافي"
 
@@ -8079,7 +8079,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "رویداد"
 
@@ -18218,17 +18218,17 @@ msgid "Error reading data for table %s:"
 msgstr "داده برای %s وارد نشده است"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "ایجاد:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "آخرین به روز رسانی:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "آخرین بازدید:"
 
@@ -18245,7 +18245,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18409,18 +18409,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "نوع صدور معتبر نیست"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Search in database"
 msgid "Schema of the %s database"
 msgstr "جستجو در پايگاه‌ داده"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 #, fuzzy
 msgid "Table of contents"
 msgstr "توضيحات جدول"

--- a/resources/po/fi.po
+++ b/resources/po/fi.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-01-21 15:38+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@mfauth.net>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -298,7 +298,7 @@ msgstr "Siirry"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Taulun kommentit:"
 
@@ -511,9 +511,9 @@ msgstr "Valitse liiteavain"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Sarake"
 
@@ -664,7 +664,7 @@ msgstr "Rakenne"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nimi"
 
@@ -695,9 +695,9 @@ msgstr "Nimi"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tyyppi"
 
@@ -740,9 +740,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Oletusarvo"
 
@@ -780,8 +780,8 @@ msgstr "Aakkosjärjestys"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Attribuutit"
 
@@ -804,9 +804,9 @@ msgstr "Attribuutit"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Tyhjä"
 
@@ -830,9 +830,9 @@ msgstr "Muokkaa käyttöoikeuksia"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Kommentit"
 
@@ -852,7 +852,7 @@ msgstr "Poista sarake/sarakkeet"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -991,7 +991,7 @@ msgstr "Pois päältä"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Kyllä"
 
@@ -1027,7 +1027,7 @@ msgstr "Kyllä"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Ei"
 
@@ -1525,9 +1525,9 @@ msgstr "Tulosta"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Viittaa sarakkeeseen"
 
@@ -1966,7 +1966,7 @@ msgstr "Loppu"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Määritys"
 
@@ -3018,7 +3018,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4150,8 +4150,8 @@ msgstr "Viedään sinut seuraavaan vaiheeseen…"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Sivunumero:"
 
@@ -4299,7 +4299,7 @@ msgstr ""
 msgid "View:"
 msgstr "Näkymät"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7067,7 +7067,7 @@ msgstr "Käynnistys"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Aika"
 
@@ -7989,8 +7989,8 @@ msgstr "Poista ositus"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Lisätiedot"
 
@@ -8263,7 +8263,7 @@ msgstr "Aika"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Tapahtuma"
 
@@ -18686,17 +18686,17 @@ msgid "Error reading data for table %s:"
 msgstr "Sallii tietojen lukemisen."
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Luotu:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Viimeksi päivitetty:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Viimeksi tarkistettu:"
 
@@ -18713,7 +18713,7 @@ msgstr ""
 msgid "Export contents"
 msgstr "Vie sisällöt"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18892,18 +18892,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Virheellinen vientitapa"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database"
 msgstr "Tietokannan \"%s\" kaavio - Sivu %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Relaatioskeema"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Sisällysluettelo"
 

--- a/resources/po/fil.po
+++ b/resources/po/fil.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2021-01-22 03:17+0000\n"
 "Last-Translator: William Desportes <williamdes@wdes.fr>\n"
 "Language-Team: Filipino <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -290,7 +290,7 @@ msgstr "Pumunta"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Mga komento ng talahanayan:"
 
@@ -488,9 +488,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kolumn"
 
@@ -609,7 +609,7 @@ msgstr "Istruktura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -640,9 +640,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Uri"
 
@@ -675,9 +675,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Default"
 
@@ -713,8 +713,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -737,9 +737,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Wala"
 
@@ -761,9 +761,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Mga komento"
 
@@ -781,7 +781,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Bad type!"
 msgid "Media type"
@@ -907,7 +907,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Oo"
 
@@ -943,7 +943,7 @@ msgstr "Oo"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Hindi"
 
@@ -1427,9 +1427,9 @@ msgstr "I-print"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Mga link sa"
 
@@ -1808,7 +1808,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3783,8 +3783,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3920,7 +3920,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6302,7 +6302,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Oras"
 
@@ -7087,8 +7087,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7325,7 +7325,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16709,17 +16709,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16736,7 +16736,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16891,17 +16891,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/fr.po
+++ b/resources/po/fr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin-docs 4.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2024-10-16 15:51+0000\n"
 "Last-Translator: kjo-sdds <kjo@domo-supply.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -281,7 +281,7 @@ msgstr "Exécuter"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Commentaires de table :"
 
@@ -479,9 +479,9 @@ msgstr "Est une clé étrangère."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Colonne"
 
@@ -600,7 +600,7 @@ msgstr "Structure"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nom"
 
@@ -631,9 +631,9 @@ msgstr "Nom"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Type"
 
@@ -671,9 +671,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Valeur par défaut"
 
@@ -711,8 +711,8 @@ msgstr "Interclassement"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Attributs"
 
@@ -735,9 +735,9 @@ msgstr "Attributs"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -759,9 +759,9 @@ msgstr "Ajuster les privilèges"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Commentaires"
 
@@ -779,7 +779,7 @@ msgstr "Déplacer une colonne"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Type de médias"
 
@@ -908,7 +908,7 @@ msgstr "Désactivé"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Oui"
 
@@ -944,7 +944,7 @@ msgstr "Oui"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Non"
 
@@ -1421,9 +1421,9 @@ msgstr "Imprimer"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Est relié à"
 
@@ -1797,7 +1797,7 @@ msgstr "Fin"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Définition"
 
@@ -2744,7 +2744,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Base de données :"
 
@@ -3779,8 +3779,8 @@ msgstr "En route vers le site cible."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Page n° :"
 
@@ -3942,7 +3942,7 @@ msgstr ""
 msgid "View:"
 msgstr "Vue :"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Table :"
 
@@ -6416,7 +6416,7 @@ msgstr "État"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Temps"
 
@@ -7204,8 +7204,8 @@ msgstr "Éditer le partitionnement"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -7438,7 +7438,7 @@ msgstr "Moment"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Évènement"
 
@@ -17655,17 +17655,17 @@ msgid "Error reading data for table %s:"
 msgstr "Erreur de lecture des données pour la table %s :"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Création :"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Dernière modification :"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Dernière vérification :"
 
@@ -17684,7 +17684,7 @@ msgstr "Options de création d'objets (toutes sont recommandées)"
 msgid "Export contents"
 msgstr "Exporter les contenus"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "But :"
 
@@ -17853,17 +17853,17 @@ msgstr "Erreur de schéma : "
 msgid "PDF export page"
 msgstr "Page d'exportation PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Schéma de la base %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Schéma relationnel"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Table des matières"
 

--- a/resources/po/fy.po
+++ b/resources/po/fy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2015-12-24 23:02+0000\n"
 "Last-Translator: Robin van der Vliet <info@robinvandervliet.nl>\n"
 "Language-Team: Frisian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -299,7 +299,7 @@ msgstr "Starte"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Tabelopmerkings:"
 
@@ -501,9 +501,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kolom"
 
@@ -644,7 +644,7 @@ msgstr "Struktuer"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Namme"
 
@@ -675,9 +675,9 @@ msgstr "Namme"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Type"
 
@@ -710,9 +710,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Standert"
 
@@ -748,8 +748,8 @@ msgstr "Kollaasje"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Attributen"
 
@@ -772,9 +772,9 @@ msgstr "Attributen"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Leech"
 
@@ -798,9 +798,9 @@ msgstr "Rjochten bewurkje"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Opmerkings"
 
@@ -818,7 +818,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -944,7 +944,7 @@ msgstr "Utskeakele"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ja"
 
@@ -980,7 +980,7 @@ msgstr "Ja"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Nee"
 
@@ -1478,9 +1478,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1872,7 +1872,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definysje"
 
@@ -2856,7 +2856,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Database:"
 
@@ -3915,8 +3915,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Sidenûmer:"
 
@@ -4052,7 +4052,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabel:"
 
@@ -6494,7 +6494,7 @@ msgstr "Tastân"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Tiid"
 
@@ -7317,8 +7317,8 @@ msgstr "Routine bewurkje"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Ekstra"
 
@@ -7559,7 +7559,7 @@ msgstr "Tiid"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Barren"
 
@@ -16983,17 +16983,17 @@ msgid "Error reading data for table %s:"
 msgstr "Gjin databases"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -17010,7 +17010,7 @@ msgstr ""
 msgid "Export contents"
 msgstr "Eksportearynhâld"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -17165,17 +17165,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Ynhâldsopjefte"
 

--- a/resources/po/gl.po
+++ b/resources/po/gl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Galician <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -295,7 +295,7 @@ msgstr "Ir"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Comentarios da táboa:"
 
@@ -502,9 +502,9 @@ msgstr "Escoller unha chave externa"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Columna"
 
@@ -655,7 +655,7 @@ msgstr "Estrutura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nome"
 
@@ -686,9 +686,9 @@ msgstr "Nome"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tipo"
 
@@ -725,9 +725,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Predeterminado"
 
@@ -765,8 +765,8 @@ msgstr "Orde alfabética"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atributos"
 
@@ -789,9 +789,9 @@ msgstr "Atributos"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Nulo"
 
@@ -815,9 +815,9 @@ msgstr "Modificar os privilexios"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Comentarios"
 
@@ -835,7 +835,7 @@ msgstr "Mover columna"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -976,7 +976,7 @@ msgstr "Desactivado"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Si"
 
@@ -1012,7 +1012,7 @@ msgstr "Si"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Non"
 
@@ -1511,9 +1511,9 @@ msgstr "Imprimir"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Liga a"
 
@@ -1926,7 +1926,7 @@ msgstr "Fin"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definición"
 
@@ -2940,7 +2940,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Base de datos:"
 
@@ -4069,8 +4069,8 @@ msgstr "Procedemos co paso seguinte…"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Número de páxina:"
 
@@ -4216,7 +4216,7 @@ msgstr ""
 msgid "View:"
 msgstr "Vistas"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Táboa:"
 
@@ -6968,7 +6968,7 @@ msgstr "Estado"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Tempo"
 
@@ -7843,8 +7843,8 @@ msgstr "Eliminar particións"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -8102,7 +8102,7 @@ msgstr "Tempo"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Acontecemento"
 
@@ -18916,17 +18916,17 @@ msgid "Error reading data for table %s:"
 msgstr "Produciuse un erro ao ler os datos:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Creación:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Última actualización:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Última revisión:"
 
@@ -18945,7 +18945,7 @@ msgstr "Opcións de creación de obxectos (recoméndanse todas)"
 msgid "Export contents"
 msgstr "Exportar o contido"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -19115,18 +19115,18 @@ msgstr "HAI UN ERRO NO ESQUEMA: "
 msgid "PDF export page"
 msgstr "Este tipo de exportación non é válido"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the %s database - Page %s"
 msgid "Schema of the %s database"
 msgstr "Esquema da base de datos %s - Páxina %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Esquema relacional"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Índice"
 

--- a/resources/po/gu.po
+++ b/resources/po/gu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2019-04-27 17:19+0000\n"
 "Last-Translator: William Desportes <williamdes@wdes.fr>\n"
 "Language-Team: Gujarati <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -283,7 +283,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -479,9 +479,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -631,9 +631,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr ""
 
@@ -666,9 +666,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -704,8 +704,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -728,9 +728,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr ""
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr ""
 
@@ -1406,9 +1406,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1782,7 +1782,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2708,7 +2708,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3711,8 +3711,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3846,7 +3846,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6139,7 +6139,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -6910,8 +6910,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7142,7 +7142,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16198,17 +16198,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16225,7 +16225,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16378,17 +16378,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/he.po
+++ b/resources/po/he.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-05-19 07:01+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -286,7 +286,7 @@ msgstr "ביצוע"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "הערות לטבלה:"
 
@@ -487,9 +487,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "עמודה"
 
@@ -624,7 +624,7 @@ msgstr "מבנה"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "שם"
 
@@ -655,9 +655,9 @@ msgstr "שם"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "סוג"
 
@@ -695,9 +695,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "בררת מחדל"
 
@@ -735,8 +735,8 @@ msgstr "איסוף"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "תכונות"
 
@@ -759,9 +759,9 @@ msgstr "תכונות"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "ריק"
 
@@ -783,9 +783,9 @@ msgstr "התאמת הרשאות"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "הערות"
 
@@ -804,7 +804,7 @@ msgstr "הוספת/מחיקת עמודות שדה"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 msgid "Media type"
 msgstr "סוג MIME"
@@ -939,7 +939,7 @@ msgstr "מבוטל"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "כן"
 
@@ -975,7 +975,7 @@ msgstr "כן"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "לא"
 
@@ -1476,9 +1476,9 @@ msgstr "הדפסה"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "מקושר אל"
 
@@ -1874,7 +1874,7 @@ msgstr "סיום"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "הגדרה"
 
@@ -2832,7 +2832,7 @@ msgstr "פעולה זו עשויה לשנות חלק מהגדרת העמודות
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 msgid "Database:"
 msgstr "מסד נתונים"
@@ -3872,8 +3872,8 @@ msgstr "מתבצעת העברה לאתר היעד."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "מספר העמוד:"
 
@@ -4010,7 +4010,7 @@ msgstr ""
 msgid "View:"
 msgstr "תצוגות:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 msgid "Table:"
 msgstr "טבלה"
@@ -6432,7 +6432,7 @@ msgstr "מצב"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "זמן"
 
@@ -7251,8 +7251,8 @@ msgstr "עריכת הפרדת המחיצות"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "תוספת"
 
@@ -7497,7 +7497,7 @@ msgstr "זמן"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "אירוע"
 
@@ -16826,17 +16826,17 @@ msgid "Error reading data for table %s:"
 msgstr "מאפשר מחיקת מידע."
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "יצירה:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "עדכון אחרון:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "נבדק לאחרונה:"
 
@@ -16853,7 +16853,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -17011,17 +17011,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr "סוג הייצוא שגוי"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 msgid "Schema of the %s database"
 msgstr "חיפוש במסד הנתונים"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "תוכן עניניים"
 

--- a/resources/po/hi.po
+++ b/resources/po/hi.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -306,7 +306,7 @@ msgstr "जाएँ"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "तालिका टिप्पणी:"
 
@@ -517,9 +517,9 @@ msgstr "परदेशी कुंजी का चयन करें"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "स्तम्भ"
 
@@ -670,7 +670,7 @@ msgstr "संरचना"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "नाम"
 
@@ -701,9 +701,9 @@ msgstr "नाम"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "प्रकार/किस्म"
 
@@ -736,9 +736,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "तयशुदा"
 
@@ -774,8 +774,8 @@ msgstr "क्रम में करें"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "विशेषता"
 
@@ -798,9 +798,9 @@ msgstr "विशेषता"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "शून्य"
 
@@ -824,9 +824,9 @@ msgstr "प्रिविलेज एडिट करें"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "टिप्पणी"
 
@@ -846,7 +846,7 @@ msgstr "काँलम हटाना"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -982,7 +982,7 @@ msgstr "अक्षम"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "हाँ"
 
@@ -1018,7 +1018,7 @@ msgstr "हाँ"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "ना"
 
@@ -1568,9 +1568,9 @@ msgstr "छापें"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "के लिए लिंक"
 
@@ -2019,7 +2019,7 @@ msgstr "आखरी"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3086,7 +3086,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4244,8 +4244,8 @@ msgstr "ट्रैकिंग रिपोर्ट"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "पृष्ठ संख्या:"
 
@@ -4389,7 +4389,7 @@ msgstr ""
 msgid "View:"
 msgstr "दृश्य"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7081,7 +7081,7 @@ msgstr "स्टार्टअप"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "समय"
 
@@ -8030,8 +8030,8 @@ msgstr "विभाजन हटायें"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "अतिरिक्त"
 
@@ -8308,7 +8308,7 @@ msgstr "समय"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "घटना"
 
@@ -18965,17 +18965,17 @@ msgid "Error reading data for table %s:"
 msgstr "डाटा पढने की अनुमति देता है"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "रचना:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "पिछला नवीनीकरण:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "पिछली जाँच:"
 
@@ -18992,7 +18992,7 @@ msgstr "वस्तु सृजन विकल्प (सभी की सि
 msgid "Export contents"
 msgstr "निर्यात सामग्री"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -19157,18 +19157,18 @@ msgstr "स्कीमा त्रुटि: "
 msgid "PDF export page"
 msgstr "अमान्य निर्यात प्रकार"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Search in database"
 msgid "Schema of the %s database"
 msgstr "डाटाबेस में खोजें"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "संबंधपरक स्कीमा"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "लेख - सूची"
 

--- a/resources/po/hr.po
+++ b/resources/po/hr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2023-12-08 16:06+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -310,7 +310,7 @@ msgstr "Kreni"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Komentari tablice:"
 
@@ -522,9 +522,9 @@ msgstr "Odaberite strani ključ"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Stupac"
 
@@ -674,7 +674,7 @@ msgstr "Struktura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Naziv"
 
@@ -705,9 +705,9 @@ msgstr "Naziv"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Vrsta"
 
@@ -750,9 +750,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Zadano"
 
@@ -790,8 +790,8 @@ msgstr "Uspoređivanje"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atributi"
 
@@ -814,9 +814,9 @@ msgstr "Atributi"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Nula"
 
@@ -840,9 +840,9 @@ msgstr "Uredi privilegije"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Komentari"
 
@@ -862,7 +862,7 @@ msgstr "Ukloni stupac / stupce"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -1008,7 +1008,7 @@ msgstr "Onemogućeno"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Da"
 
@@ -1044,7 +1044,7 @@ msgstr "Da"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Ne"
 
@@ -1595,9 +1595,9 @@ msgstr "Ispiši"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Veze do"
 
@@ -2048,7 +2048,7 @@ msgstr "Završetak"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3106,7 +3106,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4290,8 +4290,8 @@ msgstr "Izvještaj o praćenju"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Broj stranice:"
 
@@ -4433,7 +4433,7 @@ msgstr ""
 msgid "View:"
 msgstr "Prikaz"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7122,7 +7122,7 @@ msgstr "Stanje"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Vrijeme"
 
@@ -8066,8 +8066,8 @@ msgstr "Ukloni particioniranje"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Dodatno"
 
@@ -8350,7 +8350,7 @@ msgstr "Vrijeme"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Događaj"
 
@@ -18937,21 +18937,21 @@ msgid "Error reading data for table %s:"
 msgstr "Dopušta čitanje podataka."
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "Izrada"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 #, fuzzy
 #| msgid "Last update"
 msgid "Last update:"
 msgstr "Posljednje ažuriranje"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 #, fuzzy
 #| msgid "Last check"
 msgid "Last check:"
@@ -18971,7 +18971,7 @@ msgstr ""
 msgid "Export contents"
 msgstr "Vrsta izvoza"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -19140,18 +19140,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Pogrešna vrsta izvoza"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database"
 msgstr "Shema \"%s\" baza podataka - stranica %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Shema relacija"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Sadržaj tablice"
 

--- a/resources/po/hu.po
+++ b/resources/po/hu.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-17 10:35+0000\n"
 "Last-Translator: Péter Báthory <bathory86p@gmail.com>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -291,7 +291,7 @@ msgstr "Indítás"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Tábla megjegyzések:"
 
@@ -493,9 +493,9 @@ msgstr "Egy idegen kulcs-e."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Oszlop"
 
@@ -614,7 +614,7 @@ msgstr "Szerkezet"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Név"
 
@@ -645,9 +645,9 @@ msgstr "Név"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Típus"
 
@@ -684,9 +684,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Alapértelmezett"
 
@@ -724,8 +724,8 @@ msgstr "Illesztés"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Tulajdonságok"
 
@@ -748,9 +748,9 @@ msgstr "Tulajdonságok"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Nulla"
 
@@ -772,9 +772,9 @@ msgstr "Jogosultságok módosítása"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Megjegyzések"
 
@@ -792,7 +792,7 @@ msgstr "Oszlop mozgatása"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -923,7 +923,7 @@ msgstr "Letiltott"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Igen"
 
@@ -959,7 +959,7 @@ msgstr "Igen"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Nem"
 
@@ -1453,9 +1453,9 @@ msgstr "Nyomtatás"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Hivatkozás"
 
@@ -1834,7 +1834,7 @@ msgstr "Vége"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Meghatározás"
 
@@ -2828,7 +2828,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Adatbázis:"
 
@@ -3928,8 +3928,8 @@ msgstr "Átvitel a céloldalra."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Oldalszám:"
 
@@ -4074,7 +4074,7 @@ msgstr ""
 msgid "View:"
 msgstr "Nézetek:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tábla:"
 
@@ -6752,7 +6752,7 @@ msgstr "Állapot"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Idő"
 
@@ -7573,8 +7573,8 @@ msgstr "Particionálás szerkesztése"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -7818,7 +7818,7 @@ msgstr "Idő"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Esemény"
 
@@ -18317,17 +18317,17 @@ msgid "Error reading data for table %s:"
 msgstr "Hiba a(z) %s tábla adatainak olvasásakor:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Létrehozva:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Utolsó frissítés:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Utolsó ellenőrzés:"
 
@@ -18346,7 +18346,7 @@ msgstr "Objektum-létrehozási beállítások (mindegyik javasolt)"
 msgid "Export contents"
 msgstr "Tartalom exportálása"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Cél:"
 
@@ -18514,17 +18514,17 @@ msgstr "SÉMA HIBA: "
 msgid "PDF export page"
 msgstr "PDF exportálás oldal"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "A(z) „%s” adatbázis sémája"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Kapcsolati séma"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Tartalomjegyzék"
 

--- a/resources/po/hy.po
+++ b/resources/po/hy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2021-01-22 03:17+0000\n"
 "Last-Translator: William Desportes <williamdes@wdes.fr>\n"
 "Language-Team: Armenian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -295,7 +295,7 @@ msgstr "Առաջ"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Աղյուսակների մեկնաբանությունները՝"
 
@@ -497,9 +497,9 @@ msgstr "Սա՝ արտաքին բանալի է։"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Սյունակ"
 
@@ -618,7 +618,7 @@ msgstr "Կառուցվածք"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Անուն"
 
@@ -649,9 +649,9 @@ msgstr "Անուն"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Տեսակ"
 
@@ -684,9 +684,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Լռելյան"
 
@@ -722,8 +722,8 @@ msgstr "Համադրում"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Հատկանիշներ"
 
@@ -746,9 +746,9 @@ msgstr "Հատկանիշներ"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -770,9 +770,9 @@ msgstr "Կարգավորել արտոնությունները"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Մեկնաբանություններ"
 
@@ -790,7 +790,7 @@ msgstr "Տեղափոխել սյունակը"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -916,7 +916,7 @@ msgstr "Կասեցված"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Այո"
 
@@ -952,7 +952,7 @@ msgstr "Այո"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Ոչ"
 
@@ -1446,9 +1446,9 @@ msgstr "Տպել"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Հղումներ դեպի"
 
@@ -1835,7 +1835,7 @@ msgstr "Վերջ"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Սահմանում"
 
@@ -2827,7 +2827,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Տվյալների բազան՝"
 
@@ -3910,8 +3910,8 @@ msgstr "Անցում դեպի նպատակային կայք։"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "էջի համարը՝"
 
@@ -4053,7 +4053,7 @@ msgstr ""
 msgid "View:"
 msgstr "Ներկայացումներ՝"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Աղյուսակ՝"
 
@@ -6634,7 +6634,7 @@ msgstr "Կարգավիճակ"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Ժամանակ"
 
@@ -7447,8 +7447,8 @@ msgstr "Խմբագրել մասնաբաժանումը"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Լրացուցիչ"
 
@@ -7688,7 +7688,7 @@ msgstr "Ժամանակ"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Իրադարձություն"
 
@@ -17412,17 +17412,17 @@ msgid "Error reading data for table %s:"
 msgstr "Տվյալների կարդալու սխալ՝"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Ստեղծում՝"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Վերջին թարմացումը՝"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Վերջին ստուգումը՝"
 
@@ -17439,7 +17439,7 @@ msgstr ""
 msgid "Export contents"
 msgstr "Արտահանել պարունակությունը"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -17595,17 +17595,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr "PDF-ին արտահանման էջ"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "%s տվյալների բազայի ուրվագիծը"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Բովանդակության աղյուսակը"
 

--- a/resources/po/ia.po
+++ b/resources/po/ia.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Interlingua <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -295,7 +295,7 @@ msgstr "Vade"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Commentos de tabella:"
 
@@ -491,9 +491,9 @@ msgstr "Es un clave estranie."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Columna"
 
@@ -612,7 +612,7 @@ msgstr "Structura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nomine"
 
@@ -643,9 +643,9 @@ msgstr "Nomine"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Typo"
 
@@ -678,9 +678,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Predefinite"
 
@@ -716,8 +716,8 @@ msgstr "Collation"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Attributos"
 
@@ -740,9 +740,9 @@ msgstr "Attributos"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -764,9 +764,9 @@ msgstr "Adapta permissiones"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Commentos"
 
@@ -784,7 +784,7 @@ msgstr "Move columna"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Typo de media"
 
@@ -910,7 +910,7 @@ msgstr "Dishabilita"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Si"
 
@@ -946,7 +946,7 @@ msgstr "Si"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "No"
 
@@ -1428,9 +1428,9 @@ msgstr "Imprime"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Ligamines a"
 
@@ -1806,7 +1806,7 @@ msgstr "Fin"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definition"
 
@@ -2756,7 +2756,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Base de datos:"
 
@@ -3821,8 +3821,8 @@ msgstr "Ducente te al sito de destination."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Numero pagina:"
 
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "View:"
 msgstr "Vista:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabella:"
 
@@ -6384,7 +6384,7 @@ msgstr "Stato"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Tempore"
 
@@ -7167,8 +7167,8 @@ msgstr "Modifica partitionemento"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -7403,7 +7403,7 @@ msgstr "Tempore"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Evento"
 
@@ -17349,17 +17349,17 @@ msgid "Error reading data for table %s:"
 msgstr "Error quando on lege datos per tabella %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Creation:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Ultime actualisation:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Ultime controlo:"
 
@@ -17378,7 +17378,7 @@ msgstr "Optiones de creation de objecto (omnes es recommendate)"
 msgid "Export contents"
 msgstr "Exporta contentos"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Intention:"
 
@@ -17541,17 +17541,17 @@ msgstr "SCHEMA ERROR: "
 msgid "PDF export page"
 msgstr "Pagina de exportar de PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Schema de le base de datos %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Schema relational"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Tabula de contentos"
 

--- a/resources/po/id.po
+++ b/resources/po/id.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-05-20 07:03+0000\n"
 "Last-Translator: Zahid Rizky Fakhri <zahidrizkyfakhri@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -281,7 +281,7 @@ msgstr "Kirim"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Komentar tabel:"
 
@@ -479,9 +479,9 @@ msgstr "Adalah kunci asing."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kolom"
 
@@ -600,7 +600,7 @@ msgstr "Struktur"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nama"
 
@@ -631,9 +631,9 @@ msgstr "Nama"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Jenis"
 
@@ -671,9 +671,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Bawaan"
 
@@ -711,8 +711,8 @@ msgstr "Penyortiran"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atribut"
 
@@ -735,9 +735,9 @@ msgstr "Atribut"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Tak Ternilai"
 
@@ -759,9 +759,9 @@ msgstr "Sesuaikan hak istimewa"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Komentar"
 
@@ -779,7 +779,7 @@ msgstr "Pindahkan kolom"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Jenis media"
 
@@ -909,7 +909,7 @@ msgstr "Tidak aktif"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ya"
 
@@ -945,7 +945,7 @@ msgstr "Ya"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Tidak"
 
@@ -1421,9 +1421,9 @@ msgstr "Cetak"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Tautan ke"
 
@@ -1797,7 +1797,7 @@ msgstr "Selesai"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definisi"
 
@@ -2731,7 +2731,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Basis data:"
 
@@ -3761,8 +3761,8 @@ msgstr "Membawa Anda ke situs target."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Nomor halaman:"
 
@@ -3922,7 +3922,7 @@ msgstr ""
 msgid "View:"
 msgstr "Lihat:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabel:"
 
@@ -6350,7 +6350,7 @@ msgstr "Negara"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Waktu"
 
@@ -7136,8 +7136,8 @@ msgstr "Sunting partisi"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Ekstra"
 
@@ -7370,7 +7370,7 @@ msgstr "Waktu"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Kejadian"
 
@@ -17398,17 +17398,17 @@ msgid "Error reading data for table %s:"
 msgstr "Kesalahan membaca data untuk tabel %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Pembuatan:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Pembaruan terakhir:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Pemeriksaan terakhir:"
 
@@ -17427,7 +17427,7 @@ msgstr "Pilihan pembuatan obyek (semua direkomendasikan)"
 msgid "Export contents"
 msgstr "Ekspor isi"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Tujuan:"
 
@@ -17593,17 +17593,17 @@ msgstr "GALAT SKEMA: "
 msgid "PDF export page"
 msgstr "Ekspor halaman PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Skema basis data %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Skema Relational"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Daftar Isi"
 

--- a/resources/po/ig.po
+++ b/resources/po/ig.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2016-09-01 17:40+0000\n"
 "Last-Translator: CHINONSO <chinonso_patrick@yahoo.com>\n"
 "Language-Team: Igbo <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -283,7 +283,7 @@ msgstr "-aga"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Isiokwu ekwu, sị:"
 
@@ -479,9 +479,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "kọlụm"
 
@@ -600,7 +600,7 @@ msgstr "Ọdịdị"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -631,9 +631,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "ụdị"
 
@@ -666,9 +666,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "ndabere"
 
@@ -704,8 +704,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -728,9 +728,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "adịghị ịre"
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "ikwu"
 
@@ -772,7 +772,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Bad type!"
 msgid "Media type"
@@ -898,7 +898,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "ee"
 
@@ -934,7 +934,7 @@ msgstr "ee"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "ọ dịghị"
 
@@ -1415,9 +1415,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "njikọ"
 
@@ -1794,7 +1794,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2730,7 +2730,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3749,8 +3749,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3884,7 +3884,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6197,7 +6197,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -6978,8 +6978,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7212,7 +7212,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16321,17 +16321,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16348,7 +16348,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16503,17 +16503,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/it.po
+++ b/resources/po/it.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-01-20 13:00+0000\n"
 "Last-Translator: Matteo Regazzi <mregazzi@tiscali.it>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -289,7 +289,7 @@ msgstr "Esegui"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Commenti alla tabella:"
 
@@ -487,9 +487,9 @@ msgstr "E' una Foreign Key."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Colonna"
 
@@ -608,7 +608,7 @@ msgstr "Struttura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nome"
 
@@ -639,9 +639,9 @@ msgstr "Nome"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tipo"
 
@@ -678,9 +678,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Predefinito"
 
@@ -718,8 +718,8 @@ msgstr "Codifica caratteri"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Attributi"
 
@@ -742,9 +742,9 @@ msgstr "Attributi"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -766,9 +766,9 @@ msgstr "Adatta Privilegi"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Commenti"
 
@@ -786,7 +786,7 @@ msgstr "Sposta campo"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Tipo MIME"
 
@@ -916,7 +916,7 @@ msgstr "Disabilitata"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Sì"
 
@@ -952,7 +952,7 @@ msgstr "Sì"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "No"
 
@@ -1430,9 +1430,9 @@ msgstr "Stampa"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Collegamenti a"
 
@@ -1806,7 +1806,7 @@ msgstr "Fine"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definizione"
 
@@ -2754,7 +2754,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Database:"
 
@@ -3788,8 +3788,8 @@ msgstr "Trasferimento al sito di destinazione."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Numero pagina:"
 
@@ -3950,7 +3950,7 @@ msgstr ""
 msgid "View:"
 msgstr "Vista:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabella:"
 
@@ -6426,7 +6426,7 @@ msgstr "Stato"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Tempo"
 
@@ -7213,8 +7213,8 @@ msgstr "Modifica partizionamento"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -7446,7 +7446,7 @@ msgstr "Tempo"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Evento"
 
@@ -17718,17 +17718,17 @@ msgstr ""
 "Si è verificato un errore durante la lettura dei dati della tabella %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Creazione:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Ultimo aggiornamento:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Ultimo controllo:"
 
@@ -17747,7 +17747,7 @@ msgstr "Opzioni di creazione degli oggetti (sono tutte consigliate)"
 msgid "Export contents"
 msgstr "Esporta contenuti"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Scopo:"
 
@@ -17915,17 +17915,17 @@ msgstr "SCHEMA ERROR: "
 msgid "PDF export page"
 msgstr "Pagina di esportazione PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Schema del database %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Schema relazionale"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Tabella dei contenuti"
 

--- a/resources/po/ja.po
+++ b/resources/po/ja.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-01-12 23:24+0000\n"
 "Last-Translator: Masahiro Fujimoto <mfujimot@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -281,7 +281,7 @@ msgstr "実行"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "テーブルのコメント："
 
@@ -479,9 +479,9 @@ msgstr "外部キーです。"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "カラム"
 
@@ -600,7 +600,7 @@ msgstr "構造"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "名前"
 
@@ -631,9 +631,9 @@ msgstr "名前"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "タイプ"
 
@@ -669,9 +669,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "デフォルト値"
 
@@ -709,8 +709,8 @@ msgstr "照合順序"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "属性"
 
@@ -733,9 +733,9 @@ msgstr "属性"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -757,9 +757,9 @@ msgstr "権限を調整"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "コメント"
 
@@ -777,7 +777,7 @@ msgstr "カラムを移動させる"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "メディア型"
 
@@ -904,7 +904,7 @@ msgstr "無効"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "はい"
 
@@ -940,7 +940,7 @@ msgstr "はい"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "いいえ"
 
@@ -1416,9 +1416,9 @@ msgstr "印刷"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "リンク先"
 
@@ -1792,7 +1792,7 @@ msgstr "終了"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "定義"
 
@@ -2731,7 +2731,7 @@ msgstr "この操作はいくつかのカラム定義を変更します。[br]�
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "データベース:"
 
@@ -3756,8 +3756,8 @@ msgstr "ターゲットサイトにアクセスします。"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "ページ番号:"
 
@@ -3914,7 +3914,7 @@ msgstr ""
 msgid "View:"
 msgstr "ビュー："
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "テーブル:"
 
@@ -6334,7 +6334,7 @@ msgstr "状態"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "時間"
 
@@ -7117,8 +7117,8 @@ msgstr "パーティションを編集"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "その他"
 
@@ -7349,7 +7349,7 @@ msgstr "実行時機"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "イベント"
 
@@ -17264,17 +17264,17 @@ msgid "Error reading data for table %s:"
 msgstr "テーブル %s のデータ読み取りエラー:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "作成日時："
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "最終更新："
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "最終検査："
 
@@ -17291,7 +17291,7 @@ msgstr "生成オプション (すべて推奨)"
 msgid "Export contents"
 msgstr "内容をエクスポートする"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "目的："
 
@@ -17455,17 +17455,17 @@ msgstr "スキーマエラー: "
 msgid "PDF export page"
 msgstr "PDFエクスポートページ"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "データベース %s のスキーマ"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "リレーショナルスキーマ"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "テーブルの内容"
 

--- a/resources/po/ka.po
+++ b/resources/po/ka.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-05-25 12:31+0000\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
 "Language-Team: Georgian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -279,7 +279,7 @@ msgstr "გადასვლა"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "ცხრილის კომენტარები:"
 
@@ -475,9 +475,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "სვეტები"
 
@@ -596,7 +596,7 @@ msgstr "სტრუქტურა"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "სახელი"
 
@@ -627,9 +627,9 @@ msgstr "სახელი"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "ტიპი"
 
@@ -666,9 +666,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "სტანდარტული"
 
@@ -704,8 +704,8 @@ msgstr "კოლაცია"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "ატრიბუტები"
 
@@ -728,9 +728,9 @@ msgstr "ატრიბუტები"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -752,9 +752,9 @@ msgstr "პრივილეგიების მორგება"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "კომენტარები"
 
@@ -772,7 +772,7 @@ msgstr "სვეტის გადატანა"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "მედიის ტიპი"
 
@@ -896,7 +896,7 @@ msgstr "გათიშულია"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "დიახ"
 
@@ -932,7 +932,7 @@ msgstr "დიახ"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "არა"
 
@@ -1406,9 +1406,9 @@ msgstr "დაბეჭდვა"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "მიბმულია"
 
@@ -1782,7 +1782,7 @@ msgstr "დასასრული"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "აღწერა"
 
@@ -2715,7 +2715,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "მონაცემთა ბაზა:"
 
@@ -3726,8 +3726,8 @@ msgstr "სამიზნე საიტზე გადაყვანა."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "გვერდის ნომერი:"
 
@@ -3861,7 +3861,7 @@ msgstr ""
 msgid "View:"
 msgstr "ხედი:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "ცხრილი:"
 
@@ -6164,7 +6164,7 @@ msgstr "მდგომარეობა"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "დრო"
 
@@ -6935,8 +6935,8 @@ msgstr "დაყოფის ჩასწორება"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "ექსტრა"
 
@@ -7169,7 +7169,7 @@ msgstr "დრო"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "მოვლენა"
 
@@ -16342,17 +16342,17 @@ msgid "Error reading data for table %s:"
 msgstr "მონაცემების წაკითხვის შეცდომა ცხრილისთვის %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "შეიქმნა:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "უკანასკნელი განახლება:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "ბოლოს შემოწმდა:"
 
@@ -16369,7 +16369,7 @@ msgstr ""
 msgid "Export contents"
 msgstr "შემცველობის გატანა"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "დანიშნულება:"
 
@@ -16522,17 +16522,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr "PDF გვერდის გატანა"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "სქემა ბაზისთვის %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "სარჩევი"
 

--- a/resources/po/kab.po
+++ b/resources/po/kab.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-06-13 14:01+0000\n"
 "Last-Translator: ButterflyOfFire <boffire@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Kabyle <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -299,7 +299,7 @@ msgstr "Bdu"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Iwenniten n tfelwiyin:"
 
@@ -500,9 +500,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Tigejdit"
 
@@ -624,7 +624,7 @@ msgstr "Taɣessa"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 #, fuzzy
 msgid "Name"
 msgstr "ISem"
@@ -656,9 +656,9 @@ msgstr "ISem"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Anaw"
 
@@ -691,9 +691,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Amezwer"
 
@@ -729,8 +729,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 #, fuzzy
 msgid "Attributes"
 msgstr "Imyerren"
@@ -754,9 +754,9 @@ msgstr "Imyerren"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -778,9 +778,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Iwenniten"
 
@@ -798,7 +798,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 msgid "Media type"
 msgstr "Type MIME"
@@ -926,7 +926,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ih"
 
@@ -962,7 +962,7 @@ msgstr "Ih"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Uhu"
 
@@ -1472,9 +1472,9 @@ msgstr "Siggez"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Iseɣwan ar"
 
@@ -1871,7 +1871,7 @@ msgstr "Tagara"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "tabadut"
 
@@ -2847,7 +2847,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Taffa n isefka:"
 
@@ -3924,8 +3924,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 #, fuzzy
 msgid "Page number:"
 msgstr "_Uṭṭun n usebter"
@@ -4066,7 +4066,7 @@ msgstr ""
 msgid "View:"
 msgstr "Timezriyin"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 msgid "Table:"
 msgstr "Ta&felwit"
@@ -6478,7 +6478,7 @@ msgstr "Aɣir(Wilaya)"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 #, fuzzy
 msgid "Time"
 msgstr "Akud"
@@ -7292,8 +7292,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 #, fuzzy
 msgid "Extra"
 msgstr "Anef-asent i tallulin nniḍen"
@@ -7540,7 +7540,7 @@ msgstr "Akud"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16832,18 +16832,18 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 msgid "Creation:"
 msgstr "Azemz  n tmerna"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16860,7 +16860,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 #, fuzzy
 msgid "Purpose:"
 msgstr ""
@@ -17021,17 +17021,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/kk.po
+++ b/resources/po/kk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2021-01-22 17:26+0000\n"
 "Last-Translator: William Desportes <williamdes@wdes.fr>\n"
 "Language-Team: Kazakh <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -295,7 +295,7 @@ msgstr "Ótý"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Keste túsiniktemeleri:"
 
@@ -497,9 +497,9 @@ msgstr "Bul syrtqy kilt."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Baǵan"
 
@@ -618,7 +618,7 @@ msgstr "Qurylym"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Aty"
 
@@ -649,9 +649,9 @@ msgstr "Aty"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Túri"
 
@@ -688,9 +688,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Ádepki"
 
@@ -728,8 +728,8 @@ msgstr "Kolasıa"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Tólsıpattar"
 
@@ -752,9 +752,9 @@ msgstr "Tólsıpattar"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Bosmán"
 
@@ -776,9 +776,9 @@ msgstr "Artyqshylyqtardy naqtylaý"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Túsiniktemeler"
 
@@ -796,7 +796,7 @@ msgstr "Baǵandy jyljytý"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -926,7 +926,7 @@ msgstr "Óshirilgen"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ia"
 
@@ -962,7 +962,7 @@ msgstr "Ia"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Joq"
 
@@ -1452,9 +1452,9 @@ msgstr "Basyp shyǵarý"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Kelesige siltemeler"
 
@@ -1831,7 +1831,7 @@ msgstr "Sońy"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Anyqtamasy"
 
@@ -2799,7 +2799,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Derekqor:"
 
@@ -3881,8 +3881,8 @@ msgstr "Sizdi maqsatty saıtqa aparady."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Bet nómiri:"
 
@@ -4050,7 +4050,7 @@ msgstr ""
 msgid "View:"
 msgstr "Kórinister:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Keste:"
 
@@ -6692,7 +6692,7 @@ msgstr "Kúı"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Ýaqyt"
 
@@ -7510,8 +7510,8 @@ msgstr "Bólinýdi óńdeý"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Qosymsha"
 
@@ -7752,7 +7752,7 @@ msgstr "Ýaqyt"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Oqıǵa"
 
@@ -18087,17 +18087,17 @@ msgid "Error reading data for table %s:"
 msgstr "%s kestesiniń derekterin oqý qatesi:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Jasaý:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Sońǵy jańartý:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Sońǵy tekserý:"
 
@@ -18116,7 +18116,7 @@ msgstr "Nysan jasaý opsıalary (barlyǵy usynylady)"
 msgid "Export contents"
 msgstr "Mazmundardy eksporttaý"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Maqsat:"
 
@@ -18283,17 +18283,17 @@ msgstr "SULBA QATESI: "
 msgid "PDF export page"
 msgstr "PDF eksporttaý beti"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "%s derekqorynyń sulbasy"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Qatynastyq sulba"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Mazmun kestesi"
 

--- a/resources/po/km.po
+++ b/resources/po/km.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2017-08-12 14:53+0000\n"
 "Last-Translator: ប៉ុកណូ រ៉ូយ៉ាល់ <royalpokno68@gmail.com>\n"
 "Language-Team: Central Khmer <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -293,7 +293,7 @@ msgstr "ទៅ"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "យោបល់​​តារាង៖"
 
@@ -495,9 +495,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "ជួរឈរ"
 
@@ -624,7 +624,7 @@ msgstr "រចនាសម្ព័ន្ធ"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -655,9 +655,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "ប្រភេទ"
 
@@ -690,9 +690,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "លំនាំដើម"
 
@@ -728,8 +728,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "មោឃៈ"
 
@@ -776,9 +776,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "មតិ"
 
@@ -796,7 +796,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Bad type!"
 msgid "Media type"
@@ -924,7 +924,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "បាទ/ចាស"
 
@@ -960,7 +960,7 @@ msgstr "បាទ/ចាស"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "ទេ"
 
@@ -1463,9 +1463,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "តំណ​ទៅ​កាន់"
 
@@ -1864,7 +1864,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3886,8 +3886,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -4027,7 +4027,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6424,7 +6424,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -7237,8 +7237,8 @@ msgstr "កែ​សន្ទស្សន៍"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7479,7 +7479,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16806,17 +16806,17 @@ msgid "Error reading data for table %s:"
 msgstr "លុប​ទិន្នន័យ​តាមដាន​សម្រាប់​តារាង​នេះ"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "ការបង្កើត៖"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "បច្ចុប្បន្នភាពចុងក្រោយ៖"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "ពិនិត្យចុងក្រោយ៖"
 
@@ -16833,7 +16833,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16990,18 +16990,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "ប្រភេទ​នាំ​ចេញ​មិន​ត្រឹម​ត្រូវ"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Select All"
 msgid "Schema of the %s database"
 msgstr "ជ្រើសទាំងអស់"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/kn.po
+++ b/resources/po/kn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2019-04-27 17:19+0000\n"
 "Last-Translator: William Desportes <williamdes@wdes.fr>\n"
 "Language-Team: Kannada <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -287,7 +287,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "ಟೇಬಲ್ ಕಾಮೆಂಟ್ಸ್:"
 
@@ -483,9 +483,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "ಅಂಕಣ"
 
@@ -608,7 +608,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -639,9 +639,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "ಕೌಟುಂಬಿಕತೆ"
 
@@ -674,9 +674,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "ಪೂರ್ವನಿಯೋಜಿತ"
 
@@ -712,8 +712,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -736,9 +736,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "ಶೂನ್ಯ"
 
@@ -760,9 +760,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "ಪ್ರತಿಕ್ರಿಯೆಗಳು"
 
@@ -780,7 +780,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Bad type!"
 msgid "Media type"
@@ -906,7 +906,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "ಹೌದು"
 
@@ -942,7 +942,7 @@ msgstr "ಹೌದು"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "ಇಲ್ಲ"
 
@@ -1422,9 +1422,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "ಸಂಪರ್ಕ ಗೆ"
 
@@ -1808,7 +1808,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2767,7 +2767,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3788,8 +3788,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3927,7 +3927,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6266,7 +6266,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -7053,8 +7053,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7287,7 +7287,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16556,17 +16556,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "ಸೃಷ್ಟಿ:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "ಕೊನೆಯ ನವೀಕರಣ:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "ಕೊನೆಯ ಪರಿಶೀಲನೆ:"
 
@@ -16583,7 +16583,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16738,17 +16738,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/ko.po
+++ b/resources/po/ko.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2024-10-17 16:16+0000\n"
 "Last-Translator: \"Yong Kim (Neatnet)\" <neatnet@gmail.com>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -281,7 +281,7 @@ msgstr "실행"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "테이블 설명:"
 
@@ -479,9 +479,9 @@ msgstr "외래 키입니다."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "컬럼명"
 
@@ -600,7 +600,7 @@ msgstr "구조"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "이름"
 
@@ -631,9 +631,9 @@ msgstr "이름"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "종류"
 
@@ -669,9 +669,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "기본값"
 
@@ -707,8 +707,8 @@ msgstr "문자정렬순서"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "보기"
 
@@ -731,9 +731,9 @@ msgstr "보기"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -755,9 +755,9 @@ msgstr "권한 조정"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "설명"
 
@@ -775,7 +775,7 @@ msgstr "컬럼 이동"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "MIME 형식"
 
@@ -902,7 +902,7 @@ msgstr "사용불가"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "예"
 
@@ -938,7 +938,7 @@ msgstr "예"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "아니요"
 
@@ -1414,9 +1414,9 @@ msgstr "인쇄"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "링크 대상"
 
@@ -1790,7 +1790,7 @@ msgstr "완료"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "정의"
 
@@ -2729,7 +2729,7 @@ msgstr "컬럼 정의의 일부가 변경될 수도 있습니다.[br]계속하�
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "데이터베이스:"
 
@@ -3752,8 +3752,8 @@ msgstr "해당 사이트로 가는 중."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "페이지 번호:"
 
@@ -3904,7 +3904,7 @@ msgstr "WebAuthn/FIDO2 장비를 연결하세요. 그리고 장비에서 로그�
 msgid "View:"
 msgstr "뷰:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "테이블:"
 
@@ -6292,7 +6292,7 @@ msgstr "상태"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "시간"
 
@@ -7072,8 +7072,8 @@ msgstr "파티셔닝 수정"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "추가"
 
@@ -7304,7 +7304,7 @@ msgstr "시간"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "이벤트"
 
@@ -17053,17 +17053,17 @@ msgid "Error reading data for table %s:"
 msgstr "테이블 %s의 데이터를 읽는 동안 발생한 오류:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "생성:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "마지막 업데이트:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "마지막 검사:"
 
@@ -17081,7 +17081,7 @@ msgstr "개체 생성 옵션(모두 권장)"
 msgid "Export contents"
 msgstr "내용 내보내기"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "목적:"
 
@@ -17244,17 +17244,17 @@ msgstr "스키마 에러: "
 msgid "PDF export page"
 msgstr "PDF 내보내기 페이지"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "데이터베이스 %s의 스키마"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "릴레이션 스키마"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "목차(차례)"
 

--- a/resources/po/ksh.po
+++ b/resources/po/ksh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2019-04-27 17:19+0000\n"
 "Last-Translator: William Desportes <williamdes@wdes.fr>\n"
 "Language-Team: Colognian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -285,7 +285,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -481,9 +481,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kolonn"
 
@@ -604,7 +604,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -635,9 +635,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Zoot"
 
@@ -670,9 +670,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Schtandatt"
 
@@ -708,8 +708,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -732,9 +732,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -756,9 +756,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr ""
 
@@ -900,7 +900,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Joh"
 
@@ -936,7 +936,7 @@ msgstr "Joh"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Nä"
 
@@ -1426,9 +1426,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Verlengk noh"
 
@@ -1807,7 +1807,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3794,8 +3794,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3931,7 +3931,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6252,7 +6252,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -7029,8 +7029,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7261,7 +7261,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16412,17 +16412,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16439,7 +16439,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16594,18 +16594,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Select All"
 msgid "Schema of the %s database"
 msgstr "Alle ußwähle"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/ku.po
+++ b/resources/po/ku.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2017-07-06 19:45+0000\n"
 "Last-Translator: Rokar Ali <rokara10@gmail.com>\n"
 "Language-Team: Kurdish <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -283,7 +283,7 @@ msgstr "Baş"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -479,9 +479,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Derz"
 
@@ -600,7 +600,7 @@ msgstr "Dêsman"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -631,9 +631,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Cûre"
 
@@ -666,9 +666,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Yekkirî"
 
@@ -704,8 +704,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -728,9 +728,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Sifir"
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Çawan"
 
@@ -772,7 +772,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Bad type!"
 msgid "Media type"
@@ -898,7 +898,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Erê"
 
@@ -934,7 +934,7 @@ msgstr "Erê"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Na"
 
@@ -1410,9 +1410,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1786,7 +1786,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2714,7 +2714,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3717,8 +3717,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3852,7 +3852,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6149,7 +6149,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -6922,8 +6922,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7156,7 +7156,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16216,17 +16216,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16243,7 +16243,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16398,17 +16398,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/ky.po
+++ b/resources/po/ky.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Kyrgyz <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -288,7 +288,7 @@ msgstr "Кет"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Жадыбал жөнүндө маалымат:"
 
@@ -486,9 +486,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Мамыча"
 
@@ -613,7 +613,7 @@ msgstr "Структура"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -644,9 +644,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Тиби"
 
@@ -679,9 +679,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Default"
 
@@ -717,8 +717,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -741,9 +741,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -765,9 +765,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Коментарийлер"
 
@@ -785,7 +785,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Bad type!"
 msgid "Media type"
@@ -911,7 +911,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ооба"
 
@@ -947,7 +947,7 @@ msgstr "Ооба"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Жок"
 
@@ -1438,9 +1438,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Шилтемелер"
 
@@ -1832,7 +1832,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2808,7 +2808,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3849,8 +3849,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3988,7 +3988,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6340,7 +6340,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -7145,8 +7145,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7383,7 +7383,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16613,17 +16613,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Тузуу:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Акыркы жанылоо:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Акыркы текшеруу:"
 
@@ -16640,7 +16640,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16795,18 +16795,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "View dump (schema) of database"
 msgid "Schema of the %s database"
 msgstr "Берилиштер базасынан жүктөлүүчү маалыматты (схема) көрүү"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/li.po
+++ b/resources/po/li.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Limburgish <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -283,7 +283,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -479,9 +479,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -631,9 +631,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr ""
 
@@ -666,9 +666,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -704,8 +704,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -728,9 +728,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr ""
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr ""
 
@@ -1408,9 +1408,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1784,7 +1784,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Database:"
 
@@ -3721,8 +3721,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3856,7 +3856,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6157,7 +6157,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Tied"
 
@@ -6928,8 +6928,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7162,7 +7162,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16297,17 +16297,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16324,7 +16324,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16477,17 +16477,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/lt.po
+++ b/resources/po/lt.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-07-05 15:20+0000\n"
 "Last-Translator: Ugnius Vaičeskas <ugninis.vai@gmail.com>\n"
 "Language-Team: Lithuanian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -306,7 +306,7 @@ msgstr "Vykdyti"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Lentelės komentarai:"
 
@@ -519,9 +519,9 @@ msgstr "Pasirinkti Foreign Key"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Stulpelis"
 
@@ -672,7 +672,7 @@ msgstr "Struktūra"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Pavadinimas"
 
@@ -703,9 +703,9 @@ msgstr "Pavadinimas"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tipas"
 
@@ -743,9 +743,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Nutylint"
 
@@ -783,8 +783,8 @@ msgstr "Palyginimas"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atributai"
 
@@ -807,9 +807,9 @@ msgstr "Atributai"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -833,9 +833,9 @@ msgstr "Redaguoti privilegijas"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Komentarai"
 
@@ -855,7 +855,7 @@ msgstr "Pašalinti stulpelį(-ius)"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -1002,7 +1002,7 @@ msgstr "Išjungta"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Taip"
 
@@ -1038,7 +1038,7 @@ msgstr "Taip"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Ne"
 
@@ -1586,9 +1586,9 @@ msgstr "Spausdinti"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Sąryšis su"
 
@@ -2021,7 +2021,7 @@ msgstr "Pabaiga"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3054,7 +3054,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4227,8 +4227,8 @@ msgstr "Sekimo ataskaita"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Puslapis:"
 
@@ -4372,7 +4372,7 @@ msgstr ""
 msgid "View:"
 msgstr "Rodinys (Views)"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7103,7 +7103,7 @@ msgstr "Paleisti"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Laikas"
 
@@ -8036,8 +8036,8 @@ msgstr "Pašalinti skaidymą"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Papildomai"
 
@@ -8309,7 +8309,7 @@ msgstr "Laikas"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Įvykis"
 
@@ -19060,17 +19060,17 @@ msgid "Error reading data for table %s:"
 msgstr "Klaida skaitant duomenis:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Kūrimas:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Paskutinis atnaujinimas:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Paskutinis patikrinimas:"
 
@@ -19089,7 +19089,7 @@ msgstr "Objekto kūrimo nustatymai (visi yra rekomenduojami)"
 msgid "Export contents"
 msgstr "Eksportuoti turinį"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -19258,18 +19258,18 @@ msgstr "SCHEMOS KLAIDA: "
 msgid "PDF export page"
 msgstr "Neteisingas eksportavimo tipas"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the %s database - Page %s"
 msgid "Schema of the %s database"
 msgstr "Duomenų bazės %s schema - %s puslapis"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Ryšių schema"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Turinys"
 

--- a/resources/po/lv.po
+++ b/resources/po/lv.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-11-12 14:50+0000\n"
 "Last-Translator: Maris Ozo <dators.mans@gmail.com>\n"
 "Language-Team: Latvian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -303,7 +303,7 @@ msgstr "Aiziet"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Tabulas komentāri:"
 
@@ -509,9 +509,9 @@ msgstr "Nepārbaudīt ārējās atslēgas"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Lauks"
 
@@ -661,7 +661,7 @@ msgstr "Struktūra"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nosaukums"
 
@@ -692,9 +692,9 @@ msgstr "Nosaukums"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tips"
 
@@ -737,9 +737,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Noklusēts"
 
@@ -777,8 +777,8 @@ msgstr "Komplektēšana"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atribūti"
 
@@ -801,9 +801,9 @@ msgstr "Atribūti"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -827,9 +827,9 @@ msgstr "Mainīt privilēģijas"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Komentāri"
 
@@ -849,7 +849,7 @@ msgstr "Pievienot/Dzēst laukus (kolonnas)"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -995,7 +995,7 @@ msgstr "Izslēgts"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Jā"
 
@@ -1031,7 +1031,7 @@ msgstr "Jā"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Nē"
 
@@ -1579,9 +1579,9 @@ msgstr "Drukāt"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Linki uz"
 
@@ -2031,7 +2031,7 @@ msgstr "Beigas"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3098,7 +3098,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4248,8 +4248,8 @@ msgstr "Labot"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Lapas numurs:"
 
@@ -4388,7 +4388,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7041,7 +7041,7 @@ msgstr "Statuss"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Laiks"
 
@@ -7970,8 +7970,8 @@ msgstr "Pievienot jaunu lauku"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Ekstras"
 
@@ -8242,7 +8242,7 @@ msgstr "Laiks"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 #, fuzzy
 msgid "Event"
 msgstr "Nosūtīts"
@@ -18392,17 +18392,17 @@ msgid "Error reading data for table %s:"
 msgstr "Ļauj lasīt datus."
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Izveidošana:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Pēdējo reizi atjaunots:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Pēdējā pārbaude:"
 
@@ -18419,7 +18419,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18586,18 +18586,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Nepareizs eksporta veids"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database"
 msgstr "Datubāzes \"%s\" shēma, %s. lapa"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Relāciju shēma"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Satura rādītājs"
 

--- a/resources/po/mk.po
+++ b/resources/po/mk.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2024-05-13 01:02+0000\n"
 "Last-Translator: \"Kristijan \\\"Fremen\\\" Velkovski\" <me@krisfremen.com>\n"
 "Language-Team: Macedonian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -281,7 +281,7 @@ msgstr "OK"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Коментар на табелата:"
 
@@ -477,9 +477,9 @@ msgstr "Е надворешен клуч."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Колона"
 
@@ -605,7 +605,7 @@ msgstr "Структура"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Име"
 
@@ -636,9 +636,9 @@ msgstr "Име"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Тип"
 
@@ -675,9 +675,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Стандардно"
 
@@ -715,8 +715,8 @@ msgstr "Подредување"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Атрибути"
 
@@ -739,9 +739,9 @@ msgstr "Атрибути"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -764,9 +764,9 @@ msgstr "Промена на привилегии"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Коментари"
 
@@ -785,7 +785,7 @@ msgstr "Додади/избриши колона"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Медиа тип"
 
@@ -919,7 +919,7 @@ msgstr "Оневозможено"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Да"
 
@@ -955,7 +955,7 @@ msgstr "Да"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Не"
 
@@ -1460,9 +1460,9 @@ msgstr "Печати"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Врски кон"
 
@@ -1868,7 +1868,7 @@ msgstr "Крај"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 msgid "Definition"
 msgstr "Опис"
@@ -2861,7 +2861,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "База на податоци:"
 
@@ -3924,8 +3924,8 @@ msgstr "Промени"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Број на страници:"
 
@@ -4062,7 +4062,7 @@ msgstr ""
 msgid "View:"
 msgstr "Поглед"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Табела:"
 
@@ -6540,7 +6540,7 @@ msgstr "Статус"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Време"
 
@@ -7393,8 +7393,8 @@ msgstr "Додади ново поле"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Дополнително"
 
@@ -7649,7 +7649,7 @@ msgstr "Време"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 #, fuzzy
 msgid "Event"
 msgstr "Пратено"
@@ -17217,17 +17217,17 @@ msgid "Error reading data for table %s:"
 msgstr "Грешка при читање на податоци за табелата %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Создадено:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Последна измена:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Последна проверка:"
 
@@ -17244,7 +17244,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -17399,17 +17399,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Тип на извоз"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Шема на %s датабаза"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Релациона шема"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Содржина"
 

--- a/resources/po/ml.po
+++ b/resources/po/ml.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Malayalam <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -287,7 +287,7 @@ msgstr "പോകൂ"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 #, fuzzy
 #| msgid "Table comments"
 msgid "Table comments:"
@@ -491,9 +491,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "നിര"
 
@@ -628,7 +628,7 @@ msgstr "ഘടന"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -659,9 +659,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "തരം"
 
@@ -694,9 +694,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "സ്വതേ"
 
@@ -732,8 +732,8 @@ msgstr "നിബന്ധന"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -756,9 +756,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "ശൂന്യം"
 
@@ -780,9 +780,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "അഭിപ്രായങ്ങൾ"
 
@@ -800,7 +800,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr ""
 
@@ -924,7 +924,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "അതേ"
 
@@ -960,7 +960,7 @@ msgstr "അതേ"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "ഇല്ല"
 
@@ -1468,9 +1468,9 @@ msgstr "അച്ചടിക്കുക"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "കണ്ണികൾ"
 
@@ -1865,7 +1865,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2851,7 +2851,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database comment"
 msgid "Database:"
@@ -3903,8 +3903,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "താൾ:"
 
@@ -4040,7 +4040,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -6438,7 +6438,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -7272,8 +7272,8 @@ msgstr "വിവരണം"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7518,7 +7518,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16851,21 +16851,21 @@ msgid "Error reading data for table %s:"
 msgstr "വിവരശേഖരം പകർത്തുക"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "സൃഷ്‌ടി"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 #, fuzzy
 #| msgid "Last update"
 msgid "Last update:"
 msgstr "അവസാനം നവീകരിച്ചത്"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 #, fuzzy
 #| msgid "Last check"
 msgid "Last check:"
@@ -16884,7 +16884,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -17039,18 +17039,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Remove database"
 msgid "Schema of the %s database"
 msgstr "വിവരശേഖരം നീക്കുക"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/mn.po
+++ b/resources/po/mn.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Mongolian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -308,7 +308,7 @@ msgstr "Яв"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Хүснэгтийн тайлбар:"
 
@@ -519,9 +519,9 @@ msgstr "Гадаад түлхүүр сонгох"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Багана"
 
@@ -672,7 +672,7 @@ msgstr "Бүтэц"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Нэр"
 
@@ -703,9 +703,9 @@ msgstr "Нэр"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Төрөл"
 
@@ -748,9 +748,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Анхдагч"
 
@@ -788,8 +788,8 @@ msgstr "Жишилт"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Атрибутууд"
 
@@ -812,9 +812,9 @@ msgstr "Атрибутууд"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Хоосон"
 
@@ -838,9 +838,9 @@ msgstr "Онцгой эрхүүдийг засах"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Тайлбар"
 
@@ -860,7 +860,7 @@ msgstr "Багана нэмэх/устгах"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -1005,7 +1005,7 @@ msgstr "Хаагдсан"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Тийм"
 
@@ -1041,7 +1041,7 @@ msgstr "Тийм"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Үгүй"
 
@@ -1589,9 +1589,9 @@ msgstr "Хэвлэх"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Холбоос"
 
@@ -2041,7 +2041,7 @@ msgstr "Төгс"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3113,7 +3113,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4315,8 +4315,8 @@ msgstr "Хөөлтын илтгэл"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Хуудасны дугаар:"
 
@@ -4458,7 +4458,7 @@ msgstr ""
 msgid "View:"
 msgstr "Харц"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7125,7 +7125,7 @@ msgstr "Бя"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Цаг"
 
@@ -8064,8 +8064,8 @@ msgstr "Шинэ талбар нэмэх"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Нэмэлт"
 
@@ -8341,7 +8341,7 @@ msgstr "Цаг"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Үзэгдэл"
 
@@ -18739,21 +18739,21 @@ msgid "Error reading data for table %s:"
 msgstr "Өгөгдөл уншихыг зөвшөөрөх."
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "Үүсгэлт"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 #, fuzzy
 #| msgid "Last update"
 msgid "Last update:"
 msgstr "Сүүлийн шинэчлэл"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 #, fuzzy
 #| msgid "Last check"
 msgid "Last check:"
@@ -18772,7 +18772,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Зорилго:"
 
@@ -18941,18 +18941,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Буруу экспортын төрөл"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database"
 msgstr "\"%s\" өгөгдлийн сангийн схем - Хуудас %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Хамааралтай схем"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Агуулгын хүснэгт"
 

--- a/resources/po/ms.po
+++ b/resources/po/ms.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Malay <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -306,7 +306,7 @@ msgstr "Pergi"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Jadual Komen:"
 
@@ -509,9 +509,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Lajur"
 
@@ -654,7 +654,7 @@ msgstr "Struktur"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nama"
 
@@ -685,9 +685,9 @@ msgstr "Nama"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Jenis"
 
@@ -730,9 +730,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Asal"
 
@@ -768,8 +768,8 @@ msgstr "Pengumpulan"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atribut"
 
@@ -792,9 +792,9 @@ msgstr "Atribut"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -818,9 +818,9 @@ msgstr "Ubah Privilej"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Komen"
 
@@ -840,7 +840,7 @@ msgstr "Tambah/Padam Kolum Medan"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Display Features"
 msgid "Media type"
@@ -976,7 +976,7 @@ msgstr "Tidak Membenarkan"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ya"
 
@@ -1012,7 +1012,7 @@ msgstr "Ya"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Tidak"
 
@@ -1546,9 +1546,9 @@ msgstr "Cetak"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Pautan ke"
 
@@ -1991,7 +1991,7 @@ msgstr "Tamat"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3030,7 +3030,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4196,8 +4196,8 @@ msgstr "Laporan penjejak"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Muka Surat:"
 
@@ -4337,7 +4337,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -6917,7 +6917,7 @@ msgstr "Status"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Masa"
 
@@ -7830,8 +7830,8 @@ msgstr "Paparan Cetak"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Ekstra"
 
@@ -8103,7 +8103,7 @@ msgstr "Masa"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 #, fuzzy
 msgid "Event"
 msgstr "Hantar"
@@ -18021,21 +18021,21 @@ msgid "Error reading data for table %s:"
 msgstr "Melonggok data bagi jadual"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "Mewujudkan"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 #, fuzzy
 #| msgid "Last update"
 msgid "Last update:"
 msgstr "Kemaskini terakhir"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 #, fuzzy
 #| msgid "Last check"
 msgid "Last check:"
@@ -18054,7 +18054,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18217,18 +18217,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Jenis eksport tidak sah"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database"
 msgstr "Skema bagi pangkalan data \"%s\" database - Laman %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Skema Hubungan"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Kandungan"
 

--- a/resources/po/my.po
+++ b/resources/po/my.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2019-04-21 21:34+0000\n"
 "Last-Translator: AJ <necessarylion@gmail.com>\n"
 "Language-Team: Burmese <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -283,7 +283,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -479,9 +479,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -631,9 +631,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr ""
 
@@ -666,9 +666,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -704,8 +704,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -728,9 +728,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr ""
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Bad type!"
 msgid "Media type"
@@ -898,7 +898,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr ""
 
@@ -934,7 +934,7 @@ msgstr ""
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr ""
 
@@ -1408,9 +1408,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1784,7 +1784,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2707,7 +2707,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3710,8 +3710,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3845,7 +3845,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6136,7 +6136,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -6909,8 +6909,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7143,7 +7143,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16189,17 +16189,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16216,7 +16216,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16369,17 +16369,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/nb.po
+++ b/resources/po/nb.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-05-10 06:01+0000\n"
 "Last-Translator: ClearanceClarence <adrian.thomassen92@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/"
@@ -296,7 +296,7 @@ msgstr "Gå"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Tabellkommentarer:"
 
@@ -509,9 +509,9 @@ msgstr "Velg fremmednøkkel"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kolonne"
 
@@ -662,7 +662,7 @@ msgstr "Struktur"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Navn"
 
@@ -693,9 +693,9 @@ msgstr "Navn"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Type"
 
@@ -732,9 +732,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Standard"
 
@@ -772,8 +772,8 @@ msgstr "Sammenligning"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Attributter"
 
@@ -796,9 +796,9 @@ msgstr "Attributter"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -822,9 +822,9 @@ msgstr "Rediger privilegier"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Kommentarer"
 
@@ -844,7 +844,7 @@ msgstr "Fjern kolonne(r)"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -985,7 +985,7 @@ msgstr "Avslått"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ja"
 
@@ -1021,7 +1021,7 @@ msgstr "Ja"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Nei"
 
@@ -1536,9 +1536,9 @@ msgstr "Skriv ut"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Lenker til"
 
@@ -1972,7 +1972,7 @@ msgstr "Slutt"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3030,7 +3030,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4159,8 +4159,8 @@ msgstr "Tar deg til målsiden."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Sidenummer:"
 
@@ -4304,7 +4304,7 @@ msgstr ""
 msgid "View:"
 msgstr "Visning"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7064,7 +7064,7 @@ msgstr "Oppstart"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Tid"
 
@@ -7984,8 +7984,8 @@ msgstr "Fjern partisjonering"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Ekstra"
 
@@ -8249,7 +8249,7 @@ msgstr "Tid"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Hendelse"
 
@@ -18894,17 +18894,17 @@ msgid "Error reading data for table %s:"
 msgstr "Tillater lesing av data."
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Opprettet:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Sist oppdatert:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Sist sjekket:"
 
@@ -18921,7 +18921,7 @@ msgstr ""
 msgid "Export contents"
 msgstr "Eksporter innhold"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -19085,18 +19085,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Ugyldig eksport-type"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the %s database - Page %s"
 msgid "Schema of the %s database"
 msgstr "Skjema for %s databasen - Side %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Relasjonsskjema"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Innholdsfortegnelse"
 

--- a/resources/po/ne.po
+++ b/resources/po/ne.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2024-03-07 04:09+0000\n"
 "Last-Translator: Nabin Ghimire <nnabinn@hotmail.com>\n"
 "Language-Team: Nepali <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -287,7 +287,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "टेबलको टिप्पणीहरु:"
 
@@ -485,9 +485,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "स्तम्भ"
 
@@ -610,7 +610,7 @@ msgstr "संरचना"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -641,9 +641,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "प्रकार"
 
@@ -676,9 +676,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "पूर्वनिर्धारित"
 
@@ -714,8 +714,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -738,9 +738,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "रिक्त"
 
@@ -762,9 +762,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "टिप्पणीहरु"
 
@@ -782,7 +782,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Bad type!"
 msgid "Media type"
@@ -908,7 +908,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "हो/छ"
 
@@ -944,7 +944,7 @@ msgstr "हो/छ"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "छैन"
 
@@ -1427,9 +1427,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "संग सम्बन्धित छ"
 
@@ -1816,7 +1816,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2777,7 +2777,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3810,8 +3810,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3951,7 +3951,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6309,7 +6309,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -7099,8 +7099,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7334,7 +7334,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16499,17 +16499,17 @@ msgid "Error reading data for table %s:"
 msgstr "यो तालिकाको लागि ट्रैकिंग डेटा मेट्नुहोस्"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "निर्माण:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "पछिल्लो विवरण:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "पछिल्लो जाँच:"
 
@@ -16526,7 +16526,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16681,17 +16681,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/nl.po
+++ b/resources/po/nl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-05-26 13:03+0000\n"
 "Last-Translator: Marijn Scholtus <linkable@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -282,7 +282,7 @@ msgstr "Starten"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Tabelopmerkingen:"
 
@@ -480,9 +480,9 @@ msgstr "Is een vreemde sleutel."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kolom"
 
@@ -601,7 +601,7 @@ msgstr "Structuur"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Naam"
 
@@ -632,9 +632,9 @@ msgstr "Naam"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Type"
 
@@ -671,9 +671,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Standaardwaarde"
 
@@ -711,8 +711,8 @@ msgstr "Collatie"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Attributen"
 
@@ -735,9 +735,9 @@ msgstr "Attributen"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Nul"
 
@@ -759,9 +759,9 @@ msgstr "Rechten aanpassen"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Opmerkingen"
 
@@ -779,7 +779,7 @@ msgstr "Kolom verplaatsen"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Media type"
 
@@ -909,7 +909,7 @@ msgstr "Uitgeschakeld"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ja"
 
@@ -945,7 +945,7 @@ msgstr "Ja"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Nee"
 
@@ -1421,9 +1421,9 @@ msgstr "Afdrukken"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Verwijst naar"
 
@@ -1797,7 +1797,7 @@ msgstr "Einde"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definitie"
 
@@ -2731,7 +2731,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Database:"
 
@@ -3757,8 +3757,8 @@ msgstr "Neemt je naar de doel site."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Paginanummer:"
 
@@ -3917,7 +3917,7 @@ msgstr ""
 msgid "View:"
 msgstr "View:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabel:"
 
@@ -6368,7 +6368,7 @@ msgstr "Toestand"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Tijd"
 
@@ -7156,8 +7156,8 @@ msgstr "Partitionering bewerken"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -7390,7 +7390,7 @@ msgstr "Tijdstip"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Gebeurtenis"
 
@@ -17542,17 +17542,17 @@ msgid "Error reading data for table %s:"
 msgstr "Fout bij het lezen van gegevens voor tabel %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Aangemaakt:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Laatst bijgewerkt:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Laatst gecontroleerd:"
 
@@ -17571,7 +17571,7 @@ msgstr "Object-aanmaakopties (alle zijn aangeraden)"
 msgid "Export contents"
 msgstr "Exporteerinhoud"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Doel:"
 
@@ -17738,17 +17738,17 @@ msgstr "SCHEMA ERROR: "
 msgid "PDF export page"
 msgstr "PDF export pagina"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Schema van database %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Relationeel schema"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Inhoudsopgave"
 

--- a/resources/po/nn.po
+++ b/resources/po/nn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Norwegian Nynorsk <https://hosted.weblate.org/projects/"
@@ -287,7 +287,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -483,9 +483,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr ""
 
@@ -604,7 +604,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -635,9 +635,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr ""
 
@@ -670,9 +670,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -708,8 +708,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -732,9 +732,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr ""
 
@@ -756,9 +756,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr ""
 
@@ -900,7 +900,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr ""
 
@@ -936,7 +936,7 @@ msgstr ""
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr ""
 
@@ -1412,9 +1412,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1790,7 +1790,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2718,7 +2718,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3727,8 +3727,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3862,7 +3862,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6171,7 +6171,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -6942,8 +6942,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7174,7 +7174,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16229,17 +16229,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16256,7 +16256,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16409,17 +16409,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/pa.po
+++ b/resources/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:20+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -285,7 +285,7 @@ msgstr "ਚੱਲੋ"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "ਟੇਬਲ ਟਿੱਪਣੀ:"
 
@@ -481,9 +481,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "ਕਾਲਮ"
 
@@ -602,7 +602,7 @@ msgstr "ਢਾਂਚਾ"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -633,9 +633,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "ਕਿਸਮ"
 
@@ -668,9 +668,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "ਮੂਲ"
 
@@ -706,8 +706,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -730,9 +730,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "ਨੱਲ"
 
@@ -754,9 +754,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "ਟਿੱਪਣੀਆਂ"
 
@@ -774,7 +774,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Bad type!"
 msgid "Media type"
@@ -900,7 +900,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "ਹਾਂ"
 
@@ -936,7 +936,7 @@ msgstr "ਹਾਂ"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "ਨਹੀਂ"
 
@@ -1416,9 +1416,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "ਲਈ ਲਿੰਕ"
 
@@ -1809,7 +1809,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2753,7 +2753,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3780,8 +3780,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "ਪੰਨਾ ਨੰਬਰ:"
 
@@ -3917,7 +3917,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6266,7 +6266,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -7054,8 +7054,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7290,7 +7290,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16603,17 +16603,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16630,7 +16630,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16785,17 +16785,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/phpmyadmin.pot
+++ b/resources/po/phpmyadmin.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -292,7 +292,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -491,9 +491,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr ""
 
@@ -612,7 +612,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -643,9 +643,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr ""
 
@@ -678,9 +678,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -717,8 +717,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -741,9 +741,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr ""
 
@@ -765,9 +765,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -785,7 +785,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr ""
 
@@ -909,7 +909,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr ""
 
@@ -945,7 +945,7 @@ msgstr ""
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr ""
 
@@ -1427,9 +1427,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1803,7 +1803,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2742,7 +2742,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16
 #: src/Plugins/Export/ExportLatex.php:260 src/Plugins/Export/ExportSql.php:928
-#: src/Plugins/Export/ExportXml.php:367 src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/ExportXml.php:367 src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3767,8 +3767,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4
 #: src/BrowseForeigners.php:278 src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3903,7 +3903,7 @@ msgid "View:"
 msgstr ""
 
 #: resources/templates/menu/main.twig:29
-#: src/Plugins/Export/Helpers/Pdf.php:177
+#: src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6200,7 +6200,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -6972,8 +6972,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7204,7 +7204,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16258,17 +16258,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16285,7 +16285,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16438,17 +16438,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, possible-php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/pl.po
+++ b/resources/po/pl.po
@@ -4,8 +4,8 @@ msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
 "POT-Creation-Date: 2025-06-15 00:31+0000\n"
-"PO-Revision-Date: 2024-10-17 16:16+0000\n"
-"Last-Translator: KwiatekMiki <niecierpiehiszpanskiego@gmail.com>\n"
+"PO-Revision-Date: 2025-06-21 23:01+0000\n"
+"Last-Translator: \"Lisek (Damian Bartyś)\" <damianbart22@gmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/phpmyadmin/master/"
 "pl/>\n"
 "Language: pl\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
-"X-Generator: Weblate 5.8-rc\n"
+"X-Generator: Weblate 5.13-dev\n"
 
 #: resources/templates/base.twig:36 resources/templates/login/header.twig:13
 msgid "Javascript must be enabled past this point!"
@@ -1945,10 +1945,8 @@ msgid "OFF"
 msgstr "Wył"
 
 #: resources/templates/database/events/index.twig:161
-#, fuzzy
-#| msgid "Excel edition"
 msgid "Event editor"
-msgstr "Wydanie Excela"
+msgstr "Edytor wydarzeń"
 
 #: resources/templates/database/events/index.twig:166
 #: resources/templates/database/routines/index.twig:83
@@ -1973,10 +1971,8 @@ msgid "Save changes"
 msgstr "Zapisz zmiany"
 
 #: resources/templates/database/events/index.twig:181
-#, fuzzy
-#| msgid "Export of event %s"
 msgid "Export event"
-msgstr "Eksport zdarzenia %s"
+msgstr "Eksportuj zdarzenie"
 
 #: resources/templates/database/export/index.twig:61
 msgid ""
@@ -2134,10 +2130,8 @@ msgid "Update query"
 msgstr "Zaktualizuj zapytanie"
 
 #: resources/templates/database/multi_table_query/form.twig:175
-#, fuzzy
-#| msgid "Update query"
 msgid "Copy query"
-msgstr "Zaktualizuj zapytanie"
+msgstr "Skopiuj zapytanie"
 
 #: resources/templates/database/multi_table_query/form.twig:176
 #: src/Html/Generator.php:541
@@ -2443,10 +2437,8 @@ msgid "Function"
 msgstr "Funkcja"
 
 #: resources/templates/database/routines/execute_form.twig:54
-#, fuzzy
-#| msgid "This page does not contain any tables!"
 msgid "This routine does not require any parameters."
-msgstr "Ta strona nie zawiera żadnych tabel!"
+msgstr "Ta procedura nie wymaga żadnych parametrów."
 
 #: resources/templates/database/routines/index.twig:3 src/Menu.php:371
 #: src/Util.php:1368
@@ -2479,16 +2471,12 @@ msgid "Returns"
 msgstr "Powrót"
 
 #: resources/templates/database/routines/index.twig:78
-#, fuzzy
-#| msgid "Routine name"
 msgid "Routine editor"
-msgstr "Nazwa procedury"
+msgstr "Edytor procedur"
 
 #: resources/templates/database/routines/index.twig:98
-#, fuzzy
-#| msgid "Export of routine %s"
 msgid "Export routine"
-msgstr "Eksportuj procedurę %s"
+msgstr "Eksportuj procedurę"
 
 #: resources/templates/database/routines/index.twig:113
 #: src/Controllers/Database/RoutinesController.php:355
@@ -2552,7 +2540,7 @@ msgstr "Opcje:"
 
 #: resources/templates/database/search/main.twig:40
 msgid "include hex matches"
-msgstr ""
+msgstr "Uwzględnij dopasowania szesnastkowe"
 
 #: resources/templates/database/search/main.twig:45
 msgid "Inside tables:"
@@ -2586,9 +2574,7 @@ msgid "Browse"
 msgstr "Przeglądaj"
 
 #: resources/templates/database/search/results.twig:43
-#, fuzzy, php-format
-#| msgid "<strong>Total:</strong> <em>%count%</em> match"
-#| msgid_plural "<strong>Total:</strong> <em>%count%</em> matches"
+#, php-format
 msgid "<strong>Total:</strong> <em>%s</em> match"
 msgid_plural "<strong>Total:</strong> <em>%s</em> matches"
 msgstr[0] "<strong>Ogółem:</strong> <em>%s</em> dopasowanie"
@@ -3437,14 +3423,12 @@ msgid "Containing the word:"
 msgstr "Zawierające słowo:"
 
 #: resources/templates/gis_data_editor_form.twig:26
-#, fuzzy
-#| msgid "Geometry %d:"
 msgid "Geometry type:"
-msgstr "Geometria %d:"
+msgstr "Typ geometrii:"
 
 #: resources/templates/gis_data_editor_form.twig:41
 msgid "Spatial Reference System Identifier"
-msgstr ""
+msgstr "Identyfikator układu współrzędnych"
 
 #: resources/templates/gis_data_editor_form.twig:41
 msgctxt "Spatial Reference System Identifier"
@@ -3548,8 +3532,6 @@ msgid "Server:"
 msgstr "Serwer:"
 
 #: resources/templates/home/index.twig:186
-#, fuzzy
-#| msgid "Host name:"
 msgid "Hostname:"
 msgstr "Nazwa hosta:"
 
@@ -4018,10 +4000,8 @@ msgid "Clear fast filter"
 msgstr "Wyczyść szybki filtr"
 
 #: resources/templates/navigation/tree/quick_warp.twig:5
-#, fuzzy
-#| msgid "Recently used tables"
 msgid "Recently visited tables"
-msgstr "Ostatnio używane tabele"
+msgstr "Ostatnio przeglądane tabele"
 
 #: resources/templates/navigation/tree/quick_warp.twig:6
 msgid "Recent"
@@ -4784,9 +4764,8 @@ msgid "Allows executing this routine."
 msgstr "Umożliwia wykonanie tej procedury."
 
 #: resources/templates/server/privileges/initials_row.twig:1
-#, fuzzy
 msgid "Pagination of user accounts"
-msgstr "Zmień dane logowania/Skopiuj konto użytkownika"
+msgstr "Stronicowanie kont użytkowników"
 
 #: resources/templates/server/privileges/login_information_fields.twig:2
 #: resources/templates/server/privileges/user_properties.twig:105
@@ -5752,10 +5731,8 @@ msgstr ""
 "Możesz wyeksportować go, jeśli masz skomplikowany zestaw górę."
 
 #: resources/templates/server/status/monitor/index.twig:58
-#, fuzzy
-#| msgid "Import monitor configuration"
 msgid "Importing system monitor configuration"
-msgstr "Importuj konfigurację monitora"
+msgstr "Importuj konfigurację monitora systemowego"
 
 #: resources/templates/server/status/monitor/index.twig:63
 #: src/Controllers/JavaScriptMessagesController.php:299
@@ -5767,10 +5744,8 @@ msgid "Reset to default"
 msgstr "Przywróć wartość domyślną"
 
 #: resources/templates/server/status/monitor/index.twig:87
-#, fuzzy
-#| msgid "Monitor Instructions"
 msgid "System monitor instructions"
-msgstr "Instrukcje monitora"
+msgstr "Instrukcje monitora systemowego"
 
 #: resources/templates/server/status/monitor/index.twig:92
 msgid ""
@@ -5801,22 +5776,15 @@ msgstr ""
 "w 'Ustawienia' lub usunąć wykres za pomocą ikony zębatki dla każdego wykresu."
 
 #: resources/templates/server/status/monitor/index.twig:104
-#, fuzzy
-#| msgid ""
-#| "To display queries from the logs, select the relevant time span on any "
-#| "chart by holding down the left mouse button and panning over the chart. "
-#| "Once confirmed, this will load a table of grouped queries, there you may "
-#| "click on any occurring SELECT statements to further analyze them."
 msgid ""
 "To display queries from the logs, click on any chart. Once confirmed, this "
 "will load a table of grouped queries, there you may click on any occurring "
 "SELECT statements to further analyze them."
 msgstr ""
-"Aby wyświetlić zapytania z dzienników, wybierz odpowiedni przedział czasowy "
-"na dowolnym wykresie, przytrzymując lewy przycisk myszy i przesuwając po "
-"wykresie. Po potwierdzeniu spowoduje to załadowanie tabeli zgrupowanych "
-"zapytań, gdzie możesz kliknąć dowolne występujące instrukcje SELECT, aby je "
-"dalej analizować."
+"Aby wyświetlić zapytania z dzienników, kliknij dowolny wykres. Po "
+"potwierdzeniu spowoduje to załadowanie tabeli zgrupowanych zapytań, gdzie "
+"możesz kliknąć dowolne występujące instrukcje SELECT, aby je dalej "
+"analizować."
 
 #: resources/templates/server/status/monitor/index.twig:108
 msgid "Please note:"
@@ -5957,8 +5925,6 @@ msgid "Cancel request"
 msgstr "Anuluj żądanie"
 
 #: resources/templates/server/status/monitor/index.twig:294
-#, fuzzy
-#| msgid "Analysing & loading logs. This may take a while."
 msgid "Analysing and loading logs. This may take a while."
 msgstr "Analizowanie i wczytywanie dzienników. To może trochę potrwać."
 
@@ -5981,8 +5947,6 @@ msgid "Log data loaded. Queries executed in this time span:"
 msgstr "Wczytano dane dziennika. Zapytania wykonane w tym odcinku czasu:"
 
 #: resources/templates/server/status/monitor/index.twig:336
-#, fuzzy
-#| msgid "Jump to Log table"
 msgid "Jump to the log table"
 msgstr "Przejdź do dziennika tabeli"
 
@@ -5992,10 +5956,8 @@ msgstr "Odświeżanie monitora nie powiodło się"
 
 #: resources/templates/server/status/monitor/index.twig:350
 #: resources/templates/server/status/monitor/index.twig:369
-#, fuzzy
-#| msgid "Warning"
 msgid "Warning:"
-msgstr "Ostrzeżenie"
+msgstr "Ostrzeżenie:"
 
 #: resources/templates/server/status/monitor/index.twig:351
 msgid ""
@@ -6016,12 +5978,6 @@ msgid "Local monitor configuration incompatible!"
 msgstr "Konfiguracja monitora lokalnego jest niezgodna!"
 
 #: resources/templates/server/status/monitor/index.twig:370
-#, fuzzy
-#| msgid ""
-#| "The chart arrangement configuration in your browsers local storage is not "
-#| "compatible anymore to the newer version of the monitor dialog. It is very "
-#| "likely that your current configuration will not work anymore. Please "
-#| "reset your configuration to default in the <i>Settings</i> menu."
 msgid ""
 "The chart arrangement configuration in your browsers local storage is not "
 "compatible anymore to the newer version of the monitor dialog. It is very "
@@ -6031,7 +5987,7 @@ msgstr ""
 "Ustawienia konfiguracji wykresu w lokalnym magazynie przeglądarki nie są już "
 "zgodne z nowszą wersją okna dialogowego monitora. Jest bardzo prawdopodobne, "
 "że bieżąca konfiguracja nie będzie już działać. Proszę zresetować "
-"konfigurację do domyślnej w menu <i>Ustawienia</i>."
+"konfigurację do domyślnej w menu <em>Ustawienia</em>."
 
 #: resources/templates/server/status/processes/index.twig:14
 msgid "Show only active"
@@ -6442,7 +6398,7 @@ msgstr "Zapytanie SQL"
 
 #: resources/templates/sql/query.twig:41
 msgid "Format as a single line"
-msgstr ""
+msgstr "Sformatuj jako pojedynczą linię"
 
 #: resources/templates/sql/query.twig:45
 msgid "Get auto-saved query"
@@ -6607,7 +6563,7 @@ msgstr "Wartości dla kolumny:"
 #: resources/templates/table/chart/tbl_chart.twig:145
 #: resources/templates/table/zoom_search/result_form.twig:16
 msgid "The generated chart"
-msgstr ""
+msgstr "Wygenerowany wykres"
 
 #: resources/templates/table/chart/tbl_chart.twig:148
 msgid "Save chart as image"
@@ -7360,7 +7316,7 @@ msgstr "Przeglądaj/Edytuj punkty"
 
 #: resources/templates/table/zoom_search/result_form.twig:11
 msgid "How to use"
-msgstr "Jak korzystać"
+msgstr "Jak używać"
 
 #: resources/templates/table/zoom_search/result_form.twig:12
 msgid "Reset zoom"
@@ -7430,16 +7386,12 @@ msgid "There are no triggers to display."
 msgstr "Brak wyzwalaczy."
 
 #: resources/templates/triggers/list.twig:81
-#, fuzzy
-#| msgid "Trigger name"
 msgid "Trigger editor"
-msgstr "Nazwa wyzwalacza"
+msgstr "Edytor wyzwalaczy"
 
 #: resources/templates/triggers/list.twig:101
-#, fuzzy
-#| msgid "Export of trigger %s"
 msgid "Export trigger"
-msgstr "Eksport wyzwalacza %s"
+msgstr "Eksportuj wyzwalacz"
 
 #: resources/templates/view_create.twig:75
 msgid "VIEW name"
@@ -10819,7 +10771,7 @@ msgstr "%s widok"
 
 #: src/Config/Descriptions.php:710
 msgid "Use ignore inserts"
-msgstr "Użyj ignorowanych dodań"
+msgstr "Użyj ignorowanych wstawień"
 
 #: src/Config/Descriptions.php:712
 msgid "Syntax to use when inserting data"
@@ -12806,6 +12758,9 @@ msgid ""
 "configuration directive <code>AllowNoPassword</code> is false. If you "
 "proceed, the account will not be able to log in through phpMyAdmin."
 msgstr ""
+"Próbujesz ustawić to konto do logowania bez hasła, ale dyrektywa "
+"konfiguracyjna <code>AllowNoPassword</code> ma wartość false. Jeśli będziesz "
+"kontynuować, konto nie będzie mogło zalogować się przez phpMyAdmin."
 
 #: src/Controllers/JavaScriptMessagesController.php:151
 msgid "Removing Selected Users"
@@ -13479,16 +13434,12 @@ msgid "No dependencies selected!"
 msgstr "Nie wybrano żadnych zależności!"
 
 #: src/Controllers/JavaScriptMessagesController.php:425
-#, fuzzy
-#| msgid "Use this value"
 msgid "Enter first value"
-msgstr "Użyj tej wartości"
+msgstr "Wprowadź pierwszą wartość"
 
 #: src/Controllers/JavaScriptMessagesController.php:426
-#, fuzzy
-#| msgid "Session value"
 msgid "Enter second value"
-msgstr "Wartość sesji"
+msgstr "Wprowadź drugą wartość"
 
 #: src/Controllers/JavaScriptMessagesController.php:432
 msgid "Hide search criteria"
@@ -13753,10 +13704,8 @@ msgid "Double-click to copy column name."
 msgstr "Kliknij dwukrotnie, aby skopiować nazwę kolumny."
 
 #: src/Controllers/JavaScriptMessagesController.php:551
-#, fuzzy
-#| msgid "Click the drop-down arrow<br>to toggle column's visibility."
 msgid "Click the drop-down arrow to toggle column's visibility."
-msgstr "Kliknij rozwijane strzałki, <br> aby przełączyć widoczność kolumn."
+msgstr "Kliknij rozwijane strzałki, aby przełączyć widoczność kolumn."
 
 #: src/Controllers/JavaScriptMessagesController.php:554
 msgid ""
@@ -15459,14 +15408,12 @@ msgid "The columns have been moved successfully."
 msgstr "Kolumny przeniesiono pomyślnie."
 
 #: src/Controllers/Table/Structure/MoveColumnsController.php:112
-#, fuzzy
-#| msgid "The selected user was not found in the privilege table."
 msgid "The selected columns do not match the columns in the table."
-msgstr "Wybrany użytkownik nie został znaleziony w tabeli uprawnień."
+msgstr "Wybrane kolumny nie odpowiadają kolumnom w tabeli."
 
 #: src/Controllers/Table/Structure/MoveColumnsController.php:139
 msgid "The selected columns are already in the correct order."
-msgstr ""
+msgstr "Wybrane kolumny są już w poprawnej kolejności."
 
 #: src/Controllers/Table/Structure/PartitioningController.php:257
 #: src/Controllers/Table/Structure/SaveController.php:265
@@ -15736,10 +15683,8 @@ msgid "You must provide a valid return type for the routine."
 msgstr "Musisz podać poprawny typ wartości zwracanej do procedury."
 
 #: src/Database/Routines.php:809
-#, fuzzy
-#| msgid "Invalid routine type: \"%s\""
 msgid "Invalid routine type!"
-msgstr "Nieprawidłowy typ procedury: %s"
+msgstr "Nieprawidłowy typ procedury!"
 
 #: src/Database/Routines.php:815
 msgid "You must provide a routine name!"
@@ -17757,6 +17702,8 @@ msgid ""
 "Displays a link to download the binary data of the column. You can use the "
 "option to specify the filename."
 msgstr ""
+"Wyświetla link do pobrania danych binarnych z kolumny. Możesz użyć tej "
+"opcji, aby określić nazwę pliku."
 
 #: src/Plugins/Transformations/Abs/ExternalTransformationsPlugin.php:38
 msgid ""
@@ -18614,16 +18561,12 @@ msgid "You must provide a trigger definition."
 msgstr "Musisz podać definicję wyzwalacza."
 
 #: src/Types.php:97
-#, fuzzy
-#| msgid "Empty"
 msgid "empty"
-msgstr "Opróżnij"
+msgstr "opróżnij"
 
 #: src/Types.php:98
-#, fuzzy
-#| msgid "not present"
 msgid "not empty"
-msgstr "nie występuje"
+msgstr "nie jest pusty"
 
 #: src/Types.php:161
 msgid ""
@@ -18730,18 +18673,16 @@ msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Data i godzina kombinacja zakresu obsługiwanych jest %1$s %2$s"
 
 #: src/Types.php:208
-#, fuzzy
-#| msgid ""
-#| "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
-#| "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-19 03:14:07 UTC on "
 "32-bit platforms (MariaDB 11.3 and earlier), and up to 2106-02-07 06:28:15 "
 "UTC on 64-bit platforms (MariaDB 11.5 and later), stored as the number of "
 "seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
-"Sygnatura czasowa, zakres 1970-01-01 00:00:01 UTC do 2038-01-09 03:14:07 "
-"UTC, przechowywane jako liczba sekund od epoki (1970-01-01 00:00:00 UTC)"
+"Sygnatura czasowa, zakres 1970-01-01 00:00:01 UTC do 2038-01-19 03:14:07 UTC "
+"na platformach 32-bitowych (MariaDB 11.3 i wcześniejsze) oraz do 2106-02-07 "
+"06:28:15 UTC na platformach 64-bitowych (MariaDB 11.5 i nowsze), "
+"przechowywane jako liczba sekund od epoki (1970-01-01 00:00:00 UTC)"
 
 #: src/Types.php:214
 #, php-format

--- a/resources/po/pl.po
+++ b/resources/po/pl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-06-21 23:01+0000\n"
 "Last-Translator: \"Lisek (Damian Bartyś)\" <damianbart22@gmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -282,7 +282,7 @@ msgstr "Wykonaj"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Komentarze tabeli:"
 
@@ -480,9 +480,9 @@ msgstr "Jest obcym kluczem."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kolumna"
 
@@ -601,7 +601,7 @@ msgstr "Struktura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nazwa"
 
@@ -632,9 +632,9 @@ msgstr "Nazwa"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Typ"
 
@@ -671,9 +671,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Ustawienia domyślne"
 
@@ -712,8 +712,8 @@ msgstr "Metoda porównywania napisów"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atrybuty"
 
@@ -736,9 +736,9 @@ msgstr "Atrybuty"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -760,9 +760,9 @@ msgstr "Dostosuj uprawnienia"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Komentarze"
 
@@ -780,7 +780,7 @@ msgstr "Przenieść kolumnę"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Typ mediów"
 
@@ -908,7 +908,7 @@ msgstr "Wyłączone"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Tak"
 
@@ -944,7 +944,7 @@ msgstr "Tak"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Nie"
 
@@ -1420,9 +1420,9 @@ msgstr "Drukuj"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Odsyłacze do"
 
@@ -1796,7 +1796,7 @@ msgstr "Koniec"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Określenie"
 
@@ -2731,7 +2731,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Baza danych:"
 
@@ -3757,8 +3757,8 @@ msgstr "Zabiorę cię do miejsca docelowego."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Numer strony:"
 
@@ -3915,7 +3915,7 @@ msgstr ""
 msgid "View:"
 msgstr "Widok:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabela:"
 
@@ -6340,7 +6340,7 @@ msgstr "Stan"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Czas"
 
@@ -7122,8 +7122,8 @@ msgstr "Edytuj partycjonowanie"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Dodatkowo"
 
@@ -7356,7 +7356,7 @@ msgstr "Czas"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Zdarzenie"
 
@@ -17411,17 +17411,17 @@ msgid "Error reading data for table %s:"
 msgstr "Błąd odczytu danych dla tabeli %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Utworzenie:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Ostatnia aktualizacja:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Ostatnie sprawdzanie:"
 
@@ -17440,7 +17440,7 @@ msgstr "Opcje tworzenia obiektów (wszystkie są polecane)"
 msgid "Export contents"
 msgstr "Eksportuj zawartość"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Zamiar:"
 
@@ -17605,17 +17605,17 @@ msgstr "Błąd SCHEMA: "
 msgid "PDF export page"
 msgstr "Strona eksportu PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Schemat bazy danych %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Schemat relacyjny"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Spis treści"
 

--- a/resources/po/pt.po
+++ b/resources/po/pt.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-02-07 22:02+0000\n"
 "Last-Translator: Horus68 <horus68@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -285,7 +285,7 @@ msgstr "Continuar"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Comentários da tabela:"
 
@@ -483,9 +483,9 @@ msgstr "É uma chave estrangeira."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Coluna"
 
@@ -604,7 +604,7 @@ msgstr "Estrutura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nome"
 
@@ -635,9 +635,9 @@ msgstr "Nome"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tipo"
 
@@ -674,9 +674,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Predefinido"
 
@@ -714,8 +714,8 @@ msgstr "Agrupamento (Collation)"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atributos"
 
@@ -738,9 +738,9 @@ msgstr "Atributos"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Nulo"
 
@@ -762,9 +762,9 @@ msgstr "Ajustar privilégios"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Comentários"
 
@@ -782,7 +782,7 @@ msgstr "Mover coluna(s)"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Tipo de mídia"
 
@@ -911,7 +911,7 @@ msgstr "Desactidado"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Sim"
 
@@ -947,7 +947,7 @@ msgstr "Sim"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Não"
 
@@ -1426,9 +1426,9 @@ msgstr "Imprimir"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Ligações para"
 
@@ -1803,7 +1803,7 @@ msgstr "Fim"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definição"
 
@@ -2751,7 +2751,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Base de dados:"
 
@@ -3790,8 +3790,8 @@ msgstr "Indo para o site alvo."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Número da página:"
 
@@ -3951,7 +3951,7 @@ msgstr ""
 msgid "View:"
 msgstr "Ver:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabela:"
 
@@ -6463,7 +6463,7 @@ msgstr "Estado"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Tempo"
 
@@ -7251,8 +7251,8 @@ msgstr "Editar particionamento"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -7486,7 +7486,7 @@ msgstr "Tempo"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Evento"
 
@@ -17716,17 +17716,17 @@ msgid "Error reading data for table %s:"
 msgstr "Erro ao ler dados para tabela %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Criação:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Última actualização:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Última verificação:"
 
@@ -17745,7 +17745,7 @@ msgstr "Opções de criação de objetos (todas são recomendadas)"
 msgid "Export contents"
 msgstr "Exportar conteúdo"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Propósito:"
 
@@ -17911,17 +17911,17 @@ msgstr "ERRO DE ESQUEMA: "
 msgid "PDF export page"
 msgstr "Página de exportação PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Esquema da base de dados %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Esquema relacional"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Índice"
 

--- a/resources/po/pt_BR.po
+++ b/resources/po/pt_BR.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2023-12-30 21:39+0000\n"
 "Last-Translator: Marco Aurélio Cardoso <marcoaurelio.cardoso@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -281,7 +281,7 @@ msgstr "Executar"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Comentários de tabela:"
 
@@ -479,9 +479,9 @@ msgstr "É uma chave estrangeira."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Coluna"
 
@@ -600,7 +600,7 @@ msgstr "Estrutura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nome"
 
@@ -631,9 +631,9 @@ msgstr "Nome"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tipo"
 
@@ -670,9 +670,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Padrão"
 
@@ -710,8 +710,8 @@ msgstr "Colação"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atributos"
 
@@ -734,9 +734,9 @@ msgstr "Atributos"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Nulo"
 
@@ -758,9 +758,9 @@ msgstr "Ajustar privilégios"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Comentários"
 
@@ -778,7 +778,7 @@ msgstr "Mover coluna(s)"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Tipo de mídia"
 
@@ -907,7 +907,7 @@ msgstr "Desabilitado"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Sim"
 
@@ -943,7 +943,7 @@ msgstr "Sim"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Não"
 
@@ -1421,9 +1421,9 @@ msgstr "Imprimir"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Links para"
 
@@ -1797,7 +1797,7 @@ msgstr "Final"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definição"
 
@@ -2745,7 +2745,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Banco de dados:"
 
@@ -3782,8 +3782,8 @@ msgstr "Indo para o site alvo."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Número da página:"
 
@@ -3943,7 +3943,7 @@ msgstr ""
 msgid "View:"
 msgstr "View:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabela:"
 
@@ -6413,7 +6413,7 @@ msgstr "Estado"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Tempo"
 
@@ -7198,8 +7198,8 @@ msgstr "Editar particionamento"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -7432,7 +7432,7 @@ msgstr "Momento de ação"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Evento"
 
@@ -17588,17 +17588,17 @@ msgid "Error reading data for table %s:"
 msgstr "Erro ao ler dados para tabela %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Criação:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Última atualização:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Última verificação:"
 
@@ -17617,7 +17617,7 @@ msgstr "Opções de criação de objetos (todas são recomendadas)"
 msgid "Export contents"
 msgstr "Exportar conteúdo"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Propósito:"
 
@@ -17783,17 +17783,17 @@ msgstr "ERRO DE ESQUEMA: "
 msgid "PDF export page"
 msgstr "Página de exportação PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Esquema de banco de dados %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Esquema relacional"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Tabela de conteúdos"
 

--- a/resources/po/rcf.po
+++ b/resources/po/rcf.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-09-11 14:23+0000\n"
 "Last-Translator: William Desportes <williamdes@wdes.fr>\n"
 "Language-Team: Réunion Creole <https://hosted.weblate.org/projects/"
@@ -283,7 +283,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -479,9 +479,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -631,9 +631,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr ""
 
@@ -666,9 +666,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -704,8 +704,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -728,9 +728,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr ""
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr ""
 
@@ -1406,9 +1406,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1782,7 +1782,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2708,7 +2708,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3711,8 +3711,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3846,7 +3846,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6139,7 +6139,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -6910,8 +6910,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7142,7 +7142,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16199,17 +16199,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16226,7 +16226,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16379,17 +16379,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/ro.po
+++ b/resources/po/ro.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2024-04-18 08:29+0000\n"
 "Last-Translator: Nicoara Alex <alex.nicoara@yahoo.com>\n"
 "Language-Team: Romanian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -290,7 +290,7 @@ msgstr "Execută"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Comentarii tabel:"
 
@@ -488,9 +488,9 @@ msgstr "Este o cheie străină."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Coloană"
 
@@ -609,7 +609,7 @@ msgstr "Structură"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nume"
 
@@ -640,9 +640,9 @@ msgstr "Nume"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tip"
 
@@ -680,9 +680,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Implicit"
 
@@ -720,8 +720,8 @@ msgstr "Colaționare"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atribute"
 
@@ -744,9 +744,9 @@ msgstr "Atribute"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Nul"
 
@@ -768,9 +768,9 @@ msgstr "Ajustează privilegiile"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Comentarii"
 
@@ -788,7 +788,7 @@ msgstr "Mută coloana"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 msgid "Media type"
 msgstr "Tip de MIME"
@@ -917,7 +917,7 @@ msgstr "Dezactivată"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Da"
 
@@ -953,7 +953,7 @@ msgstr "Da"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Nu"
 
@@ -1434,9 +1434,9 @@ msgstr "Imprimare"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Legături la"
 
@@ -1813,7 +1813,7 @@ msgstr "Sfârșit"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definiție"
 
@@ -2772,7 +2772,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Bază de date:"
 
@@ -3821,8 +3821,8 @@ msgstr "Te duc la situl de destinație."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Număr pagină:"
 
@@ -3977,7 +3977,7 @@ msgstr ""
 msgid "View:"
 msgstr "Vizualizări:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabel:"
 
@@ -6500,7 +6500,7 @@ msgstr "Stare"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Oră"
 
@@ -7302,8 +7302,8 @@ msgstr "Editează partiționarea"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Suplimentar"
 
@@ -7540,7 +7540,7 @@ msgstr "Timp"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Eveniment"
 
@@ -17662,17 +17662,17 @@ msgid "Error reading data for table %s:"
 msgstr "Eroare la citirea datelor pentru tabelul %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Creare:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Ultima actualizare:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Ultima verificare:"
 
@@ -17691,7 +17691,7 @@ msgstr "Opțiuni creare obiect (toate sunt recomandate)"
 msgid "Export contents"
 msgstr "Exportă conținuturi"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Scop:"
 
@@ -17855,17 +17855,17 @@ msgstr "EROARE SCHEMĂ: "
 msgid "PDF export page"
 msgstr "Pagină export PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Schema bazei de date %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Schemă relațională"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Cuprins"
 

--- a/resources/po/ru.po
+++ b/resources/po/ru.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-06-09 08:03+0000\n"
 "Last-Translator: Andrei Stepanov <adem4ik@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -282,7 +282,7 @@ msgstr "Вперёд"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Комментарии к таблице:"
 
@@ -480,9 +480,9 @@ msgstr "Это внешний ключ."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Столбец"
 
@@ -601,7 +601,7 @@ msgstr "Структура"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Имя"
 
@@ -632,9 +632,9 @@ msgstr "Имя"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Тип"
 
@@ -671,9 +671,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "По умолчанию"
 
@@ -711,8 +711,8 @@ msgstr "Схема сравнения"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Атрибуты"
 
@@ -735,9 +735,9 @@ msgstr "Атрибуты"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -759,9 +759,9 @@ msgstr "Настроить привилегии"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Комментарии"
 
@@ -779,7 +779,7 @@ msgstr "Переместить поле"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Медиатип"
 
@@ -907,7 +907,7 @@ msgstr "Недоступно"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Да"
 
@@ -943,7 +943,7 @@ msgstr "Да"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Нет"
 
@@ -1419,9 +1419,9 @@ msgstr "Печать"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Ссылки на"
 
@@ -1795,7 +1795,7 @@ msgstr "Конец"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Определение"
 
@@ -2730,7 +2730,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "База данных:"
 
@@ -3758,8 +3758,8 @@ msgstr "Переход на целевой сайт."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Номер страницы:"
 
@@ -3915,7 +3915,7 @@ msgstr ""
 msgid "View:"
 msgstr "Представление:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Таблица:"
 
@@ -6349,7 +6349,7 @@ msgstr "Состояние"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Время"
 
@@ -7133,8 +7133,8 @@ msgstr "Редактировать разбиение"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Дополнительно"
 
@@ -7367,7 +7367,7 @@ msgstr "Время"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Событие"
 
@@ -17458,17 +17458,17 @@ msgid "Error reading data for table %s:"
 msgstr "Ошибка считывания данных таблицы %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Создание:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Последнее обновление:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Последняя проверка:"
 
@@ -17487,7 +17487,7 @@ msgstr "Параметры создания объекта (рекомендуе
 msgid "Export contents"
 msgstr "Экспортировать содержимое"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Цель:"
 
@@ -17653,17 +17653,17 @@ msgstr "Ошибка при создании схемы: "
 msgid "PDF export page"
 msgstr "Страница экспорта PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Схема базы данных %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Cхема связей"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Содержание"
 

--- a/resources/po/si.po
+++ b/resources/po/si.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -301,7 +301,7 @@ msgstr "යන්න"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "වගු විස්තර:"
 
@@ -510,9 +510,9 @@ msgstr "අන්‍ය මූලය තෝරන්න"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "තීර"
 
@@ -663,7 +663,7 @@ msgstr "සැකිල්ල"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "නම"
 
@@ -694,9 +694,9 @@ msgstr "නම"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "වර්ගය"
 
@@ -739,9 +739,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "පෙරනිමි"
 
@@ -777,8 +777,8 @@ msgstr "පරිතුලනය"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "ගුණාංග"
 
@@ -801,9 +801,9 @@ msgstr "ගුණාංග"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "ශුන්‍ය"
 
@@ -827,9 +827,9 @@ msgstr "වරප්‍රසාද හැඩ ගස්වන්න"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "විස්තරය"
 
@@ -847,7 +847,7 @@ msgstr "පේළිය ගෙනයන්න"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -991,7 +991,7 @@ msgstr "අක්‍රිය"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "ඔව්"
 
@@ -1027,7 +1027,7 @@ msgstr "ඔව්"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "නැත"
 
@@ -1578,9 +1578,9 @@ msgstr "මුද්‍රණය කරන්න"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "සම්බන්ද වන්නේ"
 
@@ -2002,7 +2002,7 @@ msgstr "නවතන්න"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "අර්ථ දැක්වීම"
 
@@ -3014,7 +3014,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "දත්තගබඩාව:"
 
@@ -4138,8 +4138,8 @@ msgstr "අවධානය පිළිබඳ වාර්තාව"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "පිටු අංකය:"
 
@@ -4283,7 +4283,7 @@ msgstr ""
 msgid "View:"
 msgstr "දසුන්"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "වගුව:"
 
@@ -6940,7 +6940,7 @@ msgstr "අරඹන්න"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "කාලය"
 
@@ -7823,8 +7823,8 @@ msgstr "කොටස් කිරීම ඉවත් කරන්න"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "අතිරේක"
 
@@ -8070,7 +8070,7 @@ msgstr "වේලාව"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "සිද්ධිය"
 
@@ -18487,17 +18487,17 @@ msgid "Error reading data for table %s:"
 msgstr "දත්ත කියවීමේදී දෝෂයකි:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "සෑදීම:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "අවසන් යාවත්කාලීන කිරීම:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "අවසන් පරීක්ෂාව:"
 
@@ -18514,7 +18514,7 @@ msgstr "වස්තු නිර්මාණය කිරීමේ විකල
 msgid "Export contents"
 msgstr "අන්තර්ගතය අපනයනය කරන්න"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18680,18 +18680,18 @@ msgstr "ක්‍රමානුරූප දෝෂය: "
 msgid "PDF export page"
 msgstr "වැරදි අපනයන වර්ගයකි"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the %s database - Page %s"
 msgid "Schema of the %s database"
 msgstr "%s දත්තගබඩාවේ ක්‍රමානුරූපය - %sවන පිටුව"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "ක්‍රමානුරූපය"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "පටුන"
 

--- a/resources/po/sk.po
+++ b/resources/po/sk.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2023-10-24 11:03+0000\n"
 "Last-Translator: Pavol Linet <linet.pavol@gmail.com>\n"
 "Language-Team: Slovak <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -290,7 +290,7 @@ msgstr "Vykonaj"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Komentáre k tabuľke:"
 
@@ -489,9 +489,9 @@ msgstr "Je to cudzí kľúč."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Stĺpec"
 
@@ -626,7 +626,7 @@ msgstr "Štruktúra"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Názov"
 
@@ -657,9 +657,9 @@ msgstr "Názov"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Typ"
 
@@ -696,9 +696,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Predvolené"
 
@@ -736,8 +736,8 @@ msgstr "Zotriedenie"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atribúty"
 
@@ -760,9 +760,9 @@ msgstr "Atribúty"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Prázdny"
 
@@ -784,9 +784,9 @@ msgstr "Upraviť oprávnenia"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Komentáre"
 
@@ -804,7 +804,7 @@ msgstr "Presunúť stĺpce"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 msgid "Media type"
 msgstr "MIME typ"
@@ -933,7 +933,7 @@ msgstr "Vypnuté"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Áno"
 
@@ -969,7 +969,7 @@ msgstr "Áno"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Nie"
 
@@ -1452,9 +1452,9 @@ msgstr "Vytlačiť"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Linkovať na"
 
@@ -1836,7 +1836,7 @@ msgstr "Koniec"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definícia"
 
@@ -2805,7 +2805,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Databáza:"
 
@@ -3857,8 +3857,8 @@ msgstr "Vezmeme vás na ďalší krok…"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Číslo stránky:"
 
@@ -3998,7 +3998,7 @@ msgstr ""
 msgid "View:"
 msgstr "Náhľady:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabuľka:"
 
@@ -6465,7 +6465,7 @@ msgstr "Stav"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Čas"
 
@@ -7270,8 +7270,8 @@ msgstr "Upraviť v riadku"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -7507,7 +7507,7 @@ msgstr "Čas"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Udalosť"
 
@@ -17447,17 +17447,17 @@ msgid "Error reading data for table %s:"
 msgstr "Chyba pri čítaní dát:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Vytvorené:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Posledná zmena:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Posledná kontrola:"
 
@@ -17474,7 +17474,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Účel:"
 
@@ -17629,17 +17629,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Stránka PDF exportu"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Schéma databázy %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Relačná schéma"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Obsah"
 

--- a/resources/po/sl.po
+++ b/resources/po/sl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-05-12 23:02+0000\n"
 "Last-Translator: Domen <mitenem@outlook.com>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -282,7 +282,7 @@ msgstr "Izvedi"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Pripombe tabele:"
 
@@ -480,9 +480,9 @@ msgstr "Je tuji ključ."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Stolpec"
 
@@ -601,7 +601,7 @@ msgstr "Struktura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Ime"
 
@@ -632,9 +632,9 @@ msgstr "Ime"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Vrsta"
 
@@ -671,9 +671,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Privzeto"
 
@@ -711,8 +711,8 @@ msgstr "Pravilo za razvrščanje znakov"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atributi"
 
@@ -735,9 +735,9 @@ msgstr "Atributi"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -759,9 +759,9 @@ msgstr "Prilagodi privilegije"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Pripombe"
 
@@ -779,7 +779,7 @@ msgstr "Premakni stolpec"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Vrsta predstavnosti"
 
@@ -908,7 +908,7 @@ msgstr "Onemogočeno"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Da"
 
@@ -944,7 +944,7 @@ msgstr "Da"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Ne"
 
@@ -1420,9 +1420,9 @@ msgstr "Natisni"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Povezave z"
 
@@ -1796,7 +1796,7 @@ msgstr "Konec"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Opredelitev"
 
@@ -2740,7 +2740,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Zbirka podatkov:"
 
@@ -3765,8 +3765,8 @@ msgstr "Prestavili vas bomo na naslednjo ciljno stran."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Številka strani:"
 
@@ -3923,7 +3923,7 @@ msgstr ""
 msgid "View:"
 msgstr "Pogled:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabela:"
 
@@ -6366,7 +6366,7 @@ msgstr "Stanje"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Čas"
 
@@ -7146,8 +7146,8 @@ msgstr "Uredi razdelitev"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Dodatno"
 
@@ -7379,7 +7379,7 @@ msgstr "Čas"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Dogodek"
 
@@ -17399,17 +17399,17 @@ msgid "Error reading data for table %s:"
 msgstr "Napaka pri branju podatkov tabele %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Ustvarjeno:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Zadnjič posodobljeno:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Zadnjič pregledano:"
 
@@ -17428,7 +17428,7 @@ msgstr "Možnosti ustvarjanja objektov (vse so priporočljive)"
 msgid "Export contents"
 msgstr "Izvozi vsebine"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Namen:"
 
@@ -17593,17 +17593,17 @@ msgstr "NAPAKA SHEME: "
 msgid "PDF export page"
 msgstr "Stran za izvoz PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Shema zbirke podatkov %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Relacijska shema"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Vsebina"
 

--- a/resources/po/sq.po
+++ b/resources/po/sq.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:20+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Albanian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -291,7 +291,7 @@ msgstr "Shko"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Komentet e tabelës:"
 
@@ -493,9 +493,9 @@ msgstr "Është një çelës i huaj."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kolona"
 
@@ -614,7 +614,7 @@ msgstr "Struktura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Emri"
 
@@ -645,9 +645,9 @@ msgstr "Emri"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tipi"
 
@@ -685,9 +685,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Parazgjedhur"
 
@@ -725,8 +725,8 @@ msgstr "Përshtatja"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atributet"
 
@@ -749,9 +749,9 @@ msgstr "Atributet"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -773,9 +773,9 @@ msgstr "Përshtat privilegjet"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Komente"
 
@@ -793,7 +793,7 @@ msgstr "Lëviz kolonën"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -924,7 +924,7 @@ msgstr "Pasivizuar"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Po"
 
@@ -960,7 +960,7 @@ msgstr "Po"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Jo"
 
@@ -1455,9 +1455,9 @@ msgstr "Printo"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Lidhje tek"
 
@@ -1836,7 +1836,7 @@ msgstr "Fund"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Përkufizimi"
 
@@ -2828,7 +2828,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Databaza:"
 
@@ -3916,8 +3916,8 @@ msgstr "Po kalon në faqen e objektivit."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Numri i faqes:"
 
@@ -4071,7 +4071,7 @@ msgstr ""
 msgid "View:"
 msgstr "Shfaqje:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabela:"
 
@@ -6740,7 +6740,7 @@ msgstr "Gjendja"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Koha"
 
@@ -7564,8 +7564,8 @@ msgstr "Redakto ndarjen"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Ekstra"
 
@@ -7809,7 +7809,7 @@ msgstr "Koha"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Ngjarje"
 
@@ -18294,17 +18294,17 @@ msgid "Error reading data for table %s:"
 msgstr "Gabim gjatë leximit të të dhënave për tabelën %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Krijimi:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Aktualizimi i fundit:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Kontrolli i fundit:"
 
@@ -18323,7 +18323,7 @@ msgstr "Opsionet e krijimit të objektit (të gjitha rekomandohen)"
 msgid "Export contents"
 msgstr "Përmbajtja e eksportit"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Qëllimi:"
 
@@ -18490,17 +18490,17 @@ msgstr "GABIM SKEME: "
 msgid "PDF export page"
 msgstr "PDF eksporto faqen"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Skema e databazës %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Skema relacionale"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Tabela e përmajtjes"
 

--- a/resources/po/sr.po
+++ b/resources/po/sr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -308,7 +308,7 @@ msgstr "Крени"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Коментари табеле:"
 
@@ -518,9 +518,9 @@ msgstr "Изабери страни кључ"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Колона"
 
@@ -671,7 +671,7 @@ msgstr "Структура"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Име"
 
@@ -702,9 +702,9 @@ msgstr "Име"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Тип"
 
@@ -747,9 +747,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Подразумевано"
 
@@ -787,8 +787,8 @@ msgstr "Сортирање"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Атрибути"
 
@@ -811,9 +811,9 @@ msgstr "Атрибути"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -837,9 +837,9 @@ msgstr "Промени привилегије"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Коментари"
 
@@ -859,7 +859,7 @@ msgstr "Додај/обриши колону"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -1005,7 +1005,7 @@ msgstr "Онемогућено"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Да"
 
@@ -1041,7 +1041,7 @@ msgstr "Да"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Не"
 
@@ -1580,9 +1580,9 @@ msgstr "Штампај"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Везе ка"
 
@@ -2027,7 +2027,7 @@ msgstr "Крај"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3102,7 +3102,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4309,8 +4309,8 @@ msgstr "Промени"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Број странице:"
 
@@ -4452,7 +4452,7 @@ msgstr ""
 msgid "View:"
 msgstr "Поглед"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7112,7 +7112,7 @@ msgstr "Статус"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Време"
 
@@ -8050,8 +8050,8 @@ msgstr "Додај ново поље"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Додатно"
 
@@ -8329,7 +8329,7 @@ msgstr "Време"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Догађаји"
 
@@ -18836,21 +18836,21 @@ msgid "Error reading data for table %s:"
 msgstr "Дозвољава читање података."
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "Направљено"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 #, fuzzy
 #| msgid "Last update"
 msgid "Last update:"
 msgstr "Последња измена"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 #, fuzzy
 #| msgid "Last check"
 msgid "Last check:"
@@ -18870,7 +18870,7 @@ msgstr ""
 msgid "Export contents"
 msgstr "Тип извоза"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -19038,18 +19038,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Тип извоза"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database"
 msgstr "Схема базе \"%s\" - Страна %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Релациона схема"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Садржај"
 

--- a/resources/po/sr@latin.po
+++ b/resources/po/sr@latin.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-12-13 20:50+0000\n"
 "Last-Translator: Kristijan Fremen Velkovski <me@krisfremen.com>\n"
 "Language-Team: Serbian (latin) <https://hosted.weblate.org/projects/"
@@ -305,7 +305,7 @@ msgstr "Kreni"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Komentari tabele:"
 
@@ -516,9 +516,9 @@ msgstr "Izaberi strani ključ"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kolona"
 
@@ -669,7 +669,7 @@ msgstr "Struktura"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Ime"
 
@@ -700,9 +700,9 @@ msgstr "Ime"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tip"
 
@@ -738,9 +738,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Podrazumevano"
 
@@ -778,8 +778,8 @@ msgstr "Sortiranje"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atributi"
 
@@ -802,9 +802,9 @@ msgstr "Atributi"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -828,9 +828,9 @@ msgstr "Promeni privilegije"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Komentari"
 
@@ -850,7 +850,7 @@ msgstr "Dodaj/obriši kolonu"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -997,7 +997,7 @@ msgstr "Onemogućeno"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Da"
 
@@ -1033,7 +1033,7 @@ msgstr "Da"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Ne"
 
@@ -1582,9 +1582,9 @@ msgstr "Štampaj"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Veze ka"
 
@@ -2010,7 +2010,7 @@ msgstr "Kraj"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definicija"
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4194,8 +4194,8 @@ msgstr "Izveštaj o praćenju"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Broj strane:"
 
@@ -4339,7 +4339,7 @@ msgstr ""
 msgid "View:"
 msgstr "Pogledi"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -6988,7 +6988,7 @@ msgstr "Početak"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Vreme"
 
@@ -7904,8 +7904,8 @@ msgstr "Uredi indeks"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Dodatno"
 
@@ -8165,7 +8165,7 @@ msgstr "Vreme"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Događaji"
 
@@ -18758,21 +18758,21 @@ msgid "Error reading data for table %s:"
 msgstr "Greška kod čitanja podataka:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "Napravljeno"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 #, fuzzy
 #| msgid "Last update"
 msgid "Last update:"
 msgstr "Poslednja izmena"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 #, fuzzy
 #| msgid "Last check"
 msgid "Last check:"
@@ -18791,7 +18791,7 @@ msgstr ""
 msgid "Export contents"
 msgstr "Izvoz sadržajaTip izvoza"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18953,18 +18953,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Pogrešan tip izvoza"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the %s database - Page %s"
 msgid "Schema of the %s database"
 msgstr "Shema baze %s - Strana %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Relaciona shema"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Sadržaj"
 

--- a/resources/po/sv.po
+++ b/resources/po/sv.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2023-02-17 01:47+0000\n"
 "Last-Translator: Anders Johansson <johansson@aljmedia.se>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -293,7 +293,7 @@ msgstr "Kör"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Tabellkommentarer:"
 
@@ -495,9 +495,9 @@ msgstr "Är en främmande nyckel."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Kolumn"
 
@@ -646,7 +646,7 @@ msgstr "Struktur"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Namn"
 
@@ -677,9 +677,9 @@ msgstr "Namn"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Typ"
 
@@ -716,9 +716,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Standardvärde"
 
@@ -756,8 +756,8 @@ msgstr "Kollationering"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Attribut"
 
@@ -780,9 +780,9 @@ msgstr "Attribut"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "nolläge"
 
@@ -804,9 +804,9 @@ msgstr "Ändra privilegier"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Kommentarer"
 
@@ -824,7 +824,7 @@ msgstr "Flytta kolumn"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -956,7 +956,7 @@ msgstr "Inaktiverad"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ja"
 
@@ -992,7 +992,7 @@ msgstr "Ja"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Nej"
 
@@ -1486,9 +1486,9 @@ msgstr "Skriv ut"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Länkar till"
 
@@ -1877,7 +1877,7 @@ msgstr "Slut"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Definition"
 
@@ -2879,7 +2879,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Databas:"
 
@@ -3994,8 +3994,8 @@ msgstr "Tar dig till målwebbplatsen."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Sida nummer:"
 
@@ -4139,7 +4139,7 @@ msgstr ""
 msgid "View:"
 msgstr "Vyer:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tabell:"
 
@@ -6807,7 +6807,7 @@ msgstr "Tillstånd"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Tid"
 
@@ -7633,8 +7633,8 @@ msgstr "Ta bort partitionering"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Extra"
 
@@ -7877,7 +7877,7 @@ msgstr "Tidpunkt"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Händelse"
 
@@ -18306,17 +18306,17 @@ msgid "Error reading data for table %s:"
 msgstr "Fel vid läsning av data:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Skapat:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Senaste uppdatering:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Senaste kontroll:"
 
@@ -18335,7 +18335,7 @@ msgstr "Alternativ vid skapande av objekt (alla rekommenderas)"
 msgid "Export contents"
 msgstr "Exportera innehåll"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Syfte:"
 
@@ -18502,17 +18502,17 @@ msgstr "SCHEMAFEL: "
 msgid "PDF export page"
 msgstr "PDF-export sida"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Schemat för %s databasen"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Relationsschema"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Innehållsförteckning"
 

--- a/resources/po/ta.po
+++ b/resources/po/ta.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-06-17 13:34+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@mfauth.net>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -284,7 +284,7 @@ msgstr "செல்க"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "அட்டவணைக் கருத்துரைகள்:"
 
@@ -482,9 +482,9 @@ msgstr "ஒரு வெளிநாட்டு விசை."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "நிரல்வரிசை"
 
@@ -603,7 +603,7 @@ msgstr "கட்டமைப்பு"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "பெயர்"
 
@@ -634,9 +634,9 @@ msgstr "பெயர்"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "வகை"
 
@@ -673,9 +673,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "இயல்நிலை"
 
@@ -713,8 +713,8 @@ msgstr "அடுக்கு"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "பண்புக்கூறுகள்"
 
@@ -737,9 +737,9 @@ msgstr "பண்புக்கூறுகள்"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "வெற்று"
 
@@ -761,9 +761,9 @@ msgstr "சலுகைகளை சரிசெய்யவும்"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "கருத்துரைகள்"
 
@@ -781,7 +781,7 @@ msgstr "நிரல்வரிசையை நகர்த்து"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "ஊடக வகை"
 
@@ -909,7 +909,7 @@ msgstr "முடக்கப்பட்டது"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "ஆம்"
 
@@ -945,7 +945,7 @@ msgstr "ஆம்"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "இல்லை"
 
@@ -1421,9 +1421,9 @@ msgstr "அச்சிடுக"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "இணைப்புகள்"
 
@@ -1797,7 +1797,7 @@ msgstr "முடிவு"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "வரையறை"
 
@@ -2739,7 +2739,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "தரவுத்தளம்:"
 
@@ -3766,8 +3766,8 @@ msgstr "உங்களை இலக்கு தளத்திற்கு அ
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "பக்க எண்:"
 
@@ -3920,7 +3920,7 @@ msgstr ""
 msgid "View:"
 msgstr "காண்க:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "அட்டவணை:"
 
@@ -6331,7 +6331,7 @@ msgstr "சனி->நிலை"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "நேரம்"
 
@@ -7113,8 +7113,8 @@ msgstr "பகிர்வைத் திருத்து"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "மிகை"
 
@@ -7347,7 +7347,7 @@ msgstr "நேரம்"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "நிகழ்வு"
 
@@ -7942,8 +7942,8 @@ msgid ""
 "%s%% of all temporary tables are being written to disk, this value should be "
 "below 25%%"
 msgstr ""
-"அனைத்து தற்காலிக அட்டவணைகளிலும்%s%% வட்டுக்கு எழுதப்பட்டுள்ளது, இந்த மதிப்பு 25%% குறைவா"
-"க இருக்க வேண்டும்"
+"அனைத்து தற்காலிக அட்டவணைகளிலும்%s%% வட்டுக்கு எழுதப்பட்டுள்ளது, இந்த மதிப்பு 25%% "
+"குறைவாக இருக்க வேண்டும்"
 
 #: src/Advisory/Rules.php:368
 msgid "Temp disk rate"
@@ -8470,10 +8470,10 @@ msgid ""
 "perfectly adequate for your system if you don't have much InnoDB tables or "
 "other services running on the same machine."
 msgstr ""
-"நீங்கள் தற்போது உங்கள் நினைவகத்தின்%s %% ஐ இன்னோடிபி இடையகக் குளத்திற்கு பயன்படுத்துகிறீர்கள்"
-". நீங்கள் 60 %% த்திற்கும் குறைவாக ஒதுக்குகிறீர்கள் என்றால் இந்த விதி சுடுகிறது, இருப்பினும்"
-" உங்களிடம் அதிக இன்னோடிபி அட்டவணைகள் அல்லது ஒரே கணினியில் இயங்கும் பிற சேவைகள் "
-"இல்லையென்றால் இது உங்கள் கணினிக்குப் போதுமானதாக இருக்கும்."
+"நீங்கள் தற்போது உங்கள் நினைவகத்தின்%s %% ஐ இன்னோடிபி இடையகக் குளத்திற்கு "
+"பயன்படுத்துகிறீர்கள். நீங்கள் 60 %% த்திற்கும் குறைவாக ஒதுக்குகிறீர்கள் என்றால் இந்த விதி "
+"சுடுகிறது, இருப்பினும் உங்களிடம் அதிக இன்னோடிபி அட்டவணைகள் அல்லது ஒரே கணினியில் "
+"இயங்கும் பிற சேவைகள் இல்லையென்றால் இது உங்கள் கணினிக்குப் போதுமானதாக இருக்கும்."
 
 #: src/Advisory/Rules.php:748
 msgid "MyISAM concurrent inserts"
@@ -11658,10 +11658,10 @@ msgid ""
 msgstr ""
 "இந்த %soption %s முடக்கப்பட வேண்டும், ஏனெனில் இது எந்தவொரு MySQL சேவையகத்திற்கும் "
 "உள்நுழைவதைத் தாக்குபவர்களை அனுமதிக்கிறது. இது தேவை என்று நீங்கள் நினைத்தால், %sRESTRICT "
-"உள்நுழைவை MySQL சேவையகம் %s அல்லது %s நம்பகமான பதிலாள்கள் பட்டியல் %s க்கு பயன்படுத்தவும்"
-". இருப்பினும், உங்கள் ஐபி ஒரு ஐஎச்பிக்கு சொந்தமானது என்றால், நம்பகமான ப்ராக்சீச் பட்டியலுடன் "
-"ஐபி அடிப்படையிலான பாதுகாப்பு நம்பகமானதாக இருக்காது, அங்கு நீங்கள் உட்பட ஆயிரக்கணக்கான "
-"பயனர்கள் இணைக்கப்பட்டுள்ளனர்."
+"உள்நுழைவை MySQL சேவையகம் %s அல்லது %s நம்பகமான பதிலாள்கள் பட்டியல் %s க்கு "
+"பயன்படுத்தவும். இருப்பினும், உங்கள் ஐபி ஒரு ஐஎச்பிக்கு சொந்தமானது என்றால், நம்பகமான "
+"ப்ராக்சீச் பட்டியலுடன் ஐபி அடிப்படையிலான பாதுகாப்பு நம்பகமானதாக இருக்காது, அங்கு நீங்கள் "
+"உட்பட ஆயிரக்கணக்கான பயனர்கள் இணைக்கப்பட்டுள்ளனர்."
 
 #: src/Config/ServerConfigChecks.php:77
 msgid ""
@@ -11740,8 +11740,8 @@ msgid ""
 "%5$d)."
 msgstr ""
 "%1$s உள்நுழைவு குக்கீ செல்லுபடியாகும் %2$sஐ விட அதிகமாக உள்ளது %3$sஅமர்வுக்கு "
-"அதிகமாகும். GC_MAXLIFETIME %4$sசீரற்ற அமர்வு செல்லாததை ஏற்படுத்தக்கூடும் (தற்போது அமர்வு"
-". GC_MAXLIFETIME %5$d)."
+"அதிகமாகும். GC_MAXLIFETIME %4$sசீரற்ற அமர்வு செல்லாததை ஏற்படுத்தக்கூடும் (தற்போது "
+"அமர்வு. GC_MAXLIFETIME %5$d)."
 
 #: src/Config/ServerConfigChecks.php:340
 #, fuzzy, php-format
@@ -12369,8 +12369,8 @@ msgid ""
 "The curl extension was not found and allow_url_fopen is disabled. Due to "
 "this some features such as error reporting or version check are disabled."
 msgstr ""
-"curl நீட்டிப்பு மற்றும் allow_url_fopen முடக்கப்பட்டுள்ளது. இதனால் தவறு அறிக்கை, பதிப்புச்"
-" சோதனை போன்ற அம்சங்கள் முடக்கப்பட்டுள்ளது."
+"curl நீட்டிப்பு மற்றும் allow_url_fopen முடக்கப்பட்டுள்ளது. இதனால் தவறு அறிக்கை, "
+"பதிப்புச் சோதனை போன்ற அம்சங்கள் முடக்கப்பட்டுள்ளது."
 
 #: src/Controllers/Import/ImportController.php:161
 #, php-format
@@ -12541,8 +12541,8 @@ msgid ""
 "Do you really want to DROP the selected partition(s)? This will also DELETE "
 "the data related to the selected partition(s)!"
 msgstr ""
-"தேர்ந்தெடுக்கப்பட்ட பகிர்வு(கள்)ஐக் (DROP)நீக்கம் செய்ய விரும்புகிறீர்களா? இது தேர்ந்தெடுக்கப்பட்"
-"ட பகிர்வு(கள்) தொடர்பான தரவை (DELETE) நீக்கும்!"
+"தேர்ந்தெடுக்கப்பட்ட பகிர்வு(கள்)ஐக் (DROP)நீக்கம் செய்ய விரும்புகிறீர்களா? இது "
+"தேர்ந்தெடுக்கப்பட்ட பகிர்வு(கள்) தொடர்பான தரவை (DELETE) நீக்கும்!"
 
 #: src/Controllers/JavaScriptMessagesController.php:82
 msgid "Do you really want to TRUNCATE the selected partition(s)?"
@@ -12566,10 +12566,11 @@ msgid ""
 "refer to the tips at "
 msgstr ""
 "இந்தத் தரவு, உங்கள் தரவைப் புதிய இணைப்பிற்கு மாற்றியமைக்க முயற்சிக்கும். அரிதான "
-"சந்தர்ப்பங்களில், குறிப்பாகப் புதிய குறிமுறை அடுக்குவரிசையில் (collation) ஒரு குறிமுறை"
-" இல்லை என்றால், இந்தச் செயல்முறையால் தரவு புதிய குறிமுறை அடுக்குவரிசையில்(collation) "
-"தவறாகத் தோன்றக்கூடும்; இந்த வழக்கில், நீங்கள் அசல் குறிமுறை அடுக்குவரிசைக்கு மாற்றியமைக்க "
-"நாங்கள் பரிந்துரைக்கிறோம், மேலும் உதவிக்குறிப்புகளைப் பார்க்கவும் "
+"சந்தர்ப்பங்களில், குறிப்பாகப் புதிய குறிமுறை அடுக்குவரிசையில் (collation) ஒரு "
+"குறிமுறை இல்லை என்றால், இந்தச் செயல்முறையால் தரவு புதிய குறிமுறை "
+"அடுக்குவரிசையில்(collation) தவறாகத் தோன்றக்கூடும்; இந்த வழக்கில், நீங்கள் அசல் குறிமுறை "
+"அடுக்குவரிசைக்கு மாற்றியமைக்க நாங்கள் பரிந்துரைக்கிறோம், மேலும் உதவிக்குறிப்புகளைப் "
+"பார்க்கவும் "
 
 #: src/Controllers/JavaScriptMessagesController.php:92
 msgid "Garbled Data"
@@ -17292,17 +17293,17 @@ msgid "Error reading data for table %s:"
 msgstr "அட்டவணை %s க்கான தரவைப் படிப்பது பிழை:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "உருவாக்கம்:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "கடைசி நிகழ்நிலையாக்கம்:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "கடைசி சரிபார்ப்பு:"
 
@@ -17321,7 +17322,7 @@ msgstr "பொருள் உருவாக்கும் விருப்�
 msgid "Export contents"
 msgstr "உள்ளடக்கத்தை தரவேற்றுக"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "நோக்கம்:"
 
@@ -17484,17 +17485,17 @@ msgstr "ச்கீமா பிழை: "
 msgid "PDF export page"
 msgstr "PDF தரவேற்ற பக்கம்"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "%s தரவுத்தளத்தின் ஒழுங்கமைவு"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "தொடர்புடைய திட்டம்"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "உள்ளடக்க அட்டவணை"
 

--- a/resources/po/te.po
+++ b/resources/po/te.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2024-03-15 15:17+0000\n"
 "Last-Translator: Prasanth-k <prasanthpra.k@gmail.com>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -302,7 +302,7 @@ msgstr "వెళ్ళు"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "పట్టిక వ్యాఖ్యలు:"
 
@@ -508,9 +508,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "వరుస"
 
@@ -659,7 +659,7 @@ msgstr "నిర్మాణాకృతి"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "పేరు"
 
@@ -690,9 +690,9 @@ msgstr "పేరు"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "రకం"
 
@@ -725,9 +725,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "అప్రమేయం"
 
@@ -763,8 +763,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -787,9 +787,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "శూన్యం"
 
@@ -813,9 +813,9 @@ msgstr "క్రొత్త వాడుకరిని చేర్చు"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "వ్యాఖ్యలు"
 
@@ -835,7 +835,7 @@ msgstr "పట్టిక వ్యాఖ్యలు"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "Bad type!"
 msgid "Media type"
@@ -969,7 +969,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "అవును"
 
@@ -1005,7 +1005,7 @@ msgstr "అవును"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "కాదు"
 
@@ -1550,9 +1550,9 @@ msgstr "ముద్రించు"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1999,7 +1999,7 @@ msgstr "ముగింపు"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3061,7 +3061,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4207,8 +4207,8 @@ msgstr "మార్చుము"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "పుట సంఖ్య:"
 
@@ -4351,7 +4351,7 @@ msgstr ""
 msgid "View:"
 msgstr "చూపుము"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -6943,7 +6943,7 @@ msgstr "మొదలుపెట్టు"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "సమయం"
 
@@ -7856,8 +7856,8 @@ msgstr "క్రొత్త వాడుకరిని చేర్చు"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -8129,7 +8129,7 @@ msgstr "సమయం"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -18090,21 +18090,21 @@ msgid "Error reading data for table %s:"
 msgstr "డేటాబేస్ ను ఇక్కడికి కాపీ చేయి"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "సృష్టి"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 #, fuzzy
 #| msgid "Last update"
 msgid "Last update:"
 msgstr "చివరి మార్పు"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 #, fuzzy
 #| msgid "Last check"
 msgid "Last check:"
@@ -18123,7 +18123,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18285,19 +18285,19 @@ msgid "PDF export page"
 msgstr "చెల్లని ఎగుమతి రకం"
 
 # మొదటి అనువాదము
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgctxt "short form"
 #| msgid "Create table"
 msgid "Schema of the %s database"
 msgstr "పట్టికను సృష్టించు"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "విషయ సూచిక"
 

--- a/resources/po/th.po
+++ b/resources/po/th.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-03-18 14:23+0000\n"
 "Last-Translator: AefghThreenine <aefgh39622@gmail.com>\n"
 "Language-Team: Thai <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -300,7 +300,7 @@ msgstr "ไป"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "หมายเหตุของตาราง:"
 
@@ -506,9 +506,9 @@ msgstr "เลือกคีย์นอก"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "คอลัมน์"
 
@@ -659,7 +659,7 @@ msgstr "โครงสร้าง"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "ชื่อ"
 
@@ -690,9 +690,9 @@ msgstr "ชื่อ"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "ชนิด"
 
@@ -734,9 +734,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "ค่าเริ่มต้น"
 
@@ -772,8 +772,8 @@ msgstr "การตรวจทาน"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "แอตทริบิวต์"
 
@@ -796,9 +796,9 @@ msgstr "แอตทริบิวต์"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "ค่าว่าง"
 
@@ -822,9 +822,9 @@ msgstr "แก้ไขสิทธิ"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "หมายเหตุ"
 
@@ -844,7 +844,7 @@ msgstr "เพิ่ม/ลบ คอลัมน์ (ฟิลด์)"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -980,7 +980,7 @@ msgstr "ระงับการใช้อยู่"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "ใช่"
 
@@ -1016,7 +1016,7 @@ msgstr "ใช่"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "ไม่"
 
@@ -1552,9 +1552,9 @@ msgstr "พิมพ์"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "เชื่อมไปยัง"
 
@@ -1990,7 +1990,7 @@ msgstr "ท้ายสุด"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3040,7 +3040,7 @@ msgstr "การกระทำนี้อาจเปลี่ยนกำห
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4166,8 +4166,8 @@ msgstr "รายงานผลการติดตาม"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "หมายเลขหน้า:"
 
@@ -4309,7 +4309,7 @@ msgstr ""
 msgid "View:"
 msgstr "ตารางจำลอง (View)"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -6976,7 +6976,7 @@ msgstr "สถานะ"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "เวลา"
 
@@ -7891,8 +7891,8 @@ msgstr "เพิ่มฟิลด์ใหม่"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "เพิ่มเติม"
 
@@ -8164,7 +8164,7 @@ msgstr "เวลา"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "เหตุการณ์"
 
@@ -18181,17 +18181,17 @@ msgid "Error reading data for table %s:"
 msgstr "อนุญาตให้อ่านข้อมูลได้."
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "สร้าง:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "ปรับปรุงครั้งสุดท้าย:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "ตรวจสอบครั้งสุดท้าย:"
 
@@ -18208,7 +18208,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18375,18 +18375,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "ประเภทที่ส่งออกไม่ถูกต้อง!"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database"
 msgstr "schema ของฐานข้อมูล \"%s\" - หน้า %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "รีเลชันแนล สกีมา"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "สารบัญ"
 

--- a/resources/po/tk.po
+++ b/resources/po/tk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Turkmen <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -283,7 +283,7 @@ msgstr "Git"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -479,9 +479,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr ""
 
@@ -604,7 +604,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -635,9 +635,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr ""
 
@@ -670,9 +670,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -708,8 +708,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -732,9 +732,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr ""
 
@@ -756,9 +756,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr ""
 
@@ -900,7 +900,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr ""
 
@@ -936,7 +936,7 @@ msgstr ""
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr ""
 
@@ -1422,9 +1422,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1815,7 +1815,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2763,7 +2763,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3785,8 +3785,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Sahypa belgisi:"
 
@@ -3920,7 +3920,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6257,7 +6257,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -7055,8 +7055,8 @@ msgstr "Düşündiriş"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7291,7 +7291,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16469,17 +16469,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16496,7 +16496,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16649,18 +16649,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Use this value"
 msgid "Schema of the %s database"
 msgstr "Şu bahany ulan"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/tr.po
+++ b/resources/po/tr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-05-19 07:01+0000\n"
 "Last-Translator: Burak Yavuz <hitowerdigit@hotmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -281,7 +281,7 @@ msgstr "Git"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Tablo açıklamaları:"
 
@@ -479,9 +479,9 @@ msgstr "Bir dış anahtardır."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Sütun"
 
@@ -600,7 +600,7 @@ msgstr "Yapı"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Ad"
 
@@ -631,9 +631,9 @@ msgstr "Ad"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tür"
 
@@ -670,9 +670,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Varsayılan"
 
@@ -710,8 +710,8 @@ msgstr "Karşılaştırma"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Öznitelikler"
 
@@ -734,9 +734,9 @@ msgstr "Öznitelikler"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Boş"
 
@@ -758,9 +758,9 @@ msgstr "Yetkileri ayarla"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Açıklamalar"
 
@@ -778,7 +778,7 @@ msgstr "Sütunu taşı"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Ortam türü"
 
@@ -906,7 +906,7 @@ msgstr "Etkisizleştirildi"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Evet"
 
@@ -942,7 +942,7 @@ msgstr "Evet"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Hayır"
 
@@ -1418,9 +1418,9 @@ msgstr "Yazdır"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Bağlantı verilen"
 
@@ -1794,7 +1794,7 @@ msgstr "Bitiş"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Tanım"
 
@@ -2726,7 +2726,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Veritabanı:"
 
@@ -3755,8 +3755,8 @@ msgstr "Sizi hedef siteye götürüyor."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Sayfa numarası:"
 
@@ -3916,7 +3916,7 @@ msgstr ""
 msgid "View:"
 msgstr "Görünüm:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Tablo:"
 
@@ -6344,7 +6344,7 @@ msgstr "Durum"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Süre"
 
@@ -7127,8 +7127,8 @@ msgstr "Bölümlemeyi düzenle"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Ekstra"
 
@@ -7359,7 +7359,7 @@ msgstr "Zaman"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Olay"
 
@@ -17401,17 +17401,17 @@ msgid "Error reading data for table %s:"
 msgstr "%s tablosu için veri okuma hatası:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Oluşturma:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Son güncelleme:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Son denetleme:"
 
@@ -17430,7 +17430,7 @@ msgstr "Nesne oluşturma seçenekleri (tümü önerilir)"
 msgid "Export contents"
 msgstr "İçerikleri dışa aktar"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Amacı:"
 
@@ -17594,17 +17594,17 @@ msgstr "ŞEMA HATASI: "
 msgid "PDF export page"
 msgstr "PDF dışa aktarma sayfası"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "%s veritabanının şeması"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "İlişkisel şema"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "İçerik tablosu"
 

--- a/resources/po/tt.po
+++ b/resources/po/tt.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Tatar <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -306,7 +306,7 @@ msgstr "Äydä"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 #, fuzzy
 #| msgid "Table comments"
 msgid "Table comments:"
@@ -517,9 +517,9 @@ msgstr "Yat tezeş tikşerüen sünderep"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 #, fuzzy
 #| msgid "Column names"
 msgid "Column"
@@ -672,7 +672,7 @@ msgstr "Tözeleş"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Adı"
 
@@ -703,9 +703,9 @@ msgstr "Adı"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Töre"
 
@@ -747,9 +747,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Töpcay"
 
@@ -787,8 +787,8 @@ msgstr "Tezü cayı"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Üzençälek"
 
@@ -811,9 +811,9 @@ msgstr "Üzençälek"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Buş"
 
@@ -837,9 +837,9 @@ msgstr "Xoquqlar Üzgärtü"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Açıqlama"
 
@@ -859,7 +859,7 @@ msgstr "Add/Delete Field Columns"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -1003,7 +1003,7 @@ msgstr "Sünek"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Äye"
 
@@ -1039,7 +1039,7 @@ msgstr "Äye"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Yuq"
 
@@ -1582,9 +1582,9 @@ msgstr "Bastır"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Bonı belän bäyläneş"
 
@@ -2030,7 +2030,7 @@ msgstr "Azaq"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3093,7 +3093,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4278,8 +4278,8 @@ msgstr "Üzgärt"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Bitneñ sanı:"
 
@@ -4420,7 +4420,7 @@ msgstr ""
 msgid "View:"
 msgstr "Qaraş"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7055,7 +7055,7 @@ msgstr "Torış"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Waqıt"
 
@@ -7988,8 +7988,8 @@ msgstr "Bastıru küreneşe"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Östämä"
 
@@ -8266,7 +8266,7 @@ msgstr "Waqıt"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 #, fuzzy
 msgid "Event"
 msgstr "Cibärelde"
@@ -18565,21 +18565,21 @@ msgid "Error reading data for table %s:"
 msgstr "Eçtälekne uqu xoquqı."
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "Yasalışı"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 #, fuzzy
 #| msgid "Last update"
 msgid "Last update:"
 msgstr "Soñğı yañartılu"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 #, fuzzy
 #| msgid "Last check"
 msgid "Last check:"
@@ -18599,7 +18599,7 @@ msgstr ""
 msgid "Export contents"
 msgstr "Çığaru ısulı"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18766,18 +18766,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Çığaru ısulı"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database"
 msgstr "\"%s\" biremlek tözeleşe - %s. bit"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Bäyläneşlär sxeme"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Eçtälek isemlege"
 

--- a/resources/po/tzm.po
+++ b/resources/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -283,7 +283,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -479,9 +479,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -631,9 +631,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr ""
 
@@ -666,9 +666,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -704,8 +704,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -728,9 +728,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr ""
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr ""
 
@@ -1406,9 +1406,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1782,7 +1782,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2708,7 +2708,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3711,8 +3711,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3846,7 +3846,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr ""
 
@@ -6912,8 +6912,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7144,7 +7144,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16199,17 +16199,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16226,7 +16226,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16379,17 +16379,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/ug.po
+++ b/resources/po/ug.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-06-20 21:02+0000\n"
 "Last-Translator: Abduqadir Abliz <sahranbay@gmail.com>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -286,7 +286,7 @@ msgstr "ئىجرا قىلىش"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 #, fuzzy
 #| msgid "Table comments"
 msgid "Table comments:"
@@ -497,9 +497,9 @@ msgstr "تاشقى ئاچقۇق قىممىتى"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "سۆزلەم"
 
@@ -646,7 +646,7 @@ msgstr "تۈزۈلىشى"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "ئىسمى"
 
@@ -677,9 +677,9 @@ msgstr "ئىسمى"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "تۈرى"
 
@@ -716,9 +716,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "ئەندىز"
 
@@ -756,8 +756,8 @@ msgstr "تاسقاش"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "خاسلىقى"
 
@@ -780,9 +780,9 @@ msgstr "خاسلىقى"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "بوش"
 
@@ -806,9 +806,9 @@ msgstr "ھۇقۇقى"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "ئىزاھلار"
 
@@ -828,7 +828,7 @@ msgstr "سۆزلەم قوشۇش\\ئۆچۈرۈش"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -961,7 +961,7 @@ msgstr "تاقالدى"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "بولدى"
 
@@ -997,7 +997,7 @@ msgstr "بولدى"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "يوق"
 
@@ -1537,9 +1537,9 @@ msgstr "يازدۇر"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "ئۇلانما"
 
@@ -1983,7 +1983,7 @@ msgstr "ئاخىرقىسى"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3047,7 +3047,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4232,8 +4232,8 @@ msgstr "ئىزلاش خاتىرىسى"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "بەت نومۇرى:"
 
@@ -4396,7 +4396,7 @@ msgstr ""
 msgid "View:"
 msgstr "قاراش"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7110,7 +7110,7 @@ msgstr "شەنبە"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "ۋاقىت"
 
@@ -8038,8 +8038,8 @@ msgstr "بېسىپ كۆرسىتىش"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "قوشۇمچە"
 
@@ -8304,7 +8304,7 @@ msgstr "ۋاقىت"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Event"
 
@@ -19183,21 +19183,21 @@ msgid "Error reading data for table %s:"
 msgstr "سانلىق مەلۇماتنى ئىزقوغلاپ ئۈچۈرۈش"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "قۇرۇش"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 #, fuzzy
 #| msgid "Last update"
 msgid "Last update:"
 msgstr "ئاخىرقى يېڭلىنىش"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 #, fuzzy
 #| msgid "Last check"
 msgid "Last check:"
@@ -19218,7 +19218,7 @@ msgstr "ئوبيېكت قۇرۇش تاللانمىلىرى (ھەممىسى تە�
 msgid "Export contents"
 msgstr "مەزمۇننى چىقىرىش"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "مەقسەت:"
 
@@ -19396,18 +19396,18 @@ msgstr "SCHEMA خاتالىق: "
 msgid "PDF export page"
 msgstr "چىقىرىش"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Search in database"
 msgid "Schema of the %s database"
 msgstr "سانداندىن ئىزدەش"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "مۇناسىۋەتلىك لايىھە"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "مەزمۇن جەدۋىلى"
 

--- a/resources/po/uk.po
+++ b/resources/po/uk.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-05-19 07:01+0000\n"
 "Last-Translator: Hotripak <hotr1pak@gmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -282,7 +282,7 @@ msgstr "Виконати"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Коментарі до таблиці:"
 
@@ -480,9 +480,9 @@ msgstr "Є зовнішнім ключем."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Стовпець"
 
@@ -601,7 +601,7 @@ msgstr "Структура"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Ім'я"
 
@@ -632,9 +632,9 @@ msgstr "Ім'я"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Тип"
 
@@ -671,9 +671,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "За замовчуванням"
 
@@ -711,8 +711,8 @@ msgstr "Зіставлення"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Атрибути"
 
@@ -735,9 +735,9 @@ msgstr "Атрибути"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Нуль"
 
@@ -759,9 +759,9 @@ msgstr "Налаштувати привілеї"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Коментарі"
 
@@ -779,7 +779,7 @@ msgstr "Перемістити стовпець"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Медіотип"
 
@@ -908,7 +908,7 @@ msgstr "Відключено"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Так"
 
@@ -944,7 +944,7 @@ msgstr "Так"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Ні"
 
@@ -1420,9 +1420,9 @@ msgstr "Друк"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Посилання на"
 
@@ -1796,7 +1796,7 @@ msgstr "Кінець"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Визначення"
 
@@ -2731,7 +2731,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "База даних:"
 
@@ -3761,8 +3761,8 @@ msgstr "Беручи вас на цільовий сайт."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Номер сторінки:"
 
@@ -3919,7 +3919,7 @@ msgstr ""
 msgid "View:"
 msgstr "Подання:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Таблиця:"
 
@@ -6345,7 +6345,7 @@ msgstr "Стан"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Час"
 
@@ -7129,8 +7129,8 @@ msgstr "Редагувати розділи"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Додатково"
 
@@ -7363,7 +7363,7 @@ msgstr "Час"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Подія"
 
@@ -17400,17 +17400,17 @@ msgid "Error reading data for table %s:"
 msgstr "Помилка читання даних таблиці %s:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Створення:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Останнє оновлення:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Остання перевірка:"
 
@@ -17428,7 +17428,7 @@ msgstr "Параметри створення об'єкта (рекоменду�
 msgid "Export contents"
 msgstr "Експортувати вміст"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Мета:"
 
@@ -17593,17 +17593,17 @@ msgstr "SCHEMA ERROR: "
 msgid "PDF export page"
 msgstr "Сторінка експорту PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Схема %s бази даних"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Схема зв'язків"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Зміст"
 

--- a/resources/po/ur.po
+++ b/resources/po/ur.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:20+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Urdu <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -302,7 +302,7 @@ msgstr "جائیں"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "جدول تبصرات:"
 
@@ -511,9 +511,9 @@ msgstr "فارن کلید منتخب کریں"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "کالم"
 
@@ -662,7 +662,7 @@ msgstr "ساخت"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -693,9 +693,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "قِسم"
 
@@ -728,9 +728,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "طے شدہ"
 
@@ -766,8 +766,8 @@ msgstr "ترتیب"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -790,9 +790,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "خالی"
 
@@ -816,9 +816,9 @@ msgstr "استحقاق پھر لوڈ کرتے ہوئے"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "تبصرات"
 
@@ -838,7 +838,7 @@ msgstr "فیلڈ کالمز شامل یا ختم کریں"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -972,7 +972,7 @@ msgstr "غیر فعال"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "ہاں"
 
@@ -1008,7 +1008,7 @@ msgstr "ہاں"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "نہیں"
 
@@ -1554,9 +1554,9 @@ msgstr "چھاپیں"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "ربط بطرف"
 
@@ -1998,7 +1998,7 @@ msgstr "اختتام"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3058,7 +3058,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4208,8 +4208,8 @@ msgstr "کھوج رپورٹ"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "صفحہ نمبر:"
 
@@ -4353,7 +4353,7 @@ msgstr ""
 msgid "View:"
 msgstr "ویو"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -6952,7 +6952,7 @@ msgstr "ابتدائیہ"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "وقت"
 
@@ -7876,8 +7876,8 @@ msgstr "تدوین موڈ"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -8149,7 +8149,7 @@ msgstr "وقت"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -18648,19 +18648,19 @@ msgid "Error reading data for table %s:"
 msgstr "کوائف نہیں ملا برائے %s"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "بنائیں"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "آخری تازہ کاری:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "آخری پڑتال:"
 
@@ -18677,7 +18677,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -18841,18 +18841,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "خراب برآمد قسم"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Search in database"
 msgid "Schema of the %s database"
 msgstr "کوائفیہ میں تلاش کریں"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/uz.po
+++ b/resources/po/uz.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:20+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Uzbek <https://hosted.weblate.org/projects/phpmyadmin/master/"
@@ -310,7 +310,7 @@ msgstr "OK"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Изоҳлар жадвали:"
 
@@ -523,9 +523,9 @@ msgstr "Ташқи калитни танланг"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Устун"
 
@@ -676,7 +676,7 @@ msgstr "Тузилиши"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Номи"
 
@@ -707,9 +707,9 @@ msgstr "Номи"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Тур"
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Андоза"
 
@@ -792,8 +792,8 @@ msgstr "Таққослаш"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Атрибутлар"
 
@@ -816,9 +816,9 @@ msgstr "Атрибутлар"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -842,9 +842,9 @@ msgstr "Привилегияларни таҳрирлаш"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Изоҳлар"
 
@@ -864,7 +864,7 @@ msgstr "Устун(лар)ни олиб ташлаш"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -1010,7 +1010,7 @@ msgstr "Фаолсизлантирилган"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ҳа"
 
@@ -1046,7 +1046,7 @@ msgstr "Ҳа"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Йўқ"
 
@@ -1595,9 +1595,9 @@ msgstr "Чоп этиш"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Алоқалар"
 
@@ -2050,7 +2050,7 @@ msgstr "Охири"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3121,7 +3121,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4354,8 +4354,8 @@ msgstr "Кузатиш ҳисоботи"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Саҳифа рақами:"
 
@@ -4502,7 +4502,7 @@ msgstr ""
 msgid "View:"
 msgstr "Намойиш"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7319,7 +7319,7 @@ msgstr "Бошланғич"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Вақт"
 
@@ -8276,8 +8276,8 @@ msgstr "Бўлакларни (PARTITIONS) ўчириш"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Қўшимча"
 
@@ -8561,7 +8561,7 @@ msgstr "Вақт"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Ҳодиса"
 
@@ -19841,17 +19841,17 @@ msgid "Error reading data for table %s:"
 msgstr "Маълумотларни чақиришга рухсат беради"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Тузиш:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Охирги янгиланиш:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Охирги текширув:"
 
@@ -19868,7 +19868,7 @@ msgstr ""
 msgid "Export contents"
 msgstr "Таркибини экспорт қилиш"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -20051,18 +20051,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Экспорт тури нотугри"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database"
 msgstr "\"%s\" маълумотлар базаси тузилиши - \"%s\" саҳифа"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Алоқалар схемаси"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Мундарижа"
 

--- a/resources/po/uz@latin.po
+++ b/resources/po/uz@latin.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2022-02-15 16:21+0000\n"
 "Last-Translator: Maurício Meneghini Fauth <mauricio@fauth.dev>\n"
 "Language-Team: Uzbek (latin) <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -310,7 +310,7 @@ msgstr "OK"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Jadval izohi:"
 
@@ -523,9 +523,9 @@ msgstr "Tashqi kalitni tanlang"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Ustun nomlari"
 
@@ -676,7 +676,7 @@ msgstr "Tuzilishi"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Nomi"
 
@@ -707,9 +707,9 @@ msgstr "Nomi"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Tur"
 
@@ -752,9 +752,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Andoza"
 
@@ -792,8 +792,8 @@ msgstr "Taqqoslash"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Atributlar"
 
@@ -816,9 +816,9 @@ msgstr "Atributlar"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -842,9 +842,9 @@ msgstr "Privilegiyalarni tahrirlash"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Izohlar"
 
@@ -864,7 +864,7 @@ msgstr "Ustun(lar)ni olib tashlash"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 #, fuzzy
 #| msgid "MIME type"
 msgid "Media type"
@@ -1010,7 +1010,7 @@ msgstr "Faolsizlantirilgan"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Ha"
 
@@ -1046,7 +1046,7 @@ msgstr "Ha"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Yo‘q"
 
@@ -1597,9 +1597,9 @@ msgstr "Chop etish"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Aloqalar"
 
@@ -2053,7 +2053,7 @@ msgstr "Oxiri"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 #, fuzzy
 #| msgid "Description"
 msgid "Definition"
@@ -3141,7 +3141,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 #, fuzzy
 #| msgid "Database"
 msgid "Database:"
@@ -4373,8 +4373,8 @@ msgstr "Kuzatish hisoboti"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Sahifa raqami:"
 
@@ -4521,7 +4521,7 @@ msgstr ""
 msgid "View:"
 msgstr "Namoyish"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 #, fuzzy
 #| msgid "Table"
 msgid "Table:"
@@ -7354,7 +7354,7 @@ msgstr "Boshlang‘ich"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Vaqt"
 
@@ -8314,8 +8314,8 @@ msgstr "Bo‘laklarni (PARTITIONS) o‘chirish"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Qo‘shimcha"
 
@@ -8599,7 +8599,7 @@ msgstr "Vaqt"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Hodisa"
 
@@ -19898,21 +19898,21 @@ msgid "Error reading data for table %s:"
 msgstr "Ma`lumotlarni chaqirishga ruxsat beradi"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 #, fuzzy
 #| msgid "Creation"
 msgid "Creation:"
 msgstr "Tuzish"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 #, fuzzy
 #| msgid "Last update"
 msgid "Last update:"
 msgstr "Oxirgi yangilanish"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 #, fuzzy
 #| msgid "Last check"
 msgid "Last check:"
@@ -19931,7 +19931,7 @@ msgstr ""
 msgid "Export contents"
 msgstr "Tarkibini eksport qilish"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -20116,18 +20116,18 @@ msgstr ""
 msgid "PDF export page"
 msgstr "Jadvallarni eksport qilish"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database"
 msgstr "\"%s\" ma`lumotlar bazasi tuzilishi - \"%s\" sahifa"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Aloqalar sxemasi"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Mundarija"
 

--- a/resources/po/vi.po
+++ b/resources/po/vi.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-05-14 19:50+0000\n"
 "Last-Translator: Xuan Hung <mr.hungdx@gmail.com>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -286,7 +286,7 @@ msgstr "Thực hiện"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "Chú thích của bảng:"
 
@@ -484,9 +484,9 @@ msgstr "Là một khóa ngoại."
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "Cột"
 
@@ -605,7 +605,7 @@ msgstr "Cấu trúc"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "Tên"
 
@@ -636,9 +636,9 @@ msgstr "Tên"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "Kiểu"
 
@@ -675,9 +675,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "Mặc định"
 
@@ -715,8 +715,8 @@ msgstr "Bảng mã đối chiếu"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "Thuộc tính"
 
@@ -739,9 +739,9 @@ msgstr "Thuộc tính"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "Null"
 
@@ -763,9 +763,9 @@ msgstr "Chỉnh đặc quyền"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "Ghi chú"
 
@@ -783,7 +783,7 @@ msgstr "Di chuyển cột"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "Loại phương tiện"
 
@@ -911,7 +911,7 @@ msgstr "Tắt"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "Có"
 
@@ -947,7 +947,7 @@ msgstr "Có"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "Không"
 
@@ -1423,9 +1423,9 @@ msgstr "In"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "Liên kết tới"
 
@@ -1799,7 +1799,7 @@ msgstr "Cuối"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "Định nghĩa"
 
@@ -2734,7 +2734,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "Cơ sở dữ liệu:"
 
@@ -3759,8 +3759,8 @@ msgstr "Đưa bạn đến trang đích."
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "Số trang:"
 
@@ -3918,7 +3918,7 @@ msgstr ""
 msgid "View:"
 msgstr "Xem:"
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "Bảng:"
 
@@ -6421,7 +6421,7 @@ msgstr "Tình trạng"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Thời gian"
 
@@ -7216,8 +7216,8 @@ msgstr "Sửa phân vùng"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "Thêm"
 
@@ -7451,7 +7451,7 @@ msgstr "Thời gian"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "Sự kiện"
 
@@ -17477,17 +17477,17 @@ msgid "Error reading data for table %s:"
 msgstr "Gặp lỗi khi đọc dữ liệu:"
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "Tạo:"
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "Cập nhật lần cuối:"
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "Lần kiểm tra cuối:"
 
@@ -17504,7 +17504,7 @@ msgstr ""
 msgid "Export contents"
 msgstr "Xuất nội dung"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "Mục đích:"
 
@@ -17664,17 +17664,17 @@ msgstr "LƯỢC ĐỒ SAI: "
 msgid "PDF export page"
 msgstr "Trang xuất PDF"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "Lược đồ của cơ sở dữ liệu %s"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "Lược đồ quan hệ"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "Mục lục"
 

--- a/resources/po/vls.po
+++ b/resources/po/vls.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2019-04-27 17:19+0000\n"
 "Last-Translator: William Desportes <williamdes@wdes.fr>\n"
 "Language-Team: West Flemish <https://hosted.weblate.org/projects/phpmyadmin/"
@@ -287,7 +287,7 @@ msgstr ""
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr ""
 
@@ -483,9 +483,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr ""
 
@@ -604,7 +604,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr ""
 
@@ -635,9 +635,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr ""
 
@@ -670,9 +670,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr ""
 
@@ -708,8 +708,8 @@ msgstr ""
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr ""
 
@@ -732,9 +732,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr ""
 
@@ -756,9 +756,9 @@ msgstr ""
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr ""
 
@@ -900,7 +900,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr ""
 
@@ -936,7 +936,7 @@ msgstr ""
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr ""
 
@@ -1410,9 +1410,9 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr ""
 
@@ -1788,7 +1788,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr ""
 
@@ -2718,7 +2718,7 @@ msgstr ""
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr ""
 
@@ -3727,8 +3727,8 @@ msgstr ""
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr ""
 
@@ -3862,7 +3862,7 @@ msgstr ""
 msgid "View:"
 msgstr ""
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr ""
 
@@ -6169,7 +6169,7 @@ msgstr ""
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "Tyd"
 
@@ -6942,8 +6942,8 @@ msgstr ""
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr ""
 
@@ -7176,7 +7176,7 @@ msgstr "Tyd"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr ""
 
@@ -16358,17 +16358,17 @@ msgid "Error reading data for table %s:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr ""
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr ""
 
@@ -16385,7 +16385,7 @@ msgstr ""
 msgid "Export contents"
 msgstr ""
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr ""
 
@@ -16540,17 +16540,17 @@ msgstr ""
 msgid "PDF export page"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr ""
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr ""
 

--- a/resources/po/zh_CN.po
+++ b/resources/po/zh_CN.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2025-03-20 18:17+0000\n"
 "Last-Translator: 吴绮 <rs2.free@qq.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
@@ -279,7 +279,7 @@ msgstr "执行"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "表注释："
 
@@ -476,9 +476,9 @@ msgstr "是外键。"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "字段"
 
@@ -597,7 +597,7 @@ msgstr "结构"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "名字"
 
@@ -628,9 +628,9 @@ msgstr "名字"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "类型"
 
@@ -665,9 +665,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "默认"
 
@@ -703,8 +703,8 @@ msgstr "排序规则"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "属性"
 
@@ -727,9 +727,9 @@ msgstr "属性"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "空"
 
@@ -751,9 +751,9 @@ msgstr "调整权限"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "注释"
 
@@ -771,7 +771,7 @@ msgstr "移动字段"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "媒体类型"
 
@@ -897,7 +897,7 @@ msgstr "已禁用"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "是"
 
@@ -933,7 +933,7 @@ msgstr "是"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "否"
 
@@ -1407,9 +1407,9 @@ msgstr "打印"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "链接到"
 
@@ -1783,7 +1783,7 @@ msgstr "终止时间"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "定义"
 
@@ -2720,7 +2720,7 @@ msgstr "该操作有可能影响一些列的定义[br]你确认做此更改吗�
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "数据库："
 
@@ -3737,8 +3737,8 @@ msgstr "带你到目标网站。"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "页码："
 
@@ -3880,7 +3880,7 @@ msgstr "请连接您的 WebAuthn/FIDO2 设备。然后在设备上确认登录�
 msgid "View:"
 msgstr "视图："
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "表:"
 
@@ -6236,7 +6236,7 @@ msgstr "状态"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "时间"
 
@@ -7010,8 +7010,8 @@ msgstr "编辑分区"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "额外"
 
@@ -7242,7 +7242,7 @@ msgstr "时机"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "事件"
 
@@ -16666,17 +16666,17 @@ msgid "Error reading data for table %s:"
 msgstr "读取表 %s 的数据时发生错误："
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "创建时间："
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "最后更新："
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "最后检查："
 
@@ -16693,7 +16693,7 @@ msgstr "对象创建选项 (推荐全选)"
 msgid "Export contents"
 msgstr "导出内容"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "目的："
 
@@ -16850,17 +16850,17 @@ msgstr "大纲错误: "
 msgid "PDF export page"
 msgstr "PDF导出页面"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "数据库 %s 的大纲"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "关系大纲"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "目录"
 

--- a/resources/po/zh_TW.po
+++ b/resources/po/zh_TW.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 6.0.0-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
-"POT-Creation-Date: 2025-06-15 00:31+0000\n"
+"POT-Creation-Date: 2025-06-22 00:31+0000\n"
 "PO-Revision-Date: 2024-07-03 07:27+0000\n"
 "Last-Translator: Ricky From Hong Kong <lamricky11@hotmail.com>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -287,7 +287,7 @@ msgstr "執行"
 #: resources/templates/columns_definitions/column_definitions_form.twig:68
 #: resources/templates/database/data_dictionary/index.twig:16
 #: resources/templates/table/structure/display_table_stats.twig:6
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:554
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:555
 msgid "Table comments:"
 msgstr "資料表備註："
 
@@ -483,9 +483,9 @@ msgstr "此為外鍵。"
 #: src/Plugins/Export/ExportOdt.php:441
 #: src/Plugins/Export/ExportTexytext.php:288
 #: src/Plugins/Export/ExportTexytext.php:352
-#: src/Plugins/Export/Helpers/Pdf.php:486
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:601
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:623
+#: src/Plugins/Export/Helpers/Pdf.php:487
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
 msgid "Column"
 msgstr "欄位"
 
@@ -604,7 +604,7 @@ msgstr "結構"
 #: src/Plugins/Export/ExportHtmlword.php:439
 #: src/Plugins/Export/ExportOdt.php:556
 #: src/Plugins/Export/ExportTexytext.php:424
-#: src/Plugins/Export/Helpers/Pdf.php:330
+#: src/Plugins/Export/Helpers/Pdf.php:331
 msgid "Name"
 msgstr "名稱"
 
@@ -635,9 +635,9 @@ msgstr "名稱"
 #: src/Plugins/Export/ExportOdt.php:444
 #: src/Plugins/Export/ExportTexytext.php:289
 #: src/Plugins/Export/ExportTexytext.php:353
-#: src/Plugins/Export/Helpers/Pdf.php:488
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:602
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:624
+#: src/Plugins/Export/Helpers/Pdf.php:489
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
 msgid "Type"
 msgstr "類型"
 
@@ -672,9 +672,9 @@ msgstr ""
 #: src/Plugins/Export/ExportOdt.php:450
 #: src/Plugins/Export/ExportTexytext.php:291
 #: src/Plugins/Export/ExportTexytext.php:355
-#: src/Plugins/Export/Helpers/Pdf.php:492
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
+#: src/Plugins/Export/Helpers/Pdf.php:493
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
 msgid "Default"
 msgstr "預設值"
 
@@ -710,8 +710,8 @@ msgstr "編碼與排序"
 #: resources/templates/columns_definitions/table_fields_definitions.twig:27
 #: resources/templates/database/central_columns/edit.twig:13
 #: resources/templates/table/structure/display_structure.twig:24
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:603
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:625
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
 msgid "Attributes"
 msgstr "屬性"
 
@@ -734,9 +734,9 @@ msgstr "屬性"
 #: src/Plugins/Export/ExportOdt.php:447
 #: src/Plugins/Export/ExportTexytext.php:290
 #: src/Plugins/Export/ExportTexytext.php:354
-#: src/Plugins/Export/Helpers/Pdf.php:490
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:604
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:626
+#: src/Plugins/Export/Helpers/Pdf.php:491
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:605
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:627
 msgid "Null"
 msgstr "無值(Null)"
 
@@ -758,9 +758,9 @@ msgstr "調整權限"
 #: src/Config/Descriptions.php:711 src/Plugins/Export/ExportHtmlword.php:355
 #: src/Plugins/Export/ExportLatex.php:508 src/Plugins/Export/ExportOdt.php:460
 #: src/Plugins/Export/ExportTexytext.php:361
-#: src/Plugins/Export/Helpers/Pdf.php:509
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:617
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
+#: src/Plugins/Export/Helpers/Pdf.php:510
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:618
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:631
 msgid "Comments"
 msgstr "備註"
 
@@ -778,7 +778,7 @@ msgstr "移動欄位"
 #: src/Config/Descriptions.php:714 src/Plugins/Export/ExportHtmlword.php:362
 #: src/Plugins/Export/ExportOdt.php:467
 #: src/Plugins/Export/ExportTexytext.php:366
-#: src/Plugins/Export/Helpers/Pdf.php:517
+#: src/Plugins/Export/Helpers/Pdf.php:518
 msgid "Media type"
 msgstr "媒體類型"
 
@@ -904,7 +904,7 @@ msgstr "已關閉"
 #: src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "Yes"
 msgstr "是"
 
@@ -940,7 +940,7 @@ msgstr "是"
 #: src/Indexes/Index.php:472 src/Plugins/Export/ExportHtmlword.php:562
 #: src/Plugins/Export/ExportLatex.php:567 src/Plugins/Export/ExportOdt.php:685
 #: src/Plugins/Export/ExportTexytext.php:522
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:669
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:670
 msgid "No"
 msgstr "否"
 
@@ -1416,9 +1416,9 @@ msgstr "列印"
 #: src/Plugins/Export/ExportHtmlword.php:349
 #: src/Plugins/Export/ExportLatex.php:504 src/Plugins/Export/ExportOdt.php:454
 #: src/Plugins/Export/ExportTexytext.php:357
-#: src/Plugins/Export/Helpers/Pdf.php:501
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
+#: src/Plugins/Export/Helpers/Pdf.php:502
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:608
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:630
 msgid "Links to"
 msgstr "連結到"
 
@@ -1792,7 +1792,7 @@ msgstr "結束"
 #: src/Plugins/Export/ExportHtmlword.php:442
 #: src/Plugins/Export/ExportOdt.php:565
 #: src/Plugins/Export/ExportTexytext.php:427
-#: src/Plugins/Export/Helpers/Pdf.php:336
+#: src/Plugins/Export/Helpers/Pdf.php:337
 msgid "Definition"
 msgstr "定義"
 
@@ -2735,7 +2735,7 @@ msgstr "此動作可能會變更部份欄位的定義。[br]是否確定要繼�
 #: resources/templates/database/structure/copy_form.twig:5
 #: resources/templates/menu/main.twig:16 src/Plugins/Export/ExportLatex.php:260
 #: src/Plugins/Export/ExportSql.php:928 src/Plugins/Export/ExportXml.php:367
-#: src/Plugins/Export/Helpers/Pdf.php:176
+#: src/Plugins/Export/Helpers/Pdf.php:177
 msgid "Database:"
 msgstr "資料庫："
 
@@ -3774,8 +3774,8 @@ msgstr "帶您至目標網站。"
 
 #: resources/templates/list_navigator.twig:4 src/BrowseForeigners.php:278
 #: src/Pdf.php:71 src/Pdf.php:91
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:458
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:483
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:459
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:484
 msgid "Page number:"
 msgstr "頁碼："
 
@@ -3919,7 +3919,7 @@ msgstr "請將 FIDO U2F 裝置連接電腦的 USB 埠，然後於裝置確認登
 msgid "View:"
 msgstr "檢視表："
 
-#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:177
+#: resources/templates/menu/main.twig:29 src/Plugins/Export/Helpers/Pdf.php:178
 msgid "Table:"
 msgstr "資料表："
 
@@ -6376,7 +6376,7 @@ msgstr "狀態"
 #: src/Plugins/Export/ExportHtmlword.php:440
 #: src/Plugins/Export/ExportOdt.php:559
 #: src/Plugins/Export/ExportTexytext.php:425
-#: src/Plugins/Export/Helpers/Pdf.php:332 src/Server/Status/Processes.php:95
+#: src/Plugins/Export/Helpers/Pdf.php:333 src/Server/Status/Processes.php:95
 msgid "Time"
 msgstr "時間"
 
@@ -7161,8 +7161,8 @@ msgstr "編輯分區"
 
 #: resources/templates/table/structure/display_structure.twig:30
 #: resources/templates/table/tracking/structure_snapshot_columns.twig:11
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:606
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:628
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:607
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:629
 msgid "Extra"
 msgstr "額外資訊"
 
@@ -7395,7 +7395,7 @@ msgstr "時間"
 #: src/Plugins/Export/ExportHtmlword.php:441
 #: src/Plugins/Export/ExportOdt.php:562
 #: src/Plugins/Export/ExportTexytext.php:426
-#: src/Plugins/Export/Helpers/Pdf.php:334
+#: src/Plugins/Export/Helpers/Pdf.php:335
 msgid "Event"
 msgstr "事件"
 
@@ -17056,17 +17056,17 @@ msgid "Error reading data for table %s:"
 msgstr "讀取資料表 %s 的資料時出現錯誤："
 
 #: src/Plugins/Export/ExportSql.php:2626
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:565
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:566
 msgid "Creation:"
 msgstr "建立時間："
 
 #: src/Plugins/Export/ExportSql.php:2634
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:576
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:577
 msgid "Last update:"
 msgstr "最後更新："
 
 #: src/Plugins/Export/ExportSql.php:2642
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:587
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:588
 msgid "Last check:"
 msgstr "最後檢查："
 
@@ -17083,7 +17083,7 @@ msgstr "物件建立選項 (建議全選)"
 msgid "Export contents"
 msgstr "匯出內容"
 
-#: src/Plugins/Export/Helpers/Pdf.php:178
+#: src/Plugins/Export/Helpers/Pdf.php:179
 msgid "Purpose:"
 msgstr "用途："
 
@@ -17239,17 +17239,17 @@ msgstr "綱要錯誤： "
 msgid "PDF export page"
 msgstr "PDF 匯出頁面"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:117
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:119
 #, php-format
 msgid "Schema of the %s database"
 msgstr "%s 資料庫綱要"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:145
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:494
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:147
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:495
 msgid "Relational schema"
 msgstr "關聯綱要"
 
-#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:447
+#: src/Plugins/Schema/Pdf/PdfRelationSchema.php:449
 msgid "Table of contents"
 msgstr "目錄"
 

--- a/resources/templates/database/multi_table_query/form.twig
+++ b/resources/templates/database/multi_table_query/form.twig
@@ -42,7 +42,7 @@
                   <br>
                   <input type="checkbox"
                          title="{{ t('Use this column in criteria') }}"
-                         class="criteria_col">
+                         class="criteria_col" data-bs-toggle="collapse" data-bs-target="#criteriaOptions{{ id }}" aria-expanded="false" aria-controls="criteriaOptions{{ id }}">
 
                   <button class="btn btn-link p-0 jsCriteriaButton" type="button" data-bs-toggle="collapse" data-bs-target="#criteriaOptions{{ id }}" aria-expanded="false" aria-controls="criteriaOptions{{ id }}">
                     {{ t('criteria') }}

--- a/src/Controllers/Table/Structure/SaveController.php
+++ b/src/Controllers/Table/Structure/SaveController.php
@@ -402,20 +402,38 @@ final class SaveController implements InvocableController
         return $changed;
     }
 
-    private function hasCurrentTimestampFunction($query): bool
+    /**
+     * Checks if a query has DEFAULT CURRENT_TIMESTAMP function
+     *
+     * @param string $query SQL query to check
+     *
+     * @return bool true if query has DEFAULT CURRENT_TIMESTAMP function
+     */
+    private function hasCurrentTimestampFunction(string $query): bool
     {
         preg_match("/DEFAULT\s+'current_timestamp\((\d+)\)'/i", $query, $matches);
 
         return !empty($matches[0]);
     }
 
-    private function getCurrentTimestampArgumentValue($query)
-    {
+    /**
+     * @param string $query SQL query to check
+     *
+     * @return int|null precision argument value or null if not found
+     */
+    private function getCurrentTimestampArgumentValue(string $query) {
         preg_match("/DEFAULT\s+'current_timestamp\((\d+)\)'/i", $query, $matches);
-        return !empty($matches[1]) ? $matches[1] : null;
     }
 
-    private function replaceQuotes($query): string
+    /**
+     * Replaces DEFAULT 'current_timestamp(n)' with DEFAULT CURRENT_TIMESTAMP(n)
+     * in the given query, where n is the precision argument value.
+     *
+     * @param string $query SQL query to modify
+     *
+     * @return string modified SQL query
+     */
+    private function replaceQuotes(string $query): string
     {
         $new_query = $query;
 

--- a/src/Database/MultiTableQuery.php
+++ b/src/Database/MultiTableQuery.php
@@ -80,7 +80,7 @@ class MultiTableQuery
             $dbi,
             $relation,
             new RelationCleanup($dbi, $relation),
-            new Transformations(),
+            new Transformations($dbi, $relation),
             new Template(),
             $bookmarkRepository,
             Config::getInstance(),

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -217,7 +217,7 @@ class Results
         private readonly string $sqlQuery,
     ) {
         $this->relation = new Relation($this->dbi);
-        $this->transformations = new Transformations();
+        $this->transformations = new Transformations($this->dbi, $this->relation);
         $this->template = new Template();
 
         $this->setDefaultTransformations();

--- a/src/Plugins/Export/Helpers/Pdf.php
+++ b/src/Plugins/Export/Helpers/Pdf.php
@@ -90,8 +90,9 @@ class Pdf extends PdfLib
     ) {
         parent::__construct($orientation, $unit, $format, $unicode, $encoding, $diskcache, $pdfa);
 
-        $this->relation = new Relation(DatabaseInterface::getInstance());
-        $this->transformations = new Transformations();
+        $dbi = DatabaseInterface::getInstance();
+        $this->relation = new Relation($dbi);
+        $this->transformations = new Transformations($dbi, $this->relation);
     }
 
     /**

--- a/src/Plugins/ExportPlugin.php
+++ b/src/Plugins/ExportPlugin.php
@@ -39,7 +39,7 @@ abstract class ExportPlugin implements Plugin
     final public function __construct(
         public Relation $relation,
         protected Export $export,
-        protected Transformations $transformations,
+        public Transformations $transformations,
     ) {
         $this->init();
         $this->properties = $this->setProperties();

--- a/src/Twig/TransformationsExtension.php
+++ b/src/Twig/TransformationsExtension.php
@@ -17,17 +17,9 @@ class TransformationsExtension extends AbstractExtension
      */
     public function getFunctions(): array
     {
-        $transformations = new Transformations();
-
         return [
-            new TwigFunction(
-                'get_description',
-                $transformations->getDescription(...),
-            ),
-            new TwigFunction(
-                'get_name',
-                $transformations->getName(...),
-            ),
+            new TwigFunction('get_description', [Transformations::class, 'getDescription']),
+            new TwigFunction('get_name', [Transformations::class, 'getName']),
         ];
     }
 }

--- a/tests/unit/Controllers/Normalization/AddNewPrimaryControllerTest.php
+++ b/tests/unit/Controllers/Normalization/AddNewPrimaryControllerTest.php
@@ -34,9 +34,10 @@ class AddNewPrimaryControllerTest extends AbstractTestCase
         $response = new ResponseRenderer();
         $template = new Template();
 
+        $relation = new Relation($dbi);
         $controller = new AddNewPrimaryController(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
             new UserPrivilegesFactory($dbi),
         );
         $controller(self::createStub(ServerRequest::class));

--- a/tests/unit/Controllers/Normalization/CreateNewColumnControllerTest.php
+++ b/tests/unit/Controllers/Normalization/CreateNewColumnControllerTest.php
@@ -35,9 +35,10 @@ class CreateNewColumnControllerTest extends AbstractTestCase
         $template = new Template();
         $request = self::createStub(ServerRequest::class);
 
+        $relation = new Relation($dbi);
         $controller = new CreateNewColumnController(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
             new UserPrivilegesFactory($dbi),
         );
         $controller($request);

--- a/tests/unit/Controllers/Normalization/FirstNormalForm/FirstStepControllerTest.php
+++ b/tests/unit/Controllers/Normalization/FirstNormalForm/FirstStepControllerTest.php
@@ -37,9 +37,10 @@ class FirstStepControllerTest extends AbstractTestCase
         $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/')
             ->withParsedBody(['normalizeTo' => $normalizeTo]);
 
+        $relation = new Relation($dbi);
         $controller = new FirstStepController(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
         );
         $controller($request);
 

--- a/tests/unit/Controllers/Normalization/FirstNormalForm/FourthStepControllerTest.php
+++ b/tests/unit/Controllers/Normalization/FirstNormalForm/FourthStepControllerTest.php
@@ -32,9 +32,10 @@ class FourthStepControllerTest extends AbstractTestCase
         $response = new ResponseRenderer();
         $template = new Template();
 
+        $relation = new Relation($dbi);
         $controller = new FourthStepController(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
         );
         $controller(self::createStub(ServerRequest::class));
 

--- a/tests/unit/Controllers/Normalization/FirstNormalForm/SecondStepControllerTest.php
+++ b/tests/unit/Controllers/Normalization/FirstNormalForm/SecondStepControllerTest.php
@@ -29,9 +29,10 @@ class SecondStepControllerTest extends AbstractTestCase
         $response = new ResponseRenderer();
         $template = new Template();
 
+        $relation = new Relation($dbi);
         $controller = new SecondStepController(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
         );
         $controller(self::createStub(ServerRequest::class));
 

--- a/tests/unit/Controllers/Normalization/FirstNormalForm/ThirdStepControllerTest.php
+++ b/tests/unit/Controllers/Normalization/FirstNormalForm/ThirdStepControllerTest.php
@@ -32,9 +32,10 @@ class ThirdStepControllerTest extends AbstractTestCase
         $response = new ResponseRenderer();
         $template = new Template();
 
+        $relation = new Relation($dbi);
         $controller = new ThirdStepController(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
         );
         $controller(self::createStub(ServerRequest::class));
 

--- a/tests/unit/Controllers/Normalization/GetColumnsControllerTest.php
+++ b/tests/unit/Controllers/Normalization/GetColumnsControllerTest.php
@@ -32,9 +32,10 @@ class GetColumnsControllerTest extends AbstractTestCase
         $response = new ResponseRenderer();
         $template = new Template();
 
+        $relation = new Relation($dbi);
         $controller = new GetColumnsController(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
         );
         $controller(self::createStub(ServerRequest::class));
 

--- a/tests/unit/Controllers/Normalization/MoveRepeatingGroupTest.php
+++ b/tests/unit/Controllers/Normalization/MoveRepeatingGroupTest.php
@@ -47,9 +47,10 @@ class MoveRepeatingGroupTest extends AbstractTestCase
                 'primary_columns' => 'id,col1',
             ]);
 
+        $relation = new Relation($dbi);
         $controller = new MoveRepeatingGroup(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
         );
         $controller($request);
 

--- a/tests/unit/Controllers/Normalization/PartialDependenciesControllerTest.php
+++ b/tests/unit/Controllers/Normalization/PartialDependenciesControllerTest.php
@@ -40,9 +40,10 @@ class PartialDependenciesControllerTest extends AbstractTestCase
         $response = new ResponseRenderer();
         $template = new Template();
 
+        $relation = new Relation($dbi);
         $controller = new PartialDependenciesController(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
         );
         $controller(self::createStub(ServerRequest::class));
 

--- a/tests/unit/Controllers/Normalization/SecondNormalForm/CreateNewTablesControllerTest.php
+++ b/tests/unit/Controllers/Normalization/SecondNormalForm/CreateNewTablesControllerTest.php
@@ -42,9 +42,10 @@ class CreateNewTablesControllerTest extends AbstractTestCase
                 'newTablesName' => json_encode(['ID, task' => 'batch_log2', 'task' => 'table2']),
             ]);
 
+        $relation = new Relation($dbi);
         $controller = new CreateNewTablesController(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
         );
         $controller($request);
 

--- a/tests/unit/Controllers/Normalization/SecondNormalForm/FirstStepControllerTest.php
+++ b/tests/unit/Controllers/Normalization/SecondNormalForm/FirstStepControllerTest.php
@@ -29,9 +29,10 @@ class FirstStepControllerTest extends AbstractTestCase
         $response = new ResponseRenderer();
         $template = new Template();
 
+        $relation = new Relation($dbi);
         $controller = new FirstStepController(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
         );
         $controller(self::createStub(ServerRequest::class));
 

--- a/tests/unit/Controllers/Normalization/SecondNormalForm/NewTablesControllerTest.php
+++ b/tests/unit/Controllers/Normalization/SecondNormalForm/NewTablesControllerTest.php
@@ -34,9 +34,10 @@ class NewTablesControllerTest extends AbstractTestCase
             ->withParsedBody([
                 'pd' => json_encode(['ID, task' => [], 'task' => ['timestamp']]),
             ]);
+        $relation = new Relation($dbi);
         $controller = new NewTablesController(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
         );
         $controller($request);
 

--- a/tests/unit/Controllers/Normalization/ThirdNormalForm/CreateNewTablesControllerTest.php
+++ b/tests/unit/Controllers/Normalization/ThirdNormalForm/CreateNewTablesControllerTest.php
@@ -56,9 +56,10 @@ class CreateNewTablesControllerTest extends AbstractTestCase
         $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/')
             ->withParsedBody(['newTables' => $newTables]);
 
+        $relation = new Relation($dbi);
         $controller = new CreateNewTablesController(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
         );
         $controller($request);
 

--- a/tests/unit/Controllers/Normalization/ThirdNormalForm/FirstStepControllerTest.php
+++ b/tests/unit/Controllers/Normalization/ThirdNormalForm/FirstStepControllerTest.php
@@ -34,9 +34,10 @@ class FirstStepControllerTest extends AbstractTestCase
         $request = self::createStub(ServerRequest::class);
         $request->method('getParsedBodyParam')->willReturnMap([['tables', null, ['test_table']]]);
 
+        $relation = new Relation($dbi);
         $controller = new FirstStepController(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
         );
         $controller($request);
 

--- a/tests/unit/Controllers/Normalization/ThirdNormalForm/NewTablesControllerTest.php
+++ b/tests/unit/Controllers/Normalization/ThirdNormalForm/NewTablesControllerTest.php
@@ -45,9 +45,10 @@ class NewTablesControllerTest extends AbstractTestCase
                 'pd' => $pd,
             ]);
 
+        $relation = new Relation($dbi);
         $controller = new NewTablesController(
             $response,
-            new Normalization($dbi, new Relation($dbi), new Transformations(), $template),
+            new Normalization($dbi, $relation, new Transformations($dbi, $relation), $template),
         );
         $controller($request);
 

--- a/tests/unit/Controllers/Server/Databases/DestroyControllerTest.php
+++ b/tests/unit/Controllers/Server/Databases/DestroyControllerTest.php
@@ -39,11 +39,12 @@ class DestroyControllerTest extends AbstractTestCase
         $config = Config::getInstance();
         $config->settings['AllowUserDropDatabase'] = true;
 
+        $relation = new Relation($dbi);
         $controller = new DestroyController(
             $response,
             $dbi,
-            new Transformations(),
-            new RelationCleanup($dbi, new Relation($dbi)),
+            new Transformations($dbi, $relation),
+            new RelationCleanup($dbi, $relation),
             new UserPrivilegesFactory($dbi),
             $config,
         );

--- a/tests/unit/Controllers/Table/AddFieldControllerTest.php
+++ b/tests/unit/Controllers/Table/AddFieldControllerTest.php
@@ -257,7 +257,7 @@ class AddFieldControllerTest extends AbstractTestCase
             ->withQueryParams(['db' => 'test_db', 'table' => 'test_table'])
             ->withParsedBody(['num_fields' => '1']);
 
-        $transformations = new Transformations();
+        $transformations = new Transformations($dbi, $relation);
         (new AddFieldController(
             $response,
             $transformations,

--- a/tests/unit/Controllers/Table/ChangeControllerTest.php
+++ b/tests/unit/Controllers/Table/ChangeControllerTest.php
@@ -59,10 +59,19 @@ final class ChangeControllerTest extends AbstractTestCase
 
         $relation = new Relation($dbi);
         $template = new Template();
+        $insertEdit = new InsertEdit(
+            $dbi,
+            $relation,
+            new Transformations($dbi, $relation),
+            new FileListing(),
+            $template,
+            $config,
+        );
+
         (new ChangeController(
             $response,
             $template,
-            new InsertEdit($dbi, $relation, new Transformations(), new FileListing(), $template, $config),
+            $insertEdit,
             $relation,
             $pageSettings,
             new DbTableExists($dbi),
@@ -162,10 +171,19 @@ final class ChangeControllerTest extends AbstractTestCase
 
         $relation = new Relation($dbi);
         $template = new Template();
+        $insertEdit = new InsertEdit(
+            $dbi,
+            $relation,
+            new Transformations($dbi, $relation),
+            new FileListing(),
+            $template,
+            $config,
+        );
+
         (new ChangeController(
             $response,
             $template,
-            new InsertEdit($dbi, $relation, new Transformations(), new FileListing(), $template, $config),
+            $insertEdit,
             $relation,
             $pageSettings,
             new DbTableExists($dbi),

--- a/tests/unit/Controllers/Table/CreateControllerTest.php
+++ b/tests/unit/Controllers/Table/CreateControllerTest.php
@@ -272,7 +272,7 @@ class CreateControllerTest extends AbstractTestCase
         $request = ServerRequestFactory::create()->createServerRequest('POST', 'http://example.com/')
             ->withParsedBody(['num_fields' => '2']);
 
-        $transformations = new Transformations();
+        $transformations = new Transformations($dbi, $relation);
         (new CreateController(
             $response,
             $transformations,

--- a/tests/unit/Controllers/Table/DeleteRowsControllerTest.php
+++ b/tests/unit/Controllers/Table/DeleteRowsControllerTest.php
@@ -66,7 +66,7 @@ class DeleteRowsControllerTest extends AbstractTestCase
             $dbi,
             $relation,
             new RelationCleanup($dbi, $relation),
-            new Transformations(),
+            new Transformations($dbi, $relation),
             new Template($config),
             new BookmarkRepository($dbi, $relation),
             $config,

--- a/tests/unit/Controllers/Table/ReplaceControllerTest.php
+++ b/tests/unit/Controllers/Table/ReplaceControllerTest.php
@@ -95,7 +95,7 @@ class ReplaceControllerTest extends AbstractTestCase
         $dummyDbi = $this->createDbiDummy();
         $dbi = $this->createDatabaseInterface($dummyDbi);
         $relation = new Relation($dbi);
-        $transformations = new Transformations();
+        $transformations = new Transformations($dbi, $relation);
         $template = new Template();
         $response = new ResponseRenderer();
 

--- a/tests/unit/Controllers/Table/SearchControllerTest.php
+++ b/tests/unit/Controllers/Table/SearchControllerTest.php
@@ -51,7 +51,7 @@ final class SearchControllerTest extends AbstractTestCase
             $dbi,
             $relation,
             new RelationCleanup($dbi, $relation),
-            new Transformations(),
+            new Transformations($dbi, $relation),
             $template,
             new BookmarkRepository($dbi, $relation),
             $config,

--- a/tests/unit/Controllers/Table/Structure/ChangeControllerTest.php
+++ b/tests/unit/Controllers/Table/Structure/ChangeControllerTest.php
@@ -46,10 +46,11 @@ class ChangeControllerTest extends AbstractTestCase
         $class = new ReflectionClass(ChangeController::class);
         $method = $class->getMethod('displayHtmlForColumnChange');
 
+        $relation = new Relation($this->dbi);
         $ctrl = new ChangeController(
             $response,
             $this->dbi,
-            new ColumnsDefinition($this->dbi, new Relation($this->dbi), new Transformations()),
+            new ColumnsDefinition($this->dbi, $relation, new Transformations($this->dbi, $relation)),
             new UserPrivilegesFactory($this->dbi),
         );
 

--- a/tests/unit/Controllers/Table/Structure/SaveControllerTest.php
+++ b/tests/unit/Controllers/Table/Structure/SaveControllerTest.php
@@ -94,10 +94,11 @@ class SaveControllerTest extends AbstractTestCase
         $mock->expects(self::once())->method('__invoke')->with($request)
             ->willReturn(ResponseFactory::create()->createResponse());
 
+        $relation = new Relation($dbi);
         (new SaveController(
             new ResponseRenderer(),
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             $dbi,
             $mock,
             new UserPrivilegesFactory($dbi),
@@ -117,10 +118,11 @@ class SaveControllerTest extends AbstractTestCase
         $class = new ReflectionClass(SaveController::class);
         $method = $class->getMethod('adjustColumnPrivileges');
 
+        $relation = new Relation($dbi);
         $ctrl = new SaveController(
             new ResponseRenderer(),
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             $dbi,
             self::createStub(StructureController::class),
             new UserPrivilegesFactory($dbi),

--- a/tests/unit/Controllers/Table/StructureControllerTest.php
+++ b/tests/unit/Controllers/Table/StructureControllerTest.php
@@ -99,7 +99,7 @@ class StructureControllerTest extends AbstractTestCase
             $response,
             $template,
             $relation,
-            new Transformations(),
+            new Transformations($this->dbi, $relation),
             $this->dbi,
             $pageSettings,
             new DbTableExists($this->dbi),

--- a/tests/unit/Controllers/Transformation/OverviewControllerTest.php
+++ b/tests/unit/Controllers/Transformation/OverviewControllerTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Transformation;
 
+use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\Transformation\OverviewController;
 use PhpMyAdmin\Current;
-use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
@@ -27,8 +27,6 @@ class OverviewControllerTest extends AbstractTestCase
 
         $this->setGlobalConfig();
 
-        DatabaseInterface::$instance = $this->createDatabaseInterface();
-
         Current::$database = 'db';
         Current::$table = 'table';
     }
@@ -37,7 +35,8 @@ class OverviewControllerTest extends AbstractTestCase
     {
         $response = new ResponseRenderer();
 
-        $controller = new OverviewController($response, new Transformations());
+        $dbi = $this->createDatabaseInterface();
+        $controller = new OverviewController($response, new Transformations($dbi, new Relation($dbi)));
 
         $controller(self::createStub(ServerRequest::class));
         $actual = $response->getHTMLResult();

--- a/tests/unit/Display/ResultsTest.php
+++ b/tests/unit/Display/ResultsTest.php
@@ -700,7 +700,7 @@ class ResultsTest extends AbstractTestCase
 
         DatabaseInterface::$instance = $dbi;
 
-        $transformations = new Transformations();
+        $transformations = new Transformations($dbi, new Relation($dbi));
         (new ReflectionProperty(DisplayResults::class, 'mediaTypeMap'))->setValue(
             $this->object,
             $transformations->getMime('db', 'table'),

--- a/tests/unit/Export/ExportTest.php
+++ b/tests/unit/Export/ExportTest.php
@@ -67,11 +67,8 @@ class ExportTest extends AbstractTestCase
         $dbi = $this->createDatabaseInterface();
         DatabaseInterface::$instance = $dbi;
         $export = new Export($dbi);
-        $exportPlugin = new ExportPhparray(
-            new Relation($dbi),
-            new Export($dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($dbi);
+        $exportPlugin = new ExportPhparray($relation, new Export($dbi), new Transformations($dbi, $relation));
         $finalFileName = $export->getFinalFilename($exportPlugin, 'zip', 'myfilename');
         self::assertSame('myfilename.php.zip', $finalFileName);
         $finalFileName = $export->getFinalFilename($exportPlugin, 'gzip', 'myfilename');
@@ -85,11 +82,8 @@ class ExportTest extends AbstractTestCase
         $dbi = $this->createDatabaseInterface();
         DatabaseInterface::$instance = $dbi;
         $export = new Export($dbi);
-        $exportPlugin = new ExportPhparray(
-            new Relation($dbi),
-            new Export($dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($dbi);
+        $exportPlugin = new ExportPhparray($relation, new Export($dbi), new Transformations($dbi, $relation));
         $mimeType = $export->getMimeType($exportPlugin, 'zip');
         self::assertSame('application/zip', $mimeType);
         $mimeType = $export->getMimeType($exportPlugin, 'gzip');
@@ -131,12 +125,13 @@ class ExportTest extends AbstractTestCase
         $export = new Export($dbi);
 
         ExportPlugin::$exportType = ExportType::Database;
+        $relation = new Relation($dbi);
         $export->exportDatabase(
             DatabaseName::from('test_db'),
             ['test_table'],
             ['test_table'],
             ['test_table'],
-            new ExportSql(new Relation($dbi), $export, new Transformations()),
+            new ExportSql($relation, $export, new Transformations($dbi, $relation)),
             [],
             '',
         );
@@ -205,9 +200,10 @@ SQL;
         DatabaseInterface::$instance = $dbi;
         $export = new Export($dbi);
 
+        $relation = new Relation($dbi);
         $export->exportServer(
             ['test_db'],
-            new ExportSql(new Relation($dbi), $export, new Transformations()),
+            new ExportSql($relation, $export, new Transformations($dbi, $relation)),
             [],
             '',
         );

--- a/tests/unit/InsertEditTest.php
+++ b/tests/unit/InsertEditTest.php
@@ -94,10 +94,11 @@ class InsertEditTest extends AbstractTestCase
         $config->settings['Confirm'] = true;
         $config->settings['LoginCookieValidity'] = 1440;
         $config->settings['enable_drag_drop_import'] = true;
+        $relation = new Relation($this->dbi);
         $this->insertEdit = new InsertEdit(
             $this->dbi,
-            new Relation($this->dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($this->dbi, $relation),
             new FileListing(),
             new Template(),
             $config,
@@ -207,10 +208,11 @@ class InsertEditTest extends AbstractTestCase
             ->willReturn([], []);
 
         DatabaseInterface::$instance = $dbi;
+        $relation = new Relation($dbi);
         $this->insertEdit = new InsertEdit(
             $dbi,
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             new FileListing(),
             new Template(),
             Config::getInstance(),
@@ -252,10 +254,11 @@ class InsertEditTest extends AbstractTestCase
             ->willReturn([$meta]);
 
         DatabaseInterface::$instance = $dbi;
+        $relation = new Relation($dbi);
         $this->insertEdit = new InsertEdit(
             $dbi,
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             new FileListing(),
             new Template(),
             Config::getInstance(),
@@ -287,10 +290,11 @@ class InsertEditTest extends AbstractTestCase
             ->willReturn($resultStub);
 
         DatabaseInterface::$instance = $dbi;
+        $relation = new Relation($dbi);
         $this->insertEdit = new InsertEdit(
             $dbi,
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             new FileListing(),
             new Template(),
             Config::getInstance(),
@@ -1026,10 +1030,11 @@ class InsertEditTest extends AbstractTestCase
             ->getMock();
 
         DatabaseInterface::$instance = $dbi;
+        $relation = new Relation($dbi);
         $this->insertEdit = new InsertEdit(
             $dbi,
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             new FileListing(),
             new Template(),
             Config::getInstance(),
@@ -1241,10 +1246,11 @@ class InsertEditTest extends AbstractTestCase
         DatabaseInterface::$instance = $dbi;
         Current::$database = 'db';
         Current::$table = 'table';
+        $relation = new Relation($dbi);
         $this->insertEdit = new InsertEdit(
             $dbi,
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             new FileListing(),
             new Template(),
             Config::getInstance(),
@@ -1324,10 +1330,11 @@ class InsertEditTest extends AbstractTestCase
         $_POST['submit_type'] = '';
 
         $dbi = DatabaseInterface::getInstance();
+        $relation = new Relation($dbi);
         $this->insertEdit = new InsertEdit(
             $dbi,
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             new FileListing(),
             new Template(),
             Config::getInstance(),
@@ -1347,10 +1354,11 @@ class InsertEditTest extends AbstractTestCase
         $_POST['submit_type'] = '';
 
         $dbi = DatabaseInterface::getInstance();
+        $relation = new Relation($dbi);
         $this->insertEdit = new InsertEdit(
             $dbi,
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             new FileListing(),
             new Template(),
             Config::getInstance(),
@@ -1379,10 +1387,11 @@ class InsertEditTest extends AbstractTestCase
             ->willReturn($warnings);
 
         DatabaseInterface::$instance = $dbi;
+        $relation = new Relation($dbi);
         $this->insertEdit = new InsertEdit(
             $dbi,
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             new FileListing(),
             new Template(),
             Config::getInstance(),
@@ -1429,10 +1438,11 @@ class InsertEditTest extends AbstractTestCase
             ->willReturn('2');
 
         DatabaseInterface::$instance = $dbi;
+        $relation = new Relation($dbi);
         $this->insertEdit = new InsertEdit(
             $dbi,
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             new FileListing(),
             new Template(),
             Config::getInstance(),
@@ -2169,10 +2179,11 @@ class InsertEditTest extends AbstractTestCase
             ->willReturn(false, '123', '2013-08-28 06:34:14');
 
         DatabaseInterface::$instance = $dbi;
+        $relation = new Relation($dbi);
         $this->insertEdit = new InsertEdit(
             $dbi,
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             new FileListing(),
             new Template(),
             Config::getInstance(),
@@ -2217,10 +2228,11 @@ class InsertEditTest extends AbstractTestCase
             ->willReturn($columns);
 
         DatabaseInterface::$instance = $dbi;
+        $relation = new Relation($dbi);
         $this->insertEdit = new InsertEdit(
             $dbi,
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             new FileListing(),
             new Template(),
             Config::getInstance(),
@@ -2272,10 +2284,11 @@ class InsertEditTest extends AbstractTestCase
         $response = new ReflectionProperty(ResponseRenderer::class, 'instance');
         $response->setValue(null, $responseMock);
 
+        $relation = new Relation($dbi);
         $this->insertEdit = new InsertEdit(
             $dbi,
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             new FileListing(),
             new Template(),
             Config::getInstance(),
@@ -2325,10 +2338,11 @@ class InsertEditTest extends AbstractTestCase
             ->willReturn(new Table('table', 'db', $dbi));
 
         DatabaseInterface::$instance = $dbi;
+        $relation = new Relation($dbi);
         $this->insertEdit = new InsertEdit(
             $dbi,
-            new Relation($dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($dbi, $relation),
             new FileListing(),
             new Template(),
             Config::getInstance(),

--- a/tests/unit/NormalizationTest.php
+++ b/tests/unit/NormalizationTest.php
@@ -97,7 +97,8 @@ class NormalizationTest extends AbstractTestCase
             ->method('fetchSingleRow')
             ->willReturn(['`id`_cnt' => 0, '`col1`_cnt' => 0, '`col2`_cnt' => 0]);
 
-        $this->normalization = new Normalization($dbi, new Relation($dbi), new Transformations(), new Template());
+        $relation = new Relation($dbi);
+        $this->normalization = new Normalization($dbi, $relation, new Transformations($dbi, $relation), new Template());
     }
 
     /**
@@ -131,10 +132,11 @@ class NormalizationTest extends AbstractTestCase
         $db = 'testdb';
         $table = 'mytable';
         $numFields = 1;
+        $relation = new Relation($this->dbi);
         $normalization = new Normalization(
             $this->dbi,
-            new Relation($this->dbi),
-            new Transformations(),
+            $relation,
+            new Transformations($this->dbi, $relation),
             new Template(),
         );
         $result = $normalization->getHtmlForCreateNewColumn($userPrivileges, $numFields, $db, $table);

--- a/tests/unit/Plugins/Export/ExportCodegenTest.php
+++ b/tests/unit/Plugins/Export/ExportCodegenTest.php
@@ -39,11 +39,8 @@ class ExportCodegenTest extends AbstractTestCase
 
         $dbi = $this->createDatabaseInterface();
         DatabaseInterface::$instance = $dbi;
-        $this->object = new ExportCodegen(
-            new Relation($dbi),
-            new Export($dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($dbi);
+        $this->object = new ExportCodegen($relation, new Export($dbi), new Transformations($dbi, $relation));
     }
 
     /**

--- a/tests/unit/Plugins/Export/ExportCsvTest.php
+++ b/tests/unit/Plugins/Export/ExportCsvTest.php
@@ -46,11 +46,8 @@ class ExportCsvTest extends AbstractTestCase
         Current::$lang = '';
         Export::$saveFilename = '';
 
-        $this->object = new ExportCsv(
-            new Relation($dbi),
-            new Export($dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($dbi);
+        $this->object = new ExportCsv($relation, new Export($dbi), new Transformations($dbi, $relation));
     }
 
     /**

--- a/tests/unit/Plugins/Export/ExportExcelTest.php
+++ b/tests/unit/Plugins/Export/ExportExcelTest.php
@@ -41,11 +41,8 @@ class ExportExcelTest extends AbstractTestCase
 
         $dbi = $this->createDatabaseInterface();
         DatabaseInterface::$instance = $dbi;
-        $this->object = new ExportExcel(
-            new Relation($dbi),
-            new Export($dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($dbi);
+        $this->object = new ExportExcel($relation, new Export($dbi), new Transformations($dbi, $relation));
     }
 
     /**

--- a/tests/unit/Plugins/Export/ExportHtmlwordTest.php
+++ b/tests/unit/Plugins/Export/ExportHtmlwordTest.php
@@ -57,10 +57,11 @@ class ExportHtmlwordTest extends AbstractTestCase
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;
+        $relation = new Relation($this->dbi);
         $this->object = new ExportHtmlword(
-            new Relation($this->dbi),
+            $relation,
             new Export($this->dbi),
-            new Transformations(),
+            new Transformations($this->dbi, $relation),
         );
         Export::$outputKanjiConversion = false;
         Export::$outputCharsetConversion = false;
@@ -375,9 +376,10 @@ class ExportHtmlwordTest extends AbstractTestCase
 
     public function testGetTableDef(): void
     {
+        $relation = new Relation($this->dbi);
         $this->object = $this->getMockBuilder(ExportHtmlword::class)
             ->onlyMethods(['formatOneColumnDefinition'])
-            ->setConstructorArgs([new Relation($this->dbi), new Export($this->dbi), new Transformations()])
+            ->setConstructorArgs([$relation, new Export($this->dbi), new Transformations($this->dbi, $relation)])
             ->getMock();
 
         $keys = [['Non_unique' => 0, 'Column_name' => 'name1'], ['Non_unique' => 1, 'Column_name' => 'name2']];
@@ -421,7 +423,9 @@ class ExportHtmlwordTest extends AbstractTestCase
             ->willReturn(['comment' => 'testComment']);
 
         DatabaseInterface::$instance = $dbi;
-        $this->object->relation = new Relation($dbi);
+        $relation = new Relation($dbi);
+        $this->object->relation = $relation;
+        $this->object->transformations = new Transformations($dbi, $relation);
 
         $this->object->expects(self::exactly(3))
             ->method('formatOneColumnDefinition')
@@ -497,7 +501,9 @@ class ExportHtmlwordTest extends AbstractTestCase
             ->willReturn(['comment' => 'testComment']);
 
         DatabaseInterface::$instance = $dbi;
-        $this->object->relation = new Relation($dbi);
+        $relation = new Relation($dbi);
+        $this->object->relation = $relation;
+        $this->object->transformations = new Transformations($dbi, $relation);
 
         $relationParameters = RelationParameters::fromArray([
             'relwork' => true,

--- a/tests/unit/Plugins/Export/ExportJsonTest.php
+++ b/tests/unit/Plugins/Export/ExportJsonTest.php
@@ -40,11 +40,8 @@ class ExportJsonTest extends AbstractTestCase
         Export::$bufferNeeded = false;
         Export::$asFile = true;
         Export::$saveOnServer = false;
-        $this->object = new ExportJson(
-            new Relation($dbi),
-            new Export($dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($dbi);
+        $this->object = new ExportJson($relation, new Export($dbi), new Transformations($dbi, $relation));
     }
 
     /**

--- a/tests/unit/Plugins/Export/ExportLatexTest.php
+++ b/tests/unit/Plugins/Export/ExportLatexTest.php
@@ -58,11 +58,8 @@ class ExportLatexTest extends AbstractTestCase
         ExportPlugin::$singleTable = false;
         Current::$database = 'db';
         Current::$table = 'table';
-        $this->object = new ExportLatex(
-            new Relation($dbi),
-            new Export($dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($dbi);
+        $this->object = new ExportLatex($relation, new Export($dbi), new Transformations($dbi, $relation));
     }
 
     /**
@@ -606,7 +603,9 @@ class ExportLatexTest extends AbstractTestCase
             ->willReturn(['comment' => 'testComment']);
 
         DatabaseInterface::$instance = $dbi;
-        $this->object->relation = new Relation($dbi);
+        $relation = new Relation($dbi);
+        $this->object->relation = $relation;
+        $this->object->transformations = new Transformations($dbi, $relation);
 
         $relationParameters = RelationParameters::fromArray([
             'relwork' => true,
@@ -689,7 +688,9 @@ class ExportLatexTest extends AbstractTestCase
             ->willReturn(['comment' => 'testComment']);
 
         DatabaseInterface::$instance = $dbi;
-        $this->object->relation = new Relation($dbi);
+        $relation = new Relation($dbi);
+        $this->object->relation = $relation;
+        $this->object->transformations = new Transformations($dbi, $relation);
 
         $relationParameters = RelationParameters::fromArray([
             'relwork' => true,

--- a/tests/unit/Plugins/Export/ExportMediawikiTest.php
+++ b/tests/unit/Plugins/Export/ExportMediawikiTest.php
@@ -51,11 +51,8 @@ class ExportMediawikiTest extends AbstractTestCase
         Current::$database = '';
         Current::$table = '';
         Current::$lang = 'en';
-        $this->object = new ExportMediawiki(
-            new Relation($dbi),
-            new Export($dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($dbi);
+        $this->object = new ExportMediawiki($relation, new Export($dbi), new Transformations($dbi, $relation));
     }
 
     /**

--- a/tests/unit/Plugins/Export/ExportOdsTest.php
+++ b/tests/unit/Plugins/Export/ExportOdsTest.php
@@ -57,11 +57,8 @@ class ExportOdsTest extends AbstractTestCase
         Export::$bufferNeeded = false;
         Export::$asFile = true;
         Export::$saveOnServer = false;
-        $this->object = new ExportOds(
-            new Relation($dbi),
-            new Export($dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($dbi);
+        $this->object = new ExportOds($relation, new Export($dbi), new Transformations($dbi, $relation));
     }
 
     /**

--- a/tests/unit/Plugins/Export/ExportOdtTest.php
+++ b/tests/unit/Plugins/Export/ExportOdtTest.php
@@ -75,11 +75,8 @@ class ExportOdtTest extends AbstractTestCase
         ExportPlugin::$exportType = ExportType::Table;
         ExportPlugin::$singleTable = false;
         Config::getInstance()->selectedServer['DisableIS'] = true;
-        $this->object = new ExportOdt(
-            new Relation($this->dbi),
-            new Export($this->dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($this->dbi);
+        $this->object = new ExportOdt($relation, new Export($this->dbi), new Transformations($this->dbi, $relation));
     }
 
     /**
@@ -574,9 +571,10 @@ class ExportOdtTest extends AbstractTestCase
 
     public function testGetTableDef(): void
     {
+        $relation = new Relation($this->dbi);
         $this->object = $this->getMockBuilder(ExportOdt::class)
             ->onlyMethods(['formatOneColumnDefinition'])
-            ->setConstructorArgs([new Relation($this->dbi), new Export($this->dbi), new Transformations()])
+            ->setConstructorArgs([$relation, new Export($this->dbi), new Transformations($this->dbi, $relation)])
             ->getMock();
 
         // case 1
@@ -613,7 +611,9 @@ class ExportOdtTest extends AbstractTestCase
             ->willReturn(['comment' => 'testComment']);
 
         DatabaseInterface::$instance = $dbi;
-        $this->object->relation = new Relation($dbi);
+        $relation = new Relation($dbi);
+        $this->object->relation = $relation;
+        $this->object->transformations = new Transformations($dbi, $relation);
 
         $this->object->expects(self::exactly(2))
             ->method('formatOneColumnDefinition')
@@ -694,7 +694,9 @@ class ExportOdtTest extends AbstractTestCase
             ->willReturn(['comment' => 'testComment']);
 
         DatabaseInterface::$instance = $dbi;
-        $this->object->relation = new Relation($dbi);
+        $relation = new Relation($dbi);
+        $this->object->relation = $relation;
+        $this->object->transformations = new Transformations($dbi, $relation);
         $this->object->buffer = '';
         $relationParameters = RelationParameters::fromArray([
             'relwork' => true,

--- a/tests/unit/Plugins/Export/ExportPdfTest.php
+++ b/tests/unit/Plugins/Export/ExportPdfTest.php
@@ -43,11 +43,8 @@ class ExportPdfTest extends AbstractTestCase
         Export::$bufferNeeded = false;
         Export::$asFile = true;
         Export::$saveOnServer = false;
-        $this->object = new ExportPdf(
-            new Relation($dbi),
-            new Export($dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($dbi);
+        $this->object = new ExportPdf($relation, new Export($dbi), new Transformations($dbi, $relation));
     }
 
     /**

--- a/tests/unit/Plugins/Export/ExportPhparrayTest.php
+++ b/tests/unit/Plugins/Export/ExportPhparrayTest.php
@@ -46,11 +46,8 @@ class ExportPhparrayTest extends AbstractTestCase
         Current::$database = '';
         Current::$table = '';
         Current::$lang = 'en';
-        $this->object = new ExportPhparray(
-            new Relation($dbi),
-            new Export($dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($dbi);
+        $this->object = new ExportPhparray($relation, new Export($dbi), new Transformations($dbi, $relation));
     }
 
     /**

--- a/tests/unit/Plugins/Export/ExportSqlTest.php
+++ b/tests/unit/Plugins/Export/ExportSqlTest.php
@@ -74,11 +74,8 @@ class ExportSqlTest extends AbstractTestCase
         ExportPlugin::$exportType = ExportType::Table;
         ExportPlugin::$singleTable = false;
 
-        $this->object = new ExportSql(
-            new Relation($dbi),
-            new Export($dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($dbi);
+        $this->object = new ExportSql($relation, new Export($dbi), new Transformations($dbi, $relation));
         $this->object->useSqlBackquotes(false);
     }
 
@@ -889,7 +886,9 @@ SQL;
             );
 
         DatabaseInterface::$instance = $dbi;
-        $this->object->relation = new Relation($dbi);
+        $relation = new Relation($dbi);
+        $this->object = new ExportSql($relation, new Export($dbi), new Transformations($dbi, $relation));
+        $this->object->useSqlBackquotes(false);
 
         $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/')
             ->withParsedBody(['sql_relation' => 'On', 'sql_mime' => 'On', 'sql_include_comments' => 'On']);

--- a/tests/unit/Plugins/Export/ExportTexytextTest.php
+++ b/tests/unit/Plugins/Export/ExportTexytextTest.php
@@ -68,10 +68,11 @@ class ExportTexytextTest extends AbstractTestCase
         Current::$table = '';
         Current::$lang = 'en';
         Config::getInstance()->selectedServer['DisableIS'] = true;
+        $relation = new Relation($this->dbi);
         $this->object = new ExportTexytext(
-            new Relation($this->dbi),
+            $relation,
             new Export($this->dbi),
-            new Transformations(),
+            new Transformations($this->dbi, $relation),
         );
     }
 
@@ -259,9 +260,10 @@ class ExportTexytextTest extends AbstractTestCase
 
     public function testGetTableDef(): void
     {
+        $relation = new Relation($this->dbi);
         $this->object = $this->getMockBuilder(ExportTexytext::class)
             ->onlyMethods(['formatOneColumnDefinition'])
-            ->setConstructorArgs([new Relation($this->dbi), new Export($this->dbi), new Transformations()])
+            ->setConstructorArgs([$relation, new Export($this->dbi), new Transformations($this->dbi, $relation)])
             ->getMock();
 
         // case 1
@@ -297,7 +299,9 @@ class ExportTexytextTest extends AbstractTestCase
             ]);
 
         DatabaseInterface::$instance = $dbi;
-        $this->object->relation = new Relation($dbi);
+        $relation = new Relation($dbi);
+        $this->object->relation = $relation;
+        $this->object->transformations = new Transformations($dbi, $relation);
 
         $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/')
             ->withParsedBody(['texytext_relation' => 'On', 'texytext_mime' => 'On', 'texytext_comments' => 'On']);

--- a/tests/unit/Plugins/Export/ExportXmlTest.php
+++ b/tests/unit/Plugins/Export/ExportXmlTest.php
@@ -51,11 +51,8 @@ class ExportXmlTest extends AbstractTestCase
         ExportPlugin::$singleTable = false;
         Current::$database = 'db';
         Config::getInstance()->selectedServer['DisableIS'] = true;
-        $this->object = new ExportXml(
-            new Relation($dbi),
-            new Export($dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($dbi);
+        $this->object = new ExportXml($relation, new Export($dbi), new Transformations($dbi, $relation));
     }
 
     /**

--- a/tests/unit/Plugins/Export/ExportYamlTest.php
+++ b/tests/unit/Plugins/Export/ExportYamlTest.php
@@ -45,11 +45,8 @@ class ExportYamlTest extends AbstractTestCase
         Current::$database = '';
         Current::$table = '';
         Current::$lang = 'en';
-        $this->object = new ExportYaml(
-            new Relation($dbi),
-            new Export($dbi),
-            new Transformations(),
-        );
+        $relation = new Relation($dbi);
+        $this->object = new ExportYaml($relation, new Export($dbi), new Transformations($dbi, $relation));
     }
 
     /**

--- a/tests/unit/PluginsTest.php
+++ b/tests/unit/PluginsTest.php
@@ -99,27 +99,14 @@ class PluginsTest extends AbstractTestCase
     public function testGetChoice(): void
     {
         $dbi = DatabaseInterface::getInstance();
+        $relation = new Relation($dbi);
+        $transformations = new Transformations($dbi, $relation);
+        $export = new Export($dbi);
         $exportList = [
-            new Plugins\Export\ExportJson(
-                new Relation($dbi),
-                new Export($dbi),
-                new Transformations(),
-            ),
-            new Plugins\Export\ExportOds(
-                new Relation($dbi),
-                new Export($dbi),
-                new Transformations(),
-            ),
-            new Plugins\Export\ExportSql(
-                new Relation($dbi),
-                new Export($dbi),
-                new Transformations(),
-            ),
-            new Plugins\Export\ExportXml(
-                new Relation($dbi),
-                new Export($dbi),
-                new Transformations(),
-            ),
+            new Plugins\Export\ExportJson($relation, $export, $transformations),
+            new Plugins\Export\ExportOds($relation, $export, $transformations),
+            new Plugins\Export\ExportSql($relation, $export, $transformations),
+            new Plugins\Export\ExportXml($relation, $export, $transformations),
         ];
         $actual = Plugins::getChoice($exportList, 'xml');
         $expected = [

--- a/tests/unit/SqlTest.php
+++ b/tests/unit/SqlTest.php
@@ -66,7 +66,7 @@ class SqlTest extends AbstractTestCase
             $this->dbi,
             $relation,
             new RelationCleanup($this->dbi, $relation),
-            new Transformations(),
+            new Transformations($this->dbi, $relation),
             new Template(),
             new BookmarkRepository($this->dbi, $relation),
             Config::getInstance(),

--- a/tests/unit/Table/ColumnsDefinitionTest.php
+++ b/tests/unit/Table/ColumnsDefinitionTest.php
@@ -80,7 +80,7 @@ SQL;
         );
 
         $relation = new Relation($dbi);
-        $columnsDefinition = new ColumnsDefinition($dbi, $relation, new Transformations());
+        $columnsDefinition = new ColumnsDefinition($dbi, $relation, new Transformations($dbi, $relation));
 
         Current::$database = 'sakila';
         Current::$table = 'actor';

--- a/tests/unit/TransformationsTest.php
+++ b/tests/unit/TransformationsTest.php
@@ -27,7 +27,7 @@ class TransformationsTest extends AbstractTestCase
     {
         parent::setUp();
 
-        DatabaseInterface::$instance = $this->createDatabaseInterface();
+        $dbi = DatabaseInterface::$instance = $this->createDatabaseInterface();
         Current::$table = 'table';
         Current::$database = 'db';
         $config = Config::getInstance();
@@ -40,7 +40,7 @@ class TransformationsTest extends AbstractTestCase
         $config->selectedServer['table_coords'] = '';
         $config->selectedServer['column_info'] = 'column_info';
 
-        $this->transformations = new Transformations();
+        $this->transformations = new Transformations($dbi, new Relation($dbi));
     }
 
     /**
@@ -207,10 +207,10 @@ class TransformationsTest extends AbstractTestCase
         $dbi->expects(self::any())
             ->method('tryQuery')
             ->willReturn(self::createStub(DummyResult::class));
-        DatabaseInterface::$instance = $dbi;
 
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
+        $this->transformations = new Transformations($dbi, new Relation($dbi));
         // Case 1 : no configuration storage
         $actual = $this->transformations->clear('db');
         self::assertFalse($actual);


### PR DESCRIPTION
### Description

This pull request will solves the bug that does not let's us rename the timestamp column with a current timestamp as it's default value as reported in Issue [#19367](https://github.com/phpmyadmin/phpmyadmin/issues/19367)

It was happening because the query builder was quoting the `current_timestamp()` function of SQL that was raising a Query Error of Invalid Default Value.
