### PR TITLE
Introduce support for PSR-20 ClockInterface

### DIFF
--- a/app/services.php
+++ b/app/services.php
@@ -6,6 +6,7 @@ use PhpMyAdmin\Advisory\Advisor;
 use PhpMyAdmin\Application;
 use PhpMyAdmin\Bookmarks\BookmarkRepository;
 use PhpMyAdmin\BrowseForeigners;
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\UserPreferences;
 use PhpMyAdmin\Config\UserPreferencesHandler;
@@ -66,6 +67,7 @@ use PhpMyAdmin\UserPassword;
 use PhpMyAdmin\UserPrivilegesFactory;
 use PhpMyAdmin\Utils\HttpRequest;
 use PhpMyAdmin\VersionInformation;
+use Psr\Clock\ClockInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 return [
@@ -368,4 +370,5 @@ return [
         ],
     ],
     LanguageManager::class => ['class' => LanguageManager::class, 'factory' => [LanguageManager::class, 'getInstance']],
+    ClockInterface::class => ['class' => Clock::class],
 ];

--- a/app/services.php
+++ b/app/services.php
@@ -339,7 +339,13 @@ return [
     ],
     UserPreferences::class => [
         'class' => UserPreferences::class,
-        'arguments' => [DatabaseInterface::class, Relation::class, Template::class, Config::class],
+        'arguments' => [
+            DatabaseInterface::class,
+            Relation::class,
+            Template::class,
+            Config::class,
+            ClockInterface::class,
+        ],
     ],
     UserPrivilegesFactory::class => [
         'class' => UserPrivilegesFactory::class,

--- a/app/services_controllers.php
+++ b/app/services_controllers.php
@@ -90,6 +90,7 @@ use PhpMyAdmin\Transformations;
 use PhpMyAdmin\UserPassword;
 use PhpMyAdmin\UserPrivilegesFactory;
 use PhpMyAdmin\VersionInformation;
+use Psr\Clock\ClockInterface;
 
 return [
     BrowseForeignersController::class => [
@@ -431,7 +432,10 @@ return [
         'class' => Import\SimulateDmlController::class,
         'arguments' => [ResponseRenderer::class, SimulateDml::class],
     ],
-    Import\StatusController::class => ['class' => Import\StatusController::class, 'arguments' => [Template::class]],
+    Import\StatusController::class => [
+        'class' => Import\StatusController::class,
+        'arguments' => [Template::class, ClockInterface::class],
+    ],
     JavaScriptMessagesController::class => [
         'class' => JavaScriptMessagesController::class,
         'arguments' => [ResponseFactory::class],

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
         "phpmyadmin/motranslator": "^6.0",
         "phpmyadmin/shapefile": "^4.0",
         "phpmyadmin/sql-parser": "^6.0",
+        "psr/clock": "^1.0",
         "psr/container": "^2.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f0deb322e3d0b4a9b6692c0b63c1425",
+    "content-hash": "73186323ccc5039f8a832b45873d703f",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -582,6 +582,54 @@
                 "source": "https://github.com/php-fig/cache/tree/3.0.0"
             },
             "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
         },
         {
             "name": "psr/container",
@@ -6241,54 +6289,6 @@
                 "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.5"
             },
             "time": "2025-03-31T18:49:55+00:00"
-        },
-        {
-            "name": "psr/clock",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/clock.git",
-                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
-                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Clock\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for reading the clock.",
-            "homepage": "https://github.com/php-fig/clock",
-            "keywords": [
-                "clock",
-                "now",
-                "psr",
-                "psr-20",
-                "time"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/clock/issues",
-                "source": "https://github.com/php-fig/clock/tree/1.0.0"
-            },
-            "time": "2022-11-25T14:36:26+00:00"
         },
         {
             "name": "psr/event-dispatcher",

--- a/src/Clock/Clock.php
+++ b/src/Clock/Clock.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Clock;
+
+use DateTimeImmutable;
+use Psr\Clock\ClockInterface;
+
+final class Clock implements ClockInterface
+{
+    public function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable();
+    }
+}

--- a/src/Controllers/ErrorReportController.php
+++ b/src/Controllers/ErrorReportController.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers;
 
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\UserPreferences;
 use PhpMyAdmin\ConfigStorage\Relation;
@@ -136,6 +137,7 @@ final readonly class ErrorReportController implements InvocableController
                         new Relation($this->dbi, $this->config),
                         $this->template,
                         $this->config,
+                        new Clock(),
                     );
                     $userPreferences->persistOption('SendErrorReports', 'always', 'ask');
                 }

