### PR TITLE
Fix #19941 - Export ODS column headers by default

### DIFF
--- a/src/Config/Settings/Export.php
+++ b/src/Config/Settings/Export.php
@@ -282,7 +282,7 @@ final class Export
 
     /**
      * ```php
-     * $cfg['Export']['ods_columns'] = false;
+     * $cfg['Export']['ods_columns'] = true;
      * ```
      */
     public bool $ods_columns;


### PR DESCRIPTION
### Description

When exporting into ODS file format, export column names as column headers by default.

Fixes #19941

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [X] Any new functionality is covered by tests.
