### PR TITLE
Fix #19381 - Implement csv empty to null

### DIFF
--- a/src/Plugins/Import/ImportCsv.php
+++ b/src/Plugins/Import/ImportCsv.php
@@ -394,11 +394,6 @@ class ImportCsv extends AbstractImportCsv
                         $i += $csvTerminatedLen - 1;
                     }
 
-                    // unquoted NULL string
-                    if ($needEnd === false && $value === 'NULL') {
-                        $value = null;
-                    }
-
                     if ($fail) {
                         $i = $fallbacki;
                         $ch = mb_substr($buffer, $i, 1);
@@ -517,7 +512,7 @@ class ImportCsv extends AbstractImportCsv
                             $sql .= ', ';
                         }
 
-                        if ($val === null || ($this->emptyValueAsNull && $val === '')) {
+                        if ($val === null || ($this->emptyValueAsNull && $val === '') || $val === 'NULL') {
                             $sql .= 'NULL';
                         } else {
                             $sql .= $dbi->quoteString($val);

--- a/src/Plugins/Import/ImportCsv.php
+++ b/src/Plugins/Import/ImportCsv.php
@@ -64,6 +64,7 @@ class ImportCsv extends AbstractImportCsv
     private string $columns = '';
     private int $maxLines = 0;
     private bool $csvHasColumnNames = false;
+    private bool $emptyValueAsNull = false;
     private string $newDatabaseName = '';
     private string $newTableName = '';
 
@@ -154,6 +155,12 @@ class ImportCsv extends AbstractImportCsv
         }
 
         $leaf = new BoolPropertyItem(
+            'empty_is_null',
+            __('Import empty values as NULL'),
+        );
+        $generalOptions->addProperty($leaf);
+
+        $leaf = new BoolPropertyItem(
             'ignore',
             __('Do not abort on INSERT error'),
         );
@@ -179,6 +186,7 @@ class ImportCsv extends AbstractImportCsv
         $this->columns = $request->getParsedBodyParamAsString('csv_columns', '');
         $this->maxLines = min(0, (int) $request->getParsedBodyParamAsStringOrNull('csv_partial_import'));
         $this->csvHasColumnNames = $request->getParsedBodyParam('csv_col_names') !== null;
+        $this->emptyValueAsNull = $request->getParsedBodyParam('csv_empty_is_null') !== null;
         $this->newDatabaseName = $request->getParsedBodyParamAsString('csv_new_db_name', '');
         $this->newTableName = $request->getParsedBodyParamAsString('csv_new_tbl_name', '');
     }

--- a/src/Plugins/Import/ImportCsv.php
+++ b/src/Plugins/Import/ImportCsv.php
@@ -517,7 +517,7 @@ class ImportCsv extends AbstractImportCsv
                             $sql .= ', ';
                         }
 
-                        if ($val === null) {
+                        if ($val === null || ($this->emptyValueAsNull && $val === '')) {
                             $sql .= 'NULL';
                         } else {
                             $sql .= $dbi->quoteString($val);
@@ -568,6 +568,18 @@ class ImportCsv extends AbstractImportCsv
             /* Fill out all rows */
             foreach ($rows as $i => $row) {
                 $rows[$i] = array_pad($row, $maxCols, 'NULL');
+            }
+
+            if ($this->emptyValueAsNull) {
+                foreach ($rows as &$row) {
+                    foreach ($row as &$value) {
+                        if ($value === '') {
+                            $value = 'NULL';
+                        }
+                    }
+                    unset($value);
+                }
+                unset($row);
             }
 
             $colNames = [];

--- a/src/Plugins/Import/ImportCsv.php
+++ b/src/Plugins/Import/ImportCsv.php
@@ -512,7 +512,7 @@ class ImportCsv extends AbstractImportCsv
                             $sql .= ', ';
                         }
 
-                        if ($val === null || ($this->emptyValueAsNull && $val === '') || $val === 'NULL') {
+                        if ($val === 'NULL' || ($this->emptyValueAsNull && $val === '')) {
                             $sql .= 'NULL';
                         } else {
                             $sql .= $dbi->quoteString($val);
@@ -568,12 +568,16 @@ class ImportCsv extends AbstractImportCsv
             if ($this->emptyValueAsNull) {
                 foreach ($rows as &$row) {
                     foreach ($row as &$value) {
-                        if ($value === '') {
-                            $value = 'NULL';
+                        if ($value !== '') {
+                            continue;
                         }
+
+                        $value = 'NULL';
                     }
+
                     unset($value);
                 }
+
                 unset($row);
             }
 


### PR DESCRIPTION
This PR adds a feature to add a checkbox in import which allows to treat empty values as null
Fixes [#19381](https://github.com/phpmyadmin/phpmyadmin/issues/19381)

This pull request introduces a new optional feature for CSV data imports. A new checkbox, Import empty values as NULL, has been added to the import settings. When this option is selected, the system will now treat any empty field in the CSV file as a SQL NULL value during the import.

Previously, empty fields were imported as empty strings (''), which could cause issues with database constraints and data integrity for columns intended to be nullable. This enhancement provides users with greater control over their imported data, allowing for more precise data representation.

The changes ensure consistent behavior for both new table creation (the "analyze" mode) and importing into existing tables.