### PR TITLE
Harden BrowserStack URL output in E2E tests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -14365,12 +14365,6 @@ parameters:
 			path: tests/config.e2e.inc.php
 
 		-
-			message: '#^Binary operation "\." between ''Test failed, get…'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: tests/end-to-end/TestBase.php
-
-		-
 			message: '#^Binary operation "\." between ''ajax_message_num_'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8897,7 +8897,6 @@
     <MixedAssignment>
       <code><![CDATA[$context['http']['content']]]></code>
       <code><![CDATA[$httpStatus]]></code>
-      <code><![CDATA[$http_response_header]]></code>
     </MixedAssignment>
     <MixedReturnStatement>
       <code><![CDATA[$response]]></code>
@@ -9085,7 +9084,6 @@
     </MixedAssignment>
     <MixedOperand>
       <code><![CDATA[$ajaxMessageCount]]></code>
-      <code><![CDATA[$proj->automation_session->public_url]]></code>
     </MixedOperand>
     <MixedPropertyFetch>
       <code><![CDATA[$proj->automation_session->public_url]]></code>

--- a/tests/end-to-end/TestBase.php
+++ b/tests/end-to-end/TestBase.php
@@ -1165,11 +1165,23 @@ abstract class TestBase extends TestCase
 
         $proj = json_decode($result);
         if (is_object($proj) && property_exists($proj, 'automation_session')) {
-            // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-			$url = (string) ($proj->automation_session->public_url ?? '');
-			$url = preg_replace('/[\x00-\x1F\x7F]/', '', $url) ?? $url;
-			echo 'Test failed, get more information here: ' . $url . "\n";
-        }
+			// phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+			$publicUrl = '';
+
+			if (
+			    isset($proj->automation_session->public_url)
+			    && is_string($proj->automation_session->public_url)
+			) {
+		    	$publicUrl = $proj->automation_session->public_url;
+
+		    	$sanitized = preg_replace('/[\x00-\x1F\x7F]/', '', $publicUrl);
+			    if ($sanitized !== null) {
+    	    		$publicUrl = $sanitized;
+			    }
+			}
+
+			echo 'Test failed, get more information here: ' . $publicUrl . "\n";
+		}
 
         if (curl_errno($ch) === 0) {
             return;

--- a/tests/end-to-end/TestBase.php
+++ b/tests/end-to-end/TestBase.php
@@ -1166,7 +1166,9 @@ abstract class TestBase extends TestCase
         $proj = json_decode($result);
         if (is_object($proj) && property_exists($proj, 'automation_session')) {
             // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-            echo 'Test failed, get more information here: ' . $proj->automation_session->public_url . "\n";
+			$url = (string) ($proj->automation_session->public_url ?? '');
+			$url = preg_replace('/[\x00-\x1F\x7F]/', '', $url) ?? $url;
+			echo 'Test failed, get more information here: ' . $url . "\n";
         }
 
         if (curl_errno($ch) === 0) {


### PR DESCRIPTION
### Description

This change hardens the output of the BrowserStack session URL printed by end-to-end tests.

The URL is obtained from an external API response and echoed directly to the test output. While this code path is only used in CI / test environments, the value is still externally sourced and unvalidated.

This patch strips control characters from the URL before printing it, ensuring the output remains well-formed and preventing potential log or terminal control issues.

Fixes # (none)

### Notes

- This change does not affect application runtime behavior.
- The modification is limited to test infrastructure output.
- No functional behavior of the tests is altered.

### Checklist

- [x] Read CONTRIBUTING.md
- [x] Correct target branch
- [x] Commit includes Signed-off-by line
- [x] Commit message is descriptive
- [x] No new functionality introduced