### PR TITLE
Fix #19367 - renaming timestamp column name

### DIFF
--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -611,6 +611,11 @@ class Table implements Stringable
                             }
                         } elseif ($type === 'BINARY' || $type === 'VARBINARY') {
                             $query .= ' DEFAULT 0x' . $defaultValue;
+                        } elseif (
+                            str_contains($defaultValue, 'current_timestamp')
+                                 || str_contains($defaultValue, 'CURRENT_TIMESTAMP')
+                        ) {
+                            $query .= ' DEFAULT CURRENT_TIMESTAMP(' . $length . ')';
                         } else {
                             $query .= ' DEFAULT \''
                             . $dbi->escapeString((string) $defaultValue) . '\'';

--- a/libraries/classes/Utils/HttpRequest.php
+++ b/libraries/classes/Utils/HttpRequest.php
@@ -14,6 +14,7 @@ use function curl_setopt;
 use function file_get_contents;
 use function function_exists;
 use function getenv;
+use function http_get_last_response_headers;
 use function ini_get;
 use function intval;
 use function is_array;


### PR DESCRIPTION
This PR will fix the bug that is raising a query error when we try to update the name of a timestamp column. This is because it was adding quotes to the `current_timestamp` sql function which was getting added while generating alter sql query.

For more refer this issue: [#19367](https://github.com/phpmyadmin/phpmyadmin/issues/19367)

Fixes #19367