### PR TITLE
Fix #19855 - Allow non-SQL export plugins to export table structure

### DIFF
--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -627,12 +627,12 @@ class Export
                 if ($isView) {
                     if (
                         $separateFiles === ''
-                        && $exportPlugin instanceof ExportSql && $exportPlugin->hasCreateView()
+                        && $exportPlugin->hasCreateView()
                         && ! $exportPlugin->exportStructure($db->getName(), $table, 'stand_in', $aliases)
                     ) {
                         break;
                     }
-                } elseif ($exportPlugin instanceof ExportSql && $exportPlugin->hasCreateTable()) {
+                } elseif ($exportPlugin->hasCreateTable()) {
                     $tableSize = self::$maxSize;
                     // Checking if the maximum table size constrain has been set
                     // And if that constrain is a valid number or not
@@ -679,7 +679,7 @@ class Export
             // now export the triggers (needs to be done after the data because
             // triggers can modify already imported tables)
             if (
-                ! ($exportPlugin instanceof ExportSql && $exportPlugin->hasCreateTrigger())
+                ! $exportPlugin->hasCreateTrigger()
                 || $structureOrData === StructureOrData::Data
                 || ! in_array($table, $tableStructure, true)
             ) {
@@ -697,7 +697,7 @@ class Export
             $this->saveObjectInBuffer('table_' . $table, true);
         }
 
-        if ($exportPlugin instanceof ExportSql && $exportPlugin->hasCreateView()) {
+        if ($exportPlugin->hasCreateView()) {
             foreach ($views as $view) {
                 // no data export for a view
                 if ($structureOrData === StructureOrData::Data) {
@@ -818,12 +818,12 @@ class Export
         $isView = $tableObject->isView();
         if ($structureOrData !== StructureOrData::Data) {
             if ($isView) {
-                if (! $exportPlugin instanceof ExportSql || $exportPlugin->hasCreateView()) {
+                if ($exportPlugin->hasCreateView()) {
                     if (! $exportPlugin->exportStructure($db, $table, 'create_view', $aliases)) {
                         return;
                     }
                 }
-            } elseif (! $exportPlugin instanceof ExportSql || $exportPlugin->hasCreateTable()) {
+            } elseif ($exportPlugin->hasCreateTable()) {
                 if (! $exportPlugin->exportStructure($db, $table, 'create_table', $aliases)) {
                     return;
                 }
@@ -861,7 +861,7 @@ class Export
         // now export the triggers (needs to be done after the data because
         // triggers can modify already imported tables)
         if (
-            $exportPlugin instanceof ExportSql && $exportPlugin->hasCreateTrigger()
+            $exportPlugin->hasCreateTrigger()
             && $structureOrData !== StructureOrData::Data
         ) {
             if (! $exportPlugin->exportStructure($db, $table, 'triggers', $aliases)) {

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -818,12 +818,12 @@ class Export
         $isView = $tableObject->isView();
         if ($structureOrData !== StructureOrData::Data) {
             if ($isView) {
-                if ($exportPlugin instanceof ExportSql && $exportPlugin->hasCreateView() || ! $exportPlugin instanceof ExportSql) {
+                if (! $exportPlugin instanceof ExportSql || $exportPlugin->hasCreateView()) {
                     if (! $exportPlugin->exportStructure($db, $table, 'create_view', $aliases)) {
                         return;
                     }
                 }
-            } elseif ($exportPlugin instanceof ExportSql && $exportPlugin->hasCreateTable() || ! $exportPlugin instanceof ExportSql) {
+            } elseif (! $exportPlugin instanceof ExportSql || $exportPlugin->hasCreateTable()) {
                 if (! $exportPlugin->exportStructure($db, $table, 'create_table', $aliases)) {
                     return;
                 }

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -818,12 +818,12 @@ class Export
         $isView = $tableObject->isView();
         if ($structureOrData !== StructureOrData::Data) {
             if ($isView) {
-                if ($exportPlugin instanceof ExportSql && $exportPlugin->hasCreateView()) {
+                if ($exportPlugin instanceof ExportSql && $exportPlugin->hasCreateView() || ! $exportPlugin instanceof ExportSql) {
                     if (! $exportPlugin->exportStructure($db, $table, 'create_view', $aliases)) {
                         return;
                     }
                 }
-            } elseif ($exportPlugin instanceof ExportSql && $exportPlugin->hasCreateTable()) {
+            } elseif ($exportPlugin instanceof ExportSql && $exportPlugin->hasCreateTable() || ! $exportPlugin instanceof ExportSql) {
                 if (! $exportPlugin->exportStructure($db, $table, 'create_table', $aliases)) {
                     return;
                 }

--- a/src/Plugins/ExportPlugin.php
+++ b/src/Plugins/ExportPlugin.php
@@ -324,4 +324,40 @@ abstract class ExportPlugin implements Plugin
     {
         return $text;
     }
+
+    /**
+     * Indicates whether table structure export is supported.
+     * Non-SQL plugins default to true; SQL plugin overrides based on user options.
+     */
+    public function hasCreateTable(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Indicates whether view structure export is supported.
+     * Non-SQL plugins default to true; SQL plugin overrides based on user options.
+     */
+    public function hasCreateView(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Indicates whether procedure/function export is supported.
+     * Non-SQL plugins default to false; SQL plugin overrides based on user options.
+     */
+    public function hasCreateProcedureFunction(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Indicates whether trigger export is supported.
+     * Non-SQL plugins default to false; SQL plugin overrides based on user options.
+     */
+    public function hasCreateTrigger(): bool
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
- Modified conditions on lines 822 and 826 in exportTable()
- Added OR clause to allow non-SQL plugins (PDF, Excel, etc.)
- Restores structure export for plugins without hasCreateTable()/hasCreateView()

The conditional logic in exportTable() was specific to ExportSql,
preventing other export plugins (PDF, Excel, etc.) from calling
exportStructure(). Modified conditions on lines 822 and 826 to allow
non-SQL plugins to export structure without requiring SQL-specific
methods like hasCreateTable() and hasCreateView().

Fixes #19855

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
