### PR TITLE
Fix JSON column support check for MariaDB 10.2.7

### DIFF
--- a/libraries/classes/Query/Compatibility.php
+++ b/libraries/classes/Query/Compatibility.php
@@ -204,8 +204,22 @@ class Compatibility
     }
 
     /**
+     * Check whether the database supports JSON data type
+     *
+     * @return bool true if JSON is supported
+     */
+    public static function isJsonSupported(DatabaseInterface $dbi): bool
+    {
+        // @see: https://mariadb.com/kb/en/mariadb-1027-release-notes/#json
+        // @see: https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-8.html#mysqld-5-7-8-json
+        return $dbi->isMariaDB() && $dbi->getVersion() >= 100207 || // 10.2.7
+            ! $dbi->isMariaDB() && $dbi->getVersion() >= 50708; // 5.7.8
+    }
+
+    /**
      * Check whether the database supports UUID data type
-     * true if uuid is supported
+     *
+     * @return bool true if UUID is supported
      */
     public static function isUUIDSupported(DatabaseInterface $dbi): bool
     {

--- a/libraries/classes/Types.php
+++ b/libraries/classes/Types.php
@@ -774,6 +774,7 @@ class Types
     {
         $isMariaDB = $this->dbi->isMariaDB();
         $serverVersion = $this->dbi->getVersion();
+        $isJsonSupported = Compatibility::isJsonSupported($this->dbi);
         $isUUIDSupported = Compatibility::isUUIDSupported($this->dbi);
 
         // most used types
@@ -854,7 +855,7 @@ class Types
             'GEOMETRYCOLLECTION',
         ];
 
-        if (($isMariaDB && $serverVersion > 100207) || (! $isMariaDB && $serverVersion >= 50708)) {
+        if ($isJsonSupported) {
             $ret['JSON'] = ['JSON'];
         }
 

--- a/test/classes/Query/CompatibilityTest.php
+++ b/test/classes/Query/CompatibilityTest.php
@@ -65,6 +65,33 @@ class CompatibilityTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider providerForTestIsJsonSupported
+     */
+    public function testIsJsonSupported(bool $expected, bool $isMariaDb, int $version): void
+    {
+        $dbiStub = $this->createStub(DatabaseInterface::class);
+
+        $dbiStub->method('isMariaDB')->willReturn($isMariaDb);
+        $dbiStub->method('getVersion')->willReturn($version);
+
+        self::assertSame($expected, Compatibility::isJsonSupported($dbiStub));
+    }
+
+    /**
+     * @return array[]
+     * @psalm-return array<string, array{bool, bool, int}>
+     */
+    public static function providerForTestIsJsonSupported(): array
+    {
+        return [
+            'MySQL 5.7.7' => [false, false, 50707],
+            'MySQL 5.7.8' => [false, true, 50708],
+            'MariaDB 10.2.6' => [false, true, 100206],
+            'MariaDB 10.2.7' => [true, true, 100207],
+        ];
+    }
+
     /** @dataProvider showBinLogStatusProvider */
     public function testGetShowBinLogStatusStmt(string $serverName, int $version, string $expected): void
     {


### PR DESCRIPTION
Support was introduced in >=10.2.7, not >10.2.7.
https://mariadb.com/docs/release-notes/community-server/old-releases/release-notes-mariadb-10-2-series/mariadb-1027-release-notes#notable-changes