### PR TITLE
Fix #19267 - Fix SVG dimensions reset to 0

### DIFF
--- a/resources/js/table/gis_visualization.ts
+++ b/resources/js/table/gis_visualization.ts
@@ -183,8 +183,8 @@ class SvgVisualization extends GisVisualization {
      * Resizes the GIS visualization to fit into the space available.
      */
     private resize () {
-        const visWidth = Math.ceil($(this.target).width());
-        const visHeight = Math.ceil($(this.target).height());
+        const visWidth = Math.ceil($(this.target).width() || $(this.svgEl).width());
+        const visHeight = Math.ceil($(this.target).height() || $(this.svgEl).height());
 
         this.x += (visWidth - this.width) / 2;
         this.y += (visHeight - this.height) / 2;
@@ -238,6 +238,8 @@ class SvgVisualization extends GisVisualization {
 
     show () {
         super.show();
+
+        this.resize();
     }
 
     dispose () {

--- a/resources/js/table/gis_visualization.ts
+++ b/resources/js/table/gis_visualization.ts
@@ -238,8 +238,6 @@ class SvgVisualization extends GisVisualization {
 
     show () {
         super.show();
-
-        this.resize();
     }
 
     dispose () {


### PR DESCRIPTION
### Description

`width` and `height` in svg were reset to 0.

Fixes #19267 

Before:

https://github.com/user-attachments/assets/f60034bd-b8ee-4e16-b46d-7eca78e404ef

After:

https://github.com/user-attachments/assets/81aa7137-9ba7-4d4c-9bbf-5738f360b669

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