--- a/src/Controllers/Import/StatusController.php
+++ b/src/Controllers/Import/StatusController.php
@@ -14,6 +14,7 @@ use PhpMyAdmin\Import\Ajax;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Routing\Route;
 use PhpMyAdmin\Template;
+use Psr\Clock\ClockInterface;
 
 use function __;
 use function header;
@@ -36,7 +37,7 @@ class StatusController implements InvocableController
     /** Time to wait before rechecking for the $_SESSION variable. Default is 0.25 seconds. */
     private static int $sleepMicrosecondsRetry = 250000;
 
-    public function __construct(private readonly Template $template)
+    public function __construct(private readonly Template $template, private readonly ClockInterface $clock)
     {
     }
 
@@ -47,7 +48,7 @@ class StatusController implements InvocableController
         // $_GET["message"] is used for asking for an import message
         if ($request->hasQueryParam('message')) {
             // AJAX requests can't be cached!
-            foreach (Core::getNoCacheHeaders() as $name => $value) {
+            foreach (Core::getNoCacheHeaders($this->clock) as $name => $value) {
                 header(sprintf('%s: %s', $name, $value));
             }
 

--- a/src/Header.php
+++ b/src/Header.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config\UserPreferences;
 use PhpMyAdmin\Config\UserPreferencesHandler;
 use PhpMyAdmin\ConfigStorage\Relation;
@@ -17,6 +18,7 @@ use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\I18n\LanguageManager;
 use PhpMyAdmin\Navigation\Navigation;
 use PhpMyAdmin\Theme\ThemeManager;
+use Psr\Clock\ClockInterface;
 
 use function array_merge;
 use function htmlspecialchars;
@@ -335,7 +337,7 @@ class Header
     }
 
     /** @return array<string, string> */
-    public function getHttpHeaders(string $currentDateTime = 'now'): array
+    public function getHttpHeaders(ClockInterface|null $clock = null): array
     {
         $headers = [];
 
@@ -388,7 +390,7 @@ class Header
          */
         $headers['Permissions-Policy'] = 'fullscreen=(self), interest-cohort=()';
 
-        $headers = array_merge($headers, Core::getNoCacheHeaders($currentDateTime));
+        $headers = array_merge($headers, Core::getNoCacheHeaders($clock ?? new Clock()));
 
         /**
          * A different Content-Type is set in {@see \PhpMyAdmin\Controllers\Transformation\WrapperController}.

--- a/src/Navigation/Navigation.php
+++ b/src/Navigation/Navigation.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Navigation;
 
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\Config\UserPreferences;
@@ -105,6 +106,7 @@ class Navigation
                     new Relation($this->dbi, $this->config),
                     $this->template,
                     $this->config,
+                    new Clock(),
                 );
                 $pageSettings = new PageSettings($userPreferences);
                 $pageSettings->init('Navi', 'pma_navigation_settings');

--- a/src/TwoFactor.php
+++ b/src/TwoFactor.php
@@ -9,6 +9,7 @@ namespace PhpMyAdmin;
 
 use BaconQrCode\Renderer\ImageRenderer;
 use CodeLts\U2F\U2FServer\U2FServer;
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config\UserPreferences;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Dbal\DatabaseInterface;
@@ -59,7 +60,13 @@ class TwoFactor
         $dbi = DatabaseInterface::getInstance();
         $config = Config::getInstance();
 
-        $this->userPreferences = new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config);
+        $this->userPreferences = new UserPreferences(
+            $dbi,
+            new Relation($dbi, $config),
+            new Template($config),
+            $config,
+            new Clock(),
+        );
         $this->available = $this->getAvailableBackends();
         $this->config = $this->readConfig();
         $this->writable = $this->config['type'] === 'db';

--- a/tests/unit/Clock/ClockTest.php
+++ b/tests/unit/Clock/ClockTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Clock;
+
+use DateTimeImmutable;
+use PhpMyAdmin\Clock\Clock;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function usleep;
+
+#[CoversClass(Clock::class)]
+final class ClockTest extends TestCase
+{
+    public function testNow(): void
+    {
+        $clock = new Clock();
+        $before = new DateTimeImmutable();
+        usleep(2000);
+        $now = $clock->now();
+        usleep(2000);
+        $after = new DateTimeImmutable();
+        self::assertGreaterThan($before, $now);
+        self::assertLessThan($after, $now);
+        self::assertNotSame($clock->now(), $clock->now());
+    }
+}

--- a/tests/unit/Clock/MockClock.php
+++ b/tests/unit/Clock/MockClock.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Clock;
+
+use DateTimeImmutable;
+use Psr\Clock\ClockInterface;
+
+final class MockClock implements ClockInterface
+{
+    public function __construct(public DateTimeImmutable $now)
+    {
+    }
+
+    public function now(): DateTimeImmutable
+    {
+        return clone $this->now;
+    }
+
+    /** @param non-empty-string $dateTime */
+    public static function from(string $dateTime = 'now'): ClockInterface
+    {
+        return new self(new DateTimeImmutable($dateTime));
+    }
+}

--- a/tests/unit/Config/PageSettingsTest.php
+++ b/tests/unit/Config/PageSettingsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Config;
 
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\Config\UserPreferences;
@@ -45,7 +46,13 @@ class PageSettingsTest extends AbstractTestCase
     {
         $config = Config::getInstance();
         $dbi = DatabaseInterface::getInstance();
-        $userPreferences = new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config);
+        $userPreferences = new UserPreferences(
+            $dbi,
+            new Relation($dbi, $config),
+            new Template($config),
+            $config,
+            new Clock(),
+        );
         $object = new PageSettings($userPreferences);
         $object->init('NonExistent');
 
@@ -62,7 +69,13 @@ class PageSettingsTest extends AbstractTestCase
 
         $config = Config::getInstance();
         $dbi = DatabaseInterface::getInstance();
-        $userPreferences = new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config);
+        $userPreferences = new UserPreferences(
+            $dbi,
+            new Relation($dbi, $config),
+            new Template($config),
+            $config,
+            new Clock(),
+        );
         $object = new PageSettings($userPreferences);
         $object->init('Browse');
 
