### PR TITLE
Fix #19757 - Move column with foreign key

### DIFF
--- a/libraries/classes/Controllers/Table/Structure/MoveColumnsController.php
+++ b/libraries/classes/Controllers/Table/Structure/MoveColumnsController.php
@@ -94,11 +94,11 @@ final class MoveColumnsController extends AbstractController
         $parser = new Parser($createTableSql);
         /** @var CreateStatement $statement */
         $statement = $parser->statements[0];
-        /** @var CreateDefinition[] $fields */
+        /** @var CreateDefinition[] $fields For CREATE TABLE statement the type is CreateDefinition[] */
         $fields = $statement->fields;
         $columns = [];
         foreach ($fields as $field) {
-            if ($field->name === null) {
+            if ($field->name === null || $field->isConstraint === true || $field->key !== null) {
                 continue;
             }
 

--- a/test/classes/Controllers/Table/Structure/MoveColumnsControllerTest.php
+++ b/test/classes/Controllers/Table/Structure/MoveColumnsControllerTest.php
@@ -122,6 +122,48 @@ ALTER TABLE `test`
 SQL
 ,
             ],
+            // with foreign key
+            [
+                <<<'SQL'
+CREATE TABLE orders (
+  order_id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  order_date DATE NOT NULL,
+  amount DECIMAL(10, 2) NOT NULL,
+  status VARCHAR(50) DEFAULT 'pending',
+  CONSTRAINT fk_user
+    FOREIGN KEY (user_id)
+    REFERENCES users(user_id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE
+)
+SQL
+,
+                ['order_id','user_id','order_date','status','amount'],
+                <<<'SQL'
+ALTER TABLE `orders`
+  CHANGE `status` `status` varchar(50) DEFAULT 'pending' AFTER `order_date`
+SQL
+,
+            ],
+            // With non-primary index
+            [
+                <<<'SQL'
+CREATE TABLE `test_table` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `val` int(11) DEFAULT NULL,
+  `note` varchar(100) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `val_index` (`val`)
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
+SQL
+,
+                ['id', 'note', 'val'],
+                <<<'SQL'
+ALTER TABLE `test_table`
+  CHANGE `note` `note` varchar(100) DEFAULT NULL AFTER `id`
+SQL
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fixes #19757

The fields property of CreateDefinition also includes foreign keys and indexes which need to be filtered out here.