### PR TITLE
Insufficient space export exception

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5887,9 +5887,6 @@
       <code><![CDATA[$row[0]]]></code>
       <code><![CDATA[$row[0]]]></code>
     </PossiblyNullArgument>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[bool]]></code>
-    </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Plugins/Export/ExportCsv.php">
     <DeprecatedMethod>
@@ -5926,9 +5923,6 @@
       <code><![CDATA[$comments]]></code>
       <code><![CDATA[$mimeMap]]></code>
     </PossiblyUndefinedVariable>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[bool]]></code>
-    </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Plugins/Export/ExportJson.php">
     <DeprecatedMethod>
@@ -6114,9 +6108,6 @@
       <code><![CDATA[remove]]></code>
       <code><![CDATA[remove]]></code>
     </PossiblyNullReference>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[bool]]></code>
-    </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($column->collation)]]></code>
       <code><![CDATA[empty($config->selectedServer['port'])]]></code>
@@ -6485,10 +6476,6 @@
       <code><![CDATA[$db['alias']]]></code>
       <code><![CDATA[$table['alias']]]></code>
     </MixedReturnStatement>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[bool]]></code>
-      <code><![CDATA[bool]]></code>
-    </PossiblyUnusedReturnValue>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$foreigner]]></code>
     </RiskyTruthyFalsyComparison>

--- a/src/Controllers/Export/ExportController.php
+++ b/src/Controllers/Export/ExportController.php
@@ -301,9 +301,7 @@ final readonly class ExportController implements InvocableController
             }
 
             // Add possibly some comments to export
-            if (! $exportPlugin->exportHeader()) {
-                throw new ExportException('Failure during header export.');
-            }
+            $exportPlugin->exportHeader();
 
             /**
              * Builds the dump
@@ -389,9 +387,7 @@ final readonly class ExportController implements InvocableController
                 }
             }
 
-            if (! $exportPlugin->exportFooter()) {
-                throw new ExportException('Failure during footer export.');
-            }
+            $exportPlugin->exportFooter();
         } catch (ExportException) {
             // Ignore
         }

--- a/src/Controllers/Export/ExportController.php
+++ b/src/Controllers/Export/ExportController.php
@@ -349,7 +349,7 @@ final readonly class ExportController implements InvocableController
                     );
                 }
             } elseif ($exportType === ExportType::Raw) {
-                Export::exportRaw($exportPlugin, Current::$database, Current::$sqlQuery);
+                $exportPlugin->exportRawQuery(Current::$database, Current::$sqlQuery);
             } else {
                 // We export just one table
 

--- a/src/Exceptions/InsufficientSpaceExportException.php
+++ b/src/Exceptions/InsufficientSpaceExportException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Export exception
+ */
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Exceptions;
+
+/**
+ * Export exception
+ */
+class InsufficientSpaceExportException extends ExportException
+{
+}

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -415,21 +415,6 @@ class Export
     }
 
     /**
-     * Export a raw query
-     *
-     * @param ExportPlugin $exportPlugin the selected export plugin
-     * @param  string|null  $db           the database where the query is executed
-     * @param string       $sqlQuery     the query to be executed
-     */
-    public static function exportRaw(
-        ExportPlugin $exportPlugin,
-        string|null $db,
-        string $sqlQuery,
-    ): void {
-        $exportPlugin->exportRawQuery($db, $sqlQuery);
-    }
-
-    /**
      * Export at the table level
      *
      * @param string       $db           the database to export

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -586,7 +586,9 @@ class Export
                     $val1 = $colAs[0];
                     $val2 = $colAs[1];
                     // Use aliases2 alias if non empty
-                    $aliases[$dbName]['tables'][$tableName]['columns'][$col] = $val2 !== '' && $val2 !== null ? $val2 : $val1;
+                    $aliases[$dbName]['tables'][$tableName]['columns'][$col] = $val2 !== '' && $val2 !== null
+                        ? $val2
+                        : $val1;
                 }
             }
         }

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -289,13 +289,9 @@ class Export
         $dbAlias = ! empty($aliases[$db->getName()]['alias'])
             ? $aliases[$db->getName()]['alias'] : '';
 
-        if (! $exportPlugin->exportDBHeader($db->getName(), $dbAlias)) {
-            return;
-        }
+        $exportPlugin->exportDBHeader($db->getName(), $dbAlias);
 
-        if (! $exportPlugin->exportDBCreate($db->getName(), $dbAlias)) {
-            return;
-        }
+        $exportPlugin->exportDBCreate($db->getName(), $dbAlias);
 
         if ($separateFiles === SeparateFiles::Database) {
             $this->outputHandler->saveObjectInBuffer('database', true);
@@ -331,20 +327,15 @@ class Export
                 // for a view, export a stand-in definition of the table
                 // to resolve view dependencies (only when it's a single-file export)
                 if ($isView) {
-                    if (
-                        $separateFiles === SeparateFiles::None
-                        && ! $exportPlugin->exportStructure($db->getName(), $table, 'stand_in', $aliases)
-                    ) {
-                        break;
+                    if ($separateFiles === SeparateFiles::None) {
+                        $exportPlugin->exportStructure($db->getName(), $table, 'stand_in', $aliases);
                     }
                 } else {
                     if ($this->exceedsMaxTableSize($db->getName(), $table)) {
                         continue;
                     }
 
-                    if (! $exportPlugin->exportStructure($db->getName(), $table, 'create_table', $aliases)) {
-                        break;
-                    }
+                    $exportPlugin->exportStructure($db->getName(), $table, 'create_table', $aliases);
                 }
             }
 
@@ -357,9 +348,7 @@ class Export
                     . ' FROM ' . Util::backquote($db->getName())
                     . '.' . Util::backquote($table);
 
-                if (! $exportPlugin->exportData($db->getName(), $table, $localQuery, $aliases)) {
-                    break;
-                }
+                $exportPlugin->exportData($db->getName(), $table, $localQuery, $aliases);
             }
 
             // this buffer was filled, we save it and go to the next one
@@ -373,9 +362,7 @@ class Export
                 continue;
             }
 
-            if (! $exportPlugin->exportStructure($db->getName(), $table, 'triggers', $aliases)) {
-                break;
-            }
+            $exportPlugin->exportStructure($db->getName(), $table, 'triggers', $aliases);
 
             if ($separateFiles !== SeparateFiles::Database) {
                 continue;
@@ -390,9 +377,7 @@ class Export
                 continue;
             }
 
-            if (! $exportPlugin->exportStructure($db->getName(), $view, 'create_view', $aliases)) {
-                break;
-            }
+            $exportPlugin->exportStructure($db->getName(), $view, 'create_view', $aliases);
 
             if ($separateFiles !== SeparateFiles::Database) {
                 continue;
@@ -401,9 +386,7 @@ class Export
             $this->outputHandler->saveObjectInBuffer('view_' . $view);
         }
 
-        if (! $exportPlugin->exportDBFooter($db->getName())) {
-            return;
-        }
+        $exportPlugin->exportDBFooter($db->getName());
 
         if ($separateFiles === SeparateFiles::Database) {
             $this->outputHandler->saveObjectInBuffer('extra');
@@ -443,15 +426,7 @@ class Export
         string|null $db,
         string $sqlQuery,
     ): void {
-        if ($exportPlugin->exportRawQuery($db, $sqlQuery)) {
-            return;
-        }
-
-        Current::$message = Message::error(
-            // phpcs:disable Generic.Files.LineLength.TooLong
-            /* l10n: A query written by the user is a "raw query" that could be using no tables or databases in particular */
-            __('Exporting a raw query is not supported for this export method.'),
-        );
+        $exportPlugin->exportRawQuery($db, $sqlQuery);
     }
 
     /**
@@ -478,9 +453,7 @@ class Export
     ): void {
         $dbAlias = ! empty($aliases[$db]['alias'])
             ? $aliases[$db]['alias'] : '';
-        if (! $exportPlugin->exportDBHeader($db, $dbAlias)) {
-            return;
-        }
+        $exportPlugin->exportDBHeader($db, $dbAlias);
 
         if ($allrows === '0' && $limitTo > 0 && $limitFrom >= 0) {
             $addQuery = ' LIMIT '
@@ -493,11 +466,9 @@ class Export
         if ($exportPlugin->includeStructure()) {
             $tableObject = new Table($table, $db, $this->dbi);
             if ($tableObject->isView()) {
-                if (! $exportPlugin->exportStructure($db, $table, 'create_view', $aliases)) {
-                    return;
-                }
-            } elseif (! $exportPlugin->exportStructure($db, $table, 'create_table', $aliases)) {
-                return;
+                $exportPlugin->exportStructure($db, $table, 'create_view', $aliases);
+            } else {
+                $exportPlugin->exportStructure($db, $table, 'create_table', $aliases);
             }
         }
 
@@ -524,22 +495,16 @@ class Export
                     . '.' . Util::backquote($table) . $addQuery;
             }
 
-            if (! $exportPlugin->exportData($db, $table, $localQuery, $aliases)) {
-                return;
-            }
+            $exportPlugin->exportData($db, $table, $localQuery, $aliases);
         }
 
         // now export the triggers (needs to be done after the data because
         // triggers can modify already imported tables)
         if ($exportPlugin->includeStructure()) {
-            if (! $exportPlugin->exportStructure($db, $table, 'triggers', $aliases)) {
-                return;
-            }
+            $exportPlugin->exportStructure($db, $table, 'triggers', $aliases);
         }
 
-        if (! $exportPlugin->exportDBFooter($db)) {
-            return;
-        }
+        $exportPlugin->exportDBFooter($db);
 
         // Types of metadata to export.
         // In the future these can be allowed to be selected by the user

--- a/src/Export/OutputHandler.php
+++ b/src/Export/OutputHandler.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\Export;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\Encoding;
+use PhpMyAdmin\Exceptions\InsufficientSpaceExportException;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\MessageType;
 use PhpMyAdmin\Util;
@@ -54,7 +55,8 @@ class OutputHandler
     public int $memoryLimit = 0;
     public bool $onFlyCompression = false;
 
-    public function addLine(string $line): bool
+    /** @throws InsufficientSpaceExportException */
+    public function addLine(string $line): void
     {
         // Kanji encoding convert feature
         if ($this->outputKanjiConversion) {
@@ -82,7 +84,7 @@ class OutputHandler
                             Current::$message = Message::error(__('Insufficient space to save the file %s.'));
                             Current::$message->addParam($this->saveFilename);
 
-                            return false;
+                            throw new InsufficientSpaceExportException();
                         }
                     } else {
                         echo $this->dumpBuffer;
@@ -93,14 +95,14 @@ class OutputHandler
                 }
             }
 
