### PR TITLE
Support creating and changing VECTOR column

### DIFF
--- a/libraries/classes/Query/Compatibility.php
+++ b/libraries/classes/Query/Compatibility.php
@@ -214,6 +214,19 @@ class Compatibility
     }
 
     /**
+     * Check whether the database supports VECTOR data type
+     *
+     * @return bool true if VECTOR is supported
+     */
+    public static function isVectorSupported(DatabaseInterface $dbi): bool
+    {
+        // @see: https://mariadb.com/docs/release-notes/community-server/old-releases/mariadb-11-7-rolling-releases/mariadb-11-7-1-release-notes#vectors
+        // @see: https://dev.mysql.com/doc/relnotes/mysql/9.0/en/news-9-0-0.html#mysqld-9-0-0-vectors
+        return $dbi->isMariaDB() && $dbi->getVersion() >= 110701 || // 11.7.1
+            $dbi->isMySql() && $dbi->getVersion() >= 90000; // 9.0.0
+    }
+
+    /**
      * Returns whether the database server supports virtual columns
      */
     public static function supportsStoredKeywordForVirtualColumns(int $serverVersion): bool

--- a/libraries/classes/Types.php
+++ b/libraries/classes/Types.php
@@ -775,6 +775,7 @@ class Types
         $isMariaDB = $this->dbi->isMariaDB();
         $serverVersion = $this->dbi->getVersion();
         $isUUIDSupported = Compatibility::isUUIDSupported($this->dbi);
+        $isVectorSupported = Compatibility::isVectorSupported($this->dbi);
 
         // most used types
         $ret = [
@@ -860,6 +861,10 @@ class Types
 
         if ($isUUIDSupported) {
             $ret['UUID'] = ['UUID'];
+        }
+
+        if ($isVectorSupported) {
+            $ret['VECTOR'] = ['VECTOR'];
         }
 
         return $ret;

--- a/test/classes/Query/CompatibilityTest.php
+++ b/test/classes/Query/CompatibilityTest.php
@@ -55,6 +55,33 @@ class CompatibilityTest extends TestCase
      * @return array[]
      * @psalm-return array<string, array{bool, bool, int}>
      */
+    public static function providerForTestIsVectorSupported(): array
+    {
+        return [
+            'MySQL 8.99.99' => [false, false, 89999],
+            'MySQL 9.0.0' => [false, false, 90000],
+            'MariaDB 11.6.99' => [false, true, 110699],
+            'MariaDB 11.7.1' => [true, true, 110701],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestIsVectorSupported
+     */
+    public function testIsVectorSupported(bool $expected, bool $isMariaDb, int $version): void
+    {
+        $dbiStub = $this->createStub(DatabaseInterface::class);
+
+        $dbiStub->method('isMariaDB')->willReturn($isMariaDb);
+        $dbiStub->method('getVersion')->willReturn($version);
+
+        self::assertSame($expected, Compatibility::isVectorSupported($dbiStub));
+    }
+
+    /**
+     * @return array[]
+     * @psalm-return array<string, array{bool, bool, int}>
+     */
     public static function providerForTestIsUUIDSupported(): array
     {
         return [


### PR DESCRIPTION
### Description

This adds support to create a VECTOR column and no longer changes the column type to INT when changing a VECTOR column.

Fixes second part of https://github.com/phpmyadmin/phpmyadmin/issues/19261#issuecomment-3586999119