### PR TITLE
Switch the theme used when building our HTML documents

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,7 +98,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # See: https://docs.readthedocs.io/en/stable/reference/environment-variables.html#envvar-READTHEDOCS
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'


### PR DESCRIPTION
Switch the theme used when building our HTML documents to the Read The Docs theme (rtd)

This is more consistent with the look of our online documentation.

### Description

This switches our generated HTML documentation to match the theme used by Read The Docs for our online documentation.

Fixes #19909

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
