### PR TITLE
Quoting is only needed when separators appear in text

### DIFF
--- a/src/Plugins/Export/ExportCsv.php
+++ b/src/Plugins/Export/ExportCsv.php
@@ -297,27 +297,27 @@ class ExportCsv extends ExportPlugin
         );
         $this->terminated = $this->setStringValue(
             $request->getParsedBodyParam('csv_terminated'),
-            $exportConfig['csv_terminated'] ?? null,
+            $exportConfig['csv_terminated'] ?? $this->terminated,
         );
         $this->separator = $this->setStringValue(
             $request->getParsedBodyParam('csv_separator'),
-            $exportConfig['csv_separator'] ?? null,
+            $exportConfig['csv_separator'] ?? $this->separator,
         );
         $this->columns = (bool) ($request->getParsedBodyParam('csv_columns')
             ?? $exportConfig['csv_columns'] ?? false);
         $this->enclosed = $this->setStringValue(
             $request->getParsedBodyParam('csv_enclosed'),
-            $exportConfig['csv_enclosed'] ?? null,
+            $exportConfig['csv_enclosed'] ?? $this->enclosed,
         );
         $this->escaped = $this->setStringValue(
             $request->getParsedBodyParam('csv_escaped'),
-            $exportConfig['csv_escaped'] ?? null,
+            $exportConfig['csv_escaped'] ?? $this->escaped,
         );
         $this->removeCrLf = (bool) ($request->getParsedBodyParam('csv_removeCRLF')
             ?? $exportConfig['csv_removeCRLF'] ?? false);
         $this->null = $this->setStringValue(
             $request->getParsedBodyParam('csv_null'),
-            $exportConfig['csv_null'] ?? null,
+            $exportConfig['csv_null'] ?? $this->null,
         );
     }
 

--- a/src/Plugins/Export/ExportCsv.php
+++ b/src/Plugins/Export/ExportCsv.php
@@ -22,8 +22,9 @@ use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use function __;
 use function implode;
 use function is_string;
-use function mb_strtolower;
+use function str_contains;
 use function str_replace;
