### PR TITLE
Hide `rhs` when not needed

### DIFF
--- a/resources/js/database/query_generator.ts
+++ b/resources/js/database/query_generator.ts
@@ -11,8 +11,15 @@ import { escapeBacktick, escapeSingleQuote } from '../modules/functions/escape.t
 $(document).on('change', '.criteria_op', function () {
     const op = $(this).val();
     const criteria = $(this).closest('.table').find('.rhs_text_val');
+    const rhs = $(this).closest('.table').find('.criteria_rhs');
 
-    isOpWithoutArg(op) ? criteria.hide().val('') : criteria.show();
+    if (isOpWithoutArg(op)) {
+        criteria.hide().val('');
+        rhs.hide();
+    } else {
+        criteria.show();
+        rhs.show();
+    }
 });
 
 function getFormatsText () {


### PR DESCRIPTION
### Before
`rhs` is not needed when choosing an operation that does not need any argument like `IS NULL`.

<img width="594" height="192" alt="image" src="https://github.com/user-attachments/assets/3f695c4c-4cac-4e1d-9e38-3a6dc93681b0" />

### After
When a not-arg-operation is choosen, the `rhs` is hidden, it shows up only when arguments are needed.

<img width="403" height="183" alt="image" src="https://github.com/user-attachments/assets/22ebfa5b-4564-4aa8-ac6e-6bd2d88b3956" />