### PR TITLE
Add missing export format options (json, mediawiki, phparray)

### DIFF
--- a/src/Config/Settings/Export.php
+++ b/src/Config/Settings/Export.php
@@ -136,7 +136,7 @@ final class Export
      *
      * @link https://docs.phpmyadmin.net/en/latest/config.html#cfg_Export_format
      *
-     * @psalm-var 'codegen'|'csv'|'excel'|'htmlexcel'|'htmlword'|'latex'|'ods'|'odt'|'pdf'|'sql'|'texytext'|'xml'|'yaml'
+     * @psalm-var 'codegen'|'csv'|'excel'|'htmlexcel'|'htmlword'|'json'|'latex'|'mediawiki'|'ods'|'odt'|'pdf'|'phparray'|'sql'|'texytext'|'xml'|'yaml'
      */
     public string $format;
 
@@ -1222,7 +1222,7 @@ final class Export
     /**
      * @param array<int|string, mixed> $export
      *
-     * @psalm-return 'codegen'|'csv'|'excel'|'htmlexcel'|'htmlword'|'latex'|'ods'|'odt'|'pdf'|'sql'|'texytext'|'xml'|'yaml'
+     * @psalm-return 'codegen'|'csv'|'excel'|'htmlexcel'|'htmlword'|'json'|'latex'|'mediawiki'|'ods'|'odt'|'pdf'|'phparray'|'sql'|'texytext'|'xml'|'yaml'
      */
     private function setFormat(array $export): string
     {
@@ -1233,10 +1233,14 @@ final class Export
                 'excel',
                 'htmlexcel',
                 'htmlword',
+                'json',
                 'latex',
+                'mediawiki',
                 'ods',
                 'odt',
                 'pdf',
+                'phparray',
+                'sql',
                 'texytext',
                 'xml',
                 'yaml',


### PR DESCRIPTION
### Description

This adds support for `json`, `mediawiki`, and `phparray` as valid default export format options in `config.inc.php`. Previously these formats were available in the export UI but could not be set as default formats in the configuration.

Fixes #19892

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests. (there were no tests for the existing options, but is a simple array of options)
