### PR TITLE
Fix error when opening gis editor a second time

### DIFF
--- a/resources/js/gis_data_editor.ts
+++ b/resources/js/gis_data_editor.ts
@@ -300,10 +300,9 @@ function loadGISEditor (value, field, type, inputName) {
             return;
         }
 
-        disposeGISEditorVisualization();
-
         $gisEditorModal.find('.modal-title').first().html(data.gis_editor_title);
         $gisEditorModal.find('.modal-body').first().html(data.gis_editor);
+        $gisEditorModal.on('hidden.bs.modal', disposeGISEditorVisualization);
         initGISEditorVisualization(
             JSON.parse($('#visualization-placeholder').attr('data-ol-data')),
         );


### PR DESCRIPTION
The editor not disposed when the modal was closed, which somehow caused this error.