### PR TITLE
Fix #19701 - Add symfony/polyfill-iconv

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
         "symfony/dependency-injection": "^5.2.3",
         "symfony/expression-language": "^5.2.3",
         "symfony/polyfill-ctype": "^1.17.0",
+        "symfony/polyfill-iconv": "^1.33",
         "symfony/polyfill-mbstring": "^1.17.0",
         "symfony/polyfill-php80": "^1.16",
         "twig/twig": "^3.3.5",


### PR DESCRIPTION
### Description

phpMyAdmin requires `iconv`, but `symfony/polyfill-iconv` is missing. I think this will solve the issue when PHP is built without `iconv` and `mbstring` is not enabled.

Fixes #19701

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
