### PR TITLE
Fix #19822 - Fix incorrect usage/placement of 'SQL_NO_CACHE'

### DIFF
--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -769,6 +769,17 @@ class Sql
 
                 $countQuery = 'SELECT COUNT(*) FROM (' . $statement->build() . ' ) as cnt';
 
+                // Check if SQL_NO_CACHE is present in options
+                $hasSqlNoCache = in_array('SQL_NO_CACHE', $statement->options->options, true);
+
+                if ($hasSqlNoCache) {
+                    // Remove SQL_NO_CACHE from subqueries
+                    $countQuery = preg_replace('/\b SQL_NO_CACHE\b/i', '', $countQuery);
+
+                    // Add back SQL_NO_CACHE after first SELECT
+                    $countQuery = preg_replace('/^(\s*SELECT)/i', '\\1 SQL_NO_CACHE', $countQuery);
+                }
+
                 $unlimNumRows = $this->dbi->fetchValue($countQuery);
                 if ($unlimNumRows === false) {
                     $unlimNumRows = 0;


### PR DESCRIPTION
### Description

The generated queries are:

Without `SQL_NO_CACHE`:

```SQL
SELECT * FROM `test` WHERE `date` = '2025-08-26' LIMIT 0, 25
SELECT COUNT(*) FROM (SELECT 1 FROM `test` WHERE `date` = '2025-08-26' ) as cnt
```

With `SQL_NO_CACHE`:

```SQL
SELECT SQL_NO_CACHE * FROM `test` WHERE `date` = '2025-08-26' LIMIT 0, 25
SELECT SQL_NO_CACHE COUNT(*) FROM (SELECT 1 FROM `test` WHERE `date` = '2025-08-26' ) as cnt
```

Fixes #19822

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
