### PR TITLE
Hide filter from print

### DIFF
--- a/resources/templates/filter.twig
+++ b/resources/templates/filter.twig
@@ -1,4 +1,4 @@
-<div class="card mb-3" id="tableFilter">
+<div class="card mb-3 d-print-none" id="tableFilter">
   <div class="card-header">{{ t('Filters') }}</div>
   <div class="card-body row row-cols-lg-auto gy-1 gx-3 align-items-center">
     <label class="col-12 col-form-label" for="filterText">{{ t('Containing the word:') }}</label>


### PR DESCRIPTION
`Filters` does not work on papers 😅

<img width="953" height="271" alt="image" src="https://github.com/user-attachments/assets/b35bb8e6-b49e-4ef6-b238-4e509a8076ab" />