### PR TITLE
Major cleanup of config

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -313,12 +313,6 @@ parameters:
 			path: src/Config.php
 
 		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Config.php
-
-		-
 			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept non\-empty\-array\<string, mixed\>\.$#'
 			identifier: assign.propertyType
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -313,7 +313,7 @@ parameters:
 			path: src/Config.php
 
 		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept non\-empty\-array\<string, mixed\>\.$#'
+			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\<mixed\>\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/Config.php
@@ -946,12 +946,6 @@ parameters:
 			path: src/Config/UserPreferencesHandler.php
 
 		-
-			message: '#^Cannot access offset ''userprefs_mtime'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Config/UserPreferencesHandler.php
-
-		-
 			message: '#^Cannot access offset ''userprefs_type'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
@@ -1001,12 +995,6 @@ parameters:
 
 		-
 			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Config/UserPreferencesHandler.php
-
-		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\<mixed\>\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/Config/UserPreferencesHandler.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9539,20 +9539,11 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getInstance\(\) of class PhpMyAdmin\\Config\:
-				Use dependency injection instead\.$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 2
-			path: src/Plugins/Import/ImportLdi.php
-
-		-
-			message: '''
 				#^Call to deprecated method getInstance\(\) of class PhpMyAdmin\\Dbal\\DatabaseInterface\:
 				Use dependency injection instead\.$#
 			'''
 			identifier: staticMethod.deprecated
-			count: 2
+			count: 1
 			path: src/Plugins/Import/ImportLdi.php
 
 		-
@@ -16677,7 +16668,7 @@ parameters:
 				Use dependency injection instead\.$#
 			'''
 			identifier: staticMethod.deprecated
-			count: 2
+			count: 1
 			path: tests/unit/Plugins/Import/ImportLdiTest.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -14575,15 +14575,6 @@ parameters:
 			path: tests/unit/ConfigStorage/RelationTest.php
 
 		-
-			message: '''
-				#^Call to deprecated method getInstance\(\) of class PhpMyAdmin\\Config\:
-				Use dependency injection instead\.$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: tests/unit/ConfigTest.php
-
-		-
 			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertArrayHasKey\(\) with ''Server'' and array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\} will always evaluate to false\.$#'
 			identifier: staticMethod.impossibleType
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17203,7 +17203,7 @@ parameters:
 			path: tests/unit/UtilTest.php
 
 		-
-			message: '#^Cannot access offset ''server_2'' on mixed\.$#'
+			message: '#^Cannot access offset ''server_2_'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 4
 			path: tests/unit/UtilTest.php
@@ -17212,12 +17212,6 @@ parameters:
 			message: '#^Parameter \#2 \$array of static method PHPUnit\\Framework\\Assert\:\:assertArrayNotHasKey\(\) expects array\<mixed\>\|ArrayAccess\<\(int\|string\), mixed\>, mixed given\.$#'
 			identifier: argument.type
 			count: 2
-			path: tests/unit/UtilTest.php
-
-		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$selectedServer \(array\{host\: string, port\: string, socket\: string, ssl\: bool, ssl_key\: string\|null, ssl_cert\: string\|null, ssl_ca\: string\|null, ssl_ca_path\: string\|null, \.\.\.\}\) does not accept array\{host\: string, port\: string, socket\: string, ssl\: bool, ssl_key\: string\|null, ssl_cert\: string\|null, ssl_ca\: string\|null, ssl_ca_path\: string\|null, \.\.\.\}\.$#'
-			identifier: assign.propertyType
-			count: 1
 			path: tests/unit/UtilTest.php
 
 		-
@@ -17281,7 +17275,7 @@ parameters:
 			path: tests/unit/Utils/SessionCacheTest.php
 
 		-
-			message: '#^Cannot access offset ''server_2'' on mixed\.$#'
+			message: '#^Cannot access offset ''server_2_'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 4
 			path: tests/unit/Utils/SessionCacheTest.php
@@ -17308,12 +17302,6 @@ parameters:
 			message: '#^Parameter \#2 \$array of static method PHPUnit\\Framework\\Assert\:\:assertArrayNotHasKey\(\) expects array\<mixed\>\|ArrayAccess\<\(int\|string\), mixed\>, mixed given\.$#'
 			identifier: argument.type
 			count: 2
-			path: tests/unit/Utils/SessionCacheTest.php
-
-		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$selectedServer \(array\{host\: string, port\: string, socket\: string, ssl\: bool, ssl_key\: string\|null, ssl_cert\: string\|null, ssl_ca\: string\|null, ssl_ca_path\: string\|null, \.\.\.\}\) does not accept array\{host\: string, port\: string, socket\: string, ssl\: bool, ssl_key\: string\|null, ssl_cert\: string\|null, ssl_ca\: string\|null, ssl_ca_path\: string\|null, \.\.\.\}\.$#'
-			identifier: assign.propertyType
-			count: 5
 			path: tests/unit/Utils/SessionCacheTest.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17134,12 +17134,6 @@ parameters:
 			path: tests/unit/TwoFactorTest.php
 
 		-
-			message: '#^Missing call to parent\:\:tearDown\(\) method\.$#'
-			identifier: phpunit.callParent
-			count: 1
-			path: tests/unit/TwoFactorTest.php
-
-		-
 			message: '#^Parameter \#1 \$secret of method PragmaRX\\Google2FA\\Google2FA\:\:oathTotp\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 2

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -14081,15 +14081,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getInstance\(\) of class PhpMyAdmin\\Config\:
-				Use dependency injection instead\.$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: tests/unit/AbstractTestCase.php
-
-		-
-			message: '''
 				#^Call to deprecated method getInstance\(\) of class PhpMyAdmin\\Dbal\\DatabaseInterface\:
 				Use dependency injection instead\.$#
 			'''

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -118,9 +118,6 @@
       <code><![CDATA[$this->settings]]></code>
       <code><![CDATA[$this->settings]]></code>
     </InvalidPropertyAssignmentValue>
-    <MixedPropertyTypeCoercion>
-      <code><![CDATA[array_replace_recursive($this->settings, $this->config->asArray())]]></code>
-    </MixedPropertyTypeCoercion>
     <PossiblyInvalidArrayOffset>
       <code><![CDATA[$_COOKIE[$this->getCookieName($cookieName)]]]></code>
     </PossiblyInvalidArrayOffset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8957,9 +8957,6 @@
     </TypeDoesNotContainNull>
   </file>
   <file src="tests/unit/AbstractTestCase.php">
