### PR TITLE
Remove background color from select on focus

### DIFF
--- a/public/themes/pmahomme/scss/_common.scss
+++ b/public/themes/pmahomme/scss/_common.scss
@@ -169,7 +169,6 @@ input {
 
 select:focus {
   border: 1px solid #7c7c7c;
-  background: #fff;
 }
 
 input {


### PR DESCRIPTION
Fixes #19817 

*Theoretically, border could also be removed, as both is already set in Bootstrap.*