### PR TITLE
Display table comment as preformatted text

### DIFF
--- a/templates/database/data_dictionary/index.twig
+++ b/templates/database/data_dictionary/index.twig
@@ -13,7 +13,8 @@
       <div>
         <h2>{{ table.name }}</h2>
         {% if table.comment is not empty %}
-          <p>{% trans 'Table comments:' %} <em>{{ table.comment }}</em></p>
+          {% trans 'Table comments:' %}
+          <em><pre>{{ table.comment }}</pre></em>
         {% endif %}
 
         <table class="table table-striped align-middle">

--- a/templates/table/structure/display_table_stats.twig
+++ b/templates/table/structure/display_table_stats.twig
@@ -2,10 +2,8 @@
     <fieldset class="pma-fieldset">
         <legend>{% trans 'Information' %}</legend>
         {% if showtable['TABLE_COMMENT'] %}
-            <p>
-                <strong>{% trans 'Table comments:' %}</strong>
-                {{ showtable['TABLE_COMMENT'] }}
-            </p>
+            <strong>{% trans 'Table comments:' %}</strong>
+            <em><pre>{{ showtable['TABLE_COMMENT'] }}</pre></em>
         {% endif %}
         <a id="showusage"></a>
 


### PR DESCRIPTION
### Description

Please describe your pull request.

The table structure page after this change:
<img width="672" height="802" alt="image" src="https://github.com/user-attachments/assets/edb5be2b-7d68-4e0c-a3ab-2202cc1fd70a" />


The schema Data dictionary page after this change:
<img width="393" height="642" alt="image" src="https://github.com/user-attachments/assets/4e96d202-9ff8-4835-a310-797e9bf526f6" />
