### PR TITLE
Reduce gis svg size

### DIFF
--- a/resources/js/table/gis_visualization.ts
+++ b/resources/js/table/gis_visualization.ts
@@ -396,8 +396,8 @@ class SvgVisualization extends GisVisualization {
         $('#tooltip').remove();
 
         const target = event.target as SVGElement;
-        const contents = target.getAttribute('data-label').trim();
-        if (contents === '') {
+        const contents = target.getAttribute('data-label');
+        if (!contents) {
             return;
         }
 

--- a/src/Gis/GisGeometry.php
+++ b/src/Gis/GisGeometry.php
@@ -13,13 +13,10 @@ use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
 use function array_map;
-use function defined;
 use function explode;
 use function mb_strripos;
 use function mb_substr;
-use function mt_getrandmax;
 use function preg_match;
-use function random_int;
 use function str_replace;
 use function trim;
 
@@ -322,10 +319,5 @@ abstract class GisGeometry
         $parts = explode(')),((', $wktCoords);
 
         return array_map(fn (string $coord): array => $this->extractPoints2d($coord, $scaleData), $parts);
-    }
-
-    protected function getRandomId(): int
-    {
-        return ! defined('TESTSUITE') ? random_int(0, mt_getrandmax()) : 1234567890;
     }
 }

