### PR TITLE
Lazy-load middleware in QueueRequestHandler

### DIFF
--- a/app/services.php
+++ b/app/services.php
@@ -27,6 +27,7 @@ use PhpMyAdmin\Export\TemplateModel;
 use PhpMyAdmin\FileListing;
 use PhpMyAdmin\FlashMessenger;
 use PhpMyAdmin\Http\Factory\ResponseFactory;
+use PhpMyAdmin\Http\Middleware;
 use PhpMyAdmin\Import\Import;
 use PhpMyAdmin\Import\SimulateDml;
 use PhpMyAdmin\InsertEdit;
@@ -69,16 +70,7 @@ return [
             'class' => Advisor::class,
             'arguments' => ['$dbi' => '@dbi', '$expression' => '@expression_language'],
         ],
-        Application::class => [
-            'class' => Application::class,
-            'arguments' => [
-                '$errorHandler' => '@error_handler',
-                '$config' => '@config',
-                '$template' => '@template',
-                '$responseFactory' => '@' . ResponseFactory::class,
-                '$history' => '@history',
-            ],
-        ],
+        Application::class => ['class' => Application::class, 'arguments' => ['@' . ResponseFactory::class]],
         'browse_foreigners' => [
             'class' => BrowseForeigners::class,
             'arguments' => ['@template', '@config', '@' . ThemeManager::class],
@@ -126,6 +118,104 @@ return [
         'insert_edit' => [
             'class' => InsertEdit::class,
             'arguments' => ['@dbi', '@relation', '@transformations', '@file_listing', '@template', '@config'],
+        ],
+        Middleware\ErrorHandling::class => [
+            'class' => Middleware\ErrorHandling::class,
+            'arguments' => ['@error_handler'],
+        ],
+        Middleware\OutputBuffering::class => ['class' => Middleware\OutputBuffering::class],
+        Middleware\PhpExtensionsChecking::class => [
+            'class' => Middleware\PhpExtensionsChecking::class,
+            'arguments' => ['@template', '@' . ResponseFactory::class],
+        ],
+        Middleware\ServerConfigurationChecking::class => [
+            'class' => Middleware\ServerConfigurationChecking::class,
+            'arguments' => ['@template', '@' . ResponseFactory::class],
+        ],
+        Middleware\PhpSettingsConfiguration::class => ['class' => Middleware\PhpSettingsConfiguration::class],
+        Middleware\RouteParsing::class => ['class' => Middleware\RouteParsing::class],
+        Middleware\ConfigLoading::class => [
+            'class' => Middleware\ConfigLoading::class,
+            'arguments' => ['@config', '@template', '@' . ResponseFactory::class],
+        ],
+        Middleware\UriSchemeUpdating::class => [
+            'class' => Middleware\UriSchemeUpdating::class,
+            'arguments' => ['@config'],
+        ],
+        Middleware\SessionHandling::class => [
+            'class' => Middleware\SessionHandling::class,
+            'arguments' => ['@config', '@error_handler', '@template', '@' . ResponseFactory::class],
+        ],
+        Middleware\EncryptedQueryParamsHandling::class => ['class' => Middleware\EncryptedQueryParamsHandling::class],
+        Middleware\UrlParamsSetting::class => [
+            'class' => Middleware\UrlParamsSetting::class,
+            'arguments' => ['@config'],
+        ],
+        Middleware\TokenRequestParamChecking::class => ['class' => Middleware\TokenRequestParamChecking::class],
+        Middleware\DatabaseAndTableSetting::class => ['class' => Middleware\DatabaseAndTableSetting::class],
+        Middleware\SqlQueryGlobalSetting::class => ['class' => Middleware\SqlQueryGlobalSetting::class],
+        Middleware\LanguageLoading::class => ['class' => Middleware\LanguageLoading::class],
+        Middleware\ConfigErrorAndPermissionChecking::class => [
+            'class' => Middleware\ConfigErrorAndPermissionChecking::class,
+            'arguments' => ['@config', '@template', '@' . ResponseFactory::class],
+        ],
+        Middleware\RequestProblemChecking::class => [
+            'class' => Middleware\RequestProblemChecking::class,
+            'arguments' => ['@template', '@' . ResponseFactory::class],
+        ],
+        Middleware\CurrentServerGlobalSetting::class => [
+            'class' => Middleware\CurrentServerGlobalSetting::class,
+            'arguments' => ['@config'],
+        ],
+        Middleware\ThemeInitialization::class => ['class' => Middleware\ThemeInitialization::class],
+        Middleware\UrlRedirection::class => [
+            'class' => Middleware\UrlRedirection::class,
+            'arguments' => ['@config', '@template', '@' . ResponseFactory::class],
+        ],
+        Middleware\SetupPageRedirection::class => [
+            'class' => Middleware\SetupPageRedirection::class,
+            'arguments' => ['@config', '@' . ResponseFactory::class],
+        ],
+        Middleware\MinimumCommonRedirection::class => [
+            'class' => Middleware\MinimumCommonRedirection::class,
+            'arguments' => ['@config', '@' . ResponseFactory::class],
+        ],
+        Middleware\LanguageAndThemeCookieSaving::class => [
+            'class' => Middleware\LanguageAndThemeCookieSaving::class,
+            'arguments' => ['@config'],
+        ],
+        Middleware\LoginCookieValiditySetting::class => [
+            'class' => Middleware\LoginCookieValiditySetting::class,
+            'arguments' => ['@config'],
+        ],
+        Middleware\Authentication::class => [
+            'class' => Middleware\Authentication::class,
+            'arguments' => ['@config', '@template', '@' . ResponseFactory::class],
+        ],
+        Middleware\DatabaseServerVersionChecking::class => [
+            'class' => Middleware\DatabaseServerVersionChecking::class,
+            'arguments' => ['@config', '@template', '@' . ResponseFactory::class],
+        ],
+        Middleware\SqlDelimiterSetting::class => [
+            'class' => Middleware\SqlDelimiterSetting::class,
+            'arguments' => ['@config'],
+        ],
+        Middleware\ResponseRendererLoading::class => [
+            'class' => Middleware\ResponseRendererLoading::class,
+            'arguments' => ['@config'],
+        ],
+        Middleware\ProfilingChecking::class => ['class' => Middleware\ProfilingChecking::class],
+        Middleware\UserPreferencesLoading::class => [
+            'class' => Middleware\UserPreferencesLoading::class,
+            'arguments' => ['@config'],
+        ],
+        Middleware\RecentTableHandling::class => [
+            'class' => Middleware\RecentTableHandling::class,
+            'arguments' => ['@config'],
+        ],
+        Middleware\StatementHistory::class => [
+            'class' => Middleware\StatementHistory::class,
+            'arguments' => ['@config', '@history'],
         ],
         'navigation' => [
             'class' => Navigation::class,

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4952,16 +4952,92 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/ConfigErrorAndPermissionChecking.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/ConfigLoading.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/CurrentServerGlobalSetting.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Http/Middleware/DatabaseServerVersionChecking.php">
     <DeprecatedMethod>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/ErrorHandling.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/LanguageAndThemeCookieSaving.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/LoginCookieValiditySetting.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/MinimumCommonRedirection.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/PhpExtensionsChecking.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Http/Middleware/ProfilingChecking.php">
     <DeprecatedMethod>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
+  </file>
+  <file src="src/Http/Middleware/RequestProblemChecking.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/ResponseRendererLoading.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/ServerConfigurationChecking.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/SessionHandling.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/SetupPageRedirection.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/SqlDelimiterSetting.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Http/Middleware/StatementHistory.php">
     <DeprecatedMethod>
@@ -4975,6 +5051,21 @@
     <MixedArgument>
       <code><![CDATA[$_SESSION[' PMA_token ']]]></code>
     </MixedArgument>
+  </file>
+  <file src="src/Http/Middleware/UriSchemeUpdating.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/UrlRedirection.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Http/Middleware/UserPreferencesLoading.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/I18n/LanguageManager.php">
     <DeprecatedMethod>

--- a/src/Application.php
+++ b/src/Application.php
@@ -7,9 +7,7 @@ namespace PhpMyAdmin;
 use Fig\Http\Message\StatusCodeInterface;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Laminas\HttpHandlerRunner\RequestHandlerRunner;
-use PhpMyAdmin\Console\History;
 use PhpMyAdmin\Container\ContainerBuilder;
-use PhpMyAdmin\Error\ErrorHandler;
 use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Factory\ServerRequestFactory;
 use PhpMyAdmin\Http\Handler\ApplicationHandler;
@@ -53,71 +51,59 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
+use function assert;
 use function sprintf;
 
-class Application
+readonly class Application
 {
-    public function __construct(
-        private readonly ErrorHandler $errorHandler,
-        private readonly Config $config,
-        private readonly Template $template,
-        private readonly ResponseFactory $responseFactory,
-        private readonly History $history,
-    ) {
+    public function __construct(private ResponseFactory $responseFactory)
+    {
     }
 
     public static function init(): self
     {
-        /** @var Application $application */
         $application = ContainerBuilder::getContainer()->get(self::class);
+        assert($application instanceof self);
 
         return $application;
     }
 
     public function run(bool $isSetupPage = false): void
     {
-        $requestHandler = new QueueRequestHandler(new ApplicationHandler($this));
-        $requestHandler->add(new ErrorHandling($this->errorHandler));
-        $requestHandler->add(new OutputBuffering());
-        $requestHandler->add(new PhpExtensionsChecking($this->template, $this->responseFactory));
-        $requestHandler->add(new ServerConfigurationChecking($this->template, $this->responseFactory));
-        $requestHandler->add(new PhpSettingsConfiguration());
-        $requestHandler->add(new RouteParsing());
-        $requestHandler->add(new ConfigLoading($this->config, $this->template, $this->responseFactory));
-        $requestHandler->add(new UriSchemeUpdating($this->config));
-        $requestHandler->add(new SessionHandling(
-            $this->config,
-            $this->errorHandler,
-            $this->template,
-            $this->responseFactory,
-        ));
-        $requestHandler->add(new EncryptedQueryParamsHandling());
-        $requestHandler->add(new UrlParamsSetting($this->config));
-        $requestHandler->add(new TokenRequestParamChecking());
-        $requestHandler->add(new DatabaseAndTableSetting());
-        $requestHandler->add(new SqlQueryGlobalSetting());
-        $requestHandler->add(new LanguageLoading());
-        $requestHandler->add(new ConfigErrorAndPermissionChecking(
-            $this->config,
-            $this->template,
-            $this->responseFactory,
-        ));
-        $requestHandler->add(new RequestProblemChecking($this->template, $this->responseFactory));
-        $requestHandler->add(new CurrentServerGlobalSetting($this->config));
-        $requestHandler->add(new ThemeInitialization());
-        $requestHandler->add(new UrlRedirection($this->config, $this->template, $this->responseFactory));
-        $requestHandler->add(new SetupPageRedirection($this->config, $this->responseFactory));
-        $requestHandler->add(new MinimumCommonRedirection($this->config, $this->responseFactory));
-        $requestHandler->add(new LanguageAndThemeCookieSaving($this->config));
-        $requestHandler->add(new LoginCookieValiditySetting($this->config));
-        $requestHandler->add(new Authentication($this->config, $this->template, $this->responseFactory));
-        $requestHandler->add(new DatabaseServerVersionChecking($this->config, $this->template, $this->responseFactory));
-        $requestHandler->add(new SqlDelimiterSetting($this->config));
-        $requestHandler->add(new ResponseRendererLoading($this->config));
-        $requestHandler->add(new ProfilingChecking());
-        $requestHandler->add(new UserPreferencesLoading($this->config));
-        $requestHandler->add(new RecentTableHandling($this->config));
-        $requestHandler->add(new StatementHistory($this->config, $this->history));
+        $container = ContainerBuilder::getContainer();
+        $requestHandler = new QueueRequestHandler($container, new ApplicationHandler($this));
+        $requestHandler->add(ErrorHandling::class);
+        $requestHandler->add(OutputBuffering::class);
+        $requestHandler->add(PhpExtensionsChecking::class);
+        $requestHandler->add(ServerConfigurationChecking::class);
+        $requestHandler->add(PhpSettingsConfiguration::class);
+        $requestHandler->add(RouteParsing::class);
+        $requestHandler->add(ConfigLoading::class);
+        $requestHandler->add(UriSchemeUpdating::class);
+        $requestHandler->add(SessionHandling::class);
+        $requestHandler->add(EncryptedQueryParamsHandling::class);
+        $requestHandler->add(UrlParamsSetting::class);
+        $requestHandler->add(TokenRequestParamChecking::class);
+        $requestHandler->add(DatabaseAndTableSetting::class);
+        $requestHandler->add(SqlQueryGlobalSetting::class);
+        $requestHandler->add(LanguageLoading::class);
+        $requestHandler->add(ConfigErrorAndPermissionChecking::class);
+        $requestHandler->add(RequestProblemChecking::class);
+        $requestHandler->add(CurrentServerGlobalSetting::class);
+        $requestHandler->add(ThemeInitialization::class);
+        $requestHandler->add(UrlRedirection::class);
+        $requestHandler->add(SetupPageRedirection::class);
+        $requestHandler->add(MinimumCommonRedirection::class);
+        $requestHandler->add(LanguageAndThemeCookieSaving::class);
+        $requestHandler->add(LoginCookieValiditySetting::class);
+        $requestHandler->add(Authentication::class);
+        $requestHandler->add(DatabaseServerVersionChecking::class);
+        $requestHandler->add(SqlDelimiterSetting::class);
+        $requestHandler->add(ResponseRendererLoading::class);
+        $requestHandler->add(ProfilingChecking::class);
+        $requestHandler->add(UserPreferencesLoading::class);
+        $requestHandler->add(RecentTableHandling::class);
+        $requestHandler->add(StatementHistory::class);
 
         $runner = new RequestHandlerRunner(
             $requestHandler,

--- a/src/Http/Handler/QueueRequestHandler.php
+++ b/src/Http/Handler/QueueRequestHandler.php
@@ -4,23 +4,28 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Http\Handler;
 
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 use function array_shift;
+use function assert;
 
 final class QueueRequestHandler implements RequestHandlerInterface
 {
-    /** @psalm-var list<MiddlewareInterface> */
+    /** @psalm-var list<class-string<MiddlewareInterface>> */
     private array $middleware = [];
 
-    public function __construct(private readonly RequestHandlerInterface $fallbackHandler)
-    {
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly RequestHandlerInterface $fallbackHandler,
+    ) {
     }
 
-    public function add(MiddlewareInterface $middleware): void
+    /** @param class-string<MiddlewareInterface> $middleware */
+    public function add(string $middleware): void
     {
         $this->middleware[] = $middleware;
     }
@@ -31,7 +36,8 @@ final class QueueRequestHandler implements RequestHandlerInterface
             return $this->fallbackHandler->handle($request);
         }
 
-        $middleware = array_shift($this->middleware);
+        $middleware = $this->container->get(array_shift($this->middleware));
+        assert($middleware instanceof MiddlewareInterface);
 
         return $middleware->process($request, $this);
     }

--- a/tests/unit/ApplicationTest.php
+++ b/tests/unit/ApplicationTest.php
@@ -6,9 +6,7 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Application;
 use PhpMyAdmin\Config;
-use PhpMyAdmin\Console\History;
 use PhpMyAdmin\Container\ContainerBuilder;
-use PhpMyAdmin\Error\ErrorHandler;
 use PhpMyAdmin\Exceptions\ConfigException;
 use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Template;
@@ -28,12 +26,13 @@ final class ApplicationTest extends AbstractTestCase
     #[BackupStaticProperties(true)]
     public function testRunWithConfigError(): void
     {
-        $errorHandler = self::createStub(ErrorHandler::class);
-
         $config = self::createMock(Config::class);
         $config->expects(self::once())->method('loadFromFile')
             ->willThrowException(new ConfigException('Failed to load phpMyAdmin configuration.'));
         $config->config = new Config\Settings([]);
+
+        Config::$instance = $config;
+        ContainerBuilder::$container = null;
 
         $template = new Template($config);
         $expected = $template->render('error/generic', [
@@ -41,11 +40,13 @@ final class ApplicationTest extends AbstractTestCase
             'error_message' => 'Failed to load phpMyAdmin configuration.',
         ]);
 
-        $history = self::createMock(History::class);
-        $application = new Application($errorHandler, $config, $template, ResponseFactory::create(), $history);
+        $application = new Application(ResponseFactory::create());
         $application->run();
 
         $output = $this->getActualOutputForAssertion();
         self::assertSame($expected, $output);
+
+        Config::$instance = null;
+        ContainerBuilder::$container = null;
     }
 }

--- a/tests/unit/Http/Handler/Fixtures/FallbackHandler.php
+++ b/tests/unit/Http/Handler/Fixtures/FallbackHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Http\Handler\Fixtures;
+
+use PhpMyAdmin\Http\Factory\ResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+use function implode;
+
+final readonly class FallbackHandler implements RequestHandlerInterface
+{
+    public function __construct(private ResponseFactory $responseFactory)
+    {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        /** @var string[] $attribute */
+        $attribute = $request->getAttribute('attribute');
+        $response = $this->responseFactory->createResponse();
+        $response->getBody()->write(implode(', ', $attribute) . ', ');
+        $response->getBody()->write('Fallback, ');
+
+        return $response;
+    }
+}

--- a/tests/unit/Http/Handler/Fixtures/Middleware/EarlyReturn.php
+++ b/tests/unit/Http/Handler/Fixtures/Middleware/EarlyReturn.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Http\Handler\Fixtures\Middleware;
+
+use PhpMyAdmin\Http\Factory\ResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+use function implode;
+
+final readonly class EarlyReturn implements MiddlewareInterface
+{
+    public function __construct(private ResponseFactory $responseFactory)
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ($request->getAttribute('early') !== true) {
+            return $handler->handle($request);
+        }
+
+        /** @var string[] $attribute */
+        $attribute = $request->getAttribute('attribute');
+        $response = $this->responseFactory->createResponse();
+        $response->getBody()->write(implode(', ', $attribute) . ', ');
+        $response->getBody()->write('Early, ');
+
+        return $response;
+    }
+}

--- a/tests/unit/Http/Handler/Fixtures/Middleware/First.php
+++ b/tests/unit/Http/Handler/Fixtures/Middleware/First.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Http\Handler\Fixtures\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class First implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        /** @var string[] $attribute */
+        $attribute = $request->getAttribute('attribute');
+        $attribute[] = 'First before';
+        $response = $handler->handle($request->withAttribute('attribute', $attribute));
+        $response->getBody()->write('First after, ');
+
+        return $response;
+    }
+}

--- a/tests/unit/Http/Handler/Fixtures/Middleware/Second.php
+++ b/tests/unit/Http/Handler/Fixtures/Middleware/Second.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Http\Handler\Fixtures\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class Second implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        /** @var string[] $attribute */
+        $attribute = $request->getAttribute('attribute');
+        $attribute[] = 'Second before';
+        $response = $handler->handle($request->withAttribute('attribute', $attribute));
+        $response->getBody()->write('Second after, ');
+
+        return $response;
+    }
+}


### PR DESCRIPTION
Registers only middleware class names instead of instances, and create new instances only when needed.