@@ -114,7 +127,13 @@ class PageSettingsTest extends AbstractTestCase
     {
         $config = Config::getInstance();
         $dbi = DatabaseInterface::getInstance();
-        $userPreferences = new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config);
+        $userPreferences = new UserPreferences(
+            $dbi,
+            new Relation($dbi, $config),
+            new Template($config),
+            $config,
+            new Clock(),
+        );
         $pageSettings = new PageSettings($userPreferences);
         $pageSettings->init('Navi', 'pma_navigation_settings');
 

--- a/tests/unit/Config/UserPreferencesHandlerTest.php
+++ b/tests/unit/Config/UserPreferencesHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Config;
 
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\UserPreferences;
 use PhpMyAdmin\Config\UserPreferencesHandler;
@@ -24,7 +25,7 @@ final class UserPreferencesHandlerTest extends AbstractTestCase
         $userPreferencesHandler = new UserPreferencesHandler(
             $config,
             $dbi,
-            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config),
+            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config, new Clock()),
             new LanguageManager($config),
             new ThemeManager(),
         );
@@ -42,7 +43,7 @@ final class UserPreferencesHandlerTest extends AbstractTestCase
         $userPreferencesHandler = new UserPreferencesHandler(
             $config,
             $dbi,
-            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config),
+            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config, new Clock()),
             new LanguageManager($config),
             new ThemeManager(),
         );

