### PR TITLE
Fix unrecognized feature: 'oversized-images'

### DIFF
--- a/src/Header.php
+++ b/src/Header.php
@@ -371,7 +371,7 @@ class Header
          *
          * @see https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy
          */
-        $headers['Permissions-Policy'] = 'fullscreen=(self), oversized-images=(self), interest-cohort=()';
+        $headers['Permissions-Policy'] = 'fullscreen=(self), interest-cohort=()';
 
         $headers = array_merge($headers, Core::getNoCacheHeaders());
 

--- a/tests/unit/HeaderTest.php
+++ b/tests/unit/HeaderTest.php
@@ -192,7 +192,7 @@ class HeaderTest extends AbstractTestCase
             'X-Content-Type-Options' => 'nosniff',
             'X-Permitted-Cross-Domain-Policies' => 'none',
             'X-Robots-Tag' => 'noindex, nofollow',
-            'Permissions-Policy' => 'fullscreen=(self), oversized-images=(self), interest-cohort=()',
+            'Permissions-Policy' => 'fullscreen=(self), interest-cohort=()',
             'Expires' => $date,
             'Cache-Control' => 'no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0',
             'Pragma' => 'no-cache',


### PR DESCRIPTION
### Description

There's no longer a reference to `oversized-images`:

https://www.w3.org/TR/permissions-policy/
https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Permissions_Policy

In Chrome/140.0.7324.0:

`Error with Permissions-Policy header: Unrecognized feature: 'oversized-images'.`

<img width="860" height="680" alt="oversized-images" src="https://github.com/user-attachments/assets/0dce688a-24f9-44c7-a601-28be40acff1b" />

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
