### PR TITLE
Fix #19339 - Re-apply JSON syntax highlighting after AJAX updates

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -1731,6 +1731,28 @@ Functions.highlightSql = function ($base) {
 };
 
 /**
+ * Applies JSON syntax highlighting transformation using CodeMirror
+ *
+ * @param {JQuery} $base base element which contains the JSON code blocks
+ */
+Functions.highlightJson = function ($base) {
+    var $elm = $base.find('code.json');
+    $elm.each(function () {
+        var $json = $(this);
+        var $pre = $json.find('pre');
+        /* We only care about visible elements to avoid double processing */
+        if ($pre.is(':visible')) {
+            var $highlight = $('<div class="json-highlight cm-s-default"></div>');
+            $json.append($highlight);
+            if (typeof CodeMirror !== 'undefined' && typeof CodeMirror.runMode === 'function') {
+                CodeMirror.runMode($json.text(), 'application/json', $highlight[0]);
+                $pre.hide();
+            }
+        }
+    });
+};
+
+/**
  * Updates an element containing code.
  *
  * @param {JQuery} $base     base element which contains the raw and the

--- a/js/src/sql.js
+++ b/js/src/sql.js
@@ -675,6 +675,7 @@ AJAX.registerOnload('sql.js', function () {
                 .html(data.message)
                 .trigger('makeGrid');
             Functions.highlightSql($sqlqueryresults);
+            Functions.highlightJson($sqlqueryresults);
         }); // end $.post()
     }); // end displayOptionsForm handler
 

--- a/js/src/transformations/json.js
+++ b/js/src/transformations/json.js
@@ -2,16 +2,5 @@
  * JSON syntax highlighting transformation plugin
  */
 AJAX.registerOnload('transformations/json.js', function () {
-    var $elm = $('#page_content').find('code.json');
-    $elm.each(function () {
-        var $json = $(this);
-        var $pre = $json.find('pre');
-        /* We only care about visible elements to avoid double processing */
-        if ($pre.is(':visible')) {
-            var $highlight = $('<div class="json-highlight cm-s-default"></div>');
-            $json.append($highlight);
-            CodeMirror.runMode($json.text(), 'application/json', $highlight[0]);
-            $pre.hide();
-        }
-    });
+    Functions.highlightJson($('#page_content'));
 });


### PR DESCRIPTION
- Extract JSON highlighting logic into Functions.highlightJson()
- Call highlightJson() after display options form submission
- Ensures `CodeMirror` highlighting persists on dynamic content updates
Fixes #19339

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
