### PR TITLE
QA_5_2: backport of phpmyadmin/phpmyadmin#12345 GD2 detection (use GD_MAJOR_VERSION)

### DIFF
--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -24,7 +24,7 @@ use function fileperms;
 use function fopen;
 use function fread;
 use function function_exists;
-use function gd_info;
+use function get_defined_constants;
 use function get_object_vars;
 use function implode;
 use function ini_get;
@@ -247,38 +247,20 @@ class Config
     }
 
     /**
-     * Whether GD2 is present
+     * Determines if GD2+ is available
+     *
+     * Respects the config override ('yes' / 'no') if set,
+     * otherwise checks the `GD_MAJOR_VERSION` constant (>= 2).
      */
     public function checkGd2(): void
     {
         if ($this->get('GD2Available') === 'yes') {
             $this->set('PMA_IS_GD2', 1);
-
-            return;
-        }
-
-        if ($this->get('GD2Available') === 'no') {
+        } elseif ($this->get('GD2Available') === 'no') {
             $this->set('PMA_IS_GD2', 0);
-
-            return;
+        } else {
+            $this->set('PMA_IS_GD2', (get_defined_constants()['GD_MAJOR_VERSION'] ?? 0) >= 2 ? 1 : 0);
         }
-
-        if (! function_exists('imagecreatetruecolor')) {
-            $this->set('PMA_IS_GD2', 0);
-
-            return;
-        }
-
-        if (function_exists('gd_info')) {
-            $gd_nfo = gd_info();
-            if (mb_strstr($gd_nfo['GD Version'], '2.')) {
-                $this->set('PMA_IS_GD2', 1);
-
-                return;
-            }
-        }
-
-        $this->set('PMA_IS_GD2', 0);
     }
 
     /**

--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -15,23 +15,14 @@ use function defined;
 use function file_exists;
 use function file_put_contents;
 use function fileperms;
-use function function_exists;
-use function gd_info;
-use function mb_strstr;
-use function ob_end_clean;
-use function ob_get_contents;
-use function ob_start;
-use function phpinfo;
-use function preg_match;
+use function get_defined_constants;
 use function realpath;
-use function strip_tags;
 use function stristr;
 use function sys_get_temp_dir;
 use function tempnam;
 use function unlink;
 
 use const DIRECTORY_SEPARATOR;
-use const INFO_MODULES;
 use const PHP_EOL;
 use const PHP_OS;
 use const TEST_PATH;
@@ -335,41 +326,11 @@ class ConfigTest extends AbstractTestCase
         self::assertSame(0, $this->object->get('PMA_IS_GD2'));
 
         $this->object->set('GD2Available', 'auto');
-
-        if (! function_exists('imagecreatetruecolor')) {
-            $this->object->checkGd2();
-            self::assertSame(
-                0,
-                $this->object->get('PMA_IS_GD2'),
-                'imagecreatetruecolor does not exist, PMA_IS_GD2 should be 0'
-            );
-        }
-
-        if (function_exists('gd_info')) {
-            $this->object->checkGd2();
-            $gd_nfo = gd_info();
-            if (mb_strstr($gd_nfo['GD Version'], '2.')) {
-                self::assertSame(1, $this->object->get('PMA_IS_GD2'), 'GD Version >= 2, PMA_IS_GD2 should be 1');
-            } else {
-                self::assertSame(0, $this->object->get('PMA_IS_GD2'), 'GD Version < 2, PMA_IS_GD2 should be 0');
-            }
-        }
-
-        /* Get GD version string from phpinfo output */
-        ob_start();
-        phpinfo(INFO_MODULES); /* Only modules */
-        $a = strip_tags((string) ob_get_contents());
-        ob_end_clean();
-
-        if (! preg_match('@GD Version[[:space:]]*\(.*\)@', $a, $v)) {
-            return;
-        }
-
-        if (mb_strstr($v, '2.')) {
-            self::assertSame(1, $this->object->get('PMA_IS_GD2'), 'PMA_IS_GD2 should be 1');
-        } else {
-            self::assertSame(0, $this->object->get('PMA_IS_GD2'), 'PMA_IS_GD2 should be 0');
-        }
+        $this->object->checkGd2();
+        self::assertSame(
+            (get_defined_constants()['GD_MAJOR_VERSION'] ?? 0) >= 2 ? 1 : 0,
+            $this->object->get('PMA_IS_GD2')
+        );
     }
 
     /**


### PR DESCRIPTION
### Description
Switch GD2 detection to GD_MAJOR_VERSION (>=2); remove legacy
imagecreatetruecolor/gd_info/phpinfo checks and update tests.
Behavior unchanged, detection is just more precise.

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [X] Any new functionality is covered by tests.
