### PR TITLE
Fix query not showing when dropping index

### DIFF
--- a/resources/js/modules/functions.ts
+++ b/resources/js/modules/functions.ts
@@ -1392,7 +1392,7 @@ export function previewSql ($form): void {
 export function confirmPreviewSql (sqlData, url, callback): void {
     $('#previewSqlConfirmModal').modal('show');
     $('#previewSqlConfirmModalLabel').first().html(window.Messages.strPreviewSQL);
-    $('#previewSqlConfirmCode').first().text(sqlData);
+    $('#previewSqlConfirmCode > code.sql').first().text(sqlData);
     $('#previewSqlConfirmModal').on('shown.bs.modal', function () {
         highlightSql($('#previewSqlConfirmModal'));
     });

--- a/resources/templates/modals/preview_sql_confirmation.twig
+++ b/resources/templates/modals/preview_sql_confirmation.twig
@@ -5,10 +5,10 @@
         <h5 class="modal-title" id="previewSqlConfirmModalLabel">{{ t('Loading') }}</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ t('Close') }}"></button>
       </div>
-      <div class="modal-body preview_sql">
-        <code class="sql">
-          <pre id="previewSqlConfirmCode"></pre>
-        </code>
+      <div class="modal-body">
+        <div class="preview_sql">
+          <pre id="previewSqlConfirmCode"><code class="sql" dir="ltr"></code></pre>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" id="previewSQLConfirmOkButton">{{ t('OK') }}</button>


### PR DESCRIPTION
### Description

Fix query not showing when an index is dropped and I also added language direction since it was missing.

`code` should be inside `pre`
https://github.com/phpmyadmin/phpmyadmin/blob/0b9f15cf213cb7d4dbbafb3e148b01ac8eb93ce5/resources/js/modules/sql-highlight.ts#L458-L462

Related: https://github.com/phpmyadmin/phpmyadmin/pull/19700#issuecomment-3067262023

Before:

https://github.com/user-attachments/assets/02c18bdb-78b2-4f4d-ab8f-d71a81890d43

After:

https://github.com/user-attachments/assets/963228fb-5500-4cfe-97d1-19e5a94d25af

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