--- a/tests/unit/Controllers/Console/UpdateConfigControllerTest.php
+++ b/tests/unit/Controllers/Console/UpdateConfigControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Console;
 
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\UserPreferences;
 use PhpMyAdmin\Config\UserPreferencesHandler;
@@ -36,7 +37,7 @@ final class UpdateConfigControllerTest extends AbstractTestCase
         $userPreferencesHandler = new UserPreferencesHandler(
             $config,
             $dbi,
-            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config),
+            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config, new Clock()),
             new LanguageManager($config),
             new ThemeManager(),
         );
@@ -96,7 +97,7 @@ final class UpdateConfigControllerTest extends AbstractTestCase
         $userPreferencesHandler = new UserPreferencesHandler(
             $config,
             $dbi,
-            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config),
+            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config, new Clock()),
             new LanguageManager($config),
             new ThemeManager(),
         );

--- a/tests/unit/Controllers/Export/ExportControllerTest.php
+++ b/tests/unit/Controllers/Export/ExportControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Controllers\Export;
 
 use Fig\Http\Message\StatusCodeInterface;
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\UserPreferences;
 use PhpMyAdmin\Config\UserPreferencesHandler;
@@ -198,7 +199,7 @@ final class ExportControllerTest extends AbstractTestCase
         $userPreferencesHandler = new UserPreferencesHandler(
             $config,
             $dbi,
-            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config),
+            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config, new Clock()),
             new LanguageManager($config),
             new ThemeManager(),
         );
@@ -372,7 +373,7 @@ final class ExportControllerTest extends AbstractTestCase
         $userPreferencesHandler = new UserPreferencesHandler(
             $config,
             $dbi,
-            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config),
+            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config, new Clock()),
             new LanguageManager($config),
             new ThemeManager(),
         );
@@ -535,7 +536,7 @@ final class ExportControllerTest extends AbstractTestCase
         $userPreferencesHandler = new UserPreferencesHandler(
             $config,
             $dbi,
-            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config),
+            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config, new Clock()),
             new LanguageManager($config),
             new ThemeManager(),
         );
@@ -702,7 +703,7 @@ final class ExportControllerTest extends AbstractTestCase
         $userPreferencesHandler = new UserPreferencesHandler(
             $config,
             $dbi,
-            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config),
+            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config, new Clock()),
             new LanguageManager($config),
             new ThemeManager(),
         );

--- a/tests/unit/Controllers/Import/StatusControllerTest.php
+++ b/tests/unit/Controllers/Import/StatusControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Controllers\Import;
 
 use Fig\Http\Message\StatusCodeInterface;
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\Import\StatusController;
 use PhpMyAdmin\Http\Factory\ServerRequestFactory;
@@ -41,7 +42,7 @@ final class StatusControllerTest extends AbstractTestCase
             'id' => 'abc1234567890',
         ]);
 
-        $controller = new StatusController(new Template(new Config()));
+        $controller = new StatusController(new Template(new Config()), new Clock());
         $response = $controller($request);
 
         self::assertSame(
@@ -66,7 +67,7 @@ final class StatusControllerTest extends AbstractTestCase
             'message' => '1',
         ]);
 
-        $controller = new StatusController(new Template(new Config()));
+        $controller = new StatusController(new Template(new Config()), new Clock());
         $response = $controller($request);
 
         $expected = $message->getDisplay();
@@ -97,7 +98,7 @@ final class StatusControllerTest extends AbstractTestCase
             'message' => '1',
         ]);
 
-        $controller = new StatusController(new Template(new Config()));
+        $controller = new StatusController(new Template(new Config()), new Clock());
         $response = $controller($request);
 
         self::assertSame($message->getDisplay(), self::getActualOutputForAssertion());

--- a/tests/unit/Controllers/Navigation/UpdateNavWidthConfigControllerTest.php
+++ b/tests/unit/Controllers/Navigation/UpdateNavWidthConfigControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Navigation;
 
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\UserPreferences;
 use PhpMyAdmin\Config\UserPreferencesHandler;
