### PR TITLE
Fix case where user preferences are not removed

### DIFF
--- a/libraries/classes/UserPreferences.php
+++ b/libraries/classes/UserPreferences.php
@@ -131,7 +131,7 @@ class UserPreferences
             $existingPrefs = $this->load();
             if (isset($existingPrefs['config_data']['2fa'])) {
                 // This is likely a partial save from page settings - merge to preserve 2fa
-                $config_array = array_merge($existingPrefs['config_data'], $config_array);
+                $config_array['2fa'] = $existingPrefs['config_data']['2fa'];
             }
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -48751,16 +48751,6 @@ parameters:
 			path: test/classes/UserPreferencesTest.php
 
 		-
-			message: "#^Cannot access offset '2fa' on mixed\\.$#"
-			count: 1
-			path: test/classes/UserPreferencesTest.php
-
-		-
-			message: "#^Cannot access offset 'Console/Mode' on mixed\\.$#"
-			count: 1
-			path: test/classes/UserPreferencesTest.php
-
-		-
 			message: "#^Cannot access offset 'DisableIS' on mixed\\.$#"
 			count: 1
 			path: test/classes/UserPreferencesTest.php
@@ -48791,17 +48781,7 @@ parameters:
 			path: test/classes/UserPreferencesTest.php
 
 		-
-			message: "#^Cannot access offset 'secret' on mixed\\.$#"
-			count: 1
-			path: test/classes/UserPreferencesTest.php
-
-		-
 			message: "#^Cannot access offset 'server_2' on mixed\\.$#"
-			count: 1
-			path: test/classes/UserPreferencesTest.php
-
-		-
-			message: "#^Cannot access offset 'settings' on mixed\\.$#"
 			count: 1
 			path: test/classes/UserPreferencesTest.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14186,9 +14186,10 @@
       <code>$allowList[$path]</code>
       <code>$excludeList[$path]</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="6">
       <code>$configData</code>
       <code>$configData</code>
+      <code>$config_array['2fa']</code>
       <code>$prefs['config_data'][$path]</code>
       <code>$timestamp</code>
       <code>$value</code>
@@ -16451,17 +16452,12 @@
     </MixedMethodCall>
   </file>
   <file src="test/classes/UserPreferencesTest.php">
-    <InvalidArrayOffset occurrences="2">
-      <code>$resultConfig['2fa']</code>
-      <code>$resultConfig['Console/Mode']</code>
-    </InvalidArrayOffset>
     <MixedArgument occurrences="1">
       <code>$_SESSION['userconfig']</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="3">
+    <MixedArrayAccess occurrences="2">
       <code>$_SESSION['userconfig']['db']</code>
       <code>$_SESSION['userconfig']['ts']</code>
-      <code>$resultConfig['2fa']['settings']</code>
     </MixedArrayAccess>
     <TypeDoesNotContainType occurrences="1">
       <code>assertTrue</code>

--- a/test/classes/UserPreferencesTest.php
+++ b/test/classes/UserPreferencesTest.php
@@ -233,19 +233,30 @@ class UserPreferencesTest extends AbstractNetworkTestCase
 
         // Initial save with 2fa
         $initialConfig = [
+            'CharEditing' => 'textarea',
             '2fa' => ['backend' => 'application', 'settings' => ['secret' => 'thisisasecret']],
-            'theme' => 'dark',
+            'RowActionLinks' => 'both',
+            'TableNavigationLinksMode' => 'both',
         ];
         $this->userPreferences->save($initialConfig);
 
         // Partial save without 2fa
-        $partialConfig = ['Console/Mode' => 'collapse'];
+        $partialConfig = [
+            'CharEditing' => 'textarea',
+            'TableNavigationLinksMode' => 'text',
+            'Console/Mode' => 'collapse',
+        ];
         $this->userPreferences->save($partialConfig);
 
         // Check that 2fa is still present
         $resultConfig = $_SESSION['userconfig']['db'];
-        self::assertSame('thisisasecret', $resultConfig['2fa']['settings']['secret']);
-        self::assertSame('collapse', $resultConfig['Console/Mode']);
+        $expected = [
+            'CharEditing' => 'textarea',
+            'TableNavigationLinksMode' => 'text',
+            'Console/Mode' => 'collapse',
+            '2fa' => ['backend' => 'application', 'settings' => ['secret' => 'thisisasecret']],
+        ];
+        self::assertSame($expected, $resultConfig);
     }
 
     /**


### PR DESCRIPTION
When an user revert a setting to its default value, the setting is not removed from the storage.

- Introduced by https://github.com/phpmyadmin/phpmyadmin/pull/19925
- Related to https://github.com/phpmyadmin/phpmyadmin/pull/19900


