### PR TITLE
Move exportSql checks and refactor code

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2182,12 +2182,6 @@ parameters:
 			path: src/Controllers/Export/ExportController.php
 
 		-
-			message: '#^Only booleans are allowed in &&, string\|null given on the left side\.$#'
-			identifier: booleanAnd.leftNotBoolean
-			count: 1
-			path: src/Controllers/Export/ExportController.php
-
-		-
 			message: '#^Only booleans are allowed in &&, string\|null given on the right side\.$#'
 			identifier: booleanAnd.rightNotBoolean
 			count: 2

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1304,7 +1304,6 @@
       <code><![CDATA[$tableData]]></code>
     </MixedPropertyTypeCoercion>
     <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$asSeparateFiles]]></code>
       <code><![CDATA[$onServerParam]]></code>
       <code><![CDATA[$quickExportOnServer]]></code>
       <code><![CDATA[empty($this->config->settings['MemoryLimit'])]]></code>

--- a/src/Controllers/Export/ExportController.php
+++ b/src/Controllers/Export/ExportController.php
@@ -14,6 +14,7 @@ use PhpMyAdmin\Encoding;
 use PhpMyAdmin\Exceptions\ExportException;
 use PhpMyAdmin\Export\Export;
 use PhpMyAdmin\Export\OutputHandler;
+use PhpMyAdmin\Export\SeparateFiles;
 use PhpMyAdmin\Http\Factory\ResponseFactory;
 use PhpMyAdmin\Http\Response;
 use PhpMyAdmin\Http\ServerRequest;
@@ -55,7 +56,7 @@ final readonly class ExportController implements InvocableController
         $quickOrCustom = $request->getParsedBodyParamAsStringOrNull('quick_or_custom');
         $outputFormat = $request->getParsedBodyParamAsStringOrNull('output_format');
         $compressionParam = $request->getParsedBodyParamAsString('compression', '');
-        $asSeparateFiles = $request->getParsedBodyParamAsStringOrNull('as_separate_files');
+        $asSeparateFiles = $request->getParsedBodyParamAsString('as_separate_files', '');
         $quickExportOnServer = $request->getParsedBodyParamAsStringOrNull('quick_export_onserver');
         $onServerParam = $request->getParsedBodyParamAsStringOrNull('onserver');
         /** @var array|null $aliasesParam */
@@ -135,7 +136,7 @@ final readonly class ExportController implements InvocableController
          * init and variable checking
          */
         $filename = '';
-        $separateFiles = '';
+        $separateFiles = SeparateFiles::None;
 
         // Is it a quick or custom export?
         $isQuickExport = $quickOrCustom === 'quick';