--- a/src/Gis/GisLineString.php
+++ b/src/Gis/GisLineString.php
@@ -168,7 +168,6 @@ class GisLineString extends GisGeometry
     {
         $lineOptions = [
             'data-label' => $label,
-            'id' => $label . $this->getRandomId(),
             'class' => 'linestring vector',
             'fill' => 'none',
             'stroke' => sprintf('#%02x%02x%02x', $color[0], $color[1], $color[2]),

--- a/src/Gis/GisLineString.php
+++ b/src/Gis/GisLineString.php
@@ -166,13 +166,15 @@ class GisLineString extends GisGeometry
      */
     public function prepareRowAsSvg(string $spatial, string $label, array $color, ScaleData $scaleData): string
     {
-        $lineOptions = [
-            'data-label' => $label,
+        $options = [
             'class' => 'linestring vector',
             'fill' => 'none',
             'stroke' => sprintf('#%02x%02x%02x', $color[0], $color[1], $color[2]),
             'stroke-width' => 2,
         ];
+        if ($label !== '') {
+            $options['data-label'] = $label;
+        }
 
         // Trim to remove leading 'LINESTRING(' and trailing ')'
         $linestring = mb_substr($spatial, 11, -1);
@@ -184,7 +186,7 @@ class GisLineString extends GisGeometry
         }
 
         $row .= '"';
-        foreach ($lineOptions as $option => $val) {
+        foreach ($options as $option => $val) {
             $row .= ' ' . $option . '="' . $val . '"';
         }
 

--- a/src/Gis/GisMultiLineString.php
+++ b/src/Gis/GisMultiLineString.php
@@ -187,13 +187,15 @@ class GisMultiLineString extends GisGeometry
      */
     public function prepareRowAsSvg(string $spatial, string $label, array $color, ScaleData $scaleData): string
     {
-        $lineOptions = [
-            'data-label' => $label,
+        $options = [
             'class' => 'linestring vector',
             'fill' => 'none',
             'stroke' => sprintf('#%02x%02x%02x', $color[0], $color[1], $color[2]),
             'stroke-width' => 2,
         ];
+        if ($label !== '') {
+            $options['data-label'] = $label;
+        }
 
         // Trim to remove leading 'MULTILINESTRING((' and trailing '))'
         $multilineString = mb_substr($spatial, 17, -2);
@@ -210,7 +212,7 @@ class GisMultiLineString extends GisGeometry
             }
 
             $row .= '"';
-            foreach ($lineOptions as $option => $val) {
+            foreach ($options as $option => $val) {
                 $row .= ' ' . $option . '="' . $val . '"';
             }
 

--- a/src/Gis/GisMultiLineString.php
+++ b/src/Gis/GisMultiLineString.php
@@ -210,7 +210,6 @@ class GisMultiLineString extends GisGeometry
             }
 
             $row .= '"';
-            $lineOptions['id'] = $label . $this->getRandomId();
             foreach ($lineOptions as $option => $val) {
                 $row .= ' ' . $option . '="' . $val . '"';
             }

--- a/src/Gis/GisMultiPoint.php
+++ b/src/Gis/GisMultiPoint.php
@@ -160,13 +160,15 @@ class GisMultiPoint extends GisGeometry
      */
     public function prepareRowAsSvg(string $spatial, string $label, array $color, ScaleData $scaleData): string
     {
-        $pointOptions = [
-            'data-label' => $label,
+        $options = [
             'class' => 'multipoint vector',
             'fill' => 'white',
             'stroke' => sprintf('#%02x%02x%02x', $color[0], $color[1], $color[2]),
             'stroke-width' => 2,
         ];
+        if ($label !== '') {
+            $options['data-label'] = $label;
+        }
 
         // Trim to remove leading 'MULTIPOINT(' and trailing ')'
         $multipoint = mb_substr($spatial, 11, -1);
@@ -179,7 +181,7 @@ class GisMultiPoint extends GisGeometry
             }
 
             $row .= '<circle cx="' . $point[0] . '" cy="' . $point[1] . '" r="3"';
-            foreach ($pointOptions as $option => $val) {
+            foreach ($options as $option => $val) {
                 $row .= ' ' . $option . '="' . $val . '"';
             }
 

--- a/src/Gis/GisMultiPoint.php
+++ b/src/Gis/GisMultiPoint.php
@@ -178,9 +178,7 @@ class GisMultiPoint extends GisGeometry
                 continue;
             }
 
-            $row .= '<circle cx="' . $point[0] . '" cy="'
-                . $point[1] . '" r="3"';
-            $pointOptions['id'] = $label . $this->getRandomId();
+            $row .= '<circle cx="' . $point[0] . '" cy="' . $point[1] . '" r="3"';
             foreach ($pointOptions as $option => $val) {
                 $row .= ' ' . $option . '="' . $val . '"';
             }

--- a/src/Gis/GisMultiPolygon.php
+++ b/src/Gis/GisMultiPolygon.php
@@ -218,7 +218,6 @@ class GisMultiPolygon extends GisGeometry
                 $row .= $this->drawPath($wktRing, $scaleData);
             }
 
-            $polygonOptions['id'] = $label . $this->getRandomId();
             $row .= '"';
             foreach ($polygonOptions as $option => $val) {
                 $row .= ' ' . $option . '="' . $val . '"';

--- a/src/Gis/GisMultiPolygon.php
+++ b/src/Gis/GisMultiPolygon.php
@@ -193,8 +193,7 @@ class GisMultiPolygon extends GisGeometry
      */
     public function prepareRowAsSvg(string $spatial, string $label, array $color, ScaleData $scaleData): string
     {
-        $polygonOptions = [
-            'data-label' => $label,
+        $options = [
             'class' => 'multipolygon vector',
             'stroke' => 'black',
             'stroke-width' => 0.5,
@@ -202,6 +201,9 @@ class GisMultiPolygon extends GisGeometry
             'fill-rule' => 'evenodd',
             'fill-opacity' => 0.8,
         ];
+        if ($label !== '') {
+            $options['data-label'] = $label;
+        }
 
         $row = '';
 
@@ -219,7 +221,7 @@ class GisMultiPolygon extends GisGeometry
             }
 
             $row .= '"';
-            foreach ($polygonOptions as $option => $val) {
+            foreach ($options as $option => $val) {
                 $row .= ' ' . $option . '="' . $val . '"';
             }
 

--- a/src/Gis/GisMultiPolygon.php
+++ b/src/Gis/GisMultiPolygon.php
@@ -272,13 +272,13 @@ class GisMultiPolygon extends GisGeometry
     {
         $pointsArr = $this->extractPoints1d($polygon, $scaleData);
 
-        $row = ' M ' . $pointsArr[0][0] . ', ' . $pointsArr[0][1];
+        $row = 'M' . $pointsArr[0][0] . ',' . $pointsArr[0][1];
         $otherPoints = array_slice($pointsArr, 1, count($pointsArr) - 2);
         foreach ($otherPoints as $point) {
-            $row .= ' L ' . $point[0] . ', ' . $point[1];
+            $row .= 'L' . $point[0] . ',' . $point[1];
         }
 
-        $row .= ' Z ';
+        $row .= 'Z';
 
         return $row;
     }

--- a/src/Gis/GisPoint.php
+++ b/src/Gis/GisPoint.php
@@ -159,13 +159,15 @@ class GisPoint extends GisGeometry
      */
     public function prepareRowAsSvg(string $spatial, string $label, array $color, ScaleData $scaleData): string
     {
-        $pointOptions = [
-            'data-label' => $label,
+        $options = [
             'class' => 'point vector',
             'fill' => 'white',
             'stroke' => sprintf('#%02x%02x%02x', $color[0], $color[1], $color[2]),
             'stroke-width' => 2,
         ];
+        if ($label !== '') {
+            $options['data-label'] = $label;
+        }
 
         // Trim to remove leading 'POINT(' and trailing ')'
         $point = mb_substr($spatial, 6, -1);
@@ -174,7 +176,7 @@ class GisPoint extends GisGeometry
         $row = '';
         if ($pointsArr[0] !== 0.0 && $pointsArr[1] !== 0.0) {
             $row .= '<circle cx="' . $pointsArr[0] . '" cy="' . $pointsArr[1] . '" r="3"';
-            foreach ($pointOptions as $option => $val) {
+            foreach ($options as $option => $val) {
                 $row .= ' ' . $option . '="' . $val . '"';
             }
 

--- a/src/Gis/GisPoint.php
+++ b/src/Gis/GisPoint.php
@@ -161,7 +161,6 @@ class GisPoint extends GisGeometry
     {
         $pointOptions = [
             'data-label' => $label,
-            'id' => $label . $this->getRandomId(),
             'class' => 'point vector',
             'fill' => 'white',
             'stroke' => sprintf('#%02x%02x%02x', $color[0], $color[1], $color[2]),
@@ -174,8 +173,7 @@ class GisPoint extends GisGeometry
 
         $row = '';
         if ($pointsArr[0] !== 0.0 && $pointsArr[1] !== 0.0) {
-            $row .= '<circle cx="' . $pointsArr[0]
-                . '" cy="' . $pointsArr[1] . '" r="3"';
+            $row .= '<circle cx="' . $pointsArr[0] . '" cy="' . $pointsArr[1] . '" r="3"';
             foreach ($pointOptions as $option => $val) {
                 $row .= ' ' . $option . '="' . $val . '"';
             }

--- a/src/Gis/GisPolygon.php
+++ b/src/Gis/GisPolygon.php
@@ -162,8 +162,7 @@ class GisPolygon extends GisGeometry
      */
     public function prepareRowAsSvg(string $spatial, string $label, array $color, ScaleData $scaleData): string
     {
-        $polygonOptions = [
-            'data-label' => $label,
+        $options = [
             'class' => 'polygon vector',
             'stroke' => 'black',
             'stroke-width' => 0.5,
@@ -171,6 +170,9 @@ class GisPolygon extends GisGeometry
             'fill-rule' => 'evenodd',
             'fill-opacity' => 0.8,
         ];
+        if ($label !== '') {
+            $options['data-label'] = $label;
+        }
 
         // Trim to remove leading 'POLYGON((' and trailing '))'
         $polygon = mb_substr($spatial, 9, -2);
@@ -183,7 +185,7 @@ class GisPolygon extends GisGeometry
         }
 
         $row .= '"';
-        foreach ($polygonOptions as $option => $val) {
+        foreach ($options as $option => $val) {
             $row .= ' ' . $option . '="' . $val . '"';
         }
 

--- a/src/Gis/GisPolygon.php
+++ b/src/Gis/GisPolygon.php
@@ -164,7 +164,6 @@ class GisPolygon extends GisGeometry
     {
         $polygonOptions = [
             'data-label' => $label,
-            'id' => $label . $this->getRandomId(),
             'class' => 'polygon vector',
             'stroke' => 'black',
             'stroke-width' => 0.5,

--- a/src/Gis/GisPolygon.php
+++ b/src/Gis/GisPolygon.php
@@ -235,13 +235,13 @@ class GisPolygon extends GisGeometry
     {
         $pointsArr = $this->extractPoints1d($polygon, $scaleData);
 
-        $row = ' M ' . $pointsArr[0][0] . ', ' . $pointsArr[0][1];
+        $row = 'M' . $pointsArr[0][0] . ',' . $pointsArr[0][1];
         $otherPoints = array_slice($pointsArr, 1, count($pointsArr) - 2);
         foreach ($otherPoints as $point) {
-            $row .= ' L ' . $point[0] . ', ' . $point[1];
+            $row .= 'L' . $point[0] . ',' . $point[1];
         }
 
-        $row .= ' Z ';
+        $row .= 'Z';
 
         return $row;
     }

--- a/tests/unit/Controllers/Table/GisVisualizationControllerTest.php
+++ b/tests/unit/Controllers/Table/GisVisualizationControllerTest.php
@@ -95,7 +95,7 @@ class GisVisualizationControllerTest extends AbstractTestCase
             ],
             'visualization' => '<?xml version="1.0" encoding="UTF-8" standalone="no"?>' . "\n"
                 . '<svg version="1.1" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg"'
-                . ' width="600" height="450"><g><circle cx="300" cy="225" r="3" data-label=""'
+                . ' width="600" height="450"><g><circle cx="300" cy="225" r="3"'
                 . ' class="point vector" fill="white" stroke="#b02ee0" stroke-width="2"/></g></svg>',
             'open_layers_data' => [
                 [

--- a/tests/unit/Controllers/Table/GisVisualizationControllerTest.php
+++ b/tests/unit/Controllers/Table/GisVisualizationControllerTest.php
@@ -96,7 +96,7 @@ class GisVisualizationControllerTest extends AbstractTestCase
             'visualization' => '<?xml version="1.0" encoding="UTF-8" standalone="no"?>' . "\n"
                 . '<svg version="1.1" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg"'
                 . ' width="600" height="450"><g><circle cx="300" cy="225" r="3" data-label=""'
-                . ' id="1234567890" class="point vector" fill="white" stroke="#b02ee0" stroke-width="2"/></g></svg>',
+                . ' class="point vector" fill="white" stroke="#b02ee0" stroke-width="2"/></g></svg>',
             'open_layers_data' => [
                 [
                     'geometry' => ['type' => 'Point', 'coordinates' => [100.0, 250.0], 'srid' => 0],

--- a/tests/unit/Gis/GisGeometryCollectionTest.php
+++ b/tests/unit/Gis/GisGeometryCollectionTest.php
@@ -380,8 +380,8 @@ class GisGeometryCollectionTest extends GisGeomTestCase
                 [176, 46, 224],
                 new ScaleData(offsetX: 12, offsetY: 69, scale: 2, height: 150),
                 '<path d=" M 46, 268 L -4, 248 L 6, 208 L 66, 198 Z  M 16,'
-                . ' 228 L 46, 224 L 36, 248 Z " data-label="svg" id="svg1234567890'
-                . '" class="polygon vector" stroke="black" stroke-width="0.5"'
+                . ' 228 L 46, 224 L 36, 248 Z " data-label="svg"'
+                . ' class="polygon vector" stroke="black" stroke-width="0.5"'
                 . ' fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8"/>',
             ],
         ];

--- a/tests/unit/Gis/GisGeometryCollectionTest.php
+++ b/tests/unit/Gis/GisGeometryCollectionTest.php
@@ -379,8 +379,7 @@ class GisGeometryCollectionTest extends GisGeomTestCase
                 'svg',
                 [176, 46, 224],
                 new ScaleData(offsetX: 12, offsetY: 69, scale: 2, height: 150),
-                '<path d=" M 46, 268 L -4, 248 L 6, 208 L 66, 198 Z  M 16,'
-                . ' 228 L 46, 224 L 36, 248 Z " data-label="svg"'
+                '<path d="M46,268L-4,248L6,208L66,198ZM16,228L46,224L36,248Z" data-label="svg"'
                 . ' class="polygon vector" stroke="black" stroke-width="0.5"'
                 . ' fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8"/>',
             ],

--- a/tests/unit/Gis/GisGeometryCollectionTest.php
+++ b/tests/unit/Gis/GisGeometryCollectionTest.php
@@ -379,9 +379,9 @@ class GisGeometryCollectionTest extends GisGeomTestCase
                 'svg',
                 [176, 46, 224],
                 new ScaleData(offsetX: 12, offsetY: 69, scale: 2, height: 150),
-                '<path d="M46,268L-4,248L6,208L66,198ZM16,228L46,224L36,248Z" data-label="svg"'
+                '<path d="M46,268L-4,248L6,208L66,198ZM16,228L46,224L36,248Z"'
                 . ' class="polygon vector" stroke="black" stroke-width="0.5"'
-                . ' fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8"/>',
+                . ' fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8" data-label="svg"/>',
             ],
         ];
     }

--- a/tests/unit/Gis/GisLineStringTest.php
+++ b/tests/unit/Gis/GisLineStringTest.php
@@ -251,7 +251,7 @@ class GisLineStringTest extends GisGeomTestCase
                 [176, 46, 224],
                 new ScaleData(offsetX: 12, offsetY: 69, scale: 2, height: 150),
                 '<polyline points="0,218 72,138 114,242 26,198 4,182 46,132 " '
-                . 'data-label="svg" id="svg1234567890" class="linestring vector" fill="none" '
+                . 'data-label="svg" class="linestring vector" fill="none" '
                 . 'stroke="#b02ee0" stroke-width="2"/>',
             ],
         ];

--- a/tests/unit/Gis/GisLineStringTest.php
+++ b/tests/unit/Gis/GisLineStringTest.php
@@ -251,8 +251,8 @@ class GisLineStringTest extends GisGeomTestCase
                 [176, 46, 224],
                 new ScaleData(offsetX: 12, offsetY: 69, scale: 2, height: 150),
                 '<polyline points="0,218 72,138 114,242 26,198 4,182 46,132 " '
-                . 'data-label="svg" class="linestring vector" fill="none" '
-                . 'stroke="#b02ee0" stroke-width="2"/>',
+                . 'class="linestring vector" fill="none" '
+                . 'stroke="#b02ee0" stroke-width="2" data-label="svg"/>',
             ],
         ];
     }

--- a/tests/unit/Gis/GisMultiLineStringTest.php
+++ b/tests/unit/Gis/GisMultiLineStringTest.php
@@ -258,11 +258,11 @@ class GisMultiLineStringTest extends GisGeomTestCase
                 'svg',
                 [176, 46, 224],
                 new ScaleData(offsetX: 12, offsetY: 69, scale: 2, height: 150),
-                '<polyline points="48,260 70,242 100,138 " data-label="svg" '
+                '<polyline points="48,260 70,242 100,138 " '
                 . 'class="linestring vector" fill="none" stroke="#b02ee0" '
-                . 'stroke-width="2"/><polyline points="48,268 10,'
-                . '242 332,182 " data-label="svg" class="linestring vector" fill="none" '
-                . 'stroke="#b02ee0" stroke-width="2"/>',
+                . 'stroke-width="2" data-label="svg"/><polyline points="48,268 10,'
+                . '242 332,182 " class="linestring vector" fill="none" '
+                . 'stroke="#b02ee0" stroke-width="2" data-label="svg"/>',
             ],
         ];
     }

--- a/tests/unit/Gis/GisMultiLineStringTest.php
+++ b/tests/unit/Gis/GisMultiLineStringTest.php
@@ -260,9 +260,9 @@ class GisMultiLineStringTest extends GisGeomTestCase
                 new ScaleData(offsetX: 12, offsetY: 69, scale: 2, height: 150),
                 '<polyline points="48,260 70,242 100,138 " data-label="svg" '
                 . 'class="linestring vector" fill="none" stroke="#b02ee0" '
-                . 'stroke-width="2" id="svg1234567890"/><polyline points="48,268 10,'
+                . 'stroke-width="2"/><polyline points="48,268 10,'
                 . '242 332,182 " data-label="svg" class="linestring vector" fill="none" '
-                . 'stroke="#b02ee0" stroke-width="2" id="svg1234567890"/>',
+                . 'stroke="#b02ee0" stroke-width="2"/>',
             ],
         ];
     }

--- a/tests/unit/Gis/GisMultiPointTest.php
+++ b/tests/unit/Gis/GisMultiPointTest.php
@@ -237,17 +237,16 @@ class GisMultiPointTest extends GisGeomTestCase
                 'svg',
                 [176, 46, 224],
                 new ScaleData(offsetX: 12, offsetY: 69, scale: 2, height: 150),
-                '<circle cx="72" cy="138" r="3" data-label="svg" class="multipoint '
-                . 'vector" fill="white" stroke="#b02ee0" stroke-width="2"'
-                . '/><circle cx="114" cy="242" r="3" data-label="svg" class="mult'
-                . 'ipoint vector" fill="white" stroke="#b02ee0" stroke-width="2"'
-                . '/><circle cx="26" cy="198" r="3" data-label="svg" class='
+                '<circle cx="72" cy="138" r="3" class="multipoint '
+                . 'vector" fill="white" stroke="#b02ee0" stroke-width="2" data-label="svg"'
+                . '/><circle cx="114" cy="242" r="3" class="mult'
+                . 'ipoint vector" fill="white" stroke="#b02ee0" stroke-width="2" data-label="svg"'
+                . '/><circle cx="26" cy="198" r="3" class='
                 . '"multipoint vector" fill="white" stroke="#b02ee0" stroke-width='
-                . '"2"/><circle cx="4" cy="182" r="3" data-label="svg" '
+                . '"2" data-label="svg"/><circle cx="4" cy="182" r="3" '
                 . 'class="multipoint vector" fill="white" stroke="#b02ee0" stroke-'
-                . 'width="2"/><circle cx="46" cy="132" r="3" data-label='
-                . '"svg" class="multipoint vector" fill="white" stroke="#b02ee0" '
-                . 'stroke-width="2"/>',
+                . 'width="2" data-label="svg"/><circle cx="46" cy="132" r="3" class="multipoint vector"'
+                . ' fill="white" stroke="#b02ee0" stroke-width="2" data-label="svg"/>',
             ],
         ];
     }

--- a/tests/unit/Gis/GisMultiPointTest.php
+++ b/tests/unit/Gis/GisMultiPointTest.php
@@ -238,16 +238,16 @@ class GisMultiPointTest extends GisGeomTestCase
                 [176, 46, 224],
                 new ScaleData(offsetX: 12, offsetY: 69, scale: 2, height: 150),
                 '<circle cx="72" cy="138" r="3" data-label="svg" class="multipoint '
-                . 'vector" fill="white" stroke="#b02ee0" stroke-width="2" id="'
-                . 'svg1234567890"/><circle cx="114" cy="242" r="3" data-label="svg" class="mult'
-                . 'ipoint vector" fill="white" stroke="#b02ee0" stroke-width="2" id'
-                . '="svg1234567890"/><circle cx="26" cy="198" r="3" data-label="svg" class='
+                . 'vector" fill="white" stroke="#b02ee0" stroke-width="2"'
+                . '/><circle cx="114" cy="242" r="3" data-label="svg" class="mult'
+                . 'ipoint vector" fill="white" stroke="#b02ee0" stroke-width="2"'
+                . '/><circle cx="26" cy="198" r="3" data-label="svg" class='
                 . '"multipoint vector" fill="white" stroke="#b02ee0" stroke-width='
-                . '"2" id="svg1234567890"/><circle cx="4" cy="182" r="3" data-label="svg" '
+                . '"2"/><circle cx="4" cy="182" r="3" data-label="svg" '
                 . 'class="multipoint vector" fill="white" stroke="#b02ee0" stroke-'
-                . 'width="2" id="svg1234567890"/><circle cx="46" cy="132" r="3" data-label='
+                . 'width="2"/><circle cx="46" cy="132" r="3" data-label='
                 . '"svg" class="multipoint vector" fill="white" stroke="#b02ee0" '
-                . 'stroke-width="2" id="svg1234567890"/>',
+                . 'stroke-width="2"/>',
             ],
         ];
     }

