### PR TITLE
Fix display of timestamp after inline edit

### DIFF
--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -708,7 +708,10 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
 
                         // remove decimal places if column type not supported
                         if ((decimals === 0) && ($thisField.attr('data-type').indexOf('time') !== -1)) {
-                            newHtml = newHtml.substring(0, newHtml.indexOf('.'));
+                            var index = newHtml.indexOf('.');
+                            if (index !== -1) {
+                                newHtml = newHtml.substring(0, index);
+                            }
                         }
 
                         // remove additional decimal places


### PR DESCRIPTION
Fixes #20072

The old value was being replaced by an empty string instead of the new value because the timestamp value has no decimals.