### PR TITLE
Fix failing end to end tests

### DIFF
--- a/tests/end-to-end/Database/StructureTest.php
+++ b/tests/end-to-end/Database/StructureTest.php
@@ -52,7 +52,7 @@ class StructureTest extends TestBase
         $this->waitForElement('id', 'functionConfirmOkButton')->click();
 
         $success = $this->waitForElement('cssSelector', '.alert-success');
-        self::assertStringContainsString('MySQL returned an empty result', $success->getText());
+        self::assertStringContainsString('Table test_table has been emptied.', $success->getText());
 
         $this->dbQuery(
             'SELECT CONCAT("Count: ", COUNT(*)) as c FROM `' . $this->databaseName . '`.`test_table`',

--- a/tests/end-to-end/Table/CreateTest.php
+++ b/tests/end-to-end/Table/CreateTest.php
@@ -60,7 +60,6 @@ class CreateTest extends TestBase
         $columnDropdownDetails = [
             'field_0_6' => 'UNSIGNED',
             'field_1_2' => 'VARCHAR',
-            'field_1_5' => 'utf8mb4_general_ci',
             'field_1_4' => 'As defined:',
         ];
 
@@ -70,6 +69,13 @@ class CreateTest extends TestBase
                 '//select[@id=\'' . $selector . '\']//option[contains(text(), \'' . $value . '\')]',
             )->click();
         }
+
+        // click to load select options
+        $this->byId('field_1_5')->click();
+        $this->waitForElement(
+            'xpath',
+            '//select[@id=\'field_1_5\']//option[contains(text(), \'utf8mb4_general_ci\')]',
+        )->click();
 
         $this->byName('field_default_value[1]')->sendKeys('def');
 

--- a/tests/end-to-end/Table/OperationsTest.php
+++ b/tests/end-to-end/Table/OperationsTest.php
@@ -172,7 +172,7 @@ class OperationsTest extends TestBase
         $this->waitAjax();
 
         $success = $this->waitForElement('cssSelector', '.alert-success');
-        self::assertStringContainsString('MySQL returned an empty result set', $success->getText());
+        self::assertStringContainsString('Table test_table has been emptied.', $success->getText());
 
         $this->dbQuery(
             'SELECT CONCAT("Count: ", COUNT(*)) as c FROM `' . $this->databaseName . '`.test_table',
@@ -195,7 +195,7 @@ class OperationsTest extends TestBase
         $this->waitAjax();
 
         $success = $this->waitForElement('cssSelector', '.alert-success');
-        self::assertStringContainsString('MySQL returned an empty result set', $success->getText());
+        self::assertStringContainsString('Table test_table has been dropped.', $success->getText());
 
         $this->dbQuery(
             'USE `' . $this->databaseName . '`;'


### PR DESCRIPTION
- `Table\CreateTest`: introduced by https://github.com/phpmyadmin/phpmyadmin/pull/19968
- `Table\OperationsTest` and `Database\StructureTest`: introduced by https://github.com/phpmyadmin/phpmyadmin/pull/19980