--- a/tests/unit/Gis/GisMultiPolygonTest.php
+++ b/tests/unit/Gis/GisMultiPolygonTest.php
@@ -349,12 +349,12 @@ class GisMultiPolygonTest extends GisGeomTestCase
                 [176, 46, 224],
                 new ScaleData(offsetX: -50, offsetY: -50, scale: 2, height: 400),
                 '<path d="M110,290L290,290L290,110L110,110ZM120,280L120,220L180,220L180,280ZM220,180L280,180L280,120'
-                . 'L220,120Z" data-label="svg" class="multipolygon vector" stroke='
-                . '"black" stroke-width="0.5" fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8"'
+                . 'L220,120Z" class="multipolygon vector" stroke='
+                . '"black" stroke-width="0.5" fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8" data-label="svg"'
                 . '/><path d="M90,310L-90,310L-90,490L90,490ZM80,320L80,380L20,380L20,320Z'
-                . 'M-20,420L-80,420L-80,480L-20,480Z" data-label="svg" class="multipolygon vector"'
-                . ' stroke="bla'
-                . 'ck" stroke-width="0.5" fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8"/>',
+                . 'M-20,420L-80,420L-80,480L-20,480Z" class="multipolygon vector"'
+                . ' stroke="black" stroke-width="0.5" fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8"'
+                . ' data-label="svg"/>',
             ],
         ];
     }

