### PR TITLE
Remove docs text of localized equivalent

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -2904,7 +2904,7 @@ Tabs display settings
     :default: ``'welcome'``
 
     Defines the tab displayed by default on server view. The possible values
-    are the localized equivalent of:
+    are:
 
     * ``welcome`` (recommended for multi-user setups)
     * ``databases``,
@@ -2918,7 +2918,7 @@ Tabs display settings
     :default: ``'structure'``
 
     Defines the tab displayed by default on database view. The possible values
-    are the localized equivalent of:
+    are:
 
     * ``structure``
     * ``sql``
@@ -2931,7 +2931,7 @@ Tabs display settings
     :default: ``'browse'``
 
     Defines the tab displayed by default on table view. The possible values
-    are the localized equivalent of:
+    are:
 
     * ``structure``
     * ``sql``


### PR DESCRIPTION

### Description

Remove docs text of localized equivalent since it is not actually supported.

This includes `$cfg['DefaultTabServer']`, `$cfg['DefaultTabDatabase']`, and `$cfg['DefaultTabTable']`

Followup to #19888

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
