### PR TITLE
Fix #19749 - Descending index being converted to ascending

### DIFF
--- a/libraries/classes/Index.php
+++ b/libraries/classes/Index.php
@@ -271,11 +271,14 @@ class Index
             // coming from form
             // $columns[names][]
             // $columns[sub_parts][]
+            // $columns[collations][]
             foreach ($columns['names'] as $key => $name) {
                 $sub_part = $columns['sub_parts'][$key] ?? '';
+                $collation = $columns['collations'][$key] ??
                 $_columns[] = [
                     'Column_name' => $name,
                     'Sub_part' => $sub_part,
+                    'Collation' => $collation,
                 ];
             }
         } else {

--- a/libraries/classes/Index.php
+++ b/libraries/classes/Index.php
@@ -274,7 +274,7 @@ class Index
             // $columns[collations][]
             foreach ($columns['names'] as $key => $name) {
                 $sub_part = $columns['sub_parts'][$key] ?? '';
-                $collation = $columns['collations'][$key] ??
+                $collation = $columns['collations'][$key] ?? null;
                 $_columns[] = [
                     'Column_name' => $name,
                     'Sub_part' => $sub_part,

--- a/libraries/classes/IndexColumn.php
+++ b/libraries/classes/IndexColumn.php
@@ -17,7 +17,7 @@ class IndexColumn
     /** @var int The column sequence number in the index, starting with 1. */
     private $seqInIndex = 1;
 
-    /** @var string|null How the column is sorted in the index. "A" (Ascending) or NULL (Not sorted) */
+    /** @var string|null How the column is sorted in the index. "A" (Ascending), "D" (Descending) or NULL (Not sorted) */
     private $collation = null;
 
     /**

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -2137,11 +2137,20 @@ class Table implements Stringable
         $indexFields = [];
         foreach ($index->getColumns() as $key => $column) {
             $indexFields[$key] = Util::backquote($column->getName());
-            if (! $column->getSubPart()) {
+            if ($column->getSubPart()) {
+                $indexFields[$key] .= '(' . $column->getSubPart() . ')';
+            }
+
+            if (! $column->getCollation()) {
                 continue;
             }
 
-            $indexFields[$key] .= '(' . $column->getSubPart() . ')';
+            $collation = $column->getCollation();
+            if ($collation === 'A') {
+                $indexFields[$key] .= ' ASC';
+            } elseif ($collation === 'D') {
+                $indexFields[$key] .= ' DESC';
+            }
         }
 
         if (empty($indexFields)) {

--- a/templates/table/index_form.twig
+++ b/templates/table/index_form.twig
@@ -233,6 +233,13 @@
                                     name="index[columns][sub_parts][]"
                                     value="">
                             </td>
+                            <td>
+                                <select name="index[columns][collations][]">
+                                    <option value="None" selected>None</option>
++                                   <option value="A">A</option>
++                                   <option value="D">D</option>
+                                </select>
+                            </td>
                         </tr>
                     {% endfor %}
                 {% endif %}

--- a/templates/table/index_form.twig
+++ b/templates/table/index_form.twig
@@ -143,6 +143,9 @@
                     <th>
                         {% trans 'Size' %}
                     </th>
+                    <th>
+                        {% trans 'Collation' %}
+                    </th>
                 </tr>
             </thead>
             {% set spatial_types = [
@@ -189,6 +192,13 @@
                                 name="index[columns][sub_parts][]"
                                 value="{{ index.getChoice() != 'SPATIAL' ?
                                     column.getSubPart() }}">
+                        </td>
+                        <td>
+                            <select name="index[columns][collations][]">
+                                <option value="None"{{ column.Collation ? ' selected' }}>None</option>
++                               <option value="A"{{ column.Collation == 'A' ? ' selected' }}>A</option>
++                               <option value="D"{{ column.Collation == 'D' ? ' selected' }}>D</option>
+                            </select>
                         </td>
                     </tr>
                 {% endfor %}


### PR DESCRIPTION
### Description

Please describe your pull request.

This pull request fixes an issue where descending index columns (`D`) were not preserved when editing an index. When a column had a collation of `D` (meaning DESC), phpMyAdmin generated an index definition without specifying any direction.

Since MySQL and MariaDB default to `ASC` when no direction is specified, the
original `DESC` was effectively lost.

This bug was originally reported against the `QA_5_2` branch:
Fixes #19749

The fix updates the SQL generation logic to explicitly map column collation
values:

- `A` → `ASC`
- `D` → `DESC`

ensuring the original index direction is preserved correctly.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
