### PR TITLE
Disable global submit event listener from some forms

### DIFF
--- a/resources/templates/create_tracking_version.twig
+++ b/resources/templates/create_tracking_version.twig
@@ -1,5 +1,5 @@
 <div class="card mt-3">
-    <form method="post" action="{{ url(route, url_params) }}">
+    <form method="post" action="{{ url(route, url_params) }}" class="disableAjax">
         {{ get_hidden_inputs(db) }}
         {% for selected_table in selected %}
             <input type="hidden" name="selected[]" value="{{ selected_table }}">

--- a/resources/templates/database/events/index.twig
+++ b/resources/templates/database/events/index.twig
@@ -31,7 +31,7 @@
     </div>
   </div>
 
-  <form id="rteListForm" class="ajax" action="{{ url('/database/events') }}">
+  <form id="rteListForm" class="disableAjax" action="{{ url('/database/events') }}">
     {{ get_hidden_inputs(db) }}
 
     <div id="nothing2display"{{ items is not empty ? ' class="hide"' }}>

--- a/resources/templates/database/routines/index.twig
+++ b/resources/templates/database/routines/index.twig
@@ -42,7 +42,7 @@
     {{ list_navigator_html|raw }}
   {%- endif -%}
 
-  <form id="rteListForm" class="ajax" action="{{ url('/database/routines') }}">
+  <form id="rteListForm" class="disableAjax" action="{{ url('/database/routines') }}">
     {{ get_hidden_inputs(db, table) }}
 
     <div id="nothing2display"{{ has_any_routines ? ' class="hide"' }}>

--- a/resources/templates/export.twig
+++ b/resources/templates/export.twig
@@ -15,7 +15,7 @@
     <div class="card mb-3">
       <div class="card-header">{{ t('Export templates:') }}</div>
       <div class="card-body row gy-3">
-        <form method="post" action="{{ url('/export/template/create') }}" class="col-12 col-md ajax">
+        <form method="post" action="{{ url('/export/template/create') }}" class="col-12 col-md disableAjax">
           <fieldset>
             <legend>{{ t('New template:') }}</legend>
             <div class="row g-3 align-items-center">
@@ -32,7 +32,7 @@
           </fieldset>
         </form>
 
-        <form method="post" id="existingTemplatesForm" class="col-12 col-md ajax">
+        <form method="post" id="existingTemplatesForm" class="col-12 col-md disableAjax">
           <fieldset>
             <legend>{{ t('Existing templates:') }}</legend>
             <div class="row g-3 align-items-center">

--- a/resources/templates/gis_data_editor_form.twig
+++ b/resources/templates/gis_data_editor_form.twig
@@ -1,4 +1,4 @@
-<form id="gis_data_editor_form" action="{{ url('/gis-data-editor') }}" method="post">
+<form id="gis_data_editor_form" action="{{ url('/gis-data-editor') }}" method="post" class="disableAjax">
   <div id="gis_data_editor">
     <input type="hidden" name="field" value="{{ field }}">
     <input type="hidden" name="type" value="{{ column_type }}">

--- a/resources/templates/import.twig
+++ b/resources/templates/import.twig
@@ -15,7 +15,7 @@
   <div id="importmain">
     <img src="{{ image('ajax_clock_small.gif') }}" width="16" height="16" alt="ajax clock" class="hide">
 
-    <form id="import_file_form" action="{{ url('/import') }}" method="post" enctype="multipart/form-data" name="import" class="ajax"
+    <form id="import_file_form" action="{{ url('/import') }}" method="post" enctype="multipart/form-data" name="import" class="disableAjax"
       {%- if handler != 'PhpMyAdmin\\Plugins\\Import\\Upload\\UploadNoplugin' %} target="import_upload_iframe"{% endif %}>
       {{ get_hidden_inputs(hidden_inputs) }}
 

--- a/resources/templates/server/status/monitor/index.twig
+++ b/resources/templates/server/status/monitor/index.twig
@@ -388,7 +388,7 @@
   ];
 </script>
 
-<form id="js_data" class="hide">
+<form id="js_data" class="d-none disableAjax">
   {% for name, value in form %}
     <input type="hidden" name="{{ name }}" value="{{ value }}">
   {% endfor %}

--- a/resources/templates/triggers/list.twig
+++ b/resources/templates/triggers/list.twig
@@ -33,7 +33,7 @@
 
   {{ error_message|raw -}}
 
-  <form id="rteListForm" class="ajax" action="{{ url('/triggers') }}">
+  <form id="rteListForm" class="disableAjax" action="{{ url('/triggers') }}">
     {{ get_hidden_inputs(db, table) }}
 
     <div id="nothing2display"{{ triggers is not empty ? ' class="hide"' }}>

--- a/tests/unit/Controllers/Database/EventsControllerTest.php
+++ b/tests/unit/Controllers/Database/EventsControllerTest.php
@@ -95,7 +95,7 @@ final class EventsControllerTest extends AbstractTestCase
                 </div>
               </div>
 