@@ -33,7 +34,7 @@ final class UpdateNavWidthConfigControllerTest extends AbstractTestCase
         $userPreferencesHandler = new UserPreferencesHandler(
             $config,
             $dbi,
-            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config),
+            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config, new Clock()),
             new LanguageManager($config),
             new ThemeManager(),
         );
@@ -66,7 +67,7 @@ final class UpdateNavWidthConfigControllerTest extends AbstractTestCase
         $userPreferencesHandler = new UserPreferencesHandler(
             $config,
             $dbi,
-            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config),
+            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config, new Clock()),
             new LanguageManager($config),
             new ThemeManager(),
         );

--- a/tests/unit/Controllers/NavigationControllerTest.php
+++ b/tests/unit/Controllers/NavigationControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers;
 
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\Config\UserPreferences;
@@ -124,7 +125,7 @@ class NavigationControllerTest extends AbstractTestCase
             $responseRenderer,
             new Navigation($template, $relation, $this->dbi, $config),
             $relation,
-            new PageSettings(new UserPreferences($this->dbi, $relation, $template, $config)),
+            new PageSettings(new UserPreferences($this->dbi, $relation, $template, $config, new Clock())),
         );
 
         $_POST['full'] = '1';
@@ -273,7 +274,7 @@ class NavigationControllerTest extends AbstractTestCase
             $responseRenderer,
             new Navigation($template, $relation, $this->dbi, $config),
             $relation,
-            new PageSettings(new UserPreferences($this->dbi, $relation, $template, $config)),
+            new PageSettings(new UserPreferences($this->dbi, $relation, $template, $config, new Clock())),
         );
 
         $_POST['full'] = '1';

--- a/tests/unit/Controllers/Table/ChangeControllerTest.php
+++ b/tests/unit/Controllers/Table/ChangeControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Table;
 
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\Config\UserPreferences;
@@ -46,7 +47,7 @@ final class ChangeControllerTest extends AbstractTestCase
         $config = Config::getInstance();
         $template = new Template($config);
         $relation = new Relation($dbi, $config);
-        $userPreferences = new UserPreferences($dbi, $relation, $template, $config);
+        $userPreferences = new UserPreferences($dbi, $relation, $template, $config, new Clock());
         $pageSettings = new PageSettings($userPreferences);
         $pageSettings->init('Edit');
 
@@ -155,7 +156,7 @@ final class ChangeControllerTest extends AbstractTestCase
         $config = Config::getInstance();
         $relation = new Relation($dbi, $config);
         $template = new Template($config);
-        $userPreferences = new UserPreferences($dbi, $relation, $template, $config);
+        $userPreferences = new UserPreferences($dbi, $relation, $template, $config, new Clock());
         $pageSettings = new PageSettings($userPreferences);
         $pageSettings->init('Edit');
 

--- a/tests/unit/Controllers/Table/ExportControllerTest.php
+++ b/tests/unit/Controllers/Table/ExportControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Table;
 
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\Config\UserPreferences;
@@ -60,7 +61,7 @@ class ExportControllerTest extends AbstractTestCase
         $response = new ResponseRenderer();
         $relation = new Relation($dbi, $config);
         $template = new Template($config);
-        $userPreferences = new UserPreferences($dbi, $relation, $template, $config);
+        $userPreferences = new UserPreferences($dbi, $relation, $template, $config, new Clock());
         $pageSettings = new PageSettings($userPreferences);
         $pageSettings->init('Export');
         $exportList = Plugins::getExport(ExportType::Table, true);

--- a/tests/unit/Controllers/Table/ImportControllerTest.php
+++ b/tests/unit/Controllers/Table/ImportControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Controllers\Table;
 
 use PhpMyAdmin\Charsets;
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\Config\UserPreferences;
@@ -50,7 +51,7 @@ class ImportControllerTest extends AbstractTestCase
         $options = Plugins::getOptions('Import', $importList);
 
         $template = new Template($config);