+use function strtolower;
 
 /**
  * Handles the export for the CSV format
@@ -112,7 +113,7 @@ class ExportCsv extends ExportPlugin
     public function exportHeader(): bool
     {
         // Here we just prepare some values for export
-        if ($this->terminated === '' || mb_strtolower($this->terminated) === 'auto') {
+        if ($this->terminated === '' || strtolower($this->terminated) === 'auto') {
             $this->terminated = "\n";
         } else {
             $this->terminated = str_replace(
@@ -193,7 +194,13 @@ class ExportCsv extends ExportPlugin
             foreach ($result->getFieldNames() as $colAs) {
                 $colAs = $this->getColumnAlias($aliases, $db, $table, $colAs);
 
-                if ($this->enclosed === '') {
+                if (
+                    $this->enclosed === ''
+                    || (! str_contains($colAs, $this->separator)
+                        && ! str_contains($colAs, $this->enclosed)
+                        && ! str_contains($colAs, $this->terminated)
+                    )
+                ) {
                     $insertFields[] = $colAs;
                 } else {
                     $insertFields[] = $this->enclosed
@@ -224,7 +231,13 @@ class ExportCsv extends ExportPlugin
                         );
                     }
 
-                    if ($this->enclosed === '') {
+                    if (
+                        $this->enclosed === ''
+                        || (! str_contains($field, $this->separator)
+                            && ! str_contains($field, $this->enclosed)
+                            && ! str_contains($field, $this->terminated)
+                        )
+                    ) {
                         $insertValues[] = $field;
                     } elseif ($this->escaped !== $this->enclosed) {
                         // also double the escape string if found in the data

--- a/tests/unit/Plugins/Export/ExportCsvTest.php
+++ b/tests/unit/Plugins/Export/ExportCsvTest.php
@@ -281,17 +281,19 @@ class ExportCsvTest extends AbstractTestCase
             ->withParsedBody(['csv_terminated' => ';', 'csv_columns' => 'On']);
 
         $this->object->setExportOptions($request, []);
+        $this->object->exportHeader();
 
         ob_start();
         self::assertTrue($this->object->exportData(
             'test_db',
             'test_table',
-            'SELECT * FROM `test_db`.`test_table`;',
+            'SELECT * FROM `test_db`.`test_table_csv_export`;',
         ));
         $result = ob_get_clean();
 
         self::assertSame(
-            'idnamedatetimefield;1abcd2011-01-20 02:00:02;2foo2010-01-20 02:00:02;3Abcd2012-01-20 02:00:02;',
+            'id,name,datetimefield;1,"ab""cd",2011-01-20 02:00:02;2,"foo;",2010-01-20 02:00:02;3,'
+                . "\n" . 'Abcd,2012-01-20 02:00:02;',
             $result,
         );
 
@@ -300,63 +302,42 @@ class ExportCsvTest extends AbstractTestCase
             ->withParsedBody(['csv_enclosed' => '"', 'csv_terminated' => ';', 'csv_columns' => 'On']);
 
         $this->object->setExportOptions($request, []);
+        $this->object->exportHeader();
 
         ob_start();
         self::assertTrue($this->object->exportData(
             'test_db',
-            'test_table',
-            'SELECT * FROM `test_db`.`test_table`;',
+            'test_table_csv_export',
+            'SELECT * FROM `test_db`.`test_table_csv_export`;',
         ));
         $result = ob_get_clean();
 
         self::assertSame(
-            '"id""name""datetimefield";"1""abcd""2011-01-20 02:00:02";'
-            . '"2""foo""2010-01-20 02:00:02";"3""Abcd""2012-01-20 02:00:02";',
+            'id,name,datetimefield;1,"ab""cd",2011-01-20 02:00:02;2,"foo;",2010-01-20 02:00:02;3,'
+                . "\n" . 'Abcd,2012-01-20 02:00:02;',
             $result,
         );
 
         // case 4
+        $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/')
+            ->withParsedBody(['csv_enclosed' => '|', 'csv_terminated' => "\n", 'csv_escaped' => '\\', 'csv_columns' => 'On']);
+
+        $this->object->setExportOptions($request, []);
+        $this->object->exportHeader();
+
         ob_start();
         self::assertTrue($this->object->exportData(
             'test_db',
-            'test_table',
-            'SELECT * FROM `test_db`.`test_table`;',
+            'test_table_csv_export',
+            'SELECT * FROM `test_db`.`test_table_csv_export`;',
         ));
         $result = ob_get_clean();
 
         self::assertSame(
-            '"id""name""datetimefield";"1""abcd""2011-01-20 02:00:02";'
-            . '"2""foo""2010-01-20 02:00:02";"3""Abcd""2012-01-20 02:00:02";',
-            $result,
-        );
-
-        // case 5
-        ob_start();
-        self::assertTrue($this->object->exportData(
-            'test_db',
-            'test_table',
-            'SELECT * FROM `test_db`.`test_table`;',
-        ));
-        $result = ob_get_clean();
-
-        self::assertSame(
-            '"id""name""datetimefield";"1""abcd""2011-01-20 02:00:02";'
-            . '"2""foo""2010-01-20 02:00:02";"3""Abcd""2012-01-20 02:00:02";',
-            $result,
-        );
-
-        // case 6
-        ob_start();
-        self::assertTrue($this->object->exportData(
-            'test_db',
-            'test_table',
-            'SELECT * FROM `test_db`.`test_table`;',
-        ));
-        $result = ob_get_clean();
-
-        self::assertSame(
-            '"id""name""datetimefield";"1""abcd""2011-01-20 02:00:02";'
-            . '"2""foo""2010-01-20 02:00:02";"3""Abcd""2012-01-20 02:00:02";',
+            'id,name,datetimefield' . "\n"
+                . '1,ab"cd,2011-01-20 02:00:02' . "\n"
+                . '2,foo;,2010-01-20 02:00:02' . "\n"
+                . '3,|' . "\n" . 'Abcd|,2012-01-20 02:00:02' . "\n",
             $result,
         );
     }

--- a/tests/unit/Stubs/DbiDummy.php
+++ b/tests/unit/Stubs/DbiDummy.php
@@ -1740,6 +1740,15 @@ class DbiDummy implements DbiExtension
                 ],
             ],
             [
+                'query' => 'SELECT * FROM `test_db`.`test_table_csv_export`;',
+                'columns' => ['id', 'name', 'datetimefield'],
+                'result' => [
+                    ['1', 'ab"cd', '2011-01-20 02:00:02'],
+                    ['2', 'foo;', '2010-01-20 02:00:02'],
+                    ['3', "\nAbcd", '2012-01-20 02:00:02'],
+                ],
+            ],
+            [
                 'query' => 'SELECT * FROM `test_db`.`test_table_complex`;',
                 'columns' => ['f1', 'f2', 'f3', 'f4'],
                 'result' => [


### PR DESCRIPTION
I propose to only quote the data when it is strictly necessary. As per https://www.ietf.org/rfc/rfc4180.txt it is only necessary when line breaks, double quotes, and commas exist in the text. 

PMA supports the PHP proprietary escaping mechanism, but according to the PHP manual, the escape character shouldn't be escaped, which is why it is not included in this PR. 

The reason for this change is that it creates a significantly smaller CSV file. While the disk size isn't something to be concerned with, the additional characters make processing the CSV slower. In tables with many int columns, this could add up to a lot of unnecessary processing. It also saves network bandwidth. 

Checking if a field needs to be quoted adds overhead, but it balances out because the string doesn't need to be modified, so no performance impact on exporting.