### PR TITLE
Remove nullability from $db param

### DIFF
--- a/src/Plugins/Export/ExportCsv.php
+++ b/src/Plugins/Export/ExportCsv.php
@@ -213,16 +213,16 @@ class ExportCsv extends ExportPlugin
     /**
      * Outputs result of raw query in CSV format
      *
-     * @param string|null $db       the database where the query is executed
-     * @param string      $sqlQuery the rawquery to output
+     * @param string $db       the database where the query is executed
+     * @param string $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): void
+    public function exportRawQuery(string $db, string $sqlQuery): void
     {
-        if ($db !== null) {
+        if ($db !== '') {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db, '', $sqlQuery);
     }
 
     /** @inheritDoc */

--- a/src/Plugins/Export/ExportExcel.php
+++ b/src/Plugins/Export/ExportExcel.php
@@ -211,16 +211,16 @@ class ExportExcel extends ExportPlugin
     /**
      * Outputs result of raw query in CSV format
      *
-     * @param string|null $db       the database where the query is executed
-     * @param string      $sqlQuery the rawquery to output
+     * @param string $db       the database where the query is executed
+     * @param string $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): void
+    public function exportRawQuery(string $db, string $sqlQuery): void
     {
-        if ($db !== null) {
+        if ($db !== '') {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db, '', $sqlQuery);
     }
 
     /** @inheritDoc */

--- a/src/Plugins/Export/ExportJson.php
+++ b/src/Plugins/Export/ExportJson.php
@@ -276,10 +276,10 @@ class ExportJson extends ExportPlugin
     /**
      * Outputs result raw query in JSON format
      *
-     * @param string|null $db       the database where the query is executed
-     * @param string      $sqlQuery the rawquery to output
+     * @param string $db       the database where the query is executed
+     * @param string $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): void
+    public function exportRawQuery(string $db, string $sqlQuery): void
     {
         $buffer = $this->encode(['type' => 'raw', 'data' => '@@DATA@@']);
         if ($buffer === false) {
@@ -287,7 +287,7 @@ class ExportJson extends ExportPlugin
         }
 
         $dbi = DatabaseInterface::getInstance();
-        if ($db !== null) {
+        if ($db !== '') {
             $dbi->selectDb($db);
         }
 

--- a/src/Plugins/Export/ExportLatex.php
+++ b/src/Plugins/Export/ExportLatex.php
@@ -371,16 +371,16 @@ class ExportLatex extends ExportPlugin
     /**
      * Outputs result raw query
      *
-     * @param string|null $db       the database where the query is executed
-     * @param string      $sqlQuery the rawquery to output
+     * @param string $db       the database where the query is executed
+     * @param string $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): void
+    public function exportRawQuery(string $db, string $sqlQuery): void
     {
-        if ($db !== null) {
+        if ($db !== '') {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db, '', $sqlQuery);
     }
 
     /**

--- a/src/Plugins/Export/ExportMediawiki.php
+++ b/src/Plugins/Export/ExportMediawiki.php
@@ -246,16 +246,16 @@ class ExportMediawiki extends ExportPlugin
     /**
      * Outputs result raw query in MediaWiki format
      *
-     * @param string|null $db       the database where the query is executed
-     * @param string      $sqlQuery the rawquery to output
+     * @param string $db       the database where the query is executed
+     * @param string $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): void
+    public function exportRawQuery(string $db, string $sqlQuery): void
     {
-        if ($db !== null) {
+        if ($db !== '') {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db, '', $sqlQuery);
     }
 
     /**

--- a/src/Plugins/Export/ExportOds.php
+++ b/src/Plugins/Export/ExportOds.php
@@ -259,16 +259,16 @@ class ExportOds extends ExportPlugin
     /**
      * Outputs result raw query in ODS format
      *
-     * @param string|null $db       the database where the query is executed
-     * @param string      $sqlQuery the rawquery to output
+     * @param string $db       the database where the query is executed
+     * @param string $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): void
+    public function exportRawQuery(string $db, string $sqlQuery): void
     {
-        if ($db !== null) {
+        if ($db !== '') {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db, '', $sqlQuery);
     }
 
     /** @inheritDoc */

