### PR TITLE
Fix `Disable two-factor authentication` button position

### DIFF
--- a/templates/login/twofactor/application.twig
+++ b/templates/login/twofactor/application.twig
@@ -2,4 +2,4 @@
   <label class="form-label" for="2faCodeInput">{% trans "Authentication code:" %}</label>
   <input class="form-control" id="2faCodeInput" type="text" name="2fa_code" autocomplete="off" autofocus>
 </div>
-{% trans 'Open the two-factor authentication app on your device to view your authentication code and verify your identity.' %}
+<p>{% trans 'Open the two-factor authentication app on your device to view your authentication code and verify your identity.' %}</p>


### PR DESCRIPTION
### Description

Fix `Disable two-factor authentication` button position

Before:

https://github.com/user-attachments/assets/a2a2a158-2784-41ca-9a40-e56580802a34

After:

https://github.com/user-attachments/assets/0add7e98-a6c3-4c00-8651-3692613b6ec2