### PR TITLE
Refactor the Util::formatNumber() method

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19141,12 +19141,6 @@ parameters:
 			path: tests/unit/UtilTest.php
 
 		-
-			message: '#^Casting to string something that''s already string\.$#'
-			identifier: cast.useless
-			count: 1
-			path: tests/unit/UtilTest.php
-
-		-
 			message: '#^Parameter \#2 \$array of static method PHPUnit\\Framework\\Assert\:\:assertArrayNotHasKey\(\) expects array\<mixed\>\|ArrayAccess\<\(int\|string\), mixed\>, mixed given\.$#'
 			identifier: argument.type
 			count: 2

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2884,7 +2884,13 @@ parameters:
 			path: src/Controllers/Server/Status/StatusController.php
 
 		-
-			message: '#^Parameter \#1 \$value of static method PhpMyAdmin\\Util\:\:formatNumber\(\) expects float\|int\|string, mixed given\.$#'
+			message: '#^Parameter \#1 \$value of static method PhpMyAdmin\\Util\:\:formatNumber\(\) expects float\|int\|numeric\-string, float\|int\|string given\.$#'
+			identifier: argument.type
+			count: 4
+			path: src/Controllers/Server/Status/StatusController.php
+
+		-
+			message: '#^Parameter \#1 \$value of static method PhpMyAdmin\\Util\:\:formatNumber\(\) expects float\|int\|numeric\-string, mixed given\.$#'
 			identifier: argument.type
 			count: 5
 			path: src/Controllers/Server/Status/StatusController.php
@@ -6058,7 +6064,7 @@ parameters:
 			path: src/Engines/Innodb.php
 
 		-
-			message: '#^Parameter \#1 \$value of static method PhpMyAdmin\\Util\:\:formatNumber\(\) expects float\|int\|string, mixed given\.$#'
+			message: '#^Parameter \#1 \$value of static method PhpMyAdmin\\Util\:\:formatNumber\(\) expects float\|int\|numeric\-string, mixed given\.$#'
 			identifier: argument.type
 			count: 11
 			path: src/Engines/Innodb.php
@@ -13888,7 +13894,7 @@ parameters:
 			path: src/StorageEngine.php
 
 		-
-			message: '#^Parameter \#1 \$value of static method PhpMyAdmin\\Util\:\:formatNumber\(\) expects float\|int\|string, mixed given\.$#'
+			message: '#^Parameter \#1 \$value of static method PhpMyAdmin\\Util\:\:formatNumber\(\) expects float\|int\|numeric\-string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/StorageEngine.php
@@ -15010,18 +15016,6 @@ parameters:
 			message: '#^Foreach overwrites \$quote with its value variable\.$#'
 			identifier: foreach.valueOverwrite
 			count: 1
-			path: src/Util.php
-
-		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 2
-			path: src/Util.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 3
 			path: src/Util.php
 
 		-
@@ -16888,7 +16882,7 @@ parameters:
 			path: tests/unit/Controllers/Server/Status/QueriesControllerTest.php
 
 		-
-			message: '#^Parameter \#1 \$value of static method PhpMyAdmin\\Util\:\:formatNumber\(\) expects float\|int\|string, mixed given\.$#'
+			message: '#^Parameter \#1 \$value of static method PhpMyAdmin\\Util\:\:formatNumber\(\) expects float\|int\|numeric\-string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: tests/unit/Controllers/Server/Status/QueriesControllerTest.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1925,6 +1925,12 @@
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Server/Status/StatusController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->data->status['Aborted_clients']]]></code>
+      <code><![CDATA[$this->data->status['Aborted_connects']]]></code>
+      <code><![CDATA[$this->data->status['Connections']]]></code>
+      <code><![CDATA[$this->data->status['Max_used_connections']]]></code>
+    </ArgumentTypeCoercion>
     <PossiblyInvalidOperand>
       <code><![CDATA[$this->data->status['Aborted_clients']]]></code>
       <code><![CDATA[$this->data->status['Aborted_clients']]]></code>
@@ -9256,6 +9262,10 @@
     </MixedArgument>
   </file>
   <file src="src/Util.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$value]]></code>