--- a/tests/unit/Gis/GisMultiPolygonTest.php
+++ b/tests/unit/Gis/GisMultiPolygonTest.php
@@ -351,11 +351,11 @@ class GisMultiPolygonTest extends GisGeomTestCase
                 '<path d=" M 110, 290 L 290, 290 L 290, 110 L 110, 110 Z  M 120, 280 L 120, 220 L 180, 220 L 180, 28'
                 . '0 Z  M 220, 180 L 280, 180 L 280, 120 L 220, 120 Z " data-label="svg" class="multipolygon vector"'
                 . ' stroke='
-                . '"black" stroke-width="0.5" fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8" id="svg1234567890"'
+                . '"black" stroke-width="0.5" fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8"'
                 . '/><path d=" M 90, 310 L -90, 310 L -90, 490 L 90, 490 Z  M 80, 320 L 80, 380 L 20, 380 L 20, 320 Z '
                 . ' M -20, 420 L -80, 420 L -80, 480 L -20, 480 Z " data-label="svg" class="multipolygon vector"'
                 . ' stroke="bla'
-                . 'ck" stroke-width="0.5" fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8" id="svg1234567890"/>',
+                . 'ck" stroke-width="0.5" fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8"/>',
             ],
         ];
     }

--- a/tests/unit/Gis/GisMultiPolygonTest.php
+++ b/tests/unit/Gis/GisMultiPolygonTest.php
@@ -348,12 +348,11 @@ class GisMultiPolygonTest extends GisGeomTestCase
                 'svg',
                 [176, 46, 224],
                 new ScaleData(offsetX: -50, offsetY: -50, scale: 2, height: 400),