@@ -146,8 +147,8 @@ final readonly class ExportController implements InvocableController
             OutputHandler::$asFile = false;
         } else {
             OutputHandler::$asFile = true;
-            if ($asSeparateFiles && $compressionParam === 'zip') {
-                $separateFiles = $asSeparateFiles;
+            if ($asSeparateFiles !== '' && $compressionParam === 'zip') {
+                $separateFiles = SeparateFiles::from($asSeparateFiles);
             }
 
             if (in_array($compressionParam, $compressionMethods, true)) {
@@ -413,7 +414,7 @@ final readonly class ExportController implements InvocableController
         $this->export->outputHandler->convertBufferCharset();
 
         // Compression needed?
-        $this->export->outputHandler->compress($separateFiles !== '', $filename);
+        $this->export->outputHandler->compress($separateFiles !== SeparateFiles::None, $filename);
 
         if ($saveOnServer) {
             $message = $this->export->outputHandler->closeFile();

--- a/src/Controllers/Export/ExportController.php
+++ b/src/Controllers/Export/ExportController.php
@@ -81,7 +81,7 @@ final readonly class ExportController implements InvocableController
         }
 
         if ($request->hasBodyParam('maxsize')) {
-            Export::$maxSize = $request->getParsedBodyParamAsString('maxsize');
+            Export::$tableMaxSizeInMb = $request->getParsedBodyParamAsString('maxsize');
         }
 
         $tableSelectParam = [];

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -213,13 +213,13 @@ class Export
      * @param string|mixed[] $dbSelect      the selected databases to export
      * @param ExportPlugin   $exportPlugin  the selected export plugin
      * @param mixed[]        $aliases       alias information for db/table/column
-     * @param string         $separateFiles whether it is a separate-files export
+     * @param SeparateFiles  $separateFiles whether it is a separate-files export
      */
     public function exportServer(
         string|array $dbSelect,
         ExportPlugin $exportPlugin,
         array $aliases,
-        string $separateFiles,
+        SeparateFiles $separateFiles,
     ): void {
         if (is_array($dbSelect) && $dbSelect !== []) {
             $tmpSelect = implode('|', $dbSelect);
@@ -240,9 +240,9 @@ class Export
                 $tables,
                 $exportPlugin,
                 $aliases,
-                $separateFiles === 'database' ? $separateFiles : '',
+                $separateFiles === SeparateFiles::Database ? SeparateFiles::Database : SeparateFiles::None,
             );
-            if ($separateFiles !== 'server') {
+            if ($separateFiles !== SeparateFiles::Server) {
                 continue;
             }
 
@@ -253,13 +253,13 @@ class Export
     /**
      * Export at the database level
      *
-     * @param DatabaseName $db             the database to export
-     * @param string[]     $tables         the tables to export
-     * @param string[]     $tableStructure whether to export structure for each table
-     * @param string[]     $tableData      whether to export data for each table
-     * @param ExportPlugin $exportPlugin   the selected export plugin
-     * @param mixed[]      $aliases        Alias information for db/table/column
-     * @param string       $separateFiles  whether it is a separate-files export
+     * @param DatabaseName  $db             the database to export
+     * @param string[]      $tables         the tables to export
+     * @param string[]      $tableStructure whether to export structure for each table
+     * @param string[]      $tableData      whether to export data for each table
+     * @param ExportPlugin  $exportPlugin   the selected export plugin
+     * @param mixed[]       $aliases        Alias information for db/table/column
+     * @param SeparateFiles $separateFiles  whether it is a separate-files export
      */
     public function exportDatabase(
         DatabaseName $db,
@@ -268,7 +268,7 @@ class Export
         array $tableData,
         ExportPlugin $exportPlugin,
         array $aliases,
-        string $separateFiles,
+        SeparateFiles $separateFiles,
     ): void {
         $dbAlias = ! empty($aliases[$db->getName()]['alias'])
             ? $aliases[$db->getName()]['alias'] : '';
@@ -281,14 +281,14 @@ class Export
             return;
         }
 
-        if ($separateFiles === 'database') {
+        if ($separateFiles === SeparateFiles::Database) {
             $this->outputHandler->saveObjectInBuffer('database', true);
         }
 
         if ($exportPlugin->includeStructure()) {
             $exportPlugin->exportRoutines($db->getName(), $aliases);
 
-            if ($separateFiles === 'database') {
+            if ($separateFiles === SeparateFiles::Database) {
                 $this->outputHandler->saveObjectInBuffer('routines');
             }
         }
@@ -316,7 +316,7 @@ class Export
                 // to resolve view dependencies (only when it's a single-file export)
                 if ($isView) {
                     if (
-                        $separateFiles === ''
+                        $separateFiles === SeparateFiles::None
                         && ! $exportPlugin->exportStructure($db->getName(), $table, 'stand_in', $aliases)
                     ) {
                         break;
@@ -347,7 +347,7 @@ class Export
             }
 
             // this buffer was filled, we save it and go to the next one
-            if ($separateFiles === 'database') {
+            if ($separateFiles === SeparateFiles::Database) {
                 $this->outputHandler->saveObjectInBuffer('table_' . $table);
             }
 
@@ -361,7 +361,7 @@ class Export
                 break;
             }
 
-            if ($separateFiles !== 'database') {
+            if ($separateFiles !== SeparateFiles::Database) {
                 continue;
             }
 
@@ -378,7 +378,7 @@ class Export
                 break;
             }
 
-            if ($separateFiles !== 'database') {
+            if ($separateFiles !== SeparateFiles::Database) {
                 continue;
             }
 
@@ -389,7 +389,7 @@ class Export
             return;
         }
 
-        if ($separateFiles === 'database') {
+        if ($separateFiles === SeparateFiles::Database) {
             $this->outputHandler->saveObjectInBuffer('extra');
         }
 
@@ -398,7 +398,7 @@ class Export
         $metadataTypes = $this->getMetadataTypes();
         $exportPlugin->exportMetadata($db->getName(), $tables, $metadataTypes);
 
-        if ($separateFiles === 'database') {
+        if ($separateFiles === SeparateFiles::Database) {
             $this->outputHandler->saveObjectInBuffer('metadata');
         }
 
@@ -408,7 +408,7 @@ class Export
 
         $exportPlugin->exportEvents($db->getName());
 
-        if ($separateFiles !== 'database') {
+        if ($separateFiles !== SeparateFiles::Database) {
             return;
         }
 

--- a/src/Export/SeparateFiles.php
+++ b/src/Export/SeparateFiles.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Export;
+
+enum SeparateFiles: string
+{
+    case None = '';
+    case Database = 'database';
+    case Server = 'server';
+}

--- a/src/Plugins/Export/ExportSql.php
+++ b/src/Plugins/Export/ExportSql.php
@@ -1063,21 +1063,19 @@ class ExportSql extends ExportPlugin
             return false;
         }
 
-        $r = 1;
         if (is_array($tables)) {
+            $isSuccessful = true;
             // export metadata for each table
             foreach ($tables as $table) {
-                $r &= (int) $this->exportConfigurationMetadata($db, $table, $metadataTypes);
+                $isSuccessful = $this->exportConfigurationMetadata($db, $table, $metadataTypes) && $isSuccessful;
             }
 
             // export metadata for the database
-            $r &= (int) $this->exportConfigurationMetadata($db, null, $metadataTypes);
-        } else {
-            // export metadata for single table
-            $r &= (int) $this->exportConfigurationMetadata($db, $tables, $metadataTypes);
+            return $this->exportConfigurationMetadata($db, null, $metadataTypes) && $isSuccessful;
         }
 
-        return (bool) $r;
+        // export metadata for single table
+        return $this->exportConfigurationMetadata($db, $tables, $metadataTypes);
     }
 
     /**

--- a/src/Plugins/Export/ExportSql.php
+++ b/src/Plugins/Export/ExportSql.php
@@ -848,7 +848,7 @@ class ExportSql extends ExportPlugin
             $dbAlias = $db;
         }
 
-        if ($this->structureOrData !== StructureOrData::Data && $this->dropDatabase) {
+        if ($this->includeStructure() && $this->dropDatabase) {
             if (
                 ! $this->outputHandler->addLine(
                     'DROP DATABASE IF EXISTS '

--- a/src/Plugins/Export/ExportSql.php
+++ b/src/Plugins/Export/ExportSql.php
@@ -613,6 +613,10 @@ class ExportSql extends ExportPlugin
      */
     public function exportRoutines(string $db, array $aliases = []): bool
     {
+        if (! $this->hasCreateProcedureFunction()) {
+            return true;
+        }
+
         $text = '';
         $delimiter = '$$';
 
@@ -971,6 +975,10 @@ class ExportSql extends ExportPlugin
      */
     public function exportEvents(string $db): bool
     {
+        if (! $this->hasCreateProcedureFunction()) {
+            return true;
+        }
+
         $text = '';
         $delimiter = '$$';
 
@@ -1033,6 +1041,10 @@ class ExportSql extends ExportPlugin
         string|array $tables,
         array $metadataTypes,
     ): bool {
+        if (! $this->hasMetadata()) {
+            return true;
+        }
+
         $relationParameters = $this->relation->getRelationParameters();
         if ($relationParameters->db === null) {
             return true;
@@ -1863,6 +1875,10 @@ class ExportSql extends ExportPlugin
 
         switch ($exportMode) {
             case 'create_table':
+                if (! $this->hasCreateTable()) {
+                    return true; // User requested no table structure, so the job has been successfully completed
+                }
+
                 $dump .= $this->exportComment(
                     __('Table structure for table') . ' ' . $formattedTableName,
                 );
@@ -1871,6 +1887,10 @@ class ExportSql extends ExportPlugin
                 $dump .= $this->getTableComments($db, $table, $aliases);
                 break;
             case 'triggers':
+                if (! $this->hasCreateTrigger()) {
+                    return true; // User requested no triggers, so the job has been successfully completed
+                }
+
                 $dump = '';
                 $delimiter = '$$';
                 $triggers = Triggers::getDetails(DatabaseInterface::getInstance(), $db, $table);
@@ -1920,6 +1940,10 @@ class ExportSql extends ExportPlugin
 
                 break;
             case 'create_view':
+                if (! $this->hasCreateView()) {
+                    return true; // No view to export, so the job has been successfully completed
+                }
+
                 if (! $this->viewsAsTables) {
                     $dump .= $this->exportComment(
                         __('Structure for view')
@@ -1960,6 +1984,10 @@ class ExportSql extends ExportPlugin
 
                 break;
             case 'stand_in':
+                if (! $this->hasCreateView()) {
+                    return true; // No view to export, so the job has been successfully completed
+                }
+
                 $dump .= $this->exportComment(
                     __('Stand-in structure for view') . ' ' . $formattedTableName,
                 )
@@ -2712,12 +2740,12 @@ class ExportSql extends ExportPlugin
         return 'NONE';
     }
 
-    public function hasCreateProcedureFunction(): bool
+    private function hasCreateProcedureFunction(): bool
     {
         return $this->procedureFunction;
     }
 
-    public function hasCreateTable(): bool
+    private function hasCreateTable(): bool
     {
         return $this->createTable;
     }
@@ -2732,12 +2760,12 @@ class ExportSql extends ExportPlugin
         return 'INSERT';
     }
 
-    public function hasCreateView(): bool
+    private function hasCreateView(): bool
     {
         return $this->createView;
     }
 
-    public function hasCreateTrigger(): bool
+    private function hasCreateTrigger(): bool
     {
         return $this->createTrigger;
     }

--- a/src/Plugins/ExportPlugin.php
+++ b/src/Plugins/ExportPlugin.php
@@ -312,9 +312,16 @@ abstract class ExportPlugin implements Plugin
     /** @param array<mixed> $exportConfig */
     abstract public function setExportOptions(ServerRequest $request, array $exportConfig): void;
 
-    public function getStructureOrData(): StructureOrData
+    public function includeStructure(): bool
     {
-        return $this->structureOrData;
+        return $this->structureOrData === StructureOrData::Structure
+            || $this->structureOrData === StructureOrData::StructureAndData;
+    }
+
+    public function includeData(): bool
+    {
+        return $this->structureOrData === StructureOrData::Data
+            || $this->structureOrData === StructureOrData::StructureAndData;
     }
 
     protected function setStructureOrData(

--- a/tests/unit/Export/ExportTest.php
+++ b/tests/unit/Export/ExportTest.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\Current;
 use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Export\Export;
 use PhpMyAdmin\Export\OutputHandler;
+use PhpMyAdmin\Export\SeparateFiles;
 use PhpMyAdmin\FlashMessenger;
 use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Message;
@@ -140,7 +141,7 @@ class ExportTest extends AbstractTestCase
             ['test_table'],
             new ExportSql($relation, $export->outputHandler, new Transformations($dbi, $relation)),
             [],
-            '',
+            SeparateFiles::None,
         );
 
         $expected = <<<'SQL'
@@ -210,7 +211,7 @@ class ExportTest extends AbstractTestCase
             ['test_db'],
             new ExportSql($relation, $export->outputHandler, new Transformations($dbi, $relation)),
             [],
-            '',
+            SeparateFiles::None,
         );
 
         $expected = <<<'SQL'

--- a/tests/unit/Plugins/Export/ExportSqlTest.php
+++ b/tests/unit/Plugins/Export/ExportSqlTest.php
@@ -297,7 +297,10 @@ class ExportSqlTest extends AbstractTestCase
     public function testExportRoutines(): void
     {
         $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/')
-            ->withParsedBody(['sql_drop_table' => 'On']);
+            ->withParsedBody([
+                'sql_drop_table' => 'On',
+                'sql_procedure_function' => 'On',
+            ]);
 
         $this->object->setExportOptions($request, []);
 
@@ -599,6 +602,10 @@ class ExportSqlTest extends AbstractTestCase
             ->willReturnCallback(static fn (string $string): string => "'" . $string . "'");
 
         DatabaseInterface::$instance = $dbi;
+
+        $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/')
+            ->withParsedBody(['sql_procedure_function' => 'On']);
+        $this->object->setExportOptions($request, []);
 
         ob_start();
         self::assertTrue(
@@ -915,6 +922,9 @@ class ExportSqlTest extends AbstractTestCase
                 'sql_backquotes' => 'true',
                 'sql_include_comments' => 'On',
                 'sql_compatibility' => 'MSSQL',
+                'sql_create_table' => 'On',
+                'sql_create_view' => 'On',
+                'sql_create_trigger' => 'On',
             ]);
 
         $this->object->setExportOptions($request, []);
@@ -960,7 +970,7 @@ class ExportSqlTest extends AbstractTestCase
 
         // case 4
         $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/')
-            ->withParsedBody(['sql_include_comments' => 'On', 'sql_views_as_tables' => 'On']);
+            ->withParsedBody(['sql_include_comments' => 'On', 'sql_views_as_tables' => 'On', 'sql_create_view' => 'On']);
 
         $this->object->setExportOptions($request, []);
 


### PR DESCRIPTION
Fixes #19855

@liviuconcioiu Can you check if this fixes the issue?

This PR should fix the reported problem, just like the one from @efturtle would, but it introduces other refactorings that would make the other PR immediately obsolete, which is why I recommend just merging this PR. 

The underlying reason for the bug is NOT addressed in this PR. The problem became evident after the last refactoring. The export form sends all options, not just the ones visible on the screen. In the past, the code mixed up a lot of these checks and it all kind of worked, but without any clear logic. This PR separates more of these checks, but it does not fix the UI. In my testing, I observed that there are multiple issues which will need to be addressed one by one. 