-              <form id="rteListForm" class="ajax" action="index.php?route=/database/events&server=2&lang=en">
+              <form id="rteListForm" class="disableAjax" action="index.php?route=/database/events&server=2&lang=en">
                 <input type="hidden" name="db" value="test_db"><input type="hidden" name="server" value="2"><input type="hidden" name="lang" value="en"><input type="hidden" name="token" value="token">
 
                 <div id="nothing2display" class="hide">
@@ -284,7 +284,7 @@ final class EventsControllerTest extends AbstractTestCase
                 </div>
               </div>
 
-              <form id="rteListForm" class="ajax" action="index.php?route=/database/events&server=2&lang=en">
+              <form id="rteListForm" class="disableAjax" action="index.php?route=/database/events&server=2&lang=en">
                 <input type="hidden" name="db" value="test_db"><input type="hidden" name="server" value="2"><input type="hidden" name="lang" value="en"><input type="hidden" name="token" value="token">
 
                 <div id="nothing2display">

--- a/tests/unit/Controllers/Database/RoutinesControllerTest.php
+++ b/tests/unit/Controllers/Database/RoutinesControllerTest.php
@@ -131,7 +131,7 @@ final class RoutinesControllerTest extends AbstractTestCase
                     <span class="text-nowrap"><img src="themes/dot.gif" title="Create new routine" alt="Create new routine" class="icon ic_b_routine_add">&nbsp;Create new routine</span>
                   </a>
                 </div>
-              </div><form id="rteListForm" class="ajax" action="index.php?route=/database/routines&server=2&lang=en">
+              </div><form id="rteListForm" class="disableAjax" action="index.php?route=/database/routines&server=2&lang=en">
                 <input type="hidden" name="db" value="test_db"><input type="hidden" name="server" value="2"><input type="hidden" name="lang" value="en"><input type="hidden" name="token" value="token">
 
                 <div id="nothing2display" class="hide">
@@ -345,7 +345,7 @@ final class RoutinesControllerTest extends AbstractTestCase
                     <span class="text-nowrap"><img src="themes/dot.gif" title="Create new routine" alt="Create new routine" class="icon ic_b_routine_add">&nbsp;Create new routine</span>
                   </a>
                 </div>
-              </div><form id="rteListForm" class="ajax" action="index.php?route=/database/routines&server=2&lang=en">
+              </div><form id="rteListForm" class="disableAjax" action="index.php?route=/database/routines&server=2&lang=en">
                 <input type="hidden" name="db" value="test_db"><input type="hidden" name="server" value="2"><input type="hidden" name="lang" value="en"><input type="hidden" name="token" value="token">
 
                 <div id="nothing2display">

--- a/tests/unit/Controllers/Server/Status/MonitorControllerTest.php
+++ b/tests/unit/Controllers/Server/Status/MonitorControllerTest.php
@@ -87,7 +87,7 @@ class MonitorControllerTest extends AbstractTestCase
         self::assertStringContainsString('<option>Processes</option>', $html);
         self::assertStringContainsString('<option>Connections</option>', $html);
 
-        self::assertStringContainsString('<form id="js_data" class="hide">', $html);
+        self::assertStringContainsString('<form id="js_data" class="d-none disableAjax">', $html);
         self::assertStringContainsString('<input type="hidden" name="server_time"', $html);
         //validate 2: inputs
         self::assertStringContainsString('<input type="hidden" name="is_superuser"', $html);

--- a/tests/unit/Controllers/Triggers/IndexControllerTest.php
+++ b/tests/unit/Controllers/Triggers/IndexControllerTest.php
@@ -93,7 +93,7 @@ final class IndexControllerTest extends AbstractTestCase
                 </div>
               </div>
 
-              <form id="rteListForm" class="ajax" action="index.php?route=/triggers&server=2&lang=en">
+              <form id="rteListForm" class="disableAjax" action="index.php?route=/triggers&server=2&lang=en">
                 <input type="hidden" name="db" value="test_db"><input type="hidden" name="server" value="2"><input type="hidden" name="lang" value="en"><input type="hidden" name="token" value="token">
 
                 <div id="nothing2display" class="hide">
@@ -247,7 +247,7 @@ final class IndexControllerTest extends AbstractTestCase
                 </div>
               </div>
 
-              <form id="rteListForm" class="ajax" action="index.php?route=/triggers&server=2&lang=en">
+              <form id="rteListForm" class="disableAjax" action="index.php?route=/triggers&server=2&lang=en">
                 <input type="hidden" name="db" value="test_db"><input type="hidden" name="server" value="2"><input type="hidden" name="lang" value="en"><input type="hidden" name="token" value="token">
 
                 <div id="nothing2display">


### PR DESCRIPTION
This explicitly disables the global submit event listener by adding the `disableAjax` CSS class. Either these forms do a full page change or have dedicated event listeners.