### PR TITLE
Fix export template update error

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6412,7 +6412,7 @@ parameters:
 			path: src/Export/Template.php
 
 		-
-			message: '#^Parameter \#1 \$value of static method PhpMyAdmin\\Plugins\\ExportType\:\:from\(\) expects int\|string, mixed given\.$#'
+			message: '#^Parameter \#1 \$value of static method PhpMyAdmin\\Plugins\\ExportType\:\:tryFrom\(\) expects int\|string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Export/Template.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1365,11 +1365,6 @@
       <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>
   </file>
-  <file src="src/Controllers/Export/Template/UpdateController.php">
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response]]></code>
-    </PossiblyUnusedReturnValue>
-  </file>
   <file src="src/Controllers/GitInfoController.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>

--- a/src/Controllers/Export/Template/UpdateController.php
+++ b/src/Controllers/Export/Template/UpdateController.php
@@ -29,6 +29,7 @@ final readonly class UpdateController implements InvocableController
     {
         $templateId = (int) $request->getParsedBodyParamAsStringOrNull('templateId');
         $templateData = $request->getParsedBodyParamAsString('templateData', '');
+        $exportType = $request->getParsedBodyParamAsString('exportType', '');
 
         $exportTemplatesFeature = $this->relation->getRelationParameters()->exportTemplatesFeature;
         if ($exportTemplatesFeature === null) {
@@ -37,6 +38,7 @@ final readonly class UpdateController implements InvocableController
 
         $template = ExportTemplate::fromArray([
             'id' => $templateId,
+            'exportType' => $exportType,
             'username' => $this->config->selectedServer['user'],
             'data' => $templateData,
         ]);

--- a/src/Export/Template.php
+++ b/src/Export/Template.php
@@ -24,7 +24,7 @@ final class Template
         return new self(
             $state['id'] ?? 0,
             $state['username'],
-            ExportType::from($state['exportType'] ?? ''),
+            ExportType::tryFrom($state['exportType'] ?? '') ?? ExportType::Server,
             $state['name'] ?? '',
             $state['data'],
         );

--- a/tests/unit/Controllers/Export/Template/UpdateControllerTest.php
+++ b/tests/unit/Controllers/Export/Template/UpdateControllerTest.php
@@ -4,19 +4,23 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Export\Template;
 
+use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\Controllers\Export\Template\UpdateController;
 use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Export\TemplateModel;
+use PhpMyAdmin\Http\Factory\ServerRequestFactory;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionProperty;
 
 #[CoversClass(UpdateController::class)]
-class UpdateControllerTest extends AbstractTestCase
+final class UpdateControllerTest extends AbstractTestCase
 {
     protected DatabaseInterface $dbi;
 
@@ -31,8 +35,10 @@ class UpdateControllerTest extends AbstractTestCase
         DatabaseInterface::$instance = $this->dbi;
     }
 
-    public function testUpdate(): void
+    public function testWithoutTemplatesFeature(): void
     {
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, RelationParameters::fromArray([]));
+
         $config = Config::getInstance();
         $config->selectedServer['user'] = 'user';
 
@@ -47,5 +53,44 @@ class UpdateControllerTest extends AbstractTestCase
         ))($request);
 
         self::assertTrue($response->hasSuccessState());
+    }
+
+    public function testWithTemplatesFeature(): void
+    {
+        $relationParameters = RelationParameters::fromArray([
+            RelationParameters::USER => 'test_user',
+            RelationParameters::DATABASE => 'pma_db',
+            RelationParameters::EXPORT_TEMPLATES_WORK => true,
+            RelationParameters::EXPORT_TEMPLATES => 'export_templates',
+        ]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
+
+        $config = new Config();
+        $config->selectedServer['user'] = 'test_user';
+
+        $dbiDummy = $this->createDbiDummy();
+        $dbiDummy->removeDefaultResults();
+
+        // phpcs:disable Generic.Files.LineLength.TooLong
+        $dbiDummy->addResult('UPDATE `pma_db`.`export_templates` SET `template_data` = \'{\"quick_or_custom\":\"quick\"}\' WHERE `id` = 1 AND `username` = \'test_user\';', true);
+        $dbi = $this->createDatabaseInterface($dbiDummy);
+
+        $responseRenderer = new ResponseRenderer();
+        $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/')->withParsedBody([
+            'exportType' => 'server',
+            'templateId' => '1',
+            'templateData' => '{"quick_or_custom":"quick"}',
+        ]);
+
+        $response = (new UpdateController(
+            $responseRenderer,
+            new TemplateModel($dbi),
+            new Relation($dbi, $config),
+            $config,
+        ))($request);
+
+        $dbiDummy->assertAllQueriesConsumed();
+        self::assertTrue($responseRenderer->hasSuccessState());
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
     }
 }

--- a/tests/unit/Export/TemplateTest.php
+++ b/tests/unit/Export/TemplateTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Export;
+
+use PhpMyAdmin\Export\Template;
+use PhpMyAdmin\Plugins\ExportType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Template::class)]
+final class TemplateTest extends TestCase
+{
+    /** @param array<string, int|string> $state */
+    #[DataProvider('fromArrayProvider')]
+    public function testFromArray(
+        int $id,
+        string $username,
+        ExportType $exportType,
+        string $name,
+        string $data,
+        array $state,
+    ): void {
+        $template = Template::fromArray($state);
+        self::assertSame($id, $template->getId());
+        self::assertSame($username, $template->getUsername());
+        self::assertSame($exportType, $template->getExportType());
+        self::assertSame($name, $template->getName());
+        self::assertSame($data, $template->getData());
+    }
+
+    /** @return iterable<int, array{int, string, ExportType, string, string, array<string, int|string>}> */
+    public static function fromArrayProvider(): iterable
+    {
+        yield [0, '', ExportType::Server, '', '', ['username' => '', 'data' => '']];
+        yield [0, '', ExportType::Server, '', '', ['username' => '', 'data' => '', 'exportType' => 'server']];
+        yield [0, '', ExportType::Server, '', '', ['username' => '', 'data' => '', 'exportType' => 'invalid']];
+        yield [0, '', ExportType::Database, '', '', ['username' => '', 'data' => '', 'exportType' => 'database']];
+        yield [0, '', ExportType::Table, '', '', ['username' => '', 'data' => '', 'exportType' => 'table']];
+        yield [0, '', ExportType::Raw, '', '', ['username' => '', 'data' => '', 'exportType' => 'raw']];
+        yield [
+            1,
+            'test_user',
+            ExportType::Database,
+            'Template name',
+            '{"template":"data"}',
+            [
+                'id' => 1,
+                'username' => 'test_user',
+                'exportType' => 'database',
+                'name' => 'Template name',
+                'data' => '{"template":"data"}',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
When updating an export template, the exportType request parameter is ignored by the controller, because it's not used by the UPDATE statement. However the Template value object requires a valid ExportType enum, causing a ValueError to be thrown.

```
ValueError: "" is not a valid backing value for enum PhpMyAdmin\Plugins\ExportType
```