-                '<path d=" M 110, 290 L 290, 290 L 290, 110 L 110, 110 Z  M 120, 280 L 120, 220 L 180, 220 L 180, 28'
-                . '0 Z  M 220, 180 L 280, 180 L 280, 120 L 220, 120 Z " data-label="svg" class="multipolygon vector"'
-                . ' stroke='
+                '<path d="M110,290L290,290L290,110L110,110ZM120,280L120,220L180,220L180,280ZM220,180L280,180L280,120'
+                . 'L220,120Z" data-label="svg" class="multipolygon vector" stroke='
                 . '"black" stroke-width="0.5" fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8"'
-                . '/><path d=" M 90, 310 L -90, 310 L -90, 490 L 90, 490 Z  M 80, 320 L 80, 380 L 20, 380 L 20, 320 Z '
-                . ' M -20, 420 L -80, 420 L -80, 480 L -20, 480 Z " data-label="svg" class="multipolygon vector"'
+                . '/><path d="M90,310L-90,310L-90,490L90,490ZM80,320L80,380L20,380L20,320Z'
+                . 'M-20,420L-80,420L-80,480L-20,480Z" data-label="svg" class="multipolygon vector"'
                 . ' stroke="bla'
                 . 'ck" stroke-width="0.5" fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8"/>',
             ],