+      <code><![CDATA[$value]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
@@ -9275,9 +9285,6 @@
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
-    <InvalidArrayOffset>
-      <code><![CDATA[$units[$d]]]></code>
-    </InvalidArrayOffset>
     <MixedArgument>
       <code><![CDATA[$array]]></code>
     </MixedArgument>
@@ -9296,12 +9303,9 @@
     <MixedAssignment>
       <code><![CDATA[$array]]></code>
       <code><![CDATA[$columnNames[]]]></code>
-      <code><![CDATA[$unit]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
     <MixedOperand>
-      <code><![CDATA[$unit]]></code>
-      <code><![CDATA[$unit]]></code>
       <code><![CDATA[$value]]></code>
     </MixedOperand>
     <MixedReturnStatement>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11924,7 +11924,6 @@
       <code><![CDATA[mixed[]]]></code>
       <code><![CDATA[mixed[]]]></code>
       <code><![CDATA[mixed[]]]></code>
-      <code><![CDATA[mixed[]]]></code>
     </MixedReturnStatement>
     <PossiblyInvalidArgument>
       <code><![CDATA[testBackquote]]></code>

--- a/src/Util.php
+++ b/src/Util.php
@@ -389,19 +389,17 @@ class Util
             $value = (float) $value;
         }
 
+        /* l10n: Decimal separator */
+        $decimalSep = __('.');
+        /* l10n: Thousands separator */
+        $thousandsSep = __(',');
+
         $originalValue = $value;
         //number_format is not multibyte safe, str_replace is safe
         if ($digitsLeft === 0) {
-            $value = number_format(
-                (float) $value,
-                $digitsRight,
-                /* l10n: Decimal separator */
-                __('.'),
-                /* l10n: Thousands separator */
-                __(','),
-            );
+            $value = number_format((float) $value, $digitsRight, $decimalSep, $thousandsSep);
             if ($originalValue != 0 && (float) $value == 0) {
-                return ' <' . (1 / 10 ** $digitsRight);
+                return ' <' . number_format((1 / 10 ** $digitsRight), $digitsRight, $decimalSep, $thousandsSep);
             }
 
             return $value;
@@ -427,10 +425,6 @@ class Util
             7 => 'Z',
             8 => 'Y',
         ];
-        /* l10n: Decimal separator */
-        $decimalSep = __('.');
-        /* l10n: Thousands separator */
-        $thousandsSep = __(',');
 
         // check for negative value to retain sign
         if ($value < 0) {

--- a/tests/unit/Engines/InnodbTest.php
+++ b/tests/unit/Engines/InnodbTest.php
@@ -194,7 +194,7 @@ class InnodbTest extends AbstractTestCase
             '        </tr>' . "\n" .
             '        <tr>' . "\n" .
             '            <th scope="row">Read misses in %</th>' . "\n" .
-            '            <td class="font-monospace text-end">50   %' . "\n" .
+            '            <td class="font-monospace text-end">50 %' . "\n" .
             '</td>' . "\n" .
             '        </tr>' . "\n" .
             '        <tr>' . "\n" .

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -538,7 +538,7 @@ class UtilTest extends AbstractTestCase
         ];
     }
 
-    /** @psalm-param list{0: float|int|string, 1?: int, 2?: int, 3?: bool, 4?: bool} $arguments */
+    /** @psalm-param list{0: float|int|numeric-string, 1?: int, 2?: int, 3?: bool, 4?: bool} $arguments */
     #[DataProvider('providerFormatNumber')]
     public function testFormatNumber(string $expected, array $arguments): void
     {
@@ -594,16 +594,16 @@ class UtilTest extends AbstractTestCase
         }
     }
 
