### PR TITLE
Fix #19950 - Dispose tooltips when Enter is pressed

### DIFF
--- a/resources/js/modules/ajax-message.ts
+++ b/resources/js/modules/ajax-message.ts
@@ -96,6 +96,7 @@ const ajaxShowMessage = function (message = null, timeout = null, type = null) {
     // Update message count to create distinct message elements every time
     ajaxMessageCount++;
     // Remove all old messages, if any
+    $('[role="tooltip"]').remove();
     $('span.ajax_notification[id^=ajax_message_num]').remove();
     /**
      * @var $retval    a jQuery object containing the reference

--- a/resources/js/modules/functions.ts
+++ b/resources/js/modules/functions.ts
@@ -1521,7 +1521,7 @@ export function dismissNotifications () {
             displayCopyStatus(this, copyStatus);
         });
 
-        $(document).on('mouseover mouseleave', 'a.copyQueryBtn', function (event) {
+        $(document).on('mouseover mouseleave', 'span.ajax_notification.dismissable a', function (event) {
             let message = window.Messages.strDismiss;
 
             if (event.type === 'mouseover') {

--- a/resources/js/modules/functions.ts
+++ b/resources/js/modules/functions.ts
@@ -198,10 +198,10 @@ export function addDateTimePicker () {
 
         // Add a tip regarding entering MySQL allowed-values for TIME and DATE data-type
         if (this.classList.contains('timefield')) {
-            bootstrap.Tooltip.getOrCreateInstance(this, { title: window.Messages.strMysqlAllowedValuesTipTime })
+            bootstrap.Tooltip.getOrCreateInstance(this, { title: window.Messages.strMysqlAllowedValuesTipTime, trigger: 'hover' })
                 .setContent({ '.tooltip-inner': window.Messages.strMysqlAllowedValuesTipTime });
         } else if (this.classList.contains('datefield')) {
-            bootstrap.Tooltip.getOrCreateInstance(this, { title: window.Messages.strMysqlAllowedValuesTipDate })
+            bootstrap.Tooltip.getOrCreateInstance(this, { title: window.Messages.strMysqlAllowedValuesTipDate, trigger: 'hover' })
                 .setContent({ '.tooltip-inner': window.Messages.strMysqlAllowedValuesTipDate });
         }
     });

--- a/resources/js/modules/functions.ts
+++ b/resources/js/modules/functions.ts
@@ -1521,7 +1521,7 @@ export function dismissNotifications () {
             displayCopyStatus(this, copyStatus);
         });
 
-        $(document).on('mouseover mouseleave', '.ajax_notification a', function (event) {
+        $(document).on('mouseover mouseleave', 'a.copyQueryBtn', function (event) {
             let message = window.Messages.strDismiss;
 
             if (event.type === 'mouseover') {

--- a/resources/js/table/select.ts
+++ b/resources/js/table/select.ts
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import * as bootstrap from 'bootstrap';
 import { AJAX } from '../modules/ajax.ts';
 import { addDatepicker, prepareForAjaxRequest } from '../modules/functions.ts';
 import { CommonParams } from '../modules/common.ts';
@@ -117,6 +118,14 @@ AJAX.registerOnload('table/select.js', function () {
         // jQuery object to reuse
         var $searchForm = $(this);
         event.preventDefault();
+
+        // Dispose tooltips. See #19950
+        $('input.datefield, input.timefield').each(function () {
+            const tooltipInstance = bootstrap.Tooltip.getInstance(this);
+            if (tooltipInstance) {
+                tooltipInstance.dispose();
+            }
+        });
 
         // empty previous search results while we are waiting for new results
         $('#sqlqueryresultsouter').empty();


### PR DESCRIPTION
### Description

For `master`, if the input is clicked, the tooltip will also remain there, because of focus. So I made it to show only on hover, like in `QA_5_2`.

**Before:**

https://github.com/user-attachments/assets/9caacc5a-9d06-4867-bf91-d80f927e0c11

**After:**

https://github.com/user-attachments/assets/3f145891-c678-47f4-a304-f951ea9da335

I also found another which was broken too. It was creating 2 tooltips, and also it had a wrong selector. It was dead code.

**Before:**

https://github.com/user-attachments/assets/62e108d1-4313-40d8-8cd5-1232cdc578a1

**After:**

https://github.com/user-attachments/assets/1719f0b9-4f56-4748-90a8-1e8f6ff699e5

Fixes #19950

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
