### PR TITLE
Test Core::getNoCacheHeaders() with a frozen clock

### DIFF
--- a/src/Header.php
+++ b/src/Header.php
@@ -335,7 +335,7 @@ class Header
     }
 
     /** @return array<string, string> */
-    public function getHttpHeaders(): array
+    public function getHttpHeaders(string $currentDateTime = 'now'): array
     {
         $headers = [];
 
@@ -388,7 +388,7 @@ class Header
          */
         $headers['Permissions-Policy'] = 'fullscreen=(self), interest-cohort=()';
 
-        $headers = array_merge($headers, Core::getNoCacheHeaders());
+        $headers = array_merge($headers, Core::getNoCacheHeaders($currentDateTime));
 
         /**
          * A different Content-Type is set in {@see \PhpMyAdmin\Controllers\Transformation\WrapperController}.

--- a/tests/unit/CoreTest.php
+++ b/tests/unit/CoreTest.php
@@ -658,9 +658,13 @@ class CoreTest extends AbstractTestCase
 
     public function testGetDownloadHeaders(): void
     {
-        $headersList = Core::getDownloadHeaders('test.sql', 'text/x-sql', 100, false);
+        $headersList = Core::getDownloadHeaders('test.sql', 'text/x-sql', 100, '2015-10-21T05:28:00-02:00');
 
         $expected = [
+            'Expires' => 'Wed, 21 Oct 2015 07:28:00 GMT',
+            'Cache-Control' => 'no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0',
+            'Pragma' => 'no-cache',
+            'Last-Modified' => 'Wed, 21 Oct 2015 07:28:00 GMT',
             'Content-Description' => 'File Transfer',
             'Content-Disposition' => 'attachment; filename="test.sql"',
             'Content-Type' => 'text/x-sql',
@@ -672,9 +676,13 @@ class CoreTest extends AbstractTestCase
 
     public function testGetDownloadHeaders2(): void
     {
-        $headersList = Core::getDownloadHeaders('test.sql.gz', 'application/x-gzip', 0, false);
+        $headersList = Core::getDownloadHeaders('test.sql.gz', 'application/x-gzip', 0, '2015-10-21T05:28:00-02:00');
 
         $expected = [
+            'Expires' => 'Wed, 21 Oct 2015 07:28:00 GMT',
+            'Cache-Control' => 'no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0',
+            'Pragma' => 'no-cache',
+            'Last-Modified' => 'Wed, 21 Oct 2015 07:28:00 GMT',
             'Content-Description' => 'File Transfer',
             'Content-Disposition' => 'attachment; filename="test.sql.gz"',
             'Content-Type' => 'application/x-gzip',
@@ -701,5 +709,29 @@ class CoreTest extends AbstractTestCase
         putenv('PHPMYADMIN_GET_ENV_TEST');
 
         self::assertSame('', Core::getEnv('PHPMYADMIN_GET_ENV_TEST'));
+    }
+
+    public function testGetNoCacheHeaders(): void
+    {
+        $expected = [
+            'Expires' => 'Wed, 21 Oct 2015 07:28:00 GMT',
+            'Cache-Control' => 'no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0',
+            'Pragma' => 'no-cache',
+            'Last-Modified' => 'Wed, 21 Oct 2015 07:28:00 GMT',
+        ];
+        self::assertSame($expected, Core::getNoCacheHeaders('2015-10-21T05:28:00-02:00'));
+    }
+
+    public function testHeaderJSON(): void
+    {
+        $expected = [
+            'Expires' => 'Wed, 21 Oct 2015 07:28:00 GMT',
+            'Cache-Control' => 'no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0',
+            'Pragma' => 'no-cache',
+            'Last-Modified' => 'Wed, 21 Oct 2015 07:28:00 GMT',
+            'Content-Type' => 'application/json; charset=UTF-8',
+            'X-Content-Type-Options' => 'nosniff',
+        ];
+        self::assertSame($expected, Core::headerJSON('2015-10-21T05:28:00-02:00'));
     }
 }

--- a/tests/unit/HeaderTest.php
+++ b/tests/unit/HeaderTest.php
@@ -23,10 +23,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Medium;
 use ReflectionProperty;
 
-use function gmdate;
-
-use const DATE_RFC1123;
-
 #[CoversClass(Header::class)]
 #[Medium]
 class HeaderTest extends AbstractTestCase
@@ -193,7 +189,6 @@ class HeaderTest extends AbstractTestCase
         string $expectedWebKitCsp,
     ): void {
         $header = $this->getNewHeaderInstance();
-        $date = gmdate(DATE_RFC1123);
 
         $config = Config::getInstance();
         $config->set('AllowThirdPartyFraming', $frameOptions);
@@ -203,7 +198,7 @@ class HeaderTest extends AbstractTestCase
         $config->set('CaptchaCsp', $captchaCsp);
 
         $expected = [
-            'X-Frame-Options' => $expectedFrameOptions,
+            'X-Frame-Options' => $expectedFrameOptions ?? '',
             'Referrer-Policy' => 'same-origin',
             'Content-Security-Policy' => $expectedCsp,
             'X-Content-Security-Policy' => $expectedXCsp,
@@ -213,18 +208,17 @@ class HeaderTest extends AbstractTestCase
             'X-Permitted-Cross-Domain-Policies' => 'none',
             'X-Robots-Tag' => 'noindex, nofollow',
             'Permissions-Policy' => 'fullscreen=(self), interest-cohort=()',
-            'Expires' => $date,
+            'Expires' => 'Wed, 21 Oct 2015 07:28:00 GMT',
             'Cache-Control' => 'no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0',
             'Pragma' => 'no-cache',
-            'Last-Modified' => $date,
+            'Last-Modified' => 'Wed, 21 Oct 2015 07:28:00 GMT',
             'Content-Type' => 'text/html; charset=utf-8',
         ];
         if ($expectedFrameOptions === null) {
             unset($expected['X-Frame-Options']);
         }
 
-        $headers = $this->callFunction($header, Header::class, 'getHttpHeaders', []);
-        self::assertSame($expected, $headers);
+        self::assertSame($expected, $header->getHttpHeaders('2015-10-21T05:28:00-02:00'));
     }
 
     /** @return mixed[][] */


### PR DESCRIPTION
This avoids the tests randomly failing when current time differs.

Also changes the format from RFC 1123 to RFC 7231.

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Expires
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Last-Modified