-    /** @psalm-return array<array{string, list{0: float|int|string, 1?: int, 2?: int, 3?: bool, 4?: bool}}> */
+    /** @psalm-return array<array{string, list{0: float|int|numeric-string, 1?: int, 2?: int, 3?: bool, 4?: bool}}> */
     public static function providerFormatNumber(): array
     {
         return [
-            ['10  ', [10, 2, 2]],
-            ['100  ', [100, 2, 0]],
-            ['100  ', [100, 2, 2]],
-            ['100  ', ['100', 2, 2]],
-            ['-1,000.45  ', [-1000.454, 4, 2]],
-            ['-1,000.45  ', ['-1000.454', 4, 2]],
+            ['10', [10, 2, 2]],
+            ['100', [100, 2, 0]],
+            ['100', [100, 2, 2]],
+            ['100', ['100', 2, 2]],
+            ['-1,000.45', [-1000.454, 4, 2]],
+            ['-1,000.45', ['-1000.454', 4, 2]],
             ['30 µ', [0.00003, 3, 2]],
             ['3 m', [0.003, 3, 3]],
             ['-3,000 µ', [-0.003, 6, 0]],
@@ -619,7 +619,7 @@ class UtilTest extends AbstractTestCase
             ['0', [0.0]],
             ['0', ['0']],
             ['0', ['0.0']],
-            [' <0.001', [0.000001, 0, 3]],
+            ['<0.001', [0.000001, 0, 3]],
             ['5 m', [0.005]],
             ['5 µ', [0.000005]],
             ['5 n', [0.000000005]],
@@ -628,6 +628,9 @@ class UtilTest extends AbstractTestCase
             ['5 a', [0.000000000000000005]],
             ['5 z', [0.000000000000000000005]],
             ['5 y', [0.000000000000000000000005]],
+            ['5 r', [0.000000000000000000000000005]],
+            ['5 q', [0.000000000000000000000000000005]],
+            ['<1 q', [0.000000000000000000000000000000005]],
             ['5 k', [5000]],
             ['5 M', [5000000]],
             ['5 G', [5000000000]],
@@ -636,8 +639,11 @@ class UtilTest extends AbstractTestCase
             ['5 E', [5000000000000000000]],
             ['5 Z', [5000000000000000000000]],
             ['5 Y', [5000000000000000000000000]],
+            ['5 R', [5000000000000000000000000000]],
+            ['5 Q', [5000000000000000000000000000000]],
+            ['5,000 Q', [5000000000000000000000000000000000]],
             ['100 m', [0.1, 3, 0]],
-            [' <1  ', [0.1, 3, 0, true]],
+            ['<1', [0.1, 3, 0, true]],
             ['1.000 k', [1000, 3, 3, false, false]],
         ];
     }

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -538,52 +538,25 @@ class UtilTest extends AbstractTestCase
         ];
     }
 
-    /**
-     * Core test for formatNumber
-     *
-     * @param float|int|string $a Value to format
-     * @param int              $b Sensitiveness
-     * @param int              $c Number of decimals to retain
-     * @param string           $d Expected value
-     */
-    private function assertFormatNumber(float|int|string $a, int $b, int $c, string $d): void
-    {
-        self::assertSame(
-            $d,
-            Util::formatNumber(
-                $a,
-                $b,
-                $c,
-            ),
-        );
-    }
-
-    /**
-     * format number test, globals are defined
-     *
-     * @param float|int|string $a Value to format
-     * @param int              $b Sensitiveness
-     * @param int              $c Number of decimals to retain
-     * @param string           $d Expected value
-     */
+    /** @psalm-param list{0: float|int|string, 1?: int, 2?: int, 3?: bool, 4?: bool} $arguments */
     #[DataProvider('providerFormatNumber')]
