### PR TITLE
Fix uploading of Selenium screenshots

### DIFF
--- a/.github/workflows/test-selenium.yml
+++ b/.github/workflows/test-selenium.yml
@@ -151,6 +151,6 @@ jobs:
         uses: actions/upload-artifact@v6
         if: ${{ failure() }}
         with:
-          name: selenium-screenshots
+          name: selenium-screenshots-${{ strategy.job-index }}
           path: ${{ github.workspace }}/build/selenium/**/*
           retention-days: 3


### PR DESCRIPTION
### Description

If you go to https://github.com/phpmyadmin/phpmyadmin/actions/runs/20756721449/job/59600703158, you will see:

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

For `QA_5_2`, there's no need because it runs only 1 job, while on `master` it runs 21 jobs in parallel.

**Before:**

<img width="1467" height="776" alt="selenium" src="https://github.com/user-attachments/assets/a658297c-83db-4bfd-a99b-08385561ac59" />

**After:**

<img width="1230" height="518" alt="selenium1" src="https://github.com/user-attachments/assets/4a177502-f769-4919-ba46-9e73c7bf982a" />

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
