### PR TITLE
Remove getStatusInfo from tests

### DIFF
--- a/tests/unit/Table/TableTest.php
+++ b/tests/unit/Table/TableTest.php
@@ -1571,8 +1571,6 @@ class TableTest extends AbstractTestCase
         $targetDb = 'pma_test';
         $extension = new DbiDummy();
         $dbi = DatabaseInterface::getInstanceForTest($extension);
-        $tblObject = new Table($targetTable, $targetDb, $dbi);
-        $tblObject->getStatusInfo();
         $expect = 'DBIdummy';
         $tblStorageEngine = $dbi->getTable($targetDb, $targetTable)->getStorageEngine();
         self::assertSame($expect, $tblStorageEngine);
@@ -1587,8 +1585,6 @@ class TableTest extends AbstractTestCase
         $targetDb = 'pma_test';
         $extension = new DbiDummy();
         $dbi = DatabaseInterface::getInstanceForTest($extension);
-        $tblObject = new Table($targetTable, $targetDb, $dbi);
-        $tblObject->getStatusInfo();
         $expect = 'Test comment for "table1" in \'pma_test\'';
         $showComment = $dbi->getTable($targetDb, $targetTable)->getComment();
         self::assertSame($expect, $showComment);
@@ -1603,8 +1599,6 @@ class TableTest extends AbstractTestCase
         $targetDb = 'pma_test';
         $extension = new DbiDummy();
         $dbi = DatabaseInterface::getInstanceForTest($extension);
-        $tblObject = new Table($targetTable, $targetDb, $dbi);
-        $tblObject->getStatusInfo();
         $expect = 'utf8mb4_general_ci';
         $tblCollation = $dbi->getTable($targetDb, $targetTable)->getCollation();
         self::assertSame($expect, $tblCollation);
@@ -1619,8 +1613,6 @@ class TableTest extends AbstractTestCase
         $targetDb = 'pma_test';
         $extension = new DbiDummy();
         $dbi = DatabaseInterface::getInstanceForTest($extension);
-        $tblObject = new Table($targetTable, $targetDb, $dbi);
-        $tblObject->getStatusInfo();
         $expect = 'Redundant';
         $rowFormat = $dbi->getTable($targetDb, $targetTable)->getRowFormat();
         self::assertSame($expect, $rowFormat);
@@ -1635,8 +1627,6 @@ class TableTest extends AbstractTestCase
         $targetDb = 'pma_test';
         $extension = new DbiDummy();
         $dbi = DatabaseInterface::getInstanceForTest($extension);
-        $tblObject = new Table($targetTable, $targetDb, $dbi);
-        $tblObject->getStatusInfo();
         $expect = '5';
         $autoIncrement = $dbi->getTable($targetDb, $targetTable)->getAutoIncrement();
         self::assertSame($expect, $autoIncrement);
@@ -1651,8 +1641,6 @@ class TableTest extends AbstractTestCase
         $targetDb = 'pma_test';
         $extension = new DbiDummy();
         $dbi = DatabaseInterface::getInstanceForTest($extension);
-        $tblObject = new Table($targetTable, $targetDb, $dbi);
-        $tblObject->getStatusInfo();
         $expect = ['pack_keys' => 'DEFAULT', 'row_format' => 'REDUNDANT'];
         $createOptions = $dbi->getTable($targetDb, $targetTable)->getCreateOptions();
         self::assertEquals($expect, $createOptions);


### PR DESCRIPTION
Unnecessary code in the tests. 