-    public function testFormatNumber(float|int|string $a, int $b, int $c, string $d): void
+    public function testFormatNumber(string $expected, array $arguments): void
     {
-        $this->assertFormatNumber($a, $b, $c, $d);
+        self::assertSame($expected, Util::formatNumber(...$arguments));
 
         // Test with various precisions
         $oldPrecision = ini_get('precision');
         try {
             ini_set('precision', '20');
-            $this->assertFormatNumber($a, $b, $c, $d);
+            self::assertSame($expected, Util::formatNumber(...$arguments));
             ini_set('precision', '14');
-            $this->assertFormatNumber($a, $b, $c, $d);
+            self::assertSame($expected, Util::formatNumber(...$arguments));
             ini_set('precision', '10');
-            $this->assertFormatNumber($a, $b, $c, $d);
+            self::assertSame($expected, Util::formatNumber(...$arguments));
             ini_set('precision', '5');
-            $this->assertFormatNumber($a, $b, $c, $d);
+            self::assertSame($expected, Util::formatNumber(...$arguments));
             ini_set('precision', '-1');
-            $this->assertFormatNumber($a, $b, $c, $d);
+            self::assertSame($expected, Util::formatNumber(...$arguments));
         } finally {
             ini_set('precision', $oldPrecision);
         }
@@ -592,17 +565,28 @@ class UtilTest extends AbstractTestCase
         $translator = Loader::getInstance()->getTranslator();
 
         try {
+            $translator->setTranslation('.', '/');
+            self::assertSame(
+                str_replace('.', '/', $expected),
+                Util::formatNumber(...$arguments),
+                'Decimal separator should be escaped for regex.',
+            );
+
             // German
             $translator->setTranslation(',', '.');
             $translator->setTranslation('.', ',');
-            $expected = str_replace([',', 'X'], ['.', ','], str_replace('.', 'X', $d));
-            $this->assertFormatNumber($a, $b, $c, $expected);
+            self::assertSame(
+                str_replace([',', 'X'], ['.', ','], str_replace('.', 'X', $expected)),
+                Util::formatNumber(...$arguments),
+            );
 
             // Czech
             $translator->setTranslation(',', ' ');
             $translator->setTranslation('.', ',');
-            $expected = str_replace([',', 'X'], [' ', ','], str_replace('.', 'X', $d));
-            $this->assertFormatNumber($a, $b, $c, $expected);
+            self::assertSame(
+                str_replace([',', 'X'], [' ', ','], str_replace('.', 'X', $expected)),
+                Util::formatNumber(...$arguments),
+            );
         } finally {
             // Restore
             $translator->setTranslation(',', ',');
@@ -610,49 +594,51 @@ class UtilTest extends AbstractTestCase
         }
     }
 