-            return true;
+            return;
         }
 
         if (! self::$asFile) {
             // We export as html - replace special chars
             echo htmlspecialchars($line, ENT_COMPAT);
 
-            return true;
+            return;
         }
 
         if ($this->outputCharsetConversion) {
@@ -113,14 +115,12 @@ class OutputHandler
                 Current::$message = Message::error(__('Insufficient space to save the file %s.'));
                 Current::$message->addParam($this->saveFilename);
 
-                return false;
+                throw new InsufficientSpaceExportException();
             }
         } else {
             // We export as file - output normally
             echo $line;
         }
-
-        return true;
     }
 
     /**

--- a/src/Plugins/Export/ExportCodegen.php
+++ b/src/Plugins/Export/ExportCodegen.php
@@ -95,12 +95,14 @@ class ExportCodegen extends ExportPlugin
         string $table,
         string $sqlQuery,
         array $aliases = [],
-    ): bool {
+    ): void {
         if ($this->format === self::HANDLER_NHIBERNATE_XML) {
-            return $this->outputHandler->addLine($this->handleNHibernateXMLBody($db, $table, $aliases));
+            $this->outputHandler->addLine($this->handleNHibernateXMLBody($db, $table, $aliases));
+
+            return;
         }
 
-        return $this->outputHandler->addLine($this->handleNHibernateCSBody($db, $table, $aliases));
+        $this->outputHandler->addLine($this->handleNHibernateCSBody($db, $table, $aliases));
     }
 
     /**

--- a/src/Plugins/Export/ExportCsv.php
+++ b/src/Plugins/Export/ExportCsv.php
@@ -136,7 +136,7 @@ class ExportCsv extends ExportPlugin
         string $table,
         string $sqlQuery,
         array $aliases = [],
-    ): bool {
+    ): void {
         $dbi = DatabaseInterface::getInstance();
         $result = $dbi->query($sqlQuery, ConnectionType::User, DatabaseInterface::QUERY_UNBUFFERED);
 
@@ -159,9 +159,7 @@ class ExportCsv extends ExportPlugin
             }
 
             $schemaInsert = implode($this->separator, $insertFields);
-            if (! $this->outputHandler->addLine($schemaInsert . $this->terminated)) {
-                return false;
-            }
+            $this->outputHandler->addLine($schemaInsert . $this->terminated);
         }
 
         // Format the data
@@ -208,12 +206,8 @@ class ExportCsv extends ExportPlugin
             }
 
             $schemaInsert = implode($this->separator, $insertValues);
-            if (! $this->outputHandler->addLine($schemaInsert . $this->terminated)) {
-                return false;
-            }
+            $this->outputHandler->addLine($schemaInsert . $this->terminated);
         }
-
-        return true;
     }
 
     /**
@@ -222,13 +216,13 @@ class ExportCsv extends ExportPlugin
      * @param string|null $db       the database where the query is executed
      * @param string      $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): bool
+    public function exportRawQuery(string|null $db, string $sqlQuery): void
     {
         if ($db !== null) {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        return $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db ?? '', '', $sqlQuery);
     }
 
     /** @inheritDoc */

--- a/src/Plugins/Export/ExportExcel.php
+++ b/src/Plugins/Export/ExportExcel.php
@@ -132,7 +132,7 @@ class ExportExcel extends ExportPlugin
         string $table,
         string $sqlQuery,
         array $aliases = [],