-        $userPreferences = new UserPreferences($dbi, new Relation($dbi, $config), $template, $config);
+        $userPreferences = new UserPreferences($dbi, new Relation($dbi, $config), $template, $config, new Clock());
         $pageSettings = new PageSettings($userPreferences);
         $pageSettings->init('Import');
         $expected = $template->render('table/import/index', [

--- a/tests/unit/Controllers/Table/SqlControllerTest.php
+++ b/tests/unit/Controllers/Table/SqlControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Controllers\Table;
 
 use PhpMyAdmin\Bookmarks\BookmarkRepository;
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\Config\UserPreferences;
@@ -52,7 +53,13 @@ class SqlControllerTest extends AbstractTestCase
         $this->dummyDbi->addResult('SELECT 1 FROM `test_db`.`test_table` LIMIT 1;', [['1']]);
 
         $template = new Template($config);
-        $userPreferences = new UserPreferences($this->dbi, new Relation($this->dbi, $config), $template, $config);
+        $userPreferences = new UserPreferences(
+            $this->dbi,
+            new Relation($this->dbi, $config),
+            $template,
+            $config,
+            new Clock(),
+        );
         $pageSettings = new PageSettings($userPreferences);
         $pageSettings->init('Sql');
         $fields = $this->dbi->getColumns('test_db', 'test_table');

--- a/tests/unit/Controllers/Table/StructureControllerTest.php
+++ b/tests/unit/Controllers/Table/StructureControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Controllers\Table;
 
 use PhpMyAdmin\Charsets;
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\Config\UserPreferences;
@@ -85,7 +86,7 @@ class StructureControllerTest extends AbstractTestCase
 
         $relation = new Relation($this->dbi, $config);
         $template = new Template($config);
-        $userPreferences = new UserPreferences($this->dbi, $relation, $template, $config);
+        $userPreferences = new UserPreferences($this->dbi, $relation, $template, $config, new Clock());
         $pageSettings = new PageSettings($userPreferences);
         $pageSettings->init('TableStructure');
         $fields = $this->dbi->getColumns(Current::$database, Current::$table);

--- a/tests/unit/CoreTest.php
+++ b/tests/unit/CoreTest.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\Current;
 use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\ResponseRenderer;
+use PhpMyAdmin\Tests\Clock\MockClock;
 use PhpMyAdmin\Url;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -658,7 +659,8 @@ class CoreTest extends AbstractTestCase
 
     public function testGetDownloadHeaders(): void
     {
-        $headersList = Core::getDownloadHeaders('test.sql', 'text/x-sql', 100, '2015-10-21T05:28:00-02:00');
+        $clock = MockClock::from('2015-10-21T05:28:00-02:00');
+        $headersList = Core::getDownloadHeaders($clock, 'test.sql', 'text/x-sql', 100);
 
         $expected = [
             'Expires' => 'Wed, 21 Oct 2015 07:28:00 GMT',
@@ -676,7 +678,8 @@ class CoreTest extends AbstractTestCase
 
     public function testGetDownloadHeaders2(): void
     {
-        $headersList = Core::getDownloadHeaders('test.sql.gz', 'application/x-gzip', 0, '2015-10-21T05:28:00-02:00');
+        $clock = MockClock::from('2015-10-21T05:28:00-02:00');
+        $headersList = Core::getDownloadHeaders($clock, 'test.sql.gz', 'application/x-gzip');
 
         $expected = [
             'Expires' => 'Wed, 21 Oct 2015 07:28:00 GMT',
@@ -719,7 +722,7 @@ class CoreTest extends AbstractTestCase
             'Pragma' => 'no-cache',
             'Last-Modified' => 'Wed, 21 Oct 2015 07:28:00 GMT',
         ];
-        self::assertSame($expected, Core::getNoCacheHeaders('2015-10-21T05:28:00-02:00'));
+        self::assertSame($expected, Core::getNoCacheHeaders(MockClock::from('2015-10-21T05:28:00-02:00')));
     }
 
     public function testHeaderJSON(): void
@@ -732,6 +735,6 @@ class CoreTest extends AbstractTestCase
             'Content-Type' => 'application/json; charset=UTF-8',
             'X-Content-Type-Options' => 'nosniff',
         ];
-        self::assertSame($expected, Core::headerJSON('2015-10-21T05:28:00-02:00'));
+        self::assertSame($expected, Core::headerJSON(MockClock::from('2015-10-21T05:28:00-02:00')));
     }
 }

--- a/tests/unit/Export/OptionsTest.php
+++ b/tests/unit/Export/OptionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Export;
 
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\UserPreferences;
 use PhpMyAdmin\Config\UserPreferencesHandler;
@@ -47,7 +48,7 @@ class OptionsTest extends AbstractTestCase
         $userPreferencesHandler = new UserPreferencesHandler(
             $config,
             $dbi,
-            new UserPreferences($dbi, $relation, new Template($config), $config),
+            new UserPreferences($dbi, $relation, new Template($config), $config, new Clock()),
             new LanguageManager($config),
             new ThemeManager(),
         );

--- a/tests/unit/HeaderTest.php
+++ b/tests/unit/HeaderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Bookmarks\BookmarkRepository;
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\UserPreferences;
 use PhpMyAdmin\Config\UserPreferencesHandler;
@@ -61,7 +62,7 @@ class HeaderTest extends AbstractTestCase
         $relation = new Relation($dbi, $config);
         $template = new Template($config);
         $history = new History($dbi, $relation, $config);
-        $userPreferences = new UserPreferences($dbi, $relation, $template, $config);
+        $userPreferences = new UserPreferences($dbi, $relation, $template, $config, new Clock());
         $userPreferencesHandler = new UserPreferencesHandler(
             $config,
             $dbi,
@@ -92,7 +93,7 @@ class HeaderTest extends AbstractTestCase
         $template = new Template($config);
         $history = new History($dbi, $relation, $config);
         $console = new Console($relation, $template, new BookmarkRepository($dbi, $relation), $history);
-        $userPreferences = new UserPreferences($dbi, $relation, $template, $config);
+        $userPreferences = new UserPreferences($dbi, $relation, $template, $config, new Clock());
         $userPreferencesHandler = new UserPreferencesHandler(
             $config,
             $dbi,

--- a/tests/unit/HeaderTest.php
+++ b/tests/unit/HeaderTest.php
@@ -17,6 +17,7 @@ use PhpMyAdmin\Header;
 use PhpMyAdmin\I18n\LanguageManager;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Template;
+use PhpMyAdmin\Tests\Clock\MockClock;
 use PhpMyAdmin\Theme\ThemeManager;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -218,7 +219,7 @@ class HeaderTest extends AbstractTestCase
             unset($expected['X-Frame-Options']);
         }
 
-        self::assertSame($expected, $header->getHttpHeaders('2015-10-21T05:28:00-02:00'));
+        self::assertSame($expected, $header->getHttpHeaders(MockClock::from('2015-10-21T05:28:00-02:00')));
     }
 
     /** @return mixed[][] */

--- a/tests/unit/Stubs/ResponseRenderer.php
+++ b/tests/unit/Stubs/ResponseRenderer.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Stubs;
 
 use PhpMyAdmin\Bookmarks\BookmarkRepository;
+use PhpMyAdmin\Clock\Clock;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\UserPreferences;
 use PhpMyAdmin\Config\UserPreferencesHandler;
@@ -63,7 +64,7 @@ class ResponseRenderer extends \PhpMyAdmin\ResponseRenderer
         $relation = new Relation($dbi, $config);
         $history = new History($dbi, $relation, $config);
         $console = new Console($relation, $template, new BookmarkRepository($dbi, $relation), $history);
-        $userPreferences = new UserPreferences($dbi, $relation, $template, $config);
+        $userPreferences = new UserPreferences($dbi, $relation, $template, $config, new Clock());
         $userPreferencesHandler = new UserPreferencesHandler(
             $config,
             $dbi,


### PR DESCRIPTION
Replaces `DateTimeImmutable` with `ClockInterface` in `Core::getNoCacheHeaders()` and replaces `time()` with `ClockInterface` in `UserPreferences` class.

- Related to https://github.com/phpmyadmin/phpmyadmin/pull/20030