--- a/tests/unit/Gis/GisPolygonTest.php
+++ b/tests/unit/Gis/GisPolygonTest.php
@@ -255,8 +255,7 @@ class GisPolygonTest extends GisGeomTestCase
                 [176, 46, 224],
                 new ScaleData(offsetX: 12, offsetY: 69, scale: 2, height: 150),
                 '<path d=" M 222, 288 L 22, 228 L 10, 162 Z  M 174, 264 L 36, 218 L 26, 178 Z " data-label="svg"'
-                . ' id="svg12'
-                . '34567890" class="polygon vector" stroke="black" stroke-width="0.5" fill="#b02ee0" fill-rule="evenod'
+                . ' class="polygon vector" stroke="black" stroke-width="0.5" fill="#b02ee0" fill-rule="evenod'
                 . 'd" fill-opacity="0.8"/>',
             ],
         ];

--- a/tests/unit/Gis/GisPolygonTest.php
+++ b/tests/unit/Gis/GisPolygonTest.php
@@ -254,7 +254,7 @@ class GisPolygonTest extends GisGeomTestCase
                 'svg',
                 [176, 46, 224],
                 new ScaleData(offsetX: 12, offsetY: 69, scale: 2, height: 150),
-                '<path d=" M 222, 288 L 22, 228 L 10, 162 Z  M 174, 264 L 36, 218 L 26, 178 Z " data-label="svg"'
+                '<path d="M222,288L22,228L10,162ZM174,264L36,218L26,178Z" data-label="svg"'
                 . ' class="polygon vector" stroke="black" stroke-width="0.5" fill="#b02ee0" fill-rule="evenod'
                 . 'd" fill-opacity="0.8"/>',
             ],

--- a/tests/unit/Gis/GisPolygonTest.php
+++ b/tests/unit/Gis/GisPolygonTest.php
@@ -254,9 +254,9 @@ class GisPolygonTest extends GisGeomTestCase
                 'svg',
                 [176, 46, 224],
                 new ScaleData(offsetX: 12, offsetY: 69, scale: 2, height: 150),
-                '<path d="M222,288L22,228L10,162ZM174,264L36,218L26,178Z" data-label="svg"'
+                '<path d="M222,288L22,228L10,162ZM174,264L36,218L26,178Z"'
                 . ' class="polygon vector" stroke="black" stroke-width="0.5" fill="#b02ee0" fill-rule="evenod'
-                . 'd" fill-opacity="0.8"/>',
+                . 'd" fill-opacity="0.8" data-label="svg"/>',
             ],
         ];
     }


### PR DESCRIPTION
- Remove unnecessesary spaces
  As long as digits from two different numbers are somehow seperated, spaces are optional in the `path`/`d` attribute.
- Remove id attribute
  The attribute wasn't used anywhere
- Only add the label if it is not an empty string