### PR TITLE
[PHP 8.5] Fix $http_response_header deprecation

### DIFF
--- a/libraries/classes/Utils/HttpRequest.php
+++ b/libraries/classes/Utils/HttpRequest.php
@@ -267,6 +267,10 @@ class HttpRequest
             stream_context_create($context)
         );
 
+        if (function_exists('http_get_last_response_headers')) {
+            $http_response_header = http_get_last_response_headers();
+        }
+
         if (! isset($http_response_header)) {
             return null;
         }


### PR DESCRIPTION
### Description

See https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_http_response_header_predefined_variable

<img width="978" height="802" alt="err" src="https://github.com/user-attachments/assets/50afcbdc-b685-4793-96d5-56e659c3f7fb" />

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
