### PR TITLE
Fail on lint error

### DIFF
--- a/test/ci-phplint
+++ b/test/ci-phplint
@@ -5,5 +5,9 @@ FILES=`find . -name '*.php' -not -path './vendor/*'`
 for FILE in $FILES ; do
     if [ -f $FILE ] ; then
         php -l $FILE
+        test_ret=$?
+        if [ $test_ret -ne 0 ] ; then
+            exit $test_ret
+        fi
     fi
 done


### PR DESCRIPTION
### Description

It seems that https://github.com/phpmyadmin/phpmyadmin/pull/19858/commits/4a93d79e08898e952b0bbbc25eee0d4470fcce10 fails on PHP 7.2:

<img width="651" height="131" alt="1" src="https://github.com/user-attachments/assets/563ee577-532d-485e-a46a-81f0038cd493" />

The problem is the tests didn't catch this:

**Before:**

<img width="511" height="231" alt="before" src="https://github.com/user-attachments/assets/ae9c5992-c9b4-40e2-93a9-84a65cdcd5b1" />

**After:**

<img width="614" height="218" alt="after" src="https://github.com/user-attachments/assets/cac0b8bf-fc11-406b-91a9-a90e3ca48ba5" />

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