-    <DeprecatedMethod>
-      <code><![CDATA[Config::getInstance()]]></code>
-    </DeprecatedMethod>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$_SERVER['PHP_SELF']]]></code>
       <code><![CDATA[$_SERVER['REQUEST_TIME']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9315,9 +9315,6 @@
     </TypeDoesNotContainType>
   </file>
   <file src="tests/unit/ConfigTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[Config::getInstance()]]></code>
-    </DeprecatedMethod>
     <InvalidArrayOffset>
       <code><![CDATA[$config->settings['Server']]]></code>
       <code><![CDATA[$config->settings['Server']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -118,12 +118,15 @@
       <code><![CDATA[$this->settings]]></code>
       <code><![CDATA[$this->settings]]></code>
     </InvalidPropertyAssignmentValue>
+    <MixedAssignment>
+      <code><![CDATA[$array[$part]]]></code>
+    </MixedAssignment>
+    <MixedPropertyTypeCoercion>
+      <code><![CDATA[$this->settings]]></code>
+    </MixedPropertyTypeCoercion>
     <PossiblyInvalidArrayOffset>
       <code><![CDATA[$_COOKIE[$this->getCookieName($cookieName)]]]></code>
     </PossiblyInvalidArrayOffset>
-    <PropertyTypeCoercion>
-      <code><![CDATA[$this->settings]]></code>
-    </PropertyTypeCoercion>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($path)]]></code>
     </RiskyTruthyFalsyComparison>
@@ -416,7 +419,6 @@
     <MixedArrayAccess>
       <code><![CDATA[$_SESSION['cache'][$cacheKey]['userprefs']]]></code>
       <code><![CDATA[$_SESSION['cache'][$cacheKey]['userprefs']['LoginCookieValidity']]]></code>
-      <code><![CDATA[$_SESSION['cache'][$cacheKey]['userprefs_mtime']]]></code>
       <code><![CDATA[$_SESSION['cache'][$cacheKey]['userprefs_type']]]></code>
       <code><![CDATA[$configData['lang']]]></code>
     </MixedArrayAccess>
@@ -424,10 +426,8 @@
       <code><![CDATA[$_SESSION['cache'][$cacheKey]]]></code>
       <code><![CDATA[$_SESSION['cache'][$cacheKey]]]></code>
       <code><![CDATA[$_SESSION['cache'][$cacheKey]]]></code>
-      <code><![CDATA[$_SESSION['cache'][$cacheKey]]]></code>
       <code><![CDATA[$_SESSION['cache'][$cacheKey]['config_mtime']]]></code>
       <code><![CDATA[$_SESSION['cache'][$cacheKey]['userprefs']]]></code>
-      <code><![CDATA[$_SESSION['cache'][$cacheKey]['userprefs_mtime']]]></code>
       <code><![CDATA[$_SESSION['cache'][$cacheKey]['userprefs_type']]]></code>
     </MixedArrayAssignment>
     <MixedAssignment>
@@ -438,7 +438,6 @@
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
     <MixedPropertyTypeCoercion>
-      <code><![CDATA[$this->config->settings]]></code>
       <code><![CDATA[array_replace_recursive($this->config->settings, $configData)]]></code>
     </MixedPropertyTypeCoercion>
     <PossiblyInvalidArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11018,20 +11018,17 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[Config::getInstance()->selectedServer]]></code>
-    </InvalidPropertyAssignmentValue>
     <MixedArgument>
-      <code><![CDATA[$_SESSION['cache']['server_2']]]></code>
-      <code><![CDATA[$_SESSION['cache']['server_2']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code><![CDATA[$_SESSION['cache']['server_2']]]></code>
-      <code><![CDATA[$_SESSION['cache']['server_2']]]></code>
-      <code><![CDATA[$_SESSION['cache']['server_2']]]></code>
-      <code><![CDATA[$_SESSION['cache']['server_2']]]></code>
-      <code><![CDATA[$_SESSION['cache']['server_2']['is_superuser']]]></code>
-      <code><![CDATA[$_SESSION['cache']['server_2']['mysql_cur_user']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']['is_superuser']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']['mysql_cur_user']]]></code>
     </MixedArrayAccess>
     <PossiblyInvalidArgument>
       <code><![CDATA[testBackquote]]></code>
@@ -11104,24 +11101,17 @@
       <code><![CDATA[$_SESSION['cache']]]></code>
       <code><![CDATA[$_SESSION['cache']]]></code>
     </EmptyArrayAccess>
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[Config::getInstance()->selectedServer]]></code>
-      <code><![CDATA[Config::getInstance()->selectedServer]]></code>
-      <code><![CDATA[Config::getInstance()->selectedServer]]></code>
-      <code><![CDATA[Config::getInstance()->selectedServer]]></code>
-      <code><![CDATA[Config::getInstance()->selectedServer]]></code>
-    </InvalidPropertyAssignmentValue>
     <MixedArgument>
-      <code><![CDATA[$_SESSION['cache']['server_2']]]></code>
-      <code><![CDATA[$_SESSION['cache']['server_2']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code><![CDATA[$_SESSION['cache']['server_2']]]></code>
-      <code><![CDATA[$_SESSION['cache']['server_2']]]></code>
-      <code><![CDATA[$_SESSION['cache']['server_2']]]></code>
-      <code><![CDATA[$_SESSION['cache']['server_2']]]></code>
-      <code><![CDATA[$_SESSION['cache']['server_2']['test_data']]]></code>
-      <code><![CDATA[$_SESSION['cache']['server_2']['test_data_3']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']['test_data']]]></code>
+      <code><![CDATA[$_SESSION['cache']['server_2_']['test_data_3']]]></code>
     </MixedArrayAccess>
   </file>
   <file src="tests/unit/VersionInformationTest.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6448,9 +6448,6 @@
   </file>
   <file src="src/Plugins/Import/ImportLdi.php">
     <DeprecatedMethod>
-      <code><![CDATA[Config::getInstance()]]></code>
-      <code><![CDATA[Config::getInstance()]]></code>
-      <code><![CDATA[DatabaseInterface::getInstance()]]></code>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
     <MixedArgument>
@@ -10677,11 +10674,7 @@
   <file src="tests/unit/Plugins/Import/ImportLdiTest.php">
     <DeprecatedMethod>
       <code><![CDATA[Config::getInstance()]]></code>
-      <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <TypeDoesNotContainType>
-      <code><![CDATA[assertTrue]]></code>
-    </TypeDoesNotContainType>
   </file>
   <file src="tests/unit/Plugins/Import/ImportOdsTest.php">
     <DeprecatedMethod>

--- a/src/Config.php
+++ b/src/Config.php
@@ -13,7 +13,6 @@ use Throwable;
 
 use function __;
 use function array_key_last;
-use function array_replace_recursive;
 use function array_slice;
 use function count;
 use function defined;
@@ -204,7 +203,7 @@ class Config
         }
 
         $this->config = new Settings($cfg);
-        $this->settings = array_replace_recursive($this->settings, $this->config->asArray());
+        $this->settings = $this->config->asArray();
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -68,9 +68,6 @@ class Config
 {
     public static self|null $instance = null;
 
-    /** @var mixed[]   default configuration settings */
-    public array $default;
-
     /** @var mixed[]   configuration settings, without user preferences applied */
     public array $baseSettings;
 
@@ -102,7 +99,6 @@ class Config
     {
         $this->config = new Settings([]);
         $config = $this->config->asArray();
-        $this->default = $config;
         $this->settings = $config;
         $this->baseSettings = $config;
         $this->selectedServer = (new Server())->asArray();

--- a/src/Config.php
+++ b/src/Config.php
@@ -295,6 +295,7 @@ class Config
         }
 
         $this->config = new Settings($this->settings);
+        $this->settings = $this->config->asArray();
     }
 
     /**

--- a/src/Config/ConfigFile.php
+++ b/src/Config/ConfigFile.php
@@ -656,7 +656,6 @@ class ConfigFile
                 'ldi_terminated' => 'short_string',
                 'ldi_enclosed' => 'short_string',
                 'ldi_escaped' => 'short_string',
-                'ldi_local_option' => ['auto', true, false],
             ],
 
             'Export' => [

--- a/src/Config/Forms/User/ImportForm.php
+++ b/src/Config/Forms/User/ImportForm.php
@@ -40,7 +40,6 @@ class ImportForm extends BaseForm
                 'Import/ldi_terminated',
                 'Import/ldi_enclosed',
                 'Import/ldi_escaped',
-                'Import/ldi_local_option',
             ],
             'Open_Document' => [
                 ':group:' . __('OpenDocument Spreadsheet'),

--- a/src/Config/Settings.php
+++ b/src/Config/Settings.php
@@ -3920,10 +3920,10 @@ final class Settings
         }
 
         return match ($settings['NavigationTreeDefaultTabTable']) {
-            'sql', 'tbl_sql.php' => '/table/sql',
-            'search', 'tbl_select.php' => '/table/search',
-            'insert', 'tbl_change.php' => '/table/change',
-            'browse', 'sql.php' => '/sql',
+            'sql', 'tbl_sql.php', '/table/sql' => '/table/sql',
+            'search', 'tbl_select.php', '/table/search' => '/table/search',
+            'insert', 'tbl_change.php', '/table/change' => '/table/change',
+            'browse', 'sql.php', '/sql' => '/sql',
             default => '/table/structure',
         };
     }
@@ -3940,11 +3940,11 @@ final class Settings
         }
 
         return match ($settings['NavigationTreeDefaultTabTable2']) {
-            'structure', 'tbl_structure.php' => '/table/structure',
-            'sql', 'tbl_sql.php' => '/table/sql',
-            'search', 'tbl_select.php' => '/table/search',
-            'insert', 'tbl_change.php' => '/table/change',
-            'browse', 'sql.php' => '/sql',
+            'structure', 'tbl_structure.php', '/table/structure' => '/table/structure',
+            'sql', 'tbl_sql.php', '/table/sql' => '/table/sql',
+            'search', 'tbl_select.php', '/table/search' => '/table/search',
+            'insert', 'tbl_change.php', '/table/change' => '/table/change',
+            'browse', 'sql.php', '/sql' => '/sql',
             default => '',
         };
     }
@@ -4520,10 +4520,10 @@ final class Settings
         }
 
         return match ($settings['DefaultTabServer']) {
-            'databases', 'server_databases.php' => '/server/databases',
-            'status', 'server_status.php' => '/server/status',
-            'variables', 'server_variables.php' => '/server/variables',
-            'privileges', 'server_privileges.php' => '/server/privileges',
+            'databases', 'server_databases.php', '/server/databases' => '/server/databases',
+            'status', 'server_status.php', '/server/status' => '/server/status',
+            'variables', 'server_variables.php', '/server/variables' => '/server/variables',
+            'privileges', 'server_privileges.php', '/server/privileges' => '/server/privileges',
             default => '/',
         };
     }
@@ -4540,9 +4540,9 @@ final class Settings
         }
 
         return match ($settings['DefaultTabDatabase']) {
-            'sql', 'db_sql.php' => '/database/sql',
-            'search', 'db_search.php' => '/database/search',
-            'operations', 'db_operations.php' => '/database/operations',
+            'sql', 'db_sql.php', '/database/sql' => '/database/sql',
+            'search', 'db_search.php', '/database/search' => '/database/search',
+            'operations', 'db_operations.php', '/database/operations' => '/database/operations',
             default => '/database/structure',
         };
     }
@@ -4559,10 +4559,10 @@ final class Settings
         }
 
         return match ($settings['DefaultTabTable']) {
-            'structure', 'tbl_structure.php' => '/table/structure',
-            'sql', 'tbl_sql.php' => '/table/sql',
-            'search', 'tbl_select.php' => '/table/search',
-            'insert', 'tbl_change.php' => '/table/change',
+            'structure', 'tbl_structure.php', '/table/structure' => '/table/structure',
+            'sql', 'tbl_sql.php', '/table/sql' => '/table/sql',
+            'search', 'tbl_select.php', '/table/search' => '/table/search',
+            'insert', 'tbl_change.php', '/table/change' => '/table/change',
             default => '/sql',
         };
     }

--- a/src/Config/Settings/Import.php
+++ b/src/Config/Settings/Import.php
@@ -37,7 +37,6 @@ use function in_array;
  *     ldi_escaped: string,
  *     ldi_new_line: string,
  *     ldi_columns: string,
- *     ldi_local_option: 'auto'|bool,
  *     ods_col_names: bool,
  *     ods_empty_rows: bool,
  *     ods_recognize_percentages: bool,
@@ -211,17 +210,6 @@ final class Import
     public string $ldi_columns;
 
     /**
-     * 'auto' for auto-detection, true or false for forcing
-     *
-     * ```php
-     * $cfg['Import']['ldi_local_option'] = 'auto';
-     * ```
-     *
-     * @psalm-var 'auto'|bool
-     */
-    public string|bool $ldi_local_option;
-
-    /**
      * ```php
      * $cfg['Import']['ods_col_names'] = false;
      * ```
@@ -274,7 +262,6 @@ final class Import
         $this->ldi_escaped = $this->setLdiEscaped($import);
         $this->ldi_new_line = $this->setLdiNewLine($import);
         $this->ldi_columns = $this->setLdiColumns($import);
-        $this->ldi_local_option = $this->setLdiLocalOption($import);
         $this->ods_col_names = $this->setOdsColNames($import);
         $this->ods_empty_rows = $this->setOdsEmptyRows($import);
         $this->ods_recognize_percentages = $this->setOdsRecognizePercentages($import);
@@ -307,7 +294,6 @@ final class Import
             'ldi_escaped' => $this->ldi_escaped,
             'ldi_new_line' => $this->ldi_new_line,
             'ldi_columns' => $this->ldi_columns,
-            'ldi_local_option' => $this->ldi_local_option,
             'ods_col_names' => $this->ods_col_names,
             'ods_empty_rows' => $this->ods_empty_rows,
             'ods_recognize_percentages' => $this->ods_recognize_percentages,
@@ -553,20 +539,6 @@ final class Import
         }
 
         return (string) $import['ldi_columns'];
-    }
-
-    /**
-     * @param array<int|string, mixed> $import
-     *
-     * @psalm-return 'auto'|bool
-     */
-    private function setLdiLocalOption(array $import): bool|string
-    {
-        if (! isset($import['ldi_local_option']) || $import['ldi_local_option'] === 'auto') {
-            return 'auto';
-        }
-
-        return (bool) $import['ldi_local_option'];
     }
 
     /** @param array<int|string, mixed> $import */

--- a/src/Config/UserPreferencesHandler.php
+++ b/src/Config/UserPreferencesHandler.php
@@ -21,6 +21,9 @@ class UserPreferencesHandler
     /** @var ''|'db'|'session' */
     public string $storageType = '';
 
+    /** @var mixed[]   default configuration settings */
+    public array $defaultSettings;
+
     public function __construct(
         private readonly Config $config,
         private readonly DatabaseInterface $dbi,
@@ -28,6 +31,7 @@ class UserPreferencesHandler
         private readonly LanguageManager $languageManager,
         private readonly ThemeManager $themeManager,
     ) {
+        $this->defaultSettings = (new Settings([]))->asArray();
     }
 
     /**
@@ -165,7 +169,7 @@ class UserPreferencesHandler
         // use permanent user preferences if possible
         if ($this->storageType !== '') {
             if ($defaultValue === null) {
-                $defaultValue = Core::arrayRead($cfgPath, $this->config->default);
+                $defaultValue = Core::arrayRead($cfgPath, $this->defaultSettings);
             }
 
             $result = $this->userPreferences->persistOption($cfgPath, $newCfgValue, $defaultValue);

--- a/src/Config/UserPreferencesHandler.php
+++ b/src/Config/UserPreferencesHandler.php
@@ -49,7 +49,6 @@ class UserPreferencesHandler
             ) {
                 $prefs = $this->userPreferences->load();
                 $_SESSION['cache'][$cacheKey]['userprefs'] = $this->userPreferences->apply($prefs['config_data']);
-                $_SESSION['cache'][$cacheKey]['userprefs_mtime'] = $prefs['mtime'];
                 $_SESSION['cache'][$cacheKey]['userprefs_type'] = $prefs['type'];
                 $_SESSION['cache'][$cacheKey]['config_mtime'] = $this->config->sourceMtime;
             }
@@ -62,7 +61,6 @@ class UserPreferencesHandler
         $configData = $_SESSION['cache'][$cacheKey]['userprefs'];
         // type is 'db' or 'session'
         $this->storageType = $_SESSION['cache'][$cacheKey]['userprefs_type'];
-        $this->config->set('user_preferences_mtime', $_SESSION['cache'][$cacheKey]['userprefs_mtime']);
 
         if (isset($configData['Server']) && is_array($configData['Server'])) {
             $serverConfig = array_replace_recursive($this->config->selectedServer, $configData['Server']);
@@ -184,7 +182,7 @@ class UserPreferencesHandler
             $this->config->setCookie($cookieName, (string) $newCfgValue, $defaultValue);
         }
 
-        Core::arrayWrite($cfgPath, $this->config->settings, $newCfgValue);
+        $this->config->set($cfgPath, $newCfgValue);
 
         return $result;
     }

--- a/src/Controllers/UserPasswordController.php
+++ b/src/Controllers/UserPasswordController.php
@@ -39,11 +39,12 @@ final readonly class UserPasswordController implements InvocableController
          * Displays an error message and exits if the user isn't allowed to use this
          * script
          */
+        $hasAccessPrivilege = true;
         if (! $this->config->settings['ShowChgPassword']) {
-            $this->config->settings['ShowChgPassword'] = $this->dbi->selectDb('mysql');
+            $hasAccessPrivilege = $this->dbi->selectDb('mysql');
         }
 
-        if ($this->config->selectedServer['auth_type'] === 'config' || ! $this->config->settings['ShowChgPassword']) {
+        if ($this->config->selectedServer['auth_type'] === 'config' || ! $hasAccessPrivilege) {
             $this->response->addHTML(Message::error(
                 __('You don\'t have sufficient privileges to be here right now!'),
             )->getDisplay());

--- a/src/Controllers/UserPasswordController.php
+++ b/src/Controllers/UserPasswordController.php
@@ -39,10 +39,7 @@ final readonly class UserPasswordController implements InvocableController
          * Displays an error message and exits if the user isn't allowed to use this
          * script
          */
-        $hasAccessPrivilege = true;
-        if (! $this->config->settings['ShowChgPassword']) {
-            $hasAccessPrivilege = $this->dbi->selectDb('mysql');
-        }
+        $hasAccessPrivilege = $this->config->config->ShowChgPassword || $this->dbi->selectDb('mysql');
 
         if ($this->config->selectedServer['auth_type'] === 'config' || ! $hasAccessPrivilege) {
             $this->response->addHTML(Message::error(

--- a/src/Plugins/Import/ImportLdi.php
+++ b/src/Plugins/Import/ImportLdi.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Plugins\Import;
 
-use PhpMyAdmin\Config;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\File;
@@ -53,10 +52,6 @@ class ImportLdi extends AbstractImportCsv
 
         if (! self::isAvailable()) {
             return $importPluginProperties;
-        }
-
-        if (Config::getInstance()->settings['Import']['ldi_local_option'] === 'auto') {
-            $this->setLdiLocalOptionConfig();
         }
 
         $importPluginProperties->setOptionsText(__('Options'));
@@ -203,23 +198,5 @@ class ImportLdi extends AbstractImportCsv
     {
         // We need relations enabled and we work only on database.
         return ImportSettings::$importType === 'table';
-    }
-
-    private function setLdiLocalOptionConfig(): void
-    {
-        $config = Config::getInstance();
-        $config->settings['Import']['ldi_local_option'] = false;
-        $result = DatabaseInterface::getInstance()->tryQuery('SELECT @@local_infile;');
-
-        if ($result === false || $result->numRows() <= 0) {
-            return;
-        }
-
-        $tmp = $result->fetchValue();
-        if ($tmp !== 'ON' && $tmp !== '1') {
-            return;
-        }
-
-        $config->settings['Import']['ldi_local_option'] = true;
     }
 }

--- a/src/Theme/ThemeManager.php
+++ b/src/Theme/ThemeManager.php
@@ -176,9 +176,6 @@ class ThemeManager
             $this->theme->getColorMode(),
             $this->theme->getColorModes()[0],
         );
-        // force a change of a dummy session variable to avoid problems
-        // with the caching of phpmyadmin.css.php
-        $config->set('theme-update', $this->theme->id);
     }
 
     public function loadThemes(): void

--- a/src/Utils/SessionCache.php
+++ b/src/Utils/SessionCache.php
@@ -14,11 +14,8 @@ final class SessionCache
         $key = 'server_' . Current::$server;
 
         $config = Config::getInstance();
-        if (isset($config->selectedServer['user'])) {
-            return $key . '_' . $config->selectedServer['user'];
-        }
 
-        return $key;
+        return $key . '_' . $config->selectedServer['user'];
     }
 
     public static function has(string $name): bool

--- a/tests/unit/AbstractTestCase.php
+++ b/tests/unit/AbstractTestCase.php
@@ -84,14 +84,6 @@ abstract class AbstractTestCase extends TestCase
         return new DbiDummy();
     }
 
-    protected function createConfig(): Config
-    {
-        $config = new Config();
-        $config->loadFromFile();
-
-        return $config;
-    }
-
     protected function setLanguage(string $code = 'en'): void
     {
         Current::$lang = $code;

--- a/tests/unit/AbstractTestCase.php
+++ b/tests/unit/AbstractTestCase.php
@@ -65,7 +65,6 @@ abstract class AbstractTestCase extends TestCase
         ExportSql::$noConstraintsComments = false;
 
         // Config before DBI
-        $this->setGlobalConfig();
         Cache::purge();
         Tracker::disable();
 
@@ -91,14 +90,6 @@ abstract class AbstractTestCase extends TestCase
         $config->loadFromFile();
 
         return $config;
-    }
-
-    protected function setGlobalConfig(): void
-    {
-        Config::$instance = null;
-        $config = Config::getInstance();
-        $config->loadFromFile();
-        $config->set('environment', 'development');
     }
 
     protected function setLanguage(string $code = 'en'): void

--- a/tests/unit/Advisory/AdvisorTest.php
+++ b/tests/unit/Advisory/AdvisorTest.php
@@ -20,8 +20,6 @@ class AdvisorTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         DatabaseInterface::$instance = $this->createDatabaseInterface();
     }
 

--- a/tests/unit/Bookmarks/BookmarkRepositoryTest.php
+++ b/tests/unit/Bookmarks/BookmarkRepositoryTest.php
@@ -24,8 +24,7 @@ final class BookmarkRepositoryTest extends AbstractTestCase
         ]);
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
         $dbi = $this->createDatabaseInterface();
-        $config = Config::$instance = new Config();
-        $bookmarkRepository = new BookmarkRepository($dbi, new Relation($dbi, $config));
+        $bookmarkRepository = new BookmarkRepository($dbi, new Relation($dbi, new Config()));
         $bookmark = $bookmarkRepository->createBookmark('SELECT "phpmyadmin"', 'bookmark1', 'root', 'phpmyadmin');
         self::assertNotFalse($bookmark);
         self::assertSame(0, $bookmark->getId());

--- a/tests/unit/Config/DescriptionTest.php
+++ b/tests/unit/Config/DescriptionTest.php
@@ -20,13 +20,6 @@ use function in_array;
 #[RunTestsInSeparateProcesses]
 class DescriptionTest extends AbstractTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->setGlobalConfig();
-    }
-
     /**
      * @param string $item     item
      * @param string $type     type

--- a/tests/unit/Config/FormDisplayTemplateTest.php
+++ b/tests/unit/Config/FormDisplayTemplateTest.php
@@ -25,7 +25,7 @@ class FormDisplayTemplateTest extends AbstractTestCase
 
         $this->setLanguage();
 
-        $this->config = $this->createConfig();
+        $this->config = new Config();
         $this->formDisplayTemplate = new FormDisplayTemplate($this->config);
     }
 

--- a/tests/unit/Config/FormDisplayTest.php
+++ b/tests/unit/Config/FormDisplayTest.php
@@ -31,8 +31,6 @@ class FormDisplayTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         Current::$server = 2;
         $this->object = new FormDisplay(new ConfigFile());
         Form::resetGroupCounter();

--- a/tests/unit/Config/FormTest.php
+++ b/tests/unit/Config/FormTest.php
@@ -28,8 +28,6 @@ class FormTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->object = new Form(
             'pma_form_name',
             ['pma_form1', 'pma_form2'],

--- a/tests/unit/Config/Forms/FormListTest.php
+++ b/tests/unit/Config/Forms/FormListTest.php
@@ -24,13 +24,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[CoversClass(UserFormList::class)]
 class FormListTest extends AbstractTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->setGlobalConfig();
-    }
-
     /**
      * Tests for preferences forms.
      *

--- a/tests/unit/Config/Forms/Setup/FeaturesFormTest.php
+++ b/tests/unit/Config/Forms/Setup/FeaturesFormTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Config\Forms\Setup;
 
-use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\ConfigFile;
 use PhpMyAdmin\Config\Form;
 use PhpMyAdmin\Config\FormDisplay;
@@ -22,8 +21,6 @@ final class FeaturesFormTest extends AbstractTestCase
     public function testRegisteredForms(): void
     {
         Form::resetGroupCounter();
-        $config = new Config();
-        Config::$instance = $config;
 
         $featuresForm = new FeaturesForm(new ConfigFile([]), 1);
         self::assertSame('Features', FeaturesForm::getName());

--- a/tests/unit/Config/Forms/User/ImportFormTest.php
+++ b/tests/unit/Config/Forms/User/ImportFormTest.php
@@ -79,7 +79,6 @@ final class ImportFormTest extends AbstractTestCase
                 'ldi_terminated' => 'Import/ldi_terminated',
                 'ldi_enclosed' => 'Import/ldi_enclosed',
                 'ldi_escaped' => 'Import/ldi_escaped',
-                'ldi_local_option' => 'Import/ldi_local_option',
             ],
             $form->fields,
         );
@@ -127,7 +126,6 @@ final class ImportFormTest extends AbstractTestCase
                 'Import/ldi_terminated',
                 'Import/ldi_enclosed',
                 'Import/ldi_escaped',
-                'Import/ldi_local_option',
                 ':group:OpenDocument Spreadsheet',
                 'Import/ods_col_names',
                 'Import/ods_empty_rows',

--- a/tests/unit/Config/PageSettingsTest.php
+++ b/tests/unit/Config/PageSettingsTest.php
@@ -30,8 +30,6 @@ class PageSettingsTest extends AbstractTestCase
 
         $this->setLanguage();
 
-        $this->setGlobalConfig();
-
         DatabaseInterface::$instance = $this->createDatabaseInterface();
         Current::$database = 'db';
         Current::$table = '';

--- a/tests/unit/Config/ServerConfigChecksTest.php
+++ b/tests/unit/Config/ServerConfigChecksTest.php
@@ -30,8 +30,6 @@ class ServerConfigChecksTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->configFile = new ConfigFile();
 
         $reflection = new ReflectionProperty(ConfigFile::class, 'id');

--- a/tests/unit/Config/Settings/ImportTest.php
+++ b/tests/unit/Config/Settings/ImportTest.php
@@ -366,25 +366,6 @@ class ImportTest extends TestCase
         yield 'valid value with type coercion' => [1234, '1234'];
     }
 
-    #[DataProvider('valuesForLdiLocalOptionProvider')]
-    public function testLdiLocalOption(mixed $actual, string|bool $expected): void
-    {
-        $import = new Import(['ldi_local_option' => $actual]);
-        $importArray = $import->asArray();
-        self::assertSame($expected, $import->ldi_local_option);
-        self::assertSame($expected, $importArray['ldi_local_option']);
-    }
-
-    /** @return iterable<string, array{mixed, string|bool}> */
-    public static function valuesForLdiLocalOptionProvider(): iterable
-    {
-        yield 'null value' => [null, 'auto'];
-        yield 'valid value' => ['auto', 'auto'];
-        yield 'valid value 2' => [true, true];
-        yield 'valid value 3' => [false, false];
-        yield 'valid value with type coercion' => ['1', true];
-    }
-
     #[DataProvider('booleanWithDefaultFalseProvider')]
     public function testOdsColNames(mixed $actual, bool $expected): void
     {

--- a/tests/unit/Config/UserPreferencesHandlerTest.php
+++ b/tests/unit/Config/UserPreferencesHandlerTest.php
@@ -29,8 +29,8 @@ final class UserPreferencesHandlerTest extends AbstractTestCase
             new LanguageManager($config),
             new ThemeManager(),
         );
