### PR TITLE
Fix #19900 - two factor auth disappears

### DIFF
--- a/libraries/classes/UserPreferences.php
+++ b/libraries/classes/UserPreferences.php
@@ -125,6 +125,16 @@ class UserPreferences
      */
     public function save(array $config_array)
     {
+        // Smart merge: If this looks like a partial save (missing 2fa but we have it stored),
+        // automatically merge to prevent accidental overwrites
+        if (!isset($config_array['2fa'])) {
+            $existingPrefs = $this->load();
+            if (isset($existingPrefs['config_data']['2fa'])) {
+                // This is likely a partial save from page settings - merge to preserve 2fa
+                $config_array = array_merge($existingPrefs['config_data'], $config_array);
+            }
+        }
+
         global $dbi;
 
         $relationParameters = $this->relation->getRelationParameters();
@@ -155,15 +165,6 @@ class UserPreferences
             . $dbi->escapeString($relationParameters->user)
             . '\'';
 
-        // Smart merge: If this looks like a partial save (missing 2fa but we have it stored),
-        // automatically merge to prevent accidental overwrites
-        if (!isset($config_array['2fa'])) {
-            $existingPrefs = $this->load();
-            if (isset($existingPrefs['config_data']['2fa'])) {
-                // This is likely a partial save from page settings - merge to preserve 2fa
-                $config_array = array_merge($existingPrefs['config_data'], $config_array);
-            }
-        }
         $has_config = $dbi->fetchValue($query, 0, DatabaseInterface::CONNECT_CONTROL);
         $config_data = json_encode($config_array);
         if ($has_config) {

--- a/libraries/classes/UserPreferences.php
+++ b/libraries/classes/UserPreferences.php
@@ -155,6 +155,15 @@ class UserPreferences
             . $dbi->escapeString($relationParameters->user)
             . '\'';
 
+        // Smart merge: If this looks like a partial save (missing 2fa but we have it stored),
+        // automatically merge to prevent accidental overwrites
+        if (!isset($config_array['2fa'])) {
+            $existingPrefs = $this->load();
+            if (isset($existingPrefs['config_data']['2fa'])) {
+                // This is likely a partial save from page settings - merge to preserve 2fa
+                $config_array = array_merge($existingPrefs['config_data'], $config_array);
+            }
+        }
         $has_config = $dbi->fetchValue($query, 0, DatabaseInterface::CONNECT_CONTROL);
         $config_data = json_encode($config_array);
         if ($has_config) {


### PR DESCRIPTION
Fixes issue where two-factor authentication settings were being lost when saving page-specific user preferences through the settings UI.

Fixes #19900 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
