### PR TITLE
Clean up TransformationPluginsTest

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16789,12 +16789,6 @@ parameters:
 			path: tests/unit/Plugins/Transformations/TransformationPluginsTest.php
 
 		-
-			message: '#^Static property PhpMyAdmin\\Display\\Results\:\:\$row \(list\<string\|null\>\) does not accept array\{pma\: ''aaa'', pca\: ''bbb''\}\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/unit/Plugins/Transformations/TransformationPluginsTest.php
-
-		-
 			message: '#^PHPDoc tag @var with type array\{backend\: string, settings\: array\<mixed\>\} is not subtype of native type array\{backend\: '''', settings\: array\{\}\}\.$#'
 			identifier: varTag.nativeType
 			count: 1

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10742,9 +10742,6 @@
     <PossiblyInvalidArgument>
       <code><![CDATA[testTransformation]]></code>
     </PossiblyInvalidArgument>
-    <PropertyTypeCoercion>
-      <code><![CDATA[['pma' => 'aaa', 'pca' => 'bbb']]]></code>
-    </PropertyTypeCoercion>
   </file>
   <file src="tests/unit/PluginsTest.php">
     <DeprecatedMethod>

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -198,7 +198,7 @@ class Results
     public Template $template;
 
     /** @var list<string|null> */
-    public static array $row = [];
+    private static array $row = [];
 
     /**
      * @param string $db       the database name

--- a/tests/unit/Plugins/Transformations/TransformationPluginsTest.php
+++ b/tests/unit/Plugins/Transformations/TransformationPluginsTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Plugins\Transformations;
 
 use PhpMyAdmin\Config;
-use PhpMyAdmin\Display\Results;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Plugins\IOTransformationsPlugin;
 use PhpMyAdmin\Plugins\Transformations\Abs\DateFormatTransformationsPlugin;
@@ -105,15 +104,6 @@ class TransformationPluginsTest extends AbstractTestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        $this->setLanguage();
-
-        // For Application Octetstream Download plugin
-
-        Results::$row = ['pma' => 'aaa', 'pca' => 'bbb'];
-
-        // For Image_*_Inline plugin
-        $this->setGlobalConfig();
 
         // For Date Format plugin
         date_default_timezone_set('UTC');


### PR DESCRIPTION
I don't know why `Results::$row` was ever there, but it was there for years and removing it doesn't break any test case. 

`$this->setGlobalConfig();` was obsoleted by `parent::setUp();` some time ago. 

`$this->setLanguage();` was added by William, but I assume it's no longer necessary. There is no comment explaining why it's there, so I can only guess that it was a workaround for some test limitation. 