-        $userPreferencesHandler->setUserValue(null, 'lang', 'cs', 'en');
-        $userPreferencesHandler->setUserValue('TEST_COOKIE_USER_VAL', '', 'cfg_val_1');
+        $userPreferencesHandler->setUserValue(null, 'Lang', 'cs', 'en');
+        $userPreferencesHandler->setUserValue('TEST_COOKIE_USER_VAL', 'Servers/1/hide_db', 'cfg_val_1');
         self::assertSame('cfg_val_1', $userPreferencesHandler->getUserValue('TEST_COOKIE_USER_VAL', 'fail'));
         $userPreferencesHandler->setUserValue(null, 'NavigationWidth', 300);
         self::assertSame(300, $config->settings['NavigationWidth']);

--- a/tests/unit/Config/ValidatorTest.php
+++ b/tests/unit/Config/ValidatorTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Config;
 
-use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\ConfigFile;
 use PhpMyAdmin\Config\Validator;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -15,7 +14,6 @@ final class ValidatorTest extends AbstractTestCase
 {
     public function testGetValidators(): void
     {
-        Config::$instance = new Config();
         $validator = new Validator(new ConfigFile([]));
         $validators = $validator->getValidators();
         $expected = [

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -62,6 +62,14 @@ class ConfigTest extends AbstractTestCase
         $this->permTestObj->loadFromFile(ROOT_PATH . 'config.sample.inc.php');
     }
 
+    protected function createConfig(): Config
+    {
+        $config = new Config();
+        $config->loadFromFile();
+
+        return $config;
+    }
+
     /**
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -26,7 +26,6 @@ use function tempnam;
 use function unlink;
 
 use const CHANGELOG_FILE;
-use const CONFIG_FILE;
 use const DIRECTORY_SEPARATOR;
 use const PHP_OS;
 
@@ -52,10 +51,6 @@ class ConfigTest extends AbstractTestCase
         $this->object = $this->createConfig();
         $_SESSION['git_location'] = '.git';
         $_SESSION['is_git_revision'] = true;
-        Config::$instance = null;
-        $config = Config::getInstance();
-        $config->loadFromFile(CONFIG_FILE);
-        $config->settings['ProxyUrl'] = '';
 
         //for testing file permissions
         $this->permTestObj = new Config();

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -162,7 +162,6 @@ class ConfigTest extends AbstractTestCase
         $config = $settings->asArray();
         self::assertIsArray($config['Servers']);
         self::assertEquals($settings, $object->getSettings());
-        self::assertSame($config, $object->default);
         self::assertSame($config, $object->settings);
         self::assertSame($config, $object->baseSettings);
     }

--- a/tests/unit/Controllers/Server/BinlogControllerTest.php
+++ b/tests/unit/Controllers/Server/BinlogControllerTest.php
@@ -27,8 +27,6 @@ class BinlogControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Controllers/Server/CollationsControllerTest.php
+++ b/tests/unit/Controllers/Server/CollationsControllerTest.php
@@ -28,8 +28,6 @@ class CollationsControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Controllers/Server/DatabasesControllerTest.php
+++ b/tests/unit/Controllers/Server/DatabasesControllerTest.php
@@ -28,8 +28,6 @@ class DatabasesControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Controllers/Server/EnginesControllerTest.php
+++ b/tests/unit/Controllers/Server/EnginesControllerTest.php
@@ -28,8 +28,6 @@ class EnginesControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Controllers/Server/PluginsControllerTest.php
+++ b/tests/unit/Controllers/Server/PluginsControllerTest.php
@@ -30,8 +30,6 @@ class PluginsControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Controllers/Server/ShowEngineControllerTest.php
+++ b/tests/unit/Controllers/Server/ShowEngineControllerTest.php
@@ -30,8 +30,6 @@ class ShowEngineControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Controllers/Server/Status/AdvisorControllerTest.php
+++ b/tests/unit/Controllers/Server/Status/AdvisorControllerTest.php
@@ -29,8 +29,6 @@ class AdvisorControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         DatabaseInterface::$instance = $this->createDatabaseInterface();
 
         $config = Config::getInstance();

--- a/tests/unit/Controllers/Server/Status/Monitor/GeneralLogControllerTest.php
+++ b/tests/unit/Controllers/Server/Status/Monitor/GeneralLogControllerTest.php
@@ -30,8 +30,6 @@ class GeneralLogControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Controllers/Server/Status/Monitor/LogVarsControllerTest.php
+++ b/tests/unit/Controllers/Server/Status/Monitor/LogVarsControllerTest.php
@@ -30,8 +30,6 @@ class LogVarsControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Controllers/Server/Status/Monitor/SlowLogControllerTest.php
+++ b/tests/unit/Controllers/Server/Status/Monitor/SlowLogControllerTest.php
@@ -30,8 +30,6 @@ class SlowLogControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Controllers/Server/Status/MonitorControllerTest.php
+++ b/tests/unit/Controllers/Server/Status/MonitorControllerTest.php
@@ -31,8 +31,6 @@ class MonitorControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Controllers/Server/Status/Processes/RefreshControllerTest.php
+++ b/tests/unit/Controllers/Server/Status/Processes/RefreshControllerTest.php
@@ -31,8 +31,6 @@ class RefreshControllerTest extends AbstractTestCase
 
         DatabaseInterface::$instance = $this->createDatabaseInterface();
 
-        $this->setGlobalConfig();
-
         Current::$database = 'db';
         Current::$table = 'table';
         $config = Config::getInstance();

--- a/tests/unit/Controllers/Server/Status/ProcessesControllerTest.php
+++ b/tests/unit/Controllers/Server/Status/ProcessesControllerTest.php
@@ -31,8 +31,6 @@ class ProcessesControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Controllers/Server/Status/QueriesControllerTest.php
+++ b/tests/unit/Controllers/Server/Status/QueriesControllerTest.php
@@ -34,8 +34,6 @@ class QueriesControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Controllers/Server/Status/StatusControllerTest.php
+++ b/tests/unit/Controllers/Server/Status/StatusControllerTest.php
@@ -29,8 +29,6 @@ class StatusControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Controllers/Server/Status/VariablesControllerTest.php
+++ b/tests/unit/Controllers/Server/Status/VariablesControllerTest.php
@@ -29,8 +29,6 @@ class VariablesControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Controllers/Server/VariablesControllerTest.php
+++ b/tests/unit/Controllers/Server/VariablesControllerTest.php
@@ -35,8 +35,6 @@ class VariablesControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->setLanguage();
 
         Current::$database = 'db';

--- a/tests/unit/Controllers/Table/AddFieldControllerTest.php
+++ b/tests/unit/Controllers/Table/AddFieldControllerTest.php
@@ -261,7 +261,7 @@ class AddFieldControllerTest extends AbstractTestCase
         (new AddFieldController(
             $response,
             $transformations,
-            $this->createConfig(),
+            new Config(),
             $dbi,
             new ColumnsDefinition($dbi, $relation, $transformations),
             new DbTableExists($dbi),

--- a/tests/unit/Controllers/Table/CreateControllerTest.php
+++ b/tests/unit/Controllers/Table/CreateControllerTest.php
@@ -276,7 +276,7 @@ class CreateControllerTest extends AbstractTestCase
         (new CreateController(
             $response,
             $transformations,
-            $this->createConfig(),
+            new Config(),
             $dbi,
             new ColumnsDefinition($dbi, $relation, $transformations),
             new UserPrivilegesFactory($dbi),

--- a/tests/unit/Controllers/Table/Maintenance/AnalyzeControllerTest.php
+++ b/tests/unit/Controllers/Table/Maintenance/AnalyzeControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Table\Maintenance;
 
+use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\Table\Maintenance\AnalyzeController;
 use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
@@ -25,7 +26,7 @@ class AnalyzeControllerTest extends AbstractTestCase
         $dbi = $this->createDatabaseInterface();
         DatabaseInterface::$instance = $dbi;
         $response = new ResponseRenderer();
-        $controller = new AnalyzeController($response, new Maintenance($dbi), $this->createConfig());
+        $controller = new AnalyzeController($response, new Maintenance($dbi), new Config());
         $controller($request);
         self::assertFalse($response->hasSuccessState());
         self::assertSame(['message' => 'No table selected.'], $response->getJSONResult());

--- a/tests/unit/Controllers/Table/Maintenance/CheckControllerTest.php
+++ b/tests/unit/Controllers/Table/Maintenance/CheckControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Table\Maintenance;
 
+use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\Table\Maintenance\CheckController;
 use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
@@ -25,7 +26,7 @@ class CheckControllerTest extends AbstractTestCase
         $dbi = $this->createDatabaseInterface();
         DatabaseInterface::$instance = $dbi;
         $response = new ResponseRenderer();
-        $controller = new CheckController($response, new Maintenance($dbi), $this->createConfig());
+        $controller = new CheckController($response, new Maintenance($dbi), new Config());
         $controller($request);
         self::assertFalse($response->hasSuccessState());
         self::assertSame(['message' => 'No table selected.'], $response->getJSONResult());

--- a/tests/unit/Controllers/Table/Maintenance/ChecksumControllerTest.php
+++ b/tests/unit/Controllers/Table/Maintenance/ChecksumControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Table\Maintenance;
 
+use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\Table\Maintenance\ChecksumController;
 use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
@@ -25,7 +26,7 @@ class ChecksumControllerTest extends AbstractTestCase
         $dbi = $this->createDatabaseInterface();
         DatabaseInterface::$instance = $dbi;
         $response = new ResponseRenderer();
-        $controller = new ChecksumController($response, new Maintenance($dbi), $this->createConfig());
+        $controller = new ChecksumController($response, new Maintenance($dbi), new Config());
         $controller($request);
         self::assertFalse($response->hasSuccessState());
         self::assertSame(['message' => 'No table selected.'], $response->getJSONResult());

--- a/tests/unit/Controllers/Table/Maintenance/OptimizeControllerTest.php
+++ b/tests/unit/Controllers/Table/Maintenance/OptimizeControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Table\Maintenance;
 
+use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\Table\Maintenance\OptimizeController;
 use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
@@ -25,7 +26,7 @@ class OptimizeControllerTest extends AbstractTestCase
         $dbi = $this->createDatabaseInterface();
         DatabaseInterface::$instance = $dbi;
         $response = new ResponseRenderer();
-        $controller = new OptimizeController($response, new Maintenance($dbi), $this->createConfig());
+        $controller = new OptimizeController($response, new Maintenance($dbi), new Config());
         $controller($request);
         self::assertFalse($response->hasSuccessState());
         self::assertSame(['message' => 'No table selected.'], $response->getJSONResult());

--- a/tests/unit/Controllers/Table/Maintenance/RepairControllerTest.php
+++ b/tests/unit/Controllers/Table/Maintenance/RepairControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Controllers\Table\Maintenance;
 
+use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\Table\Maintenance\RepairController;
 use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Http\ServerRequest;
@@ -25,7 +26,7 @@ class RepairControllerTest extends AbstractTestCase
         $dbi = $this->createDatabaseInterface();
         DatabaseInterface::$instance = $dbi;
         $response = new ResponseRenderer();
-        $controller = new RepairController($response, new Maintenance($dbi), $this->createConfig());
+        $controller = new RepairController($response, new Maintenance($dbi), new Config());
         $controller($request);
         self::assertFalse($response->hasSuccessState());
         self::assertSame(['message' => 'No table selected.'], $response->getJSONResult());

--- a/tests/unit/Controllers/Transformation/OverviewControllerTest.php
+++ b/tests/unit/Controllers/Transformation/OverviewControllerTest.php
@@ -25,8 +25,6 @@ class OverviewControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         Current::$database = 'db';
         Current::$table = 'table';
     }

--- a/tests/unit/Database/CentralColumnsTest.php
+++ b/tests/unit/Database/CentralColumnsTest.php
@@ -103,8 +103,6 @@ class CentralColumnsTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $config = Config::getInstance();
         $config->selectedServer['user'] = 'pma_user';
         $config->selectedServer['DisableIS'] = true;

--- a/tests/unit/Database/EventsTest.php
+++ b/tests/unit/Database/EventsTest.php
@@ -24,8 +24,6 @@ class EventsTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->setLanguage();
 
         DatabaseInterface::$instance = $this->createDatabaseInterface();

--- a/tests/unit/Database/RoutinesTest.php
+++ b/tests/unit/Database/RoutinesTest.php
@@ -28,8 +28,6 @@ class RoutinesTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->setLanguage();
 
         DatabaseInterface::$instance = $this->createDatabaseInterface();

--- a/tests/unit/Display/ResultsTest.php
+++ b/tests/unit/Display/ResultsTest.php
@@ -73,8 +73,6 @@ class ResultsTest extends AbstractTestCase
 
         $this->setLanguage();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Export/OptionsTest.php
+++ b/tests/unit/Export/OptionsTest.php
@@ -54,13 +54,6 @@ class OptionsTest extends AbstractTestCase
         $this->export = new Options($relation, new TemplateModel($dbi), $userPreferencesHandler);
     }
 
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        Config::$instance = null;
-    }
-
     public function testGetOptions(): void
     {
         $config = Config::getInstance();

--- a/tests/unit/Export/OptionsTest.php
+++ b/tests/unit/Export/OptionsTest.php
@@ -35,8 +35,6 @@ class OptionsTest extends AbstractTestCase
 
         $this->setLanguage();
 
-        $this->setGlobalConfig();
-
         $dbi = $this->createDatabaseInterface();
         DatabaseInterface::$instance = $dbi;
 

--- a/tests/unit/FooterTest.php
+++ b/tests/unit/FooterTest.php
@@ -34,8 +34,6 @@ class FooterTest extends AbstractTestCase
 
         $this->setLanguage();
 
-        $this->setGlobalConfig();
-
         DatabaseInterface::$instance = $this->createDatabaseInterface();
         $_SERVER['SCRIPT_NAME'] = 'index.php';
         Current::$database = '';

--- a/tests/unit/HeaderTest.php
+++ b/tests/unit/HeaderTest.php
@@ -44,8 +44,6 @@ class HeaderTest extends AbstractTestCase
         Current::$database = 'db';
         Current::$table = '';
 
-        $this->setGlobalConfig();
-
         $config = Config::getInstance();
         $config->settings['Servers'] = [];
         $config->selectedServer['DisableIS'] = false;

--- a/tests/unit/InsertEditTest.php
+++ b/tests/unit/InsertEditTest.php
@@ -65,8 +65,6 @@ class InsertEditTest extends AbstractTestCase
 
         $this->setLanguage();
 
-        $this->setGlobalConfig();
-
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         DatabaseInterface::$instance = $this->dbi;

--- a/tests/unit/Navigation/NavigationTreeTest.php
+++ b/tests/unit/Navigation/NavigationTreeTest.php
@@ -28,8 +28,6 @@ class NavigationTreeTest extends AbstractTestCase
 
         $this->setLanguage();
 
-        $this->setGlobalConfig();
-
         $dbi = $this->createDatabaseInterface();
         DatabaseInterface::$instance = $dbi;
         $config = Config::getInstance();

--- a/tests/unit/PdfTest.php
+++ b/tests/unit/PdfTest.php
@@ -13,16 +13,6 @@ use PHPUnit\Framework\Attributes\Large;
 class PdfTest extends AbstractTestCase
 {
     /**
-     * SetUp for test cases
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->setGlobalConfig();
-    }
-
-    /**
      * Test for Pdf::getPDFData
      */
     public function testBasic(): void

--- a/tests/unit/Plugins/Auth/AuthenticationConfigTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationConfigTest.php
@@ -32,8 +32,6 @@ class AuthenticationConfigTest extends AbstractTestCase
 
         $this->setLanguage();
 
-        $this->setGlobalConfig();
-
         DatabaseInterface::$instance = $this->createDatabaseInterface();
         Current::$server = 2;
         Current::$database = 'db';

--- a/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationCookieTest.php
@@ -52,8 +52,6 @@ class AuthenticationCookieTest extends AbstractTestCase
 
         $this->setLanguage();
 
-        $this->setGlobalConfig();
-
         DatabaseInterface::$instance = $this->createDatabaseInterface();
         Current::$database = 'db';
         Current::$table = 'table';

--- a/tests/unit/Plugins/Auth/AuthenticationHttpTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationHttpTest.php
@@ -33,8 +33,6 @@ class AuthenticationHttpTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         DatabaseInterface::$instance = $this->createDatabaseInterface();
         Config::getInstance()->settings['Servers'] = [];
         Current::$database = 'db';

--- a/tests/unit/Plugins/Auth/AuthenticationSignonTest.php
+++ b/tests/unit/Plugins/Auth/AuthenticationSignonTest.php
@@ -37,8 +37,6 @@ class AuthenticationSignonTest extends AbstractTestCase
 
         $this->setLanguage();
 
-        $this->setGlobalConfig();
-
         DatabaseInterface::$instance = $this->createDatabaseInterface();
         Current::$database = 'db';
         Current::$table = 'table';

--- a/tests/unit/Plugins/Import/ImportLdiTest.php
+++ b/tests/unit/Plugins/Import/ImportLdiTest.php
@@ -14,7 +14,6 @@ use PhpMyAdmin\Import\ImportSettings;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Plugins\Import\ImportLdi;
 use PhpMyAdmin\Tests\AbstractTestCase;
-use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Medium;
 
@@ -57,7 +56,6 @@ class ImportLdiTest extends AbstractTestCase
         $config->settings['Import']['ldi_escaped'] = '\\';
         $config->settings['Import']['ldi_new_line'] = 'auto';
         $config->settings['Import']['ldi_columns'] = '';
-        $config->settings['Import']['ldi_local_option'] = false;
         Current::$table = 'phpmyadmintest';
     }
 
@@ -67,39 +65,6 @@ class ImportLdiTest extends AbstractTestCase
     public function testGetProperties(): void
     {
         $properties = (new ImportLdi())->getProperties();
-        self::assertSame(
-            __('CSV using LOAD DATA'),
-            $properties->getText(),
-        );
-        self::assertSame(
-            'ldi',
-            $properties->getExtension(),
-        );
-    }
-
-    /**
-     * Test for getProperties for ldi_local_option = auto
-     */
-    public function testGetPropertiesAutoLdi(): void
-    {
-        $dbi = self::createMock(DatabaseInterface::class);
-        DatabaseInterface::$instance = $dbi;
-
-        $resultStub = self::createMock(DummyResult::class);
-
-        $dbi->expects(self::any())->method('tryQuery')
-            ->willReturn($resultStub);
-
-        $resultStub->expects(self::any())->method('numRows')
-            ->willReturn(10);
-
-        $resultStub->expects(self::any())->method('fetchValue')
-            ->willReturn('ON');
-
-        $config = Config::getInstance();
-        $config->settings['Import']['ldi_local_option'] = 'auto';
-        $properties = (new ImportLdi())->getProperties();
-        self::assertTrue($config->settings['Import']['ldi_local_option']);
         self::assertSame(
             __('CSV using LOAD DATA'),
             $properties->getText(),

--- a/tests/unit/Setup/ConfigGeneratorTest.php
+++ b/tests/unit/Setup/ConfigGeneratorTest.php
@@ -31,8 +31,6 @@ class ConfigGeneratorTest extends AbstractTestCase
     {
         unset($_SESSION['eol']);
 
-        $this->setGlobalConfig();
-
         Current::$server = 2;
         $cf = new ConfigFile();
         $_SESSION['ConfigFile2'] = ['a', 'b', 'c'];

--- a/tests/unit/Theme/ThemeManagerTest.php
+++ b/tests/unit/Theme/ThemeManagerTest.php
@@ -19,8 +19,6 @@ class ThemeManagerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         Current::$server = 99;
     }
 

--- a/tests/unit/Theme/ThemeTest.php
+++ b/tests/unit/Theme/ThemeTest.php
@@ -32,8 +32,6 @@ class ThemeTest extends AbstractTestCase
         parent::setUp();
 
         $this->object = new Theme();
-
-        $this->setGlobalConfig();
     }
 
     /**

--- a/tests/unit/Triggers/TriggersTest.php
+++ b/tests/unit/Triggers/TriggersTest.php
@@ -26,8 +26,6 @@ class TriggersTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->setGlobalConfig();
-
         $this->setLanguage();
 
         DatabaseInterface::$instance = $this->createDatabaseInterface();

--- a/tests/unit/TwoFactorTest.php
+++ b/tests/unit/TwoFactorTest.php
@@ -61,6 +61,8 @@ class TwoFactorTest extends AbstractTestCase
     protected function tearDown(): void
     {
         $this->dummyDbi->assertAllSelectsConsumed();
+
+        parent::tearDown();
     }
 
     private function initStorageConfigAndData(): void

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -104,17 +104,17 @@ class UtilTest extends AbstractTestCase
 
     public function testClearUserCache(): void
     {
-        Config::getInstance()->selectedServer['user'] = null;
+        Config::getInstance()->selectedServer['user'] = '';
         Current::$server = 2;
         SessionCache::set('is_superuser', 'yes');
-        self::assertSame('yes', $_SESSION['cache']['server_2']['is_superuser']);
+        self::assertSame('yes', $_SESSION['cache']['server_2_']['is_superuser']);
 
         SessionCache::set('mysql_cur_user', 'mysql');
-        self::assertSame('mysql', $_SESSION['cache']['server_2']['mysql_cur_user']);
+        self::assertSame('mysql', $_SESSION['cache']['server_2_']['mysql_cur_user']);
 
         Util::clearUserCache();
-        self::assertArrayNotHasKey('is_superuser', $_SESSION['cache']['server_2']);
-        self::assertArrayNotHasKey('mysql_cur_user', $_SESSION['cache']['server_2']);
+        self::assertArrayNotHasKey('is_superuser', $_SESSION['cache']['server_2_']);
+        self::assertArrayNotHasKey('mysql_cur_user', $_SESSION['cache']['server_2_']);
     }
 
     /**

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -160,8 +160,6 @@ class UtilTest extends AbstractTestCase
     #[DataProvider('providerExpandUserString')]
     public function testExpandUserString(string $in, string $out): void
     {
-        $this->setGlobalConfig();
-
         $config = Config::getInstance();
         $config->selectedServer['host'] = 'host&';
         $config->selectedServer['verbose'] = 'verbose';

--- a/tests/unit/Utils/SessionCacheTest.php
+++ b/tests/unit/Utils/SessionCacheTest.php
@@ -16,7 +16,7 @@ class SessionCacheTest extends TestCase
     public function testGet(): void
     {
         $_SESSION = [];
-        Config::getInstance()->selectedServer['user'] = null;
+        Config::getInstance()->selectedServer['user'] = '';
 
         SessionCache::set('test_data', 5);
         SessionCache::set('test_data_2', 5);
@@ -29,35 +29,35 @@ class SessionCacheTest extends TestCase
     public function testRemove(): void
     {
         $_SESSION = [];
-        Config::getInstance()->selectedServer['user'] = null;
+        Config::getInstance()->selectedServer['user'] = '';
         Current::$server = 2;
 
         SessionCache::set('test_data', 25);
         SessionCache::set('test_data_2', 25);
 
         SessionCache::remove('test_data');
-        self::assertArrayNotHasKey('test_data', $_SESSION['cache']['server_2']);
+        self::assertArrayNotHasKey('test_data', $_SESSION['cache']['server_2_']);
         SessionCache::remove('test_data_2');
-        self::assertArrayNotHasKey('test_data_2', $_SESSION['cache']['server_2']);
+        self::assertArrayNotHasKey('test_data_2', $_SESSION['cache']['server_2_']);
     }
 
     public function testSet(): void
     {
         $_SESSION = [];
-        Config::getInstance()->selectedServer['user'] = null;
+        Config::getInstance()->selectedServer['user'] = '';
         Current::$server = 2;
 
         SessionCache::set('test_data', 25);
         SessionCache::set('test_data', 5);
-        self::assertSame(5, $_SESSION['cache']['server_2']['test_data']);
+        self::assertSame(5, $_SESSION['cache']['server_2_']['test_data']);
         SessionCache::set('test_data_3', 3);
-        self::assertSame(3, $_SESSION['cache']['server_2']['test_data_3']);
+        self::assertSame(3, $_SESSION['cache']['server_2_']['test_data_3']);
     }
 
     public function testHas(): void
     {
         $_SESSION = [];
-        Config::getInstance()->selectedServer['user'] = null;
+        Config::getInstance()->selectedServer['user'] = '';
 
         SessionCache::set('test_data', 5);
         SessionCache::set('test_data_2', 5);
@@ -74,16 +74,16 @@ class SessionCacheTest extends TestCase
     public function testKeyWithoutUser(): void
     {
         $_SESSION = [];
-        Config::getInstance()->selectedServer['user'] = null;
+        Config::getInstance()->selectedServer['user'] = '';
         Current::$server = 123;
 
         SessionCache::set('test_data', 5);
         self::assertArrayHasKey('cache', $_SESSION);
         self::assertIsArray($_SESSION['cache']);
-        self::assertArrayHasKey('server_123', $_SESSION['cache']);
-        self::assertIsArray($_SESSION['cache']['server_123']);
-        self::assertArrayHasKey('test_data', $_SESSION['cache']['server_123']);
-        self::assertSame(5, $_SESSION['cache']['server_123']['test_data']);
+        self::assertArrayHasKey('server_123_', $_SESSION['cache']);
+        self::assertIsArray($_SESSION['cache']['server_123_']);
+        self::assertArrayHasKey('test_data', $_SESSION['cache']['server_123_']);
+        self::assertSame(5, $_SESSION['cache']['server_123_']['test_data']);
     }
 
     public function testKeyWithUser(): void


### PR DESCRIPTION
I understand that these changes can be a little difficult to understand, so please don't hesitate to ask me for more details. Most of it is just removing dead code from unit tests. `ldi_local_option` was unused and I doubt it was ever implemented properly so I removed it completely. `Config::set()` was expanded to handle nested values because it is the best way to adjust settings in unit tests. But it is far from an ideal solution so it may change in the future. `array_replace_recursive` was removed even though it would allow non-config settings to be stored prior to that. At the moment, I wasn't able to find a use for it, but I admit that I could have missed one somewhere. The coupling with `UserPreferencesHandler` is the most troubling, but I hope to improve that with time too. 