### PR TITLE
Fix #19976 - Bootstrap theme icons are not visible on bigger screens

### DIFF
--- a/themes/bootstrap/img/tree-collapse.svg
+++ b/themes/bootstrap/img/tree-collapse.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="m6 6v18h18v-18zm14 8v2h-10v-2z"/></svg>
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><rect x="7" y="7" width="14" height="14"  fill="white"/><path d="m6 6v18h18v-18zm14 8v2h-10v-2z"/></svg>

--- a/themes/bootstrap/img/tree-expand.svg
+++ b/themes/bootstrap/img/tree-expand.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="m6 6v18h18v-18zm14 8v2h-4v4h-2v-4h-4v-2h4v-4h2v4z"/></svg>
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><rect x="6" y="6" width="14" height="14" fill="white"/><path d="m6 6v18h18v-18zm14 8v2h-4v4h-2v-4h-4v-2h4v-4h2v4z"/></svg>


### PR DESCRIPTION
### Description

Please describe your pull request.
The + and - icons for the bootstrap theme were not clearly visible. The issue is the theme is using svgs unlike the other themes that seem to be png. So the + and - are just cutouts/transparent. So what you see are the lines for the tree/branched that are under the icons. For the + and - i've added rect to the svg that create a background so you don't see through the icon. There are still other icons, like the database icon that you can still see the lines sitting under. An alternative fix is to convert all to pngs.

Fixes #19976

Before:
<img width="194" height="195" alt="image" src="https://github.com/user-attachments/assets/ebec1937-c205-47f7-998d-bc772234ab59" />


After:
<img width="563" height="336" alt="Screenshot 2025-12-13 at 14 38 26" src="https://github.com/user-attachments/assets/576f4edb-dff1-49a6-b6ce-a942e53b7e93" />


Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
