### PR TITLE
Show correct result size with parser error

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -3652,11 +3652,12 @@ class Results
             $total,
         ] = $this->setDisplayPartsAndTotal($displayParts);
 
+        $hasParserError = isset($analyzedSqlResults['parser']) && $analyzedSqlResults['parser']->errors !== [];
         // 1.2 Defines offsets for the next and previous pages
         $posNext = 0;
         $posPrev = 0;
         if ($displayParts['nav_bar'] == '1') {
-            [$posNext, $posPrev] = $this->getOffsets();
+            [$posNext, $posPrev] = $hasParserError ? [$total, 0] : $this->getOffsets();
         }
 
         // 1.3 Extract sorting expressions.
@@ -3746,7 +3747,12 @@ class Results
         }
 
         $navigation = [];
-        if ($displayParts['nav_bar'] == '1' && $statement !== null && empty($statement->limit)) {
+        if (
+            $displayParts['nav_bar'] == '1' &&
+            ! $hasParserError &&
+            $statement !== null &&
+            empty($statement->limit)
+        ) {
             $navigation = $this->getTableNavigation($posNext, $posPrev, $isInnodb, $sortByKeyData);
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15851,6 +15851,11 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
+			message: "#^Cannot access property \\$errors on mixed\\.$#"
+			count: 1
+			path: libraries/classes/Display/Results.php
+
+		-
 			message: "#^Cannot access property \\$expr on mixed\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
@@ -16451,6 +16456,11 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
+			message: "#^Parameter \\#1 \\$posNext of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTableNavigation\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Display/Results.php
+
+		-
 			message: "#^Parameter \\#1 \\$printLink of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getResultsOperations\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
@@ -16551,6 +16561,11 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
+			message: "#^Parameter \\#2 \\$posPrevious of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTableNavigation\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Display/Results.php
+
+		-
 			message: "#^Parameter \\#2 \\$rows of static method PhpMyAdmin\\\\Util\\:\\:pageselector\\(\\) expects int, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
@@ -16607,6 +16622,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#4 \\$deleteLink of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getDeleteAndKillLinks\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Display/Results.php
+
+		-
+			message: "#^Parameter \\#4 \\$posNext of method PhpMyAdmin\\\\Display\\\\Results\\:\\:setMessageInformation\\(\\) expects int, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5998,7 +5998,7 @@
       <code>$GLOBALS['cfg']['Order']</code>
       <code>$delUrlParams</code>
     </InvalidArrayOffset>
-    <MixedArgument occurrences="61">
+    <MixedArgument occurrences="64">
       <code>$_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['pos'] / $_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['query']</code>
@@ -6039,6 +6039,9 @@
       <code>$newSortExpressionNoDirection</code>
       <code>$oneKey['ref_db_name'] ?? $GLOBALS['db']</code>
       <code>$oneKey['ref_table_name']</code>
+      <code>$posNext</code>
+      <code>$posNext</code>
+      <code>$posPrev</code>
       <code>$rel['foreign_db']</code>
       <code>$rel['foreign_table']</code>
       <code>$row[$i]</code>
@@ -6286,7 +6289,8 @@
       <code>$firstShownRec</code>
       <code>$sortExpressionNoDirection[$indexInExpression]</code>
     </MixedOperand>
-    <MixedPropertyFetch occurrences="17">
+    <MixedPropertyFetch occurrences="18">
+      <code>$analyzedSqlResults['parser']-&gt;errors</code>
       <code>$analyzedSqlResults['parser']-&gt;list</code>
       <code>$analyzedSqlResults['parser']-&gt;list</code>
       <code>$analyzedSqlResults['parser']-&gt;list</code>


### PR DESCRIPTION
### Description

If no limit clause is applied because of a parser error, then don't display prev/next buttons and display the total result range instead of 0-24. 
See line 387 below which causes the limit clause to not be added in this case.

Fixes #19943

https://github.com/phpmyadmin/phpmyadmin/blob/9d0f6110d5ff27ffc8a8d8e14fab339d71d7a720/libraries/classes/Sql.php#L380-L395

Before submitting pull request, please review the following checklist: