### PR TITLE
Extract function to load services from services file

### DIFF
--- a/app/services_loader.php
+++ b/app/services_loader.php
@@ -2,41 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Symfony\Component\DependencyInjection\Loader\Configurator;
-
-use Symfony\Component\DependencyInjection\Reference;
-
-use function is_string;
+use PhpMyAdmin\Container\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $configurator): void {
     $services = $configurator->services();
-    /** @param array<string, string|array{class: string, arguments?: array<string>, factory?: callable}> $servicesFile */
-    $loadServices = static function (array $servicesFile, ServicesConfigurator $services): void {
-        foreach ($servicesFile as $serviceName => $service) {
-            if (is_string($service)) {
-                $services->alias($serviceName, $service);
-                continue;
-            }
 
-            $theService = $services->set($serviceName, $service['class']);
-            if (isset($service['factory'])) {
-                $theService->factory($service['factory']);
-            }
-
-            if (! isset($service['arguments'])) {
-                continue;
-            }
-
-            foreach ($service['arguments'] as &$argumentName) {
-                $argumentName = new Reference($argumentName);
-            }
-
-            $theService->args($service['arguments']);
-        }
-    };
-
+    /** @var array<string, array{class: string, arguments?: array<string>, factory?: callable}> $servicesFile */
     $servicesFile = include ROOT_PATH . 'app/services.php';
-    $loadServices($servicesFile, $services);
+    ContainerBuilder::loadServices($servicesFile, $services);
+
+    /** @var array<string, array{class: string, arguments?: array<string>, factory?: callable}> $servicesFile */
     $servicesFile = include ROOT_PATH . 'app/services_controllers.php';
-    $loadServices($servicesFile, $services);
+    ContainerBuilder::loadServices($servicesFile, $services);
 };

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,72 +7,6 @@ parameters:
 			path: app/constants.php
 
 		-
-			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: app/services_loader.php
-
-		-
-			message: '#^Cannot access offset ''arguments'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/services_loader.php
-
-		-
-			message: '#^Cannot access offset ''class'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/services_loader.php
-
-		-
-			message: '#^Cannot access offset ''factory'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/services_loader.php
-
-		-
-			message: '#^Parameter \#1 \$arguments of method Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\ServiceConfigurator\:\:args\(\) expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/services_loader.php
-
-		-
-			message: '#^Parameter \#1 \$factory of method Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\ServiceConfigurator\:\:factory\(\) expects array\|Closure\|string\|Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\ReferenceConfigurator\|Symfony\\Component\\ExpressionLanguage\\Expression, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/services_loader.php
-
-		-
-			message: '#^Parameter \#1 \$id of class Symfony\\Component\\DependencyInjection\\Reference constructor expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/services_loader.php
-
-		-
-			message: '#^Parameter \#1 \$id of method Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\ServicesConfigurator\:\:alias\(\) expects string, \(int\|string\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/services_loader.php
-
-		-
-			message: '#^Parameter \#1 \$id of method Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\ServicesConfigurator\:\:set\(\) expects string\|null, \(int\|string\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/services_loader.php
-
-		-
-			message: '#^Parameter \#1 \$servicesFile of closure expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/services_loader.php
-
-		-
-			message: '#^Parameter \#2 \$class of method Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\ServicesConfigurator\:\:set\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/services_loader.php
-
-		-
 			message: '#^Access to constant FORMAT_HTTP on an unknown class OpenID_Message\.$#'
 			identifier: class.notFound
 			count: 1
@@ -1589,6 +1523,12 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Console/History.php
+
+		-
+			message: '#^Parameter \#1 \$factory of method Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\ServiceConfigurator\:\:factory\(\) expects array\|Closure\|string\|Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\ReferenceConfigurator\|Symfony\\Component\\ExpressionLanguage\\Expression, callable\(\)\: mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Container/ContainerBuilder.php
 
 		-
 			message: '#^Binary operation "\.\=" between mixed and '' \-\> '' results in an error\.$#'

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,27 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
-  <file src="app/services_loader.php">
-    <MixedArgument>
-      <code><![CDATA[$argumentName]]></code>
-      <code><![CDATA[$service['arguments']]]></code>
-      <code><![CDATA[$service['class']]]></code>
-      <code><![CDATA[$service['factory']]]></code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$serviceName]]></code>
-      <code><![CDATA[$serviceName]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayAccess>
-      <code><![CDATA[$service['arguments']]]></code>
-      <code><![CDATA[$service['arguments']]]></code>
-      <code><![CDATA[$service['class']]]></code>
-      <code><![CDATA[$service['factory']]]></code>
-    </MixedArrayAccess>
-    <MixedAssignment>
-      <code><![CDATA[$argumentName]]></code>
-      <code><![CDATA[$service]]></code>
-    </MixedAssignment>
-  </file>
   <file src="src/Advisory/Advisor.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$pattern]]></code>
@@ -675,6 +653,11 @@
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[! $maxTime]]></code>
     </RiskyTruthyFalsyComparison>
+  </file>
+  <file src="src/Container/ContainerBuilder.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$service['factory']]]></code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="src/Controllers/BrowseForeignersController.php">
     <PossiblyUnusedReturnValue>


### PR DESCRIPTION
Extracts to `ContainerBuilder::loadServices()`, removes service alias support and add unit tests.