-    ): bool {
+    ): void {
         $dbi = DatabaseInterface::getInstance();
         /**
          * Gets the data from the database
@@ -155,9 +155,7 @@ class ExportExcel extends ExportPlugin
             }
 
             $schemaInsert = implode($this->separator, $insertFields);
-            if (! $this->outputHandler->addLine($schemaInsert . $this->terminated)) {
-                return false;
-            }
+            $this->outputHandler->addLine($schemaInsert . $this->terminated);
         }
 
         // Format the data
@@ -206,12 +204,8 @@ class ExportExcel extends ExportPlugin
             }
 
             $schemaInsert = implode($this->separator, $insertValues);
-            if (! $this->outputHandler->addLine($schemaInsert . $this->terminated)) {
-                return false;
-            }
+            $this->outputHandler->addLine($schemaInsert . $this->terminated);
         }
-
-        return true;
     }
 
     /**
@@ -220,13 +214,13 @@ class ExportExcel extends ExportPlugin
      * @param string|null $db       the database where the query is executed
      * @param string      $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): bool
+    public function exportRawQuery(string|null $db, string $sqlQuery): void
     {
         if ($db !== null) {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        return $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db ?? '', '', $sqlQuery);
     }
 
     /** @inheritDoc */

--- a/src/Plugins/Export/ExportHtmlword.php
+++ b/src/Plugins/Export/ExportHtmlword.php
@@ -104,9 +104,9 @@ class ExportHtmlword extends ExportPlugin
     /**
      * Outputs export header
      */
-    public function exportHeader(): bool
+    public function exportHeader(): void
     {
-        return $this->outputHandler->addLine(
+        $this->outputHandler->addLine(
             '<html xmlns:o="urn:schemas-microsoft-com:office:office"
             xmlns:x="urn:schemas-microsoft-com:office:word"
             xmlns="http://www.w3.org/TR/REC-html40">
@@ -125,9 +125,9 @@ class ExportHtmlword extends ExportPlugin
     /**
      * Outputs export footer
      */
-    public function exportFooter(): bool
+    public function exportFooter(): void
     {
-        return $this->outputHandler->addLine('</body></html>');
+        $this->outputHandler->addLine('</body></html>');
     }
 
     /**
@@ -136,13 +136,13 @@ class ExportHtmlword extends ExportPlugin
      * @param string $db      Database name
      * @param string $dbAlias Aliases of db
      */
-    public function exportDBHeader(string $db, string $dbAlias = ''): bool
+    public function exportDBHeader(string $db, string $dbAlias = ''): void
     {
         if ($dbAlias === '') {
             $dbAlias = $db;
         }
 
-        return $this->outputHandler->addLine(
+        $this->outputHandler->addLine(
             '<h1>' . __('Database') . ' ' . htmlspecialchars($dbAlias) . '</h1>',
         );
     }
@@ -160,22 +160,16 @@ class ExportHtmlword extends ExportPlugin
         string $table,
         string $sqlQuery,
         array $aliases = [],
-    ): bool {
+    ): void {
         $tableAlias = $this->getTableAlias($aliases, $db, $table);
 
-        if (
-            ! $this->outputHandler->addLine(
-                '<h2>'
-                . __('Dumping data for table') . ' ' . htmlspecialchars($tableAlias)
-                . '</h2>',
-            )
-        ) {
-            return false;
-        }
+        $this->outputHandler->addLine(
+            '<h2>'
+            . __('Dumping data for table') . ' ' . htmlspecialchars($tableAlias)
+            . '</h2>',
+        );
 
-        if (! $this->outputHandler->addLine('<table width="100%" cellspacing="1">')) {
-            return false;
-        }
+        $this->outputHandler->addLine('<table width="100%" cellspacing="1">');
 
         $dbi = DatabaseInterface::getInstance();
         /**
@@ -195,9 +189,7 @@ class ExportHtmlword extends ExportPlugin
             }
 
             $schemaInsert .= '</tr>';
-            if (! $this->outputHandler->addLine($schemaInsert)) {
-                return false;
-            }
+            $this->outputHandler->addLine($schemaInsert);
         }
 
         // Format the data
@@ -210,12 +202,10 @@ class ExportHtmlword extends ExportPlugin
             }
 
             $schemaInsert .= '</tr>';
-            if (! $this->outputHandler->addLine($schemaInsert)) {
-                return false;
-            }
+            $this->outputHandler->addLine($schemaInsert);
         }
 
-        return $this->outputHandler->addLine('</table>');
+        $this->outputHandler->addLine('</table>');
     }
 
     /**
@@ -441,7 +431,7 @@ class ExportHtmlword extends ExportPlugin
      * @param string  $exportMode 'create_table', 'triggers', 'create_view', 'stand_in'
      * @param mixed[] $aliases    Aliases of db/table/columns
      */
-    public function exportStructure(string $db, string $table, string $exportMode, array $aliases = []): bool
+    public function exportStructure(string $db, string $table, string $exportMode, array $aliases = []): void
     {
         $tableAlias = $this->getTableAlias($aliases, $db, $table);
 
@@ -480,7 +470,7 @@ class ExportHtmlword extends ExportPlugin
                 $dump .= $this->getTableDefStandIn($db, $table, $aliases);
         }
 
-        return $this->outputHandler->addLine($dump);
+        $this->outputHandler->addLine($dump);
     }
 
     /**

--- a/src/Plugins/Export/ExportMediawiki.php
+++ b/src/Plugins/Export/ExportMediawiki.php
@@ -102,7 +102,7 @@ class ExportMediawiki extends ExportPlugin
      *
      * @infection-ignore-all
      */
-    public function exportStructure(string $db, string $table, string $exportMode, array $aliases = []): bool
+    public function exportStructure(string $db, string $table, string $exportMode, array $aliases = []): void
     {
         $tableAlias = $this->getTableAlias($aliases, $db, $table);
 
@@ -166,7 +166,7 @@ class ExportMediawiki extends ExportPlugin
             $output .= '|}' . str_repeat($this->exportCRLF(), 2);
         }
 
-        return $this->outputHandler->addLine($output);
+        $this->outputHandler->addLine($output);
     }
 
     /**
@@ -182,7 +182,7 @@ class ExportMediawiki extends ExportPlugin
         string $table,
         string $sqlQuery,
         array $aliases = [],
-    ): bool {
+    ): void {
         $tableAlias = $this->getTableAlias($aliases, $db, $table);
 
         // Print data comment
@@ -240,7 +240,7 @@ class ExportMediawiki extends ExportPlugin
         // End table construction
         $output .= '|}' . str_repeat($this->exportCRLF(), 2);
 
-        return $this->outputHandler->addLine($output);
+        $this->outputHandler->addLine($output);
     }
 
     /**
@@ -249,13 +249,13 @@ class ExportMediawiki extends ExportPlugin
      * @param string|null $db       the database where the query is executed
      * @param string      $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): bool
+    public function exportRawQuery(string|null $db, string $sqlQuery): void
     {
         if ($db !== null) {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        return $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db ?? '', '', $sqlQuery);
     }
 
     /**

--- a/src/Plugins/Export/ExportOds.php
+++ b/src/Plugins/Export/ExportOds.php
@@ -84,7 +84,7 @@ class ExportOds extends ExportPlugin
     /**
      * Outputs export header
      */
-    public function exportHeader(): bool
+    public function exportHeader(): void
     {
         $this->buffer .= '<?xml version="1.0" encoding="utf-8"?>'
             . '<office:document-content '
@@ -131,18 +131,16 @@ class ExportOds extends ExportPlugin
             . '</office:automatic-styles>'
             . '<office:body>'
             . '<office:spreadsheet>';
-
-        return true;
     }
 
     /**
      * Outputs export footer
      */
-    public function exportFooter(): bool
+    public function exportFooter(): void
     {
         $this->buffer .= '</office:spreadsheet></office:body></office:document-content>';
 
-        return $this->outputHandler->addLine(
+        $this->outputHandler->addLine(
             OpenDocument::create('application/vnd.oasis.opendocument.spreadsheet', $this->buffer),
         );
     }
@@ -160,7 +158,7 @@ class ExportOds extends ExportPlugin
         string $table,
         string $sqlQuery,
         array $aliases = [],
-    ): bool {
+    ): void {
         $tableAlias = $this->getTableAlias($aliases, $db, $table);
         $dbi = DatabaseInterface::getInstance();
         // Gets the data from the database
@@ -256,8 +254,6 @@ class ExportOds extends ExportPlugin
         }
 
         $this->buffer .= '</table:table>';
-
-        return true;
     }
 
     /**
@@ -266,13 +262,13 @@ class ExportOds extends ExportPlugin
      * @param string|null $db       the database where the query is executed
      * @param string      $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): bool
+    public function exportRawQuery(string|null $db, string $sqlQuery): void
     {
         if ($db !== null) {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        return $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db ?? '', '', $sqlQuery);
     }
 
     /** @inheritDoc */

--- a/src/Plugins/Export/ExportOdt.php
+++ b/src/Plugins/Export/ExportOdt.php
@@ -145,25 +145,23 @@ class ExportOdt extends ExportPlugin
     /**
      * Outputs export header
      */
-    public function exportHeader(): bool
+    public function exportHeader(): void
     {
         $this->buffer .= '<?xml version="1.0" encoding="utf-8"?>'
             . '<office:document-content '
             . OpenDocument::NS . ' office:version="1.0">'
             . '<office:body>'
             . '<office:text>';
-
-        return true;
     }
 
     /**
      * Outputs export footer
      */
-    public function exportFooter(): bool
+    public function exportFooter(): void
     {
         $this->buffer .= '</office:text></office:body></office:document-content>';
 
-        return $this->outputHandler->addLine(OpenDocument::create(
+        $this->outputHandler->addLine(OpenDocument::create(
             'application/vnd.oasis.opendocument.text',
             $this->buffer,
         ));
@@ -175,7 +173,7 @@ class ExportOdt extends ExportPlugin
      * @param string $db      Database name
      * @param string $dbAlias Aliases of db
      */
-    public function exportDBHeader(string $db, string $dbAlias = ''): bool
+    public function exportDBHeader(string $db, string $dbAlias = ''): void
     {
         if ($dbAlias === '') {
             $dbAlias = $db;
@@ -185,8 +183,6 @@ class ExportOdt extends ExportPlugin
             . ' text:is-list-header="true">'
             . __('Database') . ' ' . htmlspecialchars($dbAlias)
             . '</text:h>';
-
-        return true;
     }
 
     /**
@@ -202,7 +198,7 @@ class ExportOdt extends ExportPlugin
         string $table,
         string $sqlQuery,
         array $aliases = [],
-    ): bool {
+    ): void {
         $tableAlias = $this->getTableAlias($aliases, $db, $table);
         $dbi = DatabaseInterface::getInstance();
         // Gets the data from the database
@@ -280,8 +276,6 @@ class ExportOdt extends ExportPlugin
         }
 
         $this->buffer .= '</table:table>';
-
-        return true;
     }
 
     /**
@@ -290,13 +284,13 @@ class ExportOdt extends ExportPlugin
      * @param string|null $db       the database where the query is executed
      * @param string      $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): bool
+    public function exportRawQuery(string|null $db, string $sqlQuery): void
     {
         if ($db !== null) {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        return $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db ?? '', '', $sqlQuery);
     }
 
     /**
@@ -559,7 +553,7 @@ class ExportOdt extends ExportPlugin
      * @param string  $exportMode 'create_table', 'triggers', 'create_view', 'stand_in'
      * @param mixed[] $aliases    Aliases of db/table/columns
      */
-    public function exportStructure(string $db, string $table, string $exportMode, array $aliases = []): bool
+    public function exportStructure(string $db, string $table, string $exportMode, array $aliases = []): void
     {
         $tableAlias = $this->getTableAlias($aliases, $db, $table);
         switch ($exportMode) {
@@ -600,8 +594,6 @@ class ExportOdt extends ExportPlugin
                 // export a stand-in definition to resolve view dependencies
                 $this->getTableDefStandIn($db, $table, $aliases);
         }
-
-        return true;
     }
 
     /**

--- a/src/Plugins/Export/ExportPdf.php
+++ b/src/Plugins/Export/ExportPdf.php
@@ -101,10 +101,10 @@ class ExportPdf extends ExportPlugin
     /**
      * Outputs export footer
      */
-    public function exportFooter(): bool
+    public function exportFooter(): void
     {
         // instead of $pdf->Output():
-        return $this->outputHandler->addLine($this->pdf->getPDFData());
+        $this->outputHandler->addLine($this->pdf->getPDFData());
     }
 
     /**
@@ -120,7 +120,7 @@ class ExportPdf extends ExportPlugin
         string $table,
         string $sqlQuery,
         array $aliases = [],
-    ): bool {
+    ): void {
         $dbAlias = $this->getDbAlias($aliases, $db);
         $tableAlias = $this->getTableAlias($aliases, $db, $table);
         $this->pdf->setCurrentDb($db);
@@ -130,8 +130,6 @@ class ExportPdf extends ExportPlugin
         $this->pdf->setAliases($aliases);
         $this->pdf->setPurpose(__('Dumping data'));
         $this->pdf->mysqlReport($sqlQuery);
-
-        return true;
     }
 
     /**
@@ -140,7 +138,7 @@ class ExportPdf extends ExportPlugin
      * @param string|null $db       the database where the query is executed
      * @param string      $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): bool
+    public function exportRawQuery(string|null $db, string $sqlQuery): void
     {
         $this->pdf->setDbAlias('----');
         $this->pdf->setTableAlias('----');
@@ -152,8 +150,6 @@ class ExportPdf extends ExportPlugin
         }
 
         $this->pdf->mysqlReport($sqlQuery);
-
-        return true;
     }
 
     /**
@@ -164,7 +160,7 @@ class ExportPdf extends ExportPlugin
      * @param string  $exportMode 'create_table', 'triggers', 'create_view', 'stand_in'
      * @param mixed[] $aliases    aliases for db/table/columns
      */
-    public function exportStructure(string $db, string $table, string $exportMode, array $aliases = []): bool
+    public function exportStructure(string $db, string $table, string $exportMode, array $aliases = []): void
     {
         $purpose = '';
         $dbAlias = $this->getDbAlias($aliases, $db);
@@ -197,8 +193,6 @@ class ExportPdf extends ExportPlugin
             'triggers' => $this->pdf->getTriggers($db, $table),
             default => true,
         };
-
-        return true;
     }
 
     public static function isAvailable(): bool

--- a/src/Plugins/Export/ExportPhparray.php
+++ b/src/Plugins/Export/ExportPhparray.php
@@ -76,7 +76,7 @@ class ExportPhparray extends ExportPlugin
     /**
      * Outputs export header
      */
-    public function exportHeader(): bool
+    public function exportHeader(): void
     {
         $this->outputHandler->addLine(
             '<?php' . "\n"
@@ -85,8 +85,6 @@ class ExportPhparray extends ExportPlugin
             . ' * @version ' . Version::VERSION . "\n"
             . ' */' . "\n\n",
         );
-
-        return true;
     }
 
     /**
@@ -95,7 +93,7 @@ class ExportPhparray extends ExportPlugin
      * @param string $db      Database name
      * @param string $dbAlias Aliases of db
      */
-    public function exportDBHeader(string $db, string $dbAlias = ''): bool
+    public function exportDBHeader(string $db, string $dbAlias = ''): void
     {
         if ($dbAlias === '') {
             $dbAlias = $db;
@@ -106,8 +104,6 @@ class ExportPhparray extends ExportPlugin
             . ' * Database ' . $this->commentString(Util::backquote($dbAlias))
             . "\n" . ' */' . "\n",
         );
-
-        return true;
     }
 
     /**
@@ -123,7 +119,7 @@ class ExportPhparray extends ExportPlugin
         string $table,
         string $sqlQuery,
         array $aliases = [],
-    ): bool {
+    ): void {
         $dbAlias = $this->getDbAlias($aliases, $db);
         $tableAlias = $this->getTableAlias($aliases, $db, $table);
 
@@ -160,9 +156,7 @@ class ExportPhparray extends ExportPlugin
             . $this->commentString(Util::backquote($dbAlias)) . '.'
             . $this->commentString(Util::backquote($tableAlias)) . ' */' . "\n";
         $buffer .= '$' . $tableFixed . ' = array(';
-        if (! $this->outputHandler->addLine($buffer)) {
-            return false;
-        }
+        $this->outputHandler->addLine($buffer);
 
         // Reset the buffer
         $buffer = '';
@@ -183,9 +177,7 @@ class ExportPhparray extends ExportPlugin
             }
 
             $buffer .= ')';
-            if (! $this->outputHandler->addLine($buffer)) {
-                return false;
-            }
+            $this->outputHandler->addLine($buffer);
 
             // Reset the buffer
             $buffer = '';
@@ -193,7 +185,7 @@ class ExportPhparray extends ExportPlugin
 
         $buffer .= "\n" . ');' . "\n";
 
-        return $this->outputHandler->addLine($buffer);
+        $this->outputHandler->addLine($buffer);
     }
 
     /**
@@ -202,13 +194,13 @@ class ExportPhparray extends ExportPlugin
      * @param string|null $db       the database where the query is executed
      * @param string      $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): bool
+    public function exportRawQuery(string|null $db, string $sqlQuery): void
     {
         if ($db !== null) {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        return $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db ?? '', '', $sqlQuery);
     }
 
     /** @inheritDoc */

--- a/src/Plugins/Export/ExportTexytext.php
+++ b/src/Plugins/Export/ExportTexytext.php
@@ -105,13 +105,13 @@ class ExportTexytext extends ExportPlugin
      * @param string $db      Database name
      * @param string $dbAlias Alias of db
      */
-    public function exportDBHeader(string $db, string $dbAlias = ''): bool
+    public function exportDBHeader(string $db, string $dbAlias = ''): void
     {
         if ($dbAlias === '') {
             $dbAlias = $db;
         }
 
-        return $this->outputHandler->addLine(
+        $this->outputHandler->addLine(
             '===' . __('Database') . ' ' . $dbAlias . "\n\n",
         );
     }
@@ -129,18 +129,14 @@ class ExportTexytext extends ExportPlugin
         string $table,
         string $sqlQuery,
         array $aliases = [],
-    ): bool {
+    ): void {
         $tableAlias = $this->getTableAlias($aliases, $db, $table);
 
-        if (
-            ! $this->outputHandler->addLine(
-                $tableAlias !== ''
-                ? '== ' . __('Dumping data for table') . ' ' . $tableAlias . "\n\n"
-                : '==' . __('Dumping data for query result') . "\n\n",
-            )
-        ) {
-            return false;
-        }
+        $this->outputHandler->addLine(
+            $tableAlias !== ''
+            ? '== ' . __('Dumping data for table') . ' ' . $tableAlias . "\n\n"
+            : '==' . __('Dumping data for query result') . "\n\n",
+        );
 
         $dbi = DatabaseInterface::getInstance();
         /**
@@ -158,9 +154,7 @@ class ExportTexytext extends ExportPlugin
             }
 
             $textOutput .= "\n|------\n";
-            if (! $this->outputHandler->addLine($textOutput)) {
-                return false;
-            }
+            $this->outputHandler->addLine($textOutput);
         }
 
         // Format the data
@@ -184,12 +178,8 @@ class ExportTexytext extends ExportPlugin
             }
 
             $textOutput .= "\n";
-            if (! $this->outputHandler->addLine($textOutput)) {
-                return false;
-            }
+            $this->outputHandler->addLine($textOutput);
         }
-
-        return true;
     }
 
     /**
@@ -198,13 +188,13 @@ class ExportTexytext extends ExportPlugin
      * @param string|null $db       the database where the query is executed
      * @param string      $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): bool
+    public function exportRawQuery(string|null $db, string $sqlQuery): void
     {
         if ($db !== null) {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        return $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db ?? '', '', $sqlQuery);
     }
 
     /**
@@ -399,7 +389,7 @@ class ExportTexytext extends ExportPlugin
      * @param string  $exportMode 'create_table', 'triggers', 'create_view', 'stand_in'
      * @param mixed[] $aliases    Aliases of db/table/columns
      */
-    public function exportStructure(string $db, string $table, string $exportMode, array $aliases = []): bool
+    public function exportStructure(string $db, string $table, string $exportMode, array $aliases = []): void
     {
         $tableAlias = $this->getTableAlias($aliases, $db, $table);
         $dump = '';
@@ -429,7 +419,7 @@ class ExportTexytext extends ExportPlugin
                 $dump .= $this->getTableDefStandIn($db, $table, $aliases);
         }
 
-        return $this->outputHandler->addLine($dump);
+        $this->outputHandler->addLine($dump);
     }
 
     /**

--- a/src/Plugins/Export/ExportYaml.php
+++ b/src/Plugins/Export/ExportYaml.php
@@ -65,21 +65,17 @@ class ExportYaml extends ExportPlugin
     /**
      * Outputs export header
      */
-    public function exportHeader(): bool
+    public function exportHeader(): void
     {
         $this->outputHandler->addLine('%YAML 1.1' . "\n" . '---' . "\n");
-
-        return true;
     }
 
     /**
      * Outputs export footer
      */
-    public function exportFooter(): bool
+    public function exportFooter(): void
     {
         $this->outputHandler->addLine('...' . "\n");
-
-        return true;
     }
 
     /**
@@ -95,7 +91,7 @@ class ExportYaml extends ExportPlugin
         string $table,
         string $sqlQuery,
         array $aliases = [],
-    ): bool {
+    ): void {
         $dbAlias = $this->getDbAlias($aliases, $db);
         $tableAlias = $this->getTableAlias($aliases, $db, $table);
         $dbi = DatabaseInterface::getInstance();
@@ -148,12 +144,8 @@ class ExportYaml extends ExportPlugin
                 $buffer .= '  ' . $columns[$i] . ': "' . $record[$i] . '"' . "\n";
             }
 
-            if (! $this->outputHandler->addLine($buffer)) {
-                return false;
-            }
+            $this->outputHandler->addLine($buffer);
         }
-
-        return true;
     }
 
     /**
@@ -162,13 +154,13 @@ class ExportYaml extends ExportPlugin
      * @param string|null $db       the database where the query is executed
      * @param string      $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): bool
+    public function exportRawQuery(string|null $db, string $sqlQuery): void
     {
         if ($db !== null) {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        return $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db ?? '', '', $sqlQuery);
     }
 
     /** @inheritDoc */

--- a/src/Plugins/ExportPlugin.php
+++ b/src/Plugins/ExportPlugin.php
@@ -47,17 +47,15 @@ abstract class ExportPlugin implements Plugin
     /**
      * Outputs export header
      */
-    public function exportHeader(): bool
+    public function exportHeader(): void
     {
-        return true;
     }
 
     /**
      * Outputs export footer
      */
-    public function exportFooter(): bool
+    public function exportFooter(): void
     {
-        return true;
     }
 
     /**
@@ -66,9 +64,8 @@ abstract class ExportPlugin implements Plugin
      * @param string $db      Database name
      * @param string $dbAlias Aliases of db
      */
-    public function exportDBHeader(string $db, string $dbAlias = ''): bool
+    public function exportDBHeader(string $db, string $dbAlias = ''): void
     {
-        return true;
     }
 
     /**
@@ -76,9 +73,8 @@ abstract class ExportPlugin implements Plugin
      *
      * @param string $db Database name
      */
-    public function exportDBFooter(string $db): bool
+    public function exportDBFooter(string $db): void
     {
-        return true;
     }
 
     /**
@@ -87,9 +83,8 @@ abstract class ExportPlugin implements Plugin
      * @param string $db      Database name
      * @param string $dbAlias Aliases of db
      */
-    public function exportDBCreate(string $db, string $dbAlias = ''): bool
+    public function exportDBCreate(string $db, string $dbAlias = ''): void
     {
-        return true;
     }
 
     /**
@@ -105,7 +100,7 @@ abstract class ExportPlugin implements Plugin
         string $table,
         string $sqlQuery,
         array $aliases = [],
-    ): bool;
+    ): void;
 
     /**
      * The following methods are used in /export or in /database/operations,
@@ -118,9 +113,8 @@ abstract class ExportPlugin implements Plugin
      * @param string  $db      Database
      * @param mixed[] $aliases Aliases of db/table/columns
      */
-    public function exportRoutines(string $db, array $aliases = []): bool
+    public function exportRoutines(string $db, array $aliases = []): void
     {
-        return true;
     }
 
     /**
@@ -128,9 +122,8 @@ abstract class ExportPlugin implements Plugin
      *
      * @param string $db Database
      */
-    public function exportEvents(string $db): bool
+    public function exportEvents(string $db): void
     {
-        return true;
     }
 
     /**
@@ -139,9 +132,8 @@ abstract class ExportPlugin implements Plugin
      * @param string|null $db       the database where the query is executed
      * @param string      $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): bool
+    public function exportRawQuery(string|null $db, string $sqlQuery): void
     {
-        return false;
     }
 
     /**
@@ -152,9 +144,8 @@ abstract class ExportPlugin implements Plugin
      * @param string  $exportMode 'create_table', 'triggers', 'create_view', 'stand_in'
      * @param mixed[] $aliases    Aliases of db/table/columns
      */
-    public function exportStructure(string $db, string $table, string $exportMode, array $aliases = []): bool
+    public function exportStructure(string $db, string $table, string $exportMode, array $aliases = []): void
     {
-        return true;
     }
 
     /**
@@ -168,8 +159,7 @@ abstract class ExportPlugin implements Plugin
         string $db,
         string|array $tables,
         array $metadataTypes,
-    ): bool {
-        return true;
+    ): void {
     }
 
     /**

--- a/tests/unit/Plugins/Export/ExportCodegenTest.php
+++ b/tests/unit/Plugins/Export/ExportCodegenTest.php
@@ -136,30 +136,26 @@ class ExportCodegenTest extends AbstractTestCase
 
     public function testExportHeader(): void
     {
-        self::assertTrue(
-            $this->object->exportHeader(),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportHeader();
     }
 
     public function testExportFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportFooter(),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportFooter();
     }
 
     public function testExportDBHeader(): void
     {
-        self::assertTrue(
-            $this->object->exportDBHeader('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBHeader('testDB');
     }
 
     public function testExportDBFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportDBFooter('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBFooter('testDB');
     }
 
     public function testExportData(): void

--- a/tests/unit/Plugins/Export/ExportCsvTest.php
+++ b/tests/unit/Plugins/Export/ExportCsvTest.php
@@ -228,27 +228,32 @@ class ExportCsvTest extends AbstractTestCase
     public function testExportHeader(): void
     {
         // case 1
-        self::assertTrue($this->object->exportHeader());
+        $this->expectNotToPerformAssertions();
+        $this->object->exportHeader();
     }
 
     public function testExportFooter(): void
     {
-        self::assertTrue($this->object->exportFooter());
+        $this->expectNotToPerformAssertions();
+        $this->object->exportFooter();
     }
 
     public function testExportDBHeader(): void
     {
-        self::assertTrue($this->object->exportDBHeader('testDB'));
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBHeader('testDB');
     }
 
     public function testExportDBFooter(): void
     {
-        self::assertTrue($this->object->exportDBFooter('testDB'));
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBFooter('testDB');
     }
 
     public function testExportDBCreate(): void
     {
-        self::assertTrue($this->object->exportDBCreate('testDB'));
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBCreate('testDB');
     }
 
     public function testExportData(): void
@@ -263,11 +268,7 @@ class ExportCsvTest extends AbstractTestCase
         $this->object->exportHeader();
 
         ob_start();
-        self::assertTrue($this->object->exportData(
-            'test_db',
-            'test_table',
-            'SELECT * FROM `test_db`.`test_table_csv_export`;',
-        ));
+        $this->object->exportData('test_db', 'test_table', 'SELECT * FROM `test_db`.`test_table_csv_export`;');
         $result = ob_get_clean();
 
         self::assertSame(
@@ -284,11 +285,11 @@ class ExportCsvTest extends AbstractTestCase
         $this->object->exportHeader();
 
         ob_start();
-        self::assertTrue($this->object->exportData(
+        $this->object->exportData(
             'test_db',
             'test_table_csv_export',
             'SELECT * FROM `test_db`.`test_table_csv_export`;',
-        ));
+        );
         $result = ob_get_clean();
 
         self::assertSame(
@@ -310,11 +311,11 @@ class ExportCsvTest extends AbstractTestCase
         $this->object->exportHeader();
 
         ob_start();
-        self::assertTrue($this->object->exportData(
+        $this->object->exportData(
             'test_db',
             'test_table_csv_export',
             'SELECT * FROM `test_db`.`test_table_csv_export`;',
-        ));
+        );
         $result = ob_get_clean();
 
         self::assertSame(

--- a/tests/unit/Plugins/Export/ExportExcelTest.php
+++ b/tests/unit/Plugins/Export/ExportExcelTest.php
@@ -188,9 +188,8 @@ class ExportExcelTest extends AbstractTestCase
     public function testExportHeader(): void
     {
         // case 1
-        self::assertTrue(
-            $this->object->exportHeader(),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportHeader();
 
         // case 2
         $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/')
@@ -198,9 +197,7 @@ class ExportExcelTest extends AbstractTestCase
 
         $this->object->setExportOptions($request, []);
 
-        self::assertTrue(
-            $this->object->exportHeader(),
-        );
+        $this->object->exportHeader();
 
         // case 3
         $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/')
@@ -208,9 +205,7 @@ class ExportExcelTest extends AbstractTestCase
 
         $this->object->setExportOptions($request, []);
 
-        self::assertTrue(
-            $this->object->exportHeader(),
-        );
+        $this->object->exportHeader();
     }
 
     public function testExportData(): void
@@ -224,11 +219,7 @@ class ExportExcelTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue($this->object->exportData(
-            'test_db',
-            'test_table',
-            'SELECT * FROM `test_db`.`test_table`;',
-        ));
+        $this->object->exportData('test_db', 'test_table', 'SELECT * FROM `test_db`.`test_table`;');
         $result = ob_get_clean();
 
         self::assertSame(

--- a/tests/unit/Plugins/Export/ExportHtmlwordTest.php
+++ b/tests/unit/Plugins/Export/ExportHtmlwordTest.php
@@ -253,9 +253,7 @@ class ExportHtmlwordTest extends AbstractTestCase
     public function testExportFooter(): void
     {
         ob_start();
-        self::assertTrue(
-            $this->object->exportFooter(),
-        );
+        $this->object->exportFooter();
         $result = ob_get_clean();
 
         self::assertSame('</body></html>', $result);
@@ -264,9 +262,7 @@ class ExportHtmlwordTest extends AbstractTestCase
     public function testExportDBHeader(): void
     {
         ob_start();
-        self::assertTrue(
-            $this->object->exportDBHeader('d"b'),
-        );
+        $this->object->exportDBHeader('d"b');
         $result = ob_get_clean();
 
         self::assertSame('<h1>Database d&quot;b</h1>', $result);
@@ -274,16 +270,14 @@ class ExportHtmlwordTest extends AbstractTestCase
 
     public function testExportDBFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportDBFooter('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBFooter('testDB');
     }
 
     public function testExportDBCreate(): void
     {
-        self::assertTrue(
-            $this->object->exportDBCreate('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBCreate('testDB');
     }
 
     public function testExportData(): void
@@ -297,11 +291,7 @@ class ExportHtmlwordTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue($this->object->exportData(
-            'test_db',
-            'test_table',
-            'SELECT * FROM `test_db`.`test_table`;',
-        ));
+        $this->object->exportData('test_db', 'test_table', 'SELECT * FROM `test_db`.`test_table`;');
         $result = ob_get_clean();
 
         self::assertSame(
@@ -589,7 +579,7 @@ class ExportHtmlwordTest extends AbstractTestCase
     {
         ob_start();
         $this->dummyDbi->addSelectDb('test_db');
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'create_table'));
+        $this->object->exportStructure('test_db', 'test_table', 'create_table');
         $this->dummyDbi->assertAllSelectsConsumed();
         $result = ob_get_clean();
 
@@ -608,7 +598,7 @@ class ExportHtmlwordTest extends AbstractTestCase
         );
 
         ob_start();
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'triggers'));
+        $this->object->exportStructure('test_db', 'test_table', 'triggers');
         $result = ob_get_clean();
 
         self::assertSame(
@@ -623,7 +613,7 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         ob_start();
         $this->dummyDbi->addSelectDb('test_db');
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'create_view'));
+        $this->object->exportStructure('test_db', 'test_table', 'create_view');
         $this->dummyDbi->assertAllSelectsConsumed();
         $result = ob_get_clean();
 
@@ -642,7 +632,7 @@ class ExportHtmlwordTest extends AbstractTestCase
         );
 
         ob_start();
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'stand_in'));
+        $this->object->exportStructure('test_db', 'test_table', 'stand_in');
         $result = ob_get_clean();
 
         self::assertSame(

--- a/tests/unit/Plugins/Export/ExportJsonTest.php
+++ b/tests/unit/Plugins/Export/ExportJsonTest.php
@@ -120,41 +120,33 @@ class ExportJsonTest extends AbstractTestCase
             . "\n",
         );
 
-        self::assertTrue(
-            $this->object->exportHeader(),
-        );
+        $this->object->exportHeader();
     }
 
     public function testExportFooter(): void
     {
         $this->expectOutputString(']' . "\n");
 
-        self::assertTrue(
-            $this->object->exportFooter(),
-        );
+        $this->object->exportFooter();
     }
 
     public function testExportDBHeader(): void
     {
         $this->expectOutputString('{"type":"database","name":"testDB"},' . "\n");
 
-        self::assertTrue(
-            $this->object->exportDBHeader('testDB'),
-        );
+        $this->object->exportDBHeader('testDB');
     }
 
     public function testExportDBFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportDBFooter('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBFooter('testDB');
     }
 
     public function testExportDBCreate(): void
     {
-        self::assertTrue(
-            $this->object->exportDBCreate('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBCreate('testDB');
     }
 
     public function testExportData(): void
@@ -169,11 +161,7 @@ class ExportJsonTest extends AbstractTestCase
             . '}' . "\n",
         );
 
-        self::assertTrue($this->object->exportData(
-            'test_db',
-            'test_table',
-            'SELECT * FROM `test_db`.`test_table`;',
-        ));
+        $this->object->exportData('test_db', 'test_table', 'SELECT * FROM `test_db`.`test_table`;');
     }
 
     public function testExportComplexData(): void
@@ -190,13 +178,7 @@ class ExportJsonTest extends AbstractTestCase
             . "]\n}\n",
         );
 
-        self::assertTrue(
-            $this->object->exportData(
-                'test_db',
-                'test_table_complex',
-                'SELECT * FROM `test_db`.`test_table_complex`;',
-            ),
-        );
+        $this->object->exportData('test_db', 'test_table_complex', 'SELECT * FROM `test_db`.`test_table_complex`;');
     }
 
     public function testExportRawComplexData(): void
@@ -212,11 +194,6 @@ class ExportJsonTest extends AbstractTestCase
             . "]\n}\n",
         );
 
-        self::assertTrue(
-            $this->object->exportRawQuery(
-                null,
-                'SELECT * FROM `test_db`.`test_table_complex`;',
-            ),
-        );
+        $this->object->exportRawQuery(null, 'SELECT * FROM `test_db`.`test_table_complex`;');
     }
 }

--- a/tests/unit/Plugins/Export/ExportLatexTest.php
+++ b/tests/unit/Plugins/Export/ExportLatexTest.php
@@ -432,9 +432,7 @@ class ExportLatexTest extends AbstractTestCase
         $config->selectedServer['host'] = 'localhost';
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportHeader(),
-        );
+        $this->object->exportHeader();
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -444,32 +442,27 @@ class ExportLatexTest extends AbstractTestCase
 
     public function testExportFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportFooter(),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportFooter();
     }
 
     public function testExportDBHeader(): void
     {
         $this->expectOutputString("% \n% Database: 'testDB'\n% \n");
 
-        self::assertTrue(
-            $this->object->exportDBHeader('testDB'),
-        );
+        $this->object->exportDBHeader('testDB');
     }
 
     public function testExportDBFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportDBFooter('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBFooter('testDB');
     }
 
     public function testExportDBCreate(): void
     {
-        self::assertTrue(
-            $this->object->exportDBCreate('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBCreate('testDB');
     }
 
     public function testExportData(): void
@@ -491,11 +484,7 @@ class ExportLatexTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue($this->object->exportData(
-            'test_db',
-            'test_table',
-            'SELECT * FROM `test_db`.`test_table`;',
-        ));
+        $this->object->exportData('test_db', 'test_table', 'SELECT * FROM `test_db`.`test_table`;');
         $result = ob_get_clean();
 
         self::assertSame(
@@ -530,11 +519,7 @@ class ExportLatexTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue($this->object->exportData(
-            'test_db',
-            'test_table',
-            'SELECT * FROM `test_db`.`test_table`;',
-        ));
+        $this->object->exportData('test_db', 'test_table', 'SELECT * FROM `test_db`.`test_table`;');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -619,7 +604,7 @@ class ExportLatexTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue($this->object->exportStructure('database', '', 'test'));
+        $this->object->exportStructure('database', '', 'test');
         $result = ob_get_clean();
 
         //echo $result; die;
@@ -699,7 +684,7 @@ class ExportLatexTest extends AbstractTestCase
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         ob_start();
-        self::assertTrue($this->object->exportStructure('database', '', 'test'));
+        $this->object->exportStructure('database', '', 'test');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -753,7 +738,7 @@ class ExportLatexTest extends AbstractTestCase
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         ob_start();
-        self::assertTrue($this->object->exportStructure('database', '', 'test'));
+        $this->object->exportStructure('database', '', 'test');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -763,7 +748,7 @@ class ExportLatexTest extends AbstractTestCase
         self::assertStringContainsString('caption{latexcontinued}', $result);
 
         // case 4
-        self::assertTrue($this->object->exportStructure('database', '', 'triggers'));
+        $this->object->exportStructure('database', '', 'triggers');
     }
 
     public function testTexEscape(): void

--- a/tests/unit/Plugins/Export/ExportMediawikiTest.php
+++ b/tests/unit/Plugins/Export/ExportMediawikiTest.php
@@ -179,37 +179,32 @@ class ExportMediawikiTest extends AbstractTestCase
 
     public function testExportHeader(): void
     {
-        self::assertTrue(
-            $this->object->exportHeader(),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportHeader();
     }
 
     public function testExportFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportFooter(),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportFooter();
     }
 
     public function testExportDBHeader(): void
     {
-        self::assertTrue(
-            $this->object->exportDBHeader('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBHeader('testDB');
     }
 
     public function testExportDBFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportDBFooter('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBFooter('testDB');
     }
 
     public function testExportDBCreate(): void
     {
-        self::assertTrue(
-            $this->object->exportDBCreate('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBCreate('testDB');
     }
 
     /**
@@ -239,7 +234,7 @@ class ExportMediawikiTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue($this->object->exportStructure('db', 'table', 'create_table'));
+        $this->object->exportStructure('db', 'table', 'create_table');
         $result = ob_get_clean();
 
         self::assertSame(
@@ -282,13 +277,7 @@ class ExportMediawikiTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportData(
-                'test_db',
-                'test_table',
-                'SELECT * FROM `test_db`.`test_table`;',
-            ),
-        );
+        $this->object->exportData('test_db', 'test_table', 'SELECT * FROM `test_db`.`test_table`;');
         $result = ob_get_clean();
 
         self::assertSame(

--- a/tests/unit/Plugins/Export/ExportOdsTest.php
+++ b/tests/unit/Plugins/Export/ExportOdsTest.php
@@ -166,7 +166,7 @@ class ExportOdsTest extends AbstractTestCase
     public function testExportHeader(): void
     {
         $this->object->buffer = '';
-        self::assertTrue($this->object->exportHeader());
+        $this->object->exportHeader();
         self::assertStringStartsWith(
             '<?xml version="1.0" encoding="utf-8"?><office:document-content',
             $this->object->buffer,
@@ -176,7 +176,7 @@ class ExportOdsTest extends AbstractTestCase
     public function testExportFooter(): void
     {
         $this->object->buffer = 'header';
-        self::assertTrue($this->object->exportFooter());
+        $this->object->exportFooter();
         $output = $this->getActualOutputForAssertion();
         self::assertMatchesRegularExpression('/^504b.*636f6e74656e742e786d6c/', bin2hex($output));
         self::assertStringContainsString('header', $this->object->buffer);
@@ -187,23 +187,20 @@ class ExportOdsTest extends AbstractTestCase
 
     public function testExportDBHeader(): void
     {
-        self::assertTrue(
-            $this->object->exportDBHeader('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBHeader('testDB');
     }
 
     public function testExportDBFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportDBFooter('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBFooter('testDB');
     }
 
     public function testExportDBCreate(): void
     {
-        self::assertTrue(
-            $this->object->exportDBCreate('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBCreate('testDB');
     }
 
     public function testExportData(): void
@@ -256,13 +253,7 @@ class ExportOdsTest extends AbstractTestCase
 
         $this->object->setExportOptions($request, []);
 
-        self::assertTrue(
-            $this->object->exportData(
-                'db',
-                'table',
-                'SELECT',
-            ),
-        );
+        $this->object->exportData('db', 'table', 'SELECT');
 
         self::assertSame(
             '<table:table table:name="table"><table:table-row><table:table-cell ' .
@@ -341,13 +332,7 @@ class ExportOdsTest extends AbstractTestCase
 
         $this->object->setExportOptions($request, []);
 
-        self::assertTrue(
-            $this->object->exportData(
-                'db',
-                'table',
-                'SELECT',
-            ),
-        );
+        $this->object->exportData('db', 'table', 'SELECT');
 
         self::assertSame(
             '<table:table table:name="table"><table:table-row><table:table-cell ' .
@@ -388,13 +373,7 @@ class ExportOdsTest extends AbstractTestCase
         DatabaseInterface::$instance = $dbi;
         $this->object->buffer = '';
 
-        self::assertTrue(
-            $this->object->exportData(
-                'db',
-                'table',
-                'SELECT',
-            ),
-        );
+        $this->object->exportData('db', 'table', 'SELECT');
 
         self::assertSame(
             '<table:table table:name="table"><table:table-row></table:table-row></table:table>',

--- a/tests/unit/Plugins/Export/ExportOdtTest.php
+++ b/tests/unit/Plugins/Export/ExportOdtTest.php
@@ -301,9 +301,7 @@ class ExportOdtTest extends AbstractTestCase
 
     public function testExportHeader(): void
     {
-        self::assertTrue(
-            $this->object->exportHeader(),
-        );
+        $this->object->exportHeader();
 
         self::assertStringContainsString('<office:document-content', $this->object->buffer);
         self::assertStringContainsString('office:version', $this->object->buffer);
@@ -312,7 +310,7 @@ class ExportOdtTest extends AbstractTestCase
     public function testExportFooter(): void
     {
         $this->object->buffer = 'header';
-        self::assertTrue($this->object->exportFooter());
+        $this->object->exportFooter();
         $output = $this->getActualOutputForAssertion();
         self::assertMatchesRegularExpression('/^504b.*636f6e74656e742e786d6c/', bin2hex($output));
         self::assertStringContainsString('header', $this->object->buffer);
@@ -326,9 +324,7 @@ class ExportOdtTest extends AbstractTestCase
     {
         $this->object->buffer = 'header';
 
-        self::assertTrue(
-            $this->object->exportDBHeader('d&b'),
-        );
+        $this->object->exportDBHeader('d&b');
 
         self::assertStringContainsString('header', $this->object->buffer);
 
@@ -337,16 +333,14 @@ class ExportOdtTest extends AbstractTestCase
 
     public function testExportDBFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportDBFooter('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBFooter('testDB');
     }
 
     public function testExportDBCreate(): void
     {
-        self::assertTrue(
-            $this->object->exportDBCreate('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBCreate('testDB');
     }
 
     public function testExportData(): void
@@ -392,13 +386,7 @@ class ExportOdtTest extends AbstractTestCase
 
         $this->object->setExportOptions($request, []);
 
-        self::assertTrue(
-            $this->object->exportData(
-                'db',
-                'ta<ble',
-                'SELECT',
-            ),
-        );
+        $this->object->exportData('db', 'ta<ble', 'SELECT');
 
         self::assertSame(
             '<text:h text:outline-level="2" text:style-name="Heading_2" ' .
@@ -462,13 +450,7 @@ class ExportOdtTest extends AbstractTestCase
 
         $this->object->setExportOptions($request, []);
 
-        self::assertTrue(
-            $this->object->exportData(
-                'db',
-                'table',
-                'SELECT',
-            ),
-        );
+        $this->object->exportData('db', 'table', 'SELECT');
 
         self::assertSame(
             '<text:h text:outline-level="2" text:style-name="Heading_2" text:' .
@@ -511,13 +493,7 @@ class ExportOdtTest extends AbstractTestCase
         DatabaseInterface::$instance = $dbi;
         $this->object->buffer = '';
 
-        self::assertTrue(
-            $this->object->exportData(
-                'db',
-                'table',
-                'SELECT',
-            ),
-        );
+        $this->object->exportData('db', 'table', 'SELECT');
 
         self::assertSame(
             '<text:h text:outline-level="2" text:style-name="Heading_2" ' .
@@ -742,7 +718,7 @@ class ExportOdtTest extends AbstractTestCase
     {
         // case 1
         $this->dummyDbi->addSelectDb('test_db');
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'create_table'));
+        $this->object->exportStructure('test_db', 'test_table', 'create_table');
         $this->dummyDbi->assertAllSelectsConsumed();
 
         self::assertSame(
@@ -775,7 +751,7 @@ class ExportOdtTest extends AbstractTestCase
         // case 2
         $this->object->buffer = '';
 
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'triggers'));
+        $this->object->exportStructure('test_db', 'test_table', 'triggers');
 
         self::assertSame(
             '<text:h text:outline-level="2" text:style-name="Heading_2" text:is-list-header="true">'
@@ -798,7 +774,7 @@ class ExportOdtTest extends AbstractTestCase
         $this->object->buffer = '';
 
         $this->dummyDbi->addSelectDb('test_db');
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'create_view'));
+        $this->object->exportStructure('test_db', 'test_table', 'create_view');
         $this->dummyDbi->assertAllSelectsConsumed();
 
         self::assertSame(
@@ -831,7 +807,7 @@ class ExportOdtTest extends AbstractTestCase
         // case 4
         $this->dummyDbi->addSelectDb('test_db');
         $this->object->buffer = '';
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'stand_in'));
+        $this->object->exportStructure('test_db', 'test_table', 'stand_in');
         $this->dummyDbi->assertAllSelectsConsumed();
 
         self::assertSame(

--- a/tests/unit/Plugins/Export/ExportPdfTest.php
+++ b/tests/unit/Plugins/Export/ExportPdfTest.php
@@ -175,30 +175,25 @@ class ExportPdfTest extends AbstractTestCase
         $attrPdf = new ReflectionProperty(ExportPdf::class, 'pdf');
         $attrPdf->setValue($this->object, $pdf);
 
-        self::assertTrue(
-            $this->object->exportFooter(),
-        );
+        $this->object->exportFooter();
     }
 
     public function testExportDBHeader(): void
     {
-        self::assertTrue(
-            $this->object->exportDBHeader('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBHeader('testDB');
     }
 
     public function testExportDBFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportDBFooter('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBFooter('testDB');
     }
 
     public function testExportDBCreate(): void
     {
-        self::assertTrue(
-            $this->object->exportDBCreate('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBCreate('testDB');
     }
 
     public function testExportData(): void
@@ -214,12 +209,6 @@ class ExportPdfTest extends AbstractTestCase
         $attrPdf = new ReflectionProperty(ExportPdf::class, 'pdf');
         $attrPdf->setValue($this->object, $pdf);
 
-        self::assertTrue(
-            $this->object->exportData(
-                'db',
-                'table',
-                'SELECT',
-            ),
-        );
+        $this->object->exportData('db', 'table', 'SELECT');
     }
 }

--- a/tests/unit/Plugins/Export/ExportPhparrayTest.php
+++ b/tests/unit/Plugins/Export/ExportPhparrayTest.php
@@ -115,9 +115,7 @@ class ExportPhparrayTest extends AbstractTestCase
     public function testExportHeader(): void
     {
         ob_start();
-        self::assertTrue(
-            $this->object->exportHeader(),
-        );
+        $this->object->exportHeader();
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -127,17 +125,14 @@ class ExportPhparrayTest extends AbstractTestCase
 
     public function testExportFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportFooter(),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportFooter();
     }
 
     public function testExportDBHeader(): void
     {
         ob_start();
-        self::assertTrue(
-            $this->object->exportDBHeader('db'),
-        );
+        $this->object->exportDBHeader('db');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -147,28 +142,20 @@ class ExportPhparrayTest extends AbstractTestCase
 
     public function testExportDBFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportDBFooter('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBFooter('testDB');
     }
 
     public function testExportDBCreate(): void
     {
-        self::assertTrue(
-            $this->object->exportDBCreate('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBCreate('testDB');
     }
 
     public function testExportData(): void
     {
         ob_start();
-        self::assertTrue(
-            $this->object->exportData(
-                'test_db',
-                'test_table',
-                'SELECT * FROM `test_db`.`test_table`;',
-            ),
-        );
+        $this->object->exportData('test_db', 'test_table', 'SELECT * FROM `test_db`.`test_table`;');
         $result = ob_get_clean();
 
         self::assertSame(
@@ -183,13 +170,7 @@ class ExportPhparrayTest extends AbstractTestCase
 
         // case 2: test invalid variable name fix
         ob_start();
-        self::assertTrue(
-            $this->object->exportData(
-                'test_db',
-                '0`932table',
-                'SELECT * FROM `test_db`.`test_table`;',
-            ),
-        );
+        $this->object->exportData('test_db', '0`932table', 'SELECT * FROM `test_db`.`test_table`;');
         $result = ob_get_clean();
 
         self::assertIsString($result);

--- a/tests/unit/Plugins/Export/ExportSqlTest.php
+++ b/tests/unit/Plugins/Export/ExportSqlTest.php
@@ -404,9 +404,7 @@ class ExportSqlTest extends AbstractTestCase
 
         $this->expectOutputString('SET FOREIGN_KEY_CHECKS=1;' . "\n" . 'COMMIT;' . "\n");
 
-        self::assertTrue(
-            $this->object->exportFooter(),
-        );
+        $this->object->exportFooter();
     }
 
     public function testExportHeader(): void
@@ -449,9 +447,7 @@ class ExportSqlTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportHeader(),
-        );
+        $this->object->exportHeader();
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -496,9 +492,7 @@ class ExportSqlTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportDBCreate('db'),
-        );
+        $this->object->exportDBCreate('db');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -529,9 +523,7 @@ class ExportSqlTest extends AbstractTestCase
         $this->object->useSqlBackquotes(false);
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportDBCreate('db'),
-        );
+        $this->object->exportDBCreate('db');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -558,9 +550,7 @@ class ExportSqlTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportDBHeader('testDB'),
-        );
+        $this->object->exportDBHeader('testDB');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -571,9 +561,7 @@ class ExportSqlTest extends AbstractTestCase
         $this->object->useSqlBackquotes(false);
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportDBHeader('testDB'),
-        );
+        $this->object->exportDBHeader('testDB');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -608,9 +596,7 @@ class ExportSqlTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportEvents('db'),
-        );
+        $this->object->exportEvents('db');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -635,9 +621,7 @@ class ExportSqlTest extends AbstractTestCase
         DatabaseInterface::$instance = $dbi;
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportDBFooter('db'),
-        );
+        $this->object->exportDBFooter('db');
         $result = ob_get_clean();
 
         self::assertSame('SqlConstraints', $result);
@@ -931,7 +915,7 @@ class ExportSqlTest extends AbstractTestCase
 
         // case 1
         ob_start();
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'create_table'));
+        $this->object->exportStructure('test_db', 'test_table', 'create_table');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -942,7 +926,7 @@ class ExportSqlTest extends AbstractTestCase
         $this->object->useSqlBackquotes(false);
 
         ob_start();
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'triggers'));
+        $this->object->exportStructure('test_db', 'test_table', 'triggers');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -957,7 +941,7 @@ class ExportSqlTest extends AbstractTestCase
         ExportPlugin::$exportType = ExportType::Raw;
 
         ob_start();
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'create_view'));
+        $this->object->exportStructure('test_db', 'test_table', 'create_view');
         $result = ob_get_clean();
 
         $sqlViews = (new ReflectionProperty(ExportSql::class, 'sqlViews'))->getValue($this->object);
@@ -977,7 +961,7 @@ class ExportSqlTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'create_view'));
+        $this->object->exportStructure('test_db', 'test_table', 'create_view');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -987,7 +971,7 @@ class ExportSqlTest extends AbstractTestCase
 
         // case 5
         ob_start();
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'stand_in'));
+        $this->object->exportStructure('test_db', 'test_table', 'stand_in');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -1222,9 +1206,7 @@ class ExportSqlTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportData('db', 'tbl', 'SELECT'),
-        );
+        $this->object->exportData('db', 'tbl', 'SELECT');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -1269,9 +1251,7 @@ class ExportSqlTest extends AbstractTestCase
         $this->expectException(ExportException::class);
         $this->expectExceptionMessage('Error reading data for table db.table: err');
 
-        self::assertTrue(
-            $this->object->exportData('db', 'table', 'SELECT'),
-        );
+        $this->object->exportData('db', 'table', 'SELECT');
     }
 
     public function testMakeCreateTableMSSQLCompatible(): void

--- a/tests/unit/Plugins/Export/ExportTexytextTest.php
+++ b/tests/unit/Plugins/Export/ExportTexytextTest.php
@@ -174,38 +174,32 @@ class ExportTexytextTest extends AbstractTestCase
 
     public function testExportHeader(): void
     {
-        self::assertTrue(
-            $this->object->exportHeader(),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportHeader();
     }
 
     public function testExportFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportFooter(),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportFooter();
     }
 
     public function testExportDBHeader(): void
     {
         $this->expectOutputString("===Database testDb\n\n");
-        self::assertTrue(
-            $this->object->exportDBHeader('testDb'),
-        );
+        $this->object->exportDBHeader('testDb');
     }
 
     public function testExportDBFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportDBFooter('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBFooter('testDB');
     }
 
     public function testExportDBCreate(): void
     {
-        self::assertTrue(
-            $this->object->exportDBCreate('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBCreate('testDB');
     }
 
     public function testExportData(): void
@@ -216,13 +210,7 @@ class ExportTexytextTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportData(
-                'test_db',
-                'test_table',
-                'SELECT * FROM `test_db`.`test_table`;',
-            ),
-        );
+        $this->object->exportData('test_db', 'test_table', 'SELECT * FROM `test_db`.`test_table`;');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -350,7 +338,7 @@ class ExportTexytextTest extends AbstractTestCase
         // case 1
         ob_start();
         $this->dummyDbi->addSelectDb('test_db');
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'create_table'));
+        $this->object->exportStructure('test_db', 'test_table', 'create_table');
         $this->dummyDbi->assertAllSelectsConsumed();
         $result = ob_get_clean();
 
@@ -368,7 +356,7 @@ class ExportTexytextTest extends AbstractTestCase
 
         // case 2
         ob_start();
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'triggers'));
+        $this->object->exportStructure('test_db', 'test_table', 'triggers');
         $result = ob_get_clean();
 
         self::assertSame(
@@ -383,7 +371,7 @@ class ExportTexytextTest extends AbstractTestCase
         // case 3
         ob_start();
         $this->dummyDbi->addSelectDb('test_db');
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'create_view'));
+        $this->object->exportStructure('test_db', 'test_table', 'create_view');
         $this->dummyDbi->assertAllSelectsConsumed();
         $result = ob_get_clean();
 
@@ -401,7 +389,7 @@ class ExportTexytextTest extends AbstractTestCase
         // case 4
         ob_start();
         $this->dummyDbi->addSelectDb('test_db');
-        self::assertTrue($this->object->exportStructure('test_db', 'test_table', 'stand_in'));
+        $this->object->exportStructure('test_db', 'test_table', 'stand_in');
         $this->dummyDbi->assertAllSelectsConsumed();
         $result = ob_get_clean();
 

--- a/tests/unit/Plugins/Export/ExportXmlTest.php
+++ b/tests/unit/Plugins/Export/ExportXmlTest.php
@@ -249,9 +249,7 @@ class ExportXmlTest extends AbstractTestCase
         Current::$table = 'table';
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportHeader(),
-        );
+        $this->object->exportHeader();
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -313,9 +311,7 @@ class ExportXmlTest extends AbstractTestCase
         $this->object->setTables(['t1', 't2']);
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportHeader(),
-        );
+        $this->object->exportHeader();
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -334,9 +330,7 @@ class ExportXmlTest extends AbstractTestCase
     public function testExportFooter(): void
     {
         $this->expectOutputString('&lt;/pma_xml_export&gt;');
-        self::assertTrue(
-            $this->object->exportFooter(),
-        );
+        $this->object->exportFooter();
     }
 
     public function testExportDBHeader(): void
@@ -347,9 +341,7 @@ class ExportXmlTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportDBHeader('&db'),
-        );
+        $this->object->exportDBHeader('&db');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -361,9 +353,7 @@ class ExportXmlTest extends AbstractTestCase
 
         $this->object->setExportOptions($request, []);
 
-        self::assertTrue(
-            $this->object->exportDBHeader('&db'),
-        );
+        $this->object->exportDBHeader('&db');
     }
 
     public function testExportDBFooter(): void
@@ -374,9 +364,7 @@ class ExportXmlTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportDBFooter('&db'),
-        );
+        $this->object->exportDBFooter('&db');
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -388,16 +376,13 @@ class ExportXmlTest extends AbstractTestCase
 
         $this->object->setExportOptions($request, []);
 
-        self::assertTrue(
-            $this->object->exportDBFooter('&db'),
-        );
+        $this->object->exportDBFooter('&db');
     }
 
     public function testExportDBCreate(): void
     {
-        self::assertTrue(
-            $this->object->exportDBCreate('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBCreate('testDB');
     }
 
     public function testExportData(): void
@@ -410,13 +395,7 @@ class ExportXmlTest extends AbstractTestCase
         $this->object->setExportOptions($request, []);
 
         ob_start();
-        self::assertTrue(
-            $this->object->exportData(
-                'test_db',
-                'test_table',
-                'SELECT * FROM `test_db`.`test_table`;',
-            ),
-        );
+        $this->object->exportData('test_db', 'test_table', 'SELECT * FROM `test_db`.`test_table`;');
         $result = ob_get_clean();
 
         self::assertIsString($result);

--- a/tests/unit/Plugins/Export/ExportYamlTest.php
+++ b/tests/unit/Plugins/Export/ExportYamlTest.php
@@ -111,9 +111,7 @@ class ExportYamlTest extends AbstractTestCase
     public function testExportHeader(): void
     {
         ob_start();
-        self::assertTrue(
-            $this->object->exportHeader(),
-        );
+        $this->object->exportHeader();
         $result = ob_get_clean();
 
         self::assertIsString($result);
@@ -124,42 +122,31 @@ class ExportYamlTest extends AbstractTestCase
     public function testExportFooter(): void
     {
         $this->expectOutputString("...\n");
-        self::assertTrue(
-            $this->object->exportFooter(),
-        );
+        $this->object->exportFooter();
     }
 
     public function testExportDBHeader(): void
     {
-        self::assertTrue(
-            $this->object->exportDBHeader('&db'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBHeader('&db');
     }
 
     public function testExportDBFooter(): void
     {
-        self::assertTrue(
-            $this->object->exportDBFooter('&db'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBFooter('&db');
     }
 
     public function testExportDBCreate(): void
     {
-        self::assertTrue(
-            $this->object->exportDBCreate('testDB'),
-        );
+        $this->expectNotToPerformAssertions();
+        $this->object->exportDBCreate('testDB');
     }
 
     public function testExportData(): void
     {
         ob_start();
-        self::assertTrue(
-            $this->object->exportData(
-                'test_db',
-                'test_table',
-                'SELECT * FROM `test_db`.`test_table_yaml`;',
-            ),
-        );
+        $this->object->exportData('test_db', 'test_table', 'SELECT * FROM `test_db`.`test_table_yaml`;');
         $result = ob_get_clean();
 
         self::assertSame(


### PR DESCRIPTION
This refactors all Export plugins. All methods now return void instead of bool. There were only two reasons when any of these methods would return false: 

 - when OutputHandler has insufficient disk space to save file
 - when ExportJson cannot `json_encode` the output

`ExportException` exception was reused to handle these two cases. In the next PR, `json_encode` handling can be improved.