### PR TITLE
Fix #20065 - event creation when server drops past event

### DIFF
--- a/libraries/classes/Database/Events.php
+++ b/libraries/classes/Database/Events.php
@@ -174,6 +174,16 @@ class Events
             if ($this->response->isAjax()) {
                 if ($message->isSuccess()) {
                     $events = $this->dbi->getEvents($db, $_POST['item_name']);
+                    if ($events === []) {
+                        $this->response->setRequestStatus(false);
+                        $this->response->addJSON(
+                            'message',
+                            __('The event was dropped immediately after creation.')
+                        );
+                        $this->response->addJSON('tableType', 'events');
+                        exit;
+                    }
+
                     $event = $events[0];
                     $this->response->addJSON(
                         'name',


### PR DESCRIPTION
### Description
Fixes a fatal error when creating a one-time event scheduled in the past with `ON COMPLETION NOT PRESERVE`. In this case the server drops the event immediately, so the events list is empty and `$events[0]` triggers “Undefined array key 0”. This change detects the empty result and returns a clear error message instead of crashing.

Fixes #20065

### Checklist
- [x] Read CONTRIBUTING.md
- [x] Targeted the correct branch
- [x] Signed-off-by line present
- [x] Descriptive commit message
- [ ] Tests added/updated (not applicable for this small guard)
