### PR TITLE
Fix decorateColumnMetaDefault

### DIFF
--- a/src/Table/ColumnsDefinition.php
+++ b/src/Table/ColumnsDefinition.php
@@ -365,30 +365,12 @@ final class ColumnsDefinition
      */
     public static function decorateColumnMetaDefault(string|null $default, bool $isNull): array
     {
-        $metaDefault = ['DefaultType' => 'USER_DEFINED', 'DefaultValue' => ''];
-
-        switch ($default) {
-            case null:
-                $metaDefault['DefaultType'] = $isNull ? 'NULL' : 'NONE';
-
-                break;
-            case 'CURRENT_TIMESTAMP':
-            case 'current_timestamp()':
-                $metaDefault['DefaultType'] = 'CURRENT_TIMESTAMP';
-
-                break;
-            case 'UUID':
-            case 'uuid()':
-                $metaDefault['DefaultType'] = 'UUID';
-
-                break;
-            default:
-                $metaDefault['DefaultValue'] = $default;
-
-                break;
-        }
-
-        return $metaDefault;
+        return match ($default) {
+            null => ['DefaultType' => $isNull ? 'NULL' : 'NONE', 'DefaultValue' => ''],
+            'CURRENT_TIMESTAMP', 'current_timestamp()' => ['DefaultType' => 'CURRENT_TIMESTAMP', 'DefaultValue' => ''],
+            'UUID', 'uuid()' => ['DefaultType' => 'UUID', 'DefaultValue' => ''],
+            default => ['DefaultType' => 'USER_DEFINED', 'DefaultValue' => $default],
+        };
     }
 
     /**

--- a/tests/unit/Table/ColumnsDefinitionTest.php
+++ b/tests/unit/Table/ColumnsDefinitionTest.php
@@ -282,6 +282,11 @@ class ColumnsDefinitionTest extends AbstractTestCase
                 false,
                 ['DefaultType' => 'USER_DEFINED', 'DefaultValue' => '"some\/thing"'],
             ],
+            'when Default is an empty string' => [
+                '',
+                false,
+                ['DefaultType' => 'USER_DEFINED', 'DefaultValue' => ''],
+            ],
         ];
     }
 }


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/phpmyadmin/phpmyadmin/issues/16801#issuecomment-3581416906 on 6.0

To fix this on 5.2, I recommend `switch(true)` and in each case add `$default === `.