### PR TITLE
Set sql mode for sql-parser when connecting to db

### DIFF
--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -1104,10 +1104,11 @@ class DatabaseInterface implements DbalInterface
      */
     public function postConnect(): void
     {
-        $version = $this->fetchSingleRow('SELECT @@version, @@version_comment');
+        $version = $this->fetchSingleRow('SELECT @@version, @@version_comment, @@sql_mode');
 
         if (is_array($version)) {
             $this->setVersion($version);
+            Context::setMode($version['@@sql_mode']);
         }
 
         if ($this->versionInt > 50503) {

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -1103,11 +1103,6 @@ class Table implements Stringable
              */
             $destination = new Expression($targetDb, $targetTable, '');
 
-            // Find server's SQL mode so the builder can generate correct
-            // queries.
-            // One of the options that alters the behaviour is `ANSI_QUOTES`.
-            Context::setMode((string) $dbi->fetchValue('SELECT @@sql_mode'));
-
             // -----------------------------------------------------------------
             // Phase 1: Dropping existent element of the same name (if exists
             // and required).

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15066,6 +15066,11 @@ parameters:
 			path: libraries/classes/DatabaseInterface.php
 
 		-
+			message: "#^Parameter \\#1 \\$mode of static method PhpMyAdmin\\\\SqlParser\\\\Context\\:\\:setMode\\(\\) expects int\\|string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/DatabaseInterface.php
+
+		-
 			message: "#^Parameter \\#1 \\$path of function basename expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php
@@ -35121,11 +35126,6 @@ parameters:
 			path: libraries/classes/Table.php
 
 		-
-			message: "#^Cannot call method fetchValue\\(\\) on mixed\\.$#"
-			count: 1
-			path: libraries/classes/Table.php
-
-		-
 			message: "#^Cannot call method insertId\\(\\) on mixed\\.$#"
 			count: 1
 			path: libraries/classes/Table.php
@@ -35152,7 +35152,7 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
-			count: 4
+			count: 3
 			path: libraries/classes/Table.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5706,7 +5706,7 @@
     <InvalidReturnType occurrences="1">
       <code>int|bool</code>
     </InvalidReturnType>
-    <MixedArgument occurrences="46">
+    <MixedArgument occurrences="47">
       <code>$a</code>
       <code>$arrayKeys</code>
       <code>$b</code>
@@ -5752,6 +5752,7 @@
       <code>$user</code>
       <code>$user</code>
       <code>$user</code>
+      <code>$version['@@sql_mode']</code>
       <code>$warningsCount</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="5">

--- a/test/classes/DatabaseInterfaceTest.php
+++ b/test/classes/DatabaseInterfaceTest.php
@@ -277,6 +277,8 @@ class DatabaseInterfaceTest extends AbstractTestCase
         $versionQueryResult = [
             '@@version' => '10.20.7-MariaDB-1:10.9.3+maria~ubu2204',
             '@@version_comment' => 'mariadb.org binary distribution',
+            '@@sql_mode' => 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,'
+                . 'NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION',
         ];
 
         $mock = $this->getMockBuilder(DatabaseInterface::class)
@@ -905,6 +907,8 @@ class DatabaseInterfaceTest extends AbstractTestCase
                 [
                     '@@version' => '6.1.0',
                     '@@version_comment' => "Percona Server (GPL), Release '11', Revision 'c1y2gr1df4a'",
+                    '@@sql_mode' => 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,'
+                        . 'NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION',
                 ],
                 60100,
                 false,
@@ -914,6 +918,8 @@ class DatabaseInterfaceTest extends AbstractTestCase
                 [
                     '@@version' => '10.01.40-MariaDB-1:10.01.40+maria~ubu2204',
                     '@@version_comment' => 'mariadb.org binary distribution',
+                    '@@sql_mode' => 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,'
+                        . 'NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION',
                 ],
                 100140,
                 true,
@@ -923,6 +929,8 @@ class DatabaseInterfaceTest extends AbstractTestCase
                 [
                     '@@version' => '7.10.3',
                     '@@version_comment' => 'MySQL Community Server (GPL)',
+                    '@@sql_mode' => 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,'
+                        . 'NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION',
                 ],
                 71003,
                 false,
@@ -932,6 +940,8 @@ class DatabaseInterfaceTest extends AbstractTestCase
                 [
                     '@@version' => '5.5.0',
                     '@@version_comment' => '',
+                    '@@sql_mode' => 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,'
+                        . 'NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION',
                 ],
                 50500,
                 false,


### PR DESCRIPTION
Always use the actual server sql mode for the sql parser instead of assuming a default.