-    /**
-     * format number data provider
-     *
-     * @return mixed[]
-     */
+    /** @psalm-return array<array{string, list{0: float|int|string, 1?: int, 2?: int, 3?: bool, 4?: bool}}> */
     public static function providerFormatNumber(): array
     {
         return [
-            [10, 2, 2, '10  '],
-            [100, 2, 0, '100  '],
-            [100, 2, 2, '100  '],
-            ['100', 2, 2, '100  '],
-            [-1000.454, 4, 2, '-1,000.45  '],
-            ['-1000.454', 4, 2, '-1,000.45  '],
-            [0.00003, 3, 2, '30 µ'],
-            [0.003, 3, 3, '3 m'],
-            [-0.003, 6, 0, '-3,000 µ'],
-            [100.98, 0, 2, '100.98'],
-            [21010101, 0, 2, '21,010,101.00'],
-            [1100000000, 5, 0, '1,100 M'],
-            ['1100000000', 5, 0, '1,100 M'],
-            [20000, 2, 2, '20 k'],
-            [20011, 2, 2, '20.01 k'],
-            [123456789, 6, 0, '123,457 k'],
-            [-123456789, 4, 2, '-123.46 M'],
-            [0, 6, 0, '0'],
-            [0.000001, 0, 3, ' <0.001'],
-            [0.005, 3, 0, '5 m'],
-            [0.000005, 3, 0, '5 µ'],
-            [0.000000005, 3, 0, '5 n'],
-            [0.000000000005, 3, 0, '5 p'],
-            [0.000000000000005, 3, 0, '5 f'],
-            [0.000000000000000005, 3, 0, '5 a'],
-            [0.000000000000000000005, 3, 0, '5 z'],
-            [0.000000000000000000000005, 3, 0, '5 y'],
-            [5000, 3, 0, '5 k'],
-            [5000000, 3, 0, '5 M'],
-            [5000000000, 3, 0, '5 G'],
-            [5000000000000, 3, 0, '5 T'],
-            [5000000000000000, 3, 0, '5 P'],
-            [5000000000000000000, 3, 0, '5 E'],
-            [5000000000000000000000, 3, 0, '5 Z'],
-            [5000000000000000000000000, 3, 0, '5 Y'],
+            ['10  ', [10, 2, 2]],
+            ['100  ', [100, 2, 0]],
+            ['100  ', [100, 2, 2]],
+            ['100  ', ['100', 2, 2]],
+            ['-1,000.45  ', [-1000.454, 4, 2]],
+            ['-1,000.45  ', ['-1000.454', 4, 2]],
+            ['30 µ', [0.00003, 3, 2]],
+            ['3 m', [0.003, 3, 3]],
+            ['-3,000 µ', [-0.003, 6, 0]],
+            ['100.98', [100.98, 0, 2]],
+            ['21,010,101.00', [21010101, 0, 2]],
+            ['1,100 M', [1100000000, 5, 0]],
+            ['1,100 M', ['1100000000', 5, 0]],
+            ['20 k', [20000, 2, 2]],
+            ['20.01 k', [20011, 2, 2]],
+            ['123,457 k', [123456789, 6, 0]],
+            ['-123.46 M', [-123456789, 4, 2]],
+            ['0', [0]],
+            ['0', [0.0]],
+            ['0', ['0']],
+            ['0', ['0.0']],
+            [' <0.001', [0.000001, 0, 3]],
+            ['5 m', [0.005]],
+            ['5 µ', [0.000005]],
+            ['5 n', [0.000000005]],
+            ['5 p', [0.000000000005]],
+            ['5 f', [0.000000000000005]],
+            ['5 a', [0.000000000000000005]],
+            ['5 z', [0.000000000000000000005]],
+            ['5 y', [0.000000000000000000000005]],
+            ['5 k', [5000]],
+            ['5 M', [5000000]],
+            ['5 G', [5000000000]],
+            ['5 T', [5000000000000]],
+            ['5 P', [5000000000000000]],
+            ['5 E', [5000000000000000000]],
+            ['5 Z', [5000000000000000000000]],
+            ['5 Y', [5000000000000000000000000]],
+            ['100 m', [0.1, 3, 0]],
+            [' <1  ', [0.1, 3, 0, true]],
+            ['1.000 k', [1000, 3, 3, false, false]],
         ];
     }
 

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -554,7 +554,6 @@ class UtilTest extends AbstractTestCase
                 $a,
                 $b,
                 $c,
-                false,
             ),
         );
     }
@@ -573,7 +572,7 @@ class UtilTest extends AbstractTestCase
         $this->assertFormatNumber($a, $b, $c, $d);
 
         // Test with various precisions
-        $oldPrecision = (string) ini_get('precision');
+        $oldPrecision = ini_get('precision');
         try {
             ini_set('precision', '20');
             $this->assertFormatNumber($a, $b, $c, $d);
@@ -637,6 +636,23 @@ class UtilTest extends AbstractTestCase
             [123456789, 6, 0, '123,457 k'],
             [-123456789, 4, 2, '-123.46 M'],
             [0, 6, 0, '0'],
+            [0.000001, 0, 3, ' <0.001'],
+            [0.005, 3, 0, '5 m'],
+            [0.000005, 3, 0, '5 µ'],
+            [0.000000005, 3, 0, '5 n'],
+            [0.000000000005, 3, 0, '5 p'],
+            [0.000000000000005, 3, 0, '5 f'],
+            [0.000000000000000005, 3, 0, '5 a'],
+            [0.000000000000000000005, 3, 0, '5 z'],
+            [0.000000000000000000000005, 3, 0, '5 y'],
+            [5000, 3, 0, '5 k'],
+            [5000000, 3, 0, '5 M'],
+            [5000000000, 3, 0, '5 G'],
+            [5000000000000, 3, 0, '5 T'],
+            [5000000000000000, 3, 0, '5 P'],
+            [5000000000000000000, 3, 0, '5 E'],
+            [5000000000000000000000, 3, 0, '5 Z'],
+            [5000000000000000000000000, 3, 0, '5 Y'],
         ];
     }
 


### PR DESCRIPTION
Remove loose comparisons, trim white-space and add more unit prefixes.
