### PR TITLE
Fix #19987 - Reopening a function removes charset

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13846,11 +13846,6 @@ parameters:
 			path: libraries/classes/Database/Routines.php
 
 		-
-			message: "#^Cannot access offset 'value' on mixed\\.$#"
-			count: 1
-			path: libraries/classes/Database/Routines.php
-
-		-
 			message: "#^Cannot access offset \\(float\\|int\\) on mixed\\.$#"
 			count: 6
 			path: libraries/classes/Database/Routines.php
@@ -13901,21 +13896,6 @@ parameters:
 			path: libraries/classes/Database/Routines.php
 
 		-
-			message: "#^Cannot access property \\$name on PhpMyAdmin\\\\SqlParser\\\\Components\\\\DataType\\|null\\.$#"
-			count: 1
-			path: libraries/classes/Database/Routines.php
-
-		-
-			message: "#^Cannot access property \\$options on PhpMyAdmin\\\\SqlParser\\\\Components\\\\DataType\\|null\\.$#"
-			count: 1
-			path: libraries/classes/Database/Routines.php
-
-		-
-			message: "#^Cannot access property \\$parameters on PhpMyAdmin\\\\SqlParser\\\\Components\\\\DataType\\|null\\.$#"
-			count: 1
-			path: libraries/classes/Database/Routines.php
-
-		-
 			message: "#^Cannot access property \\$types on mixed\\.$#"
 			count: 4
 			path: libraries/classes/Database/Routines.php
@@ -13923,11 +13903,6 @@ parameters:
 		-
 			message: "#^Cannot call method getTypeClass\\(\\) on mixed\\.$#"
 			count: 4
-			path: libraries/classes/Database/Routines.php
-
-		-
-			message: "#^Cannot call method has\\(\\) on PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
-			count: 1
 			path: libraries/classes/Database/Routines.php
 
 		-

--- a/templates/database/routines/editor_form.twig
+++ b/templates/database/routines/editor_form.twig
@@ -94,7 +94,7 @@
                 <option value="">{% trans 'Charset' %}</option>
                 <option value=""></option>
                 {% for charset in charsets %}
-                  <option value="{{ charset.getName() }}" title="{{ charset.getDescription() }}"{{ routine.item_returnopts_text == charset.getName() ? ' selected' }}>{{ charset.getName() }}</option>
+                  <option value="{{ charset.getName() }}" title="{{ charset.getDescription() }}"{{ routine.item_returnopts_text|lower == charset.getName() ? ' selected' }}>{{ charset.getName() }}</option>
                 {% endfor %}
               </select>
             </div>


### PR DESCRIPTION
### Description
Opening and updating an existing function that has a different return CHARSET than the default CHARSET for the table or database. On saving, the CHARSET for the function changes to the DB default. Note: this online happens when the function created also uses COLLATE.

Please describe your pull request.
Took a bit of time to diagnose and replicate  but ultimately was only happening when a function was created that had both a CHARSET and COLLATE sets.

So starting off, created 2 functions that had a different return CHARSET than the database default. (so DB was ASCII., Functions Latin1)

```sql
  DROP FUNCTION IF EXISTS test_charset_latin1_collate;
  CREATE FUNCTION test_charset_latin1_collate()
  RETURNS VARCHAR(100) CHARACTER SET LATIN1 COLLATE latin1_general_ci
  DETERMINISTIC
  RETURN 'test';

  DROP FUNCTION IF EXISTS test_charset_latin1_no_collate;
  CREATE FUNCTION test_charset_latin1_no_collate()
  RETURNS VARCHAR(100) CHARACTER SET latin1
  DETERMINISTIC
  RETURN 'test';
```

On viewing the 2 functions in the UI, the function with no COLLATE was correctly showing the return CHARSET
<img width="326" height="237" alt="Screenshot 2026-01-11 at 13 44 55" src="https://github.com/user-attachments/assets/02dfd160-9219-45f5-a048-12285efa3746" />

where as the function with a COLLATE set was not, and the 'charset'  from the dropdown as no option was selected..
<img width="333" height="244" alt="Screenshot 2026-01-11 at 13 44 50" src="https://github.com/user-attachments/assets/7333fa62-336b-472e-a604-3ad88e0d5d56" />

So in this instance when you saved, it set the CHARSET of the function to the database default.

This was happening due to the $options value used here
```
            $retval['item_returnopts_num'] = implode(' ', $options);
            $retval['item_returnopts_text'] = implode(' ', $options);
```
returning an array of 2 items - the CHARSET and COLLATE, so the string for item_returnopts_text used in the twig template was in my example was "latin1 latin1_general_ci", and in turned used to compare with charset.getName

`{{ routine.item_returnopts_text == charset.getName() ? ' selected' }}
`

So my fix separately works out the charset text and numeric values. I did contemplate doing a hackier fix in the twig template  but better to return the actual CHARSET to the view 

Fixes #19987 Reopening a function removes charset


Before submitting pull request, please review the following checklist:

- [ X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ X] Every commit has a descriptive commit message.
- [ X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
