### PR TITLE
Fix #19964 - decimal column type detection for import

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -20522,7 +20522,7 @@ parameters:
 
 		-
 			message: "#^Casting to string something that's already string\\.$#"
-			count: 4
+			count: 3
 			path: libraries/classes/Import.php
 
 		-
@@ -20571,17 +20571,7 @@ parameters:
 			path: libraries/classes/Import.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Import\\:\\:detectSize\\(\\) should return int\\|string but returns mixed\\.$#"
-			count: 3
-			path: libraries/classes/Import.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Import\\:\\:executeQuery\\(\\) has parameter \\$sqlData with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Import.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Import\\:\\:getDecimalSize\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Import.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7838,14 +7838,11 @@
       <code>$sql_query</code>
       <code>$table</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>string|int</code>
-    </MixedInferredReturnType>
     <MixedMethodCall occurrences="2">
       <code>getExtension</code>
       <code>getProperties</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="19">
+    <MixedOperand occurrences="16">
       <code>$complete_query</code>
       <code>$display_query</code>
       <code>$executed_queries</code>
@@ -7855,9 +7852,6 @@
       <code>$read_multiply</code>
       <code>$size</code>
       <code>$size</code>
-      <code>$size[self::D]</code>
-      <code>$size[self::D] &gt; $oldD ? $size[self::D] : $oldD</code>
-      <code>$size[self::M] &gt; $oldM ? $size[self::M] : $oldM</code>
       <code>$skip_queries</code>
       <code>$sqlData['valid_queries']</code>
       <code>$sqlData['valid_queries']</code>
@@ -7866,11 +7860,6 @@
       <code>$sql_query</code>
       <code>$timestamp</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="3">
-      <code>$size[self::FULL]</code>
-      <code>$size[self::FULL]</code>
-      <code>$size[self::M]</code>
-    </MixedReturnStatement>
     <PossiblyFalseOperand occurrences="3">
       <code>$decPos</code>
       <code>strpos($lastCumulativeSize, ',')</code>
@@ -7890,7 +7879,7 @@
     <PossiblyNullArrayAccess occurrences="1">
       <code>$additionalSql[$i]</code>
     </PossiblyNullArrayAccess>
-    <RedundantCast occurrences="4">
+    <RedundantCast occurrences="3">
       <code>(string) $cell</code>
       <code>(string) $cell</code>
       <code>(string) $cell</code>

--- a/test/classes/ImportTest.php
+++ b/test/classes/ImportTest.php
@@ -456,6 +456,45 @@ class ImportTest extends AbstractTestCase
     }
 
     /**
+     * Test for detectSize
+     *
+     * @param string|int $lastCumulativeSize Last cumulative column size
+     * @param int|null   $lastCumulativeType Last cumulative column type (NONE or VARCHAR or DECIMAL or INT or BIGINT)
+     * @param int        $currentCellType    Type of the current cell (NONE or VARCHAR or DECIMAL or INT or BIGINT)
+     * @param string     $cell               The current cell
+     *
+     * @dataProvider provTestDetectSize
+     */
+    public function testDetectSize(
+        string $expected,
+        $lastCumulativeSize,
+        ?int $lastCumulativeType,
+        int $currentCellType,
+        string $cell
+    ): void {
+        $actual = $this->import->detectSize($lastCumulativeSize, $lastCumulativeType, $currentCellType, $cell);
+        self::assertSame($expected, $actual);
+    }
+
+    /**
+     * Data provider for testDetectSize
+     *
+     * @return array<array{string,string|int,int,int,string}>
+     */
+    public function provTestDetectSize(): array
+    {
+        return [
+            [
+                '8,3',
+                '7,2',
+                Import::DECIMAL,
+                Import::DECIMAL,
+                '11.555',
+            ],
+        ];
+    }
+
+    /**
      * Test for checkIfRollbackPossible
      */
     public function testPMACheckIfRollbackPossible(): void


### PR DESCRIPTION
### Description

First number of decimal type is all digits, second number is the number of decimals.
To check if the type should be larger the number of digits before the decimal point and after the decimal point need to be compared.

Fixes #19964