### PR TITLE
Fix #19760 - Variable 'lc_messages' can't be set to the value of 'fr_FR' prevents tables listing & logs out.

### DIFF
--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -1125,7 +1125,7 @@ class DatabaseInterface implements DbalInterface
         /* Locale for messages */
         $locale = LanguageManager::getInstance()->getCurrentLanguage()->getMySQLLocale();
         if ($locale) {
-            $this->query("SET lc_messages = '" . $locale . "';");
+            $this->tryQuery("SET lc_messages = '" . $locale . "';");
         }
 
         // Set timezone for the session, if required.


### PR DESCRIPTION
### Description

Please describe your pull request.

Fixes #19760 

Using `tryQuery()` stops crashes when language settings fail to achieve silent failure.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