--- a/src/Plugins/Export/ExportOdt.php
+++ b/src/Plugins/Export/ExportOdt.php
@@ -281,16 +281,16 @@ class ExportOdt extends ExportPlugin
     /**
      * Outputs result raw query in ODT format
      *
-     * @param string|null $db       the database where the query is executed
-     * @param string      $sqlQuery the rawquery to output
+     * @param string $db       the database where the query is executed
+     * @param string $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): void
+    public function exportRawQuery(string $db, string $sqlQuery): void
     {
-        if ($db !== null) {
+        if ($db !== '') {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db, '', $sqlQuery);
     }
 
     /**

--- a/src/Plugins/Export/ExportPdf.php
+++ b/src/Plugins/Export/ExportPdf.php
@@ -135,16 +135,16 @@ class ExportPdf extends ExportPlugin
     /**
      * Outputs result of raw query in PDF format
      *
-     * @param string|null $db       the database where the query is executed
-     * @param string      $sqlQuery the rawquery to output
+     * @param string $db       the database where the query is executed
+     * @param string $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): void
+    public function exportRawQuery(string $db, string $sqlQuery): void
     {
         $this->pdf->setDbAlias('----');
         $this->pdf->setTableAlias('----');
         $this->pdf->setPurpose(__('Query result data'));
 
-        if ($db !== null) {
+        if ($db !== '') {
             $this->pdf->setCurrentDb($db);
             DatabaseInterface::getInstance()->selectDb($db);
         }

--- a/src/Plugins/Export/ExportPhparray.php
+++ b/src/Plugins/Export/ExportPhparray.php
@@ -191,16 +191,16 @@ class ExportPhparray extends ExportPlugin
     /**
      * Outputs result of raw query as PHP array
      *
-     * @param string|null $db       the database where the query is executed
-     * @param string      $sqlQuery the rawquery to output
+     * @param string $db       the database where the query is executed
+     * @param string $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): void
+    public function exportRawQuery(string $db, string $sqlQuery): void
     {
-        if ($db !== null) {
+        if ($db !== '') {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db, '', $sqlQuery);
     }
 
     /** @inheritDoc */

--- a/src/Plugins/Export/ExportSql.php
+++ b/src/Plugins/Export/ExportSql.php
@@ -1807,16 +1807,16 @@ class ExportSql extends ExportPlugin
     /**
      * Outputs a raw query
      *
-     * @param string|null $db       the database where the query is executed
-     * @param string      $sqlQuery the rawquery to output
+     * @param string $db       the database where the query is executed
+     * @param string $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): void
+    public function exportRawQuery(string $db, string $sqlQuery): void
     {
-        if ($db !== null) {
+        if ($db !== '') {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db, '', $sqlQuery);
     }
 
     /**

--- a/src/Plugins/Export/ExportTexytext.php
+++ b/src/Plugins/Export/ExportTexytext.php
@@ -185,16 +185,16 @@ class ExportTexytext extends ExportPlugin
     /**
      * Outputs result raw query in TexyText format
      *
-     * @param string|null $db       the database where the query is executed
-     * @param string      $sqlQuery the rawquery to output
+     * @param string $db       the database where the query is executed
+     * @param string $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): void
+    public function exportRawQuery(string $db, string $sqlQuery): void
     {
-        if ($db !== null) {
+        if ($db !== '') {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db, '', $sqlQuery);
     }
 
     /**

--- a/src/Plugins/Export/ExportYaml.php
+++ b/src/Plugins/Export/ExportYaml.php
@@ -151,16 +151,16 @@ class ExportYaml extends ExportPlugin
     /**
      * Outputs result raw query in YAML format
      *
-     * @param string|null $db       the database where the query is executed
-     * @param string      $sqlQuery the rawquery to output
+     * @param string $db       the database where the query is executed
+     * @param string $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): void
+    public function exportRawQuery(string $db, string $sqlQuery): void
     {
-        if ($db !== null) {
+        if ($db !== '') {
             DatabaseInterface::getInstance()->selectDb($db);
         }
 
-        $this->exportData($db ?? '', '', $sqlQuery);
+        $this->exportData($db, '', $sqlQuery);
     }
 
     /** @inheritDoc */

--- a/src/Plugins/ExportPlugin.php
+++ b/src/Plugins/ExportPlugin.php
@@ -129,10 +129,10 @@ abstract class ExportPlugin implements Plugin
     /**
      * Outputs for raw query
      *
-     * @param string|null $db       the database where the query is executed
-     * @param string      $sqlQuery the rawquery to output
+     * @param string $db       the database where the query is executed
+     * @param string $sqlQuery the rawquery to output
      */
-    public function exportRawQuery(string|null $db, string $sqlQuery): void
+    public function exportRawQuery(string $db, string $sqlQuery): void
     {
     }
 

--- a/tests/unit/Plugins/Export/ExportJsonTest.php
+++ b/tests/unit/Plugins/Export/ExportJsonTest.php
@@ -194,6 +194,6 @@ class ExportJsonTest extends AbstractTestCase
             . "]\n}\n",
         );
 
-        $this->object->exportRawQuery(null, 'SELECT * FROM `test_db`.`test_table_complex`;');
+        $this->object->exportRawQuery('', 'SELECT * FROM `test_db`.`test_table_complex`;');
     }
 }


### PR DESCRIPTION
The param is never null. The `selectDb` needs to stay because queries like `SELECT foo FROM (SELECT * FROM t) a` will fail otherwise. This whole feature is a bit wonky though because some export types just don't make sense, e.g. SQL. 