### PR TITLE
Improve error message if table is not available

### DIFF
--- a/templates/database/structure/structure_table_row.twig
+++ b/templates/database/structure/structure_table_row.twig
@@ -234,7 +234,11 @@
 
         <td colspan="{{ action_colspan }}"
             class="text-center">
-            {% trans 'in use' %}
+            {% if current_table['TABLE_COMMENT'] is not empty %}
+                {{ current_table['TABLE_COMMENT'] }}
+            {% else %}
+                {% trans 'in use' %}
+            {% endif %}
         </td>
     {% endif %}
 </tr>

--- a/templates/database/structure/structure_table_row.twig
+++ b/templates/database/structure/structure_table_row.twig
@@ -234,8 +234,8 @@
 
         <td colspan="{{ action_colspan }}"
             class="text-center">
-            {% if current_table['TABLE_COMMENT'] is not empty %}
-                {{ current_table['TABLE_COMMENT'] }}
+            {% if current_table['Comment'] is not empty %}
+                {{ current_table['Comment'] }}
             {% else %}
                 {% trans 'in use' %}
             {% endif %}


### PR DESCRIPTION
### Description

I think we should show why the table can't be accessible. Because, on 6.0.0-dev, it redirects to homepage without why it happened, and it shows only `in use`. This way, the user will know the error and fix it.

Related to #18183

Before:

<img width="1411" height="451" alt="before" src="https://github.com/user-attachments/assets/107c63ef-64ff-41ce-92ce-2454ec507631" />

After:

<img width="1411" height="450" alt="after" src="https://github.com/user-attachments/assets/c7473fe7-77e1-424d-ae2c-87d0dc8682f8" />

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
