### PR TITLE
Insert: Add padding below action buttons

### DIFF
--- a/resources/templates/table/insert/actions_panel.twig
+++ b/resources/templates/table/insert/actions_panel.twig
@@ -32,7 +32,7 @@
       <td>
         {{ show_hint(t('Use TAB key to move from value to value, or CTRL+arrows to move anywhere.')) }}
       </td>
-      <td colspan="3" class="text-end align-middle">
+      <td colspan="3" class="text-end align-middle pb-2">
         <input type="button" class="btn btn-secondary preview_sql control_at_footer" value="{{ t('Preview SQL') }}">
         <input type="reset" class="btn btn-secondary control_at_footer" value="{{ t('Reset') }}">
         <input type="submit" class="btn btn-primary control_at_footer" value="{{ t('Go') }}" id="buttonYes">


### PR DESCRIPTION
I have added padding below the action buttons: Preview SQL, Reset, and Go in the Insert tab of tables.

**Before:-**
<img width="1896" height="864" alt="Screenshot 2025-12-11 235010" src="https://github.com/user-attachments/assets/e3d38674-e8a9-41d6-9b68-043e8c19178a" />

**After:-**
<img width="1897" height="867" alt="Screenshot 2025-12-11 235144" src="https://github.com/user-attachments/assets/e2c8d807-abb0-4fe2-8a8d-69e389e748e7" />


