### PR TITLE
Fix #19998 - stale grid edit state after AJAX table refresh

### DIFF
--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -2319,11 +2319,9 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
     // some adjustment
     $(t).removeClass('data');
     $(g.gDiv).addClass('data');
-
-    /* Store the grid controller instance on the table element so it can be accessed later by other modules 
+    /* Store the grid controller instance on the table element so it can be accessed later by other modules
        (e.g. during AJAX teardown) without exposing the grid object as a global variable.*/
     $(t).data('pmaGrid', g);
-
 };
 
 /**

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -281,6 +281,20 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
         },
 
         /**
+         * Clears the current cell edit state, internal flags,
+         * and any pending save request.
+         */
+        resetGridEditState: function () {
+            g.isCellEditActive = false;
+            g.isEditCellTextEditable = false;
+            g.currentEditCell = null;
+            g.wasEditedCellNull = false;
+            g.isCellEdited = false;
+            g.isSaving = false;
+            g.lastXHR = null;
+        },
+
+        /**
          * Shift column from index oldn to newn.
          *
          * @param oldn old zero-based column index
@@ -2305,6 +2319,11 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
     // some adjustment
     $(t).removeClass('data');
     $(g.gDiv).addClass('data');
+
+    /* Store the grid controller instance on the table element so it can be accessed later by other modules 
+       (e.g. during AJAX teardown) without exposing the grid object as a global variable.*/
+    $(t).data('pmaGrid', g);
+
 };
 
 /**

--- a/js/src/table/change.js
+++ b/js/src/table/change.js
@@ -452,12 +452,11 @@ AJAX.registerTeardown('table/change.js', function () {
     $(document).off('change', '#insert_rows');
 
     // Reset grid edit state
-    $('table').each(function () {
-        var grid = $(this).data('pmaGrid');
-        if (grid && typeof grid.resetGridEditState === 'function') {
-            grid.resetGridEditState();
-        }
-    });
+    var grid = $('table.table_results').data('pmaGrid');
+
+    if (grid && typeof grid.resetGridEditState === 'function') {
+        grid.resetGridEditState();
+    }
 });
 
 /**

--- a/js/src/table/change.js
+++ b/js/src/table/change.js
@@ -450,7 +450,7 @@ AJAX.registerTeardown('table/change.js', function () {
     $(document).off('click', 'input.checkbox_null');
     $('select[name="submit_type"]').off('change');
     $(document).off('change', '#insert_rows');
-    
+
     // Reset grid edit state
     $('table').each(function () {
         var grid = $(this).data('pmaGrid');

--- a/js/src/table/change.js
+++ b/js/src/table/change.js
@@ -450,6 +450,14 @@ AJAX.registerTeardown('table/change.js', function () {
     $(document).off('click', 'input.checkbox_null');
     $('select[name="submit_type"]').off('change');
     $(document).off('change', '#insert_rows');
+    
+    // Reset grid edit state
+    $('table').each(function () {
+        var grid = $(this).data('pmaGrid');
+        if (grid && typeof grid.resetGridEditState === 'function') {
+            grid.resetGridEditState();
+        }
+    });
 });
 
 /**


### PR DESCRIPTION
### Description
This pull request fixes a client-side issue where inline-edit errors reappear after refreshing a table via AJAX.

#### Root cause:
When an inline grid edit fails (e.g. invalid JSON), the grid editing controller created by makeGrid() keeps edit-session state (active cell, last XHR, edit flags). Since the “Refresh” action reloads the table via AJAX rather than a full page reload, this state persists and causes the previous error to be re-triggered on subsequent interactions.

#### Solution:
Expose a small reset method on the grid instance created by makeGrid().
Associate the grid instance with its table element using jQuery .data().
During AJAX teardown in change.js, retrieve the grid instance and reset its edit-related state, ensuring refreshed tables start with a clean client-side state.
This keeps responsibilities properly scoped to the owning modules and aligns with phpMyAdmin’s AJAX lifecycle.

Fixes #19998

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.

Video proof after solving the bug:
[Screencast from 2026-01-12 11-43-17.webm](https://github.com/user-attachments/assets/ba66c793-12c8-4249-9d16-126aaafc4600)
