### PR TITLE
Change `Drop` to `Delete` wording

### DIFF
--- a/resources/templates/database/structure/structure_table_row.twig
+++ b/resources/templates/database/structure/structure_table_row.twig
@@ -84,7 +84,7 @@
                   'sql_query': drop_query,
                   'message_to_show': drop_message
                 }), '') }}">
-                {{ get_icon('b_drop', t('Drop')) }}
+                {{ get_icon('b_drop', t('Delete')) }}
             </a>
         </td>
     {% endif %}

--- a/resources/templates/database/structure/structure_table_row.twig
+++ b/resources/templates/database/structure/structure_table_row.twig
@@ -84,7 +84,7 @@
                   'sql_query': drop_query,
                   'message_to_show': drop_message
                 }), '') }}">
-                {{ get_icon('b_drop', t('Delete')) }}
+                {{ get_icon('b_drop', t('DROP')) }}
             </a>
         </td>
     {% endif %}


### PR DESCRIPTION
I have changed "Drop" to "Delete" under the Action section of tables in a database, because "Delete" is more user-friendly. Currently, I have only changed Drop in the table section of a database, but if this change is merged, then I will be making changes in other files also.