### PR TITLE
Fix #19368 - Improve line ending handling in grid editor

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -4070,16 +4070,28 @@ Functions.getCellValue = function (td) {
 /**
  * Validate and return stringified JSON inputs, or plain if invalid.
  *
- * @param json the json input to be validated and stringified
+ * @param value the json input to be validated and stringified
  * @param replacer An array of strings and numbers that acts as an approved list for selecting the object properties that will be stringified.
  * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
  * @return {string}
  */
-Functions.stringifyJSON = function (json, replacer = null, space = 0) {
+Functions.stringifyJSON = function (value, replacer = null, space = 0) {
     try {
-        return JSON.stringify(JSON.parse(json), replacer, space);
+        // If already an object/array, stringify directly
+        if (typeof value === 'object' && value !== null) {
+            return JSON.stringify(value, replacer, space);
+        }
+
+        // If string, try to parse then stringify (normalizes formatting)
+        if (typeof value === 'string') {
+            return JSON.stringify(JSON.parse(value), replacer, space);
+        }
+
+        // Fallback: force string
+        return String(value);
     } catch (e) {
-        return json;
+        console.log('error occured in stringifying json');
+        return String(value);
     }
 };
 

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -4090,7 +4090,6 @@ Functions.stringifyJSON = function (value, replacer = null, space = 0) {
         // Fallback: force string
         return String(value);
     } catch (e) {
-        console.log('error occured in stringifying json');
         return String(value);
     }
 };

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -4037,6 +4037,17 @@ AJAX.registerOnload('functions.js', function () {
 }(jQuery));
 
 /**
+ * Normalize line endings for comparison purposes.
+ * Browsers normalize textarea values to LF per HTML spec.
+ *
+ * @param {string} value
+ * @return {string}
+ */
+Functions.normalizeNewlines = function (value) {
+    return value.replace(/\r\n|\r/g, '\n');
+};
+
+/**
  * Return value of a cell in a table.
  *
  * @param {string} td

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -751,8 +751,8 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                             $target.html(newHtml);
                         }
                         $thisField.data('originalValue', value);
-                        if ($(g.currentEditCell).data('lineEnding') !== $(g.currentEditCell).attr('data-line-ending')) {
-                            $(g.currentEditCell).attr('data-line-ending', $(g.currentEditCell).data('lineEnding'));
+                        if ($thisField.data('lineEnding') !== $thisField.attr('data-line-ending')) {
+                            $thisField.attr('data-line-ending', $thisField.data('lineEnding'));
                         }
                     }
                     if ($thisField.is('.bit')) {
@@ -924,13 +924,13 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
 
                 if (hasLineEnding) {
                     // Canonical server truth (preferred)
-                    let originalValue = $td.data('originalValue');
+                    let originalValue = $(g.currentEditCell).data('originalValue');
                     // Fallback ONLY if not present (AJAX-fetched truncated case)
                     if (originalValue === undefined) {
                         originalValue = Functions.normalizeNewlines(
                             Functions.getCellValue(g.currentEditCell)
                         );
-                        $td.data('originalValue', originalValue);
+                        $(g.currentEditCell).data('originalValue', originalValue);
                     }
                     // Cache it once
                     $editArea.append(
@@ -949,11 +949,11 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                             '</label>' +
                         '</div>'
                     );
-                    var detectedEnding = $td.data('lineEnding');
+                    var detectedEnding = $(g.currentEditCell).data('lineEnding');
                     $editArea.find('.line-ending-select').val(detectedEnding);
                     // handle change of line ending selection
-                    $editArea.on('change', '.line-ending-select', function () {
-                        $td.data('lineEnding', this.value);
+                    $editArea.find('.line-ending-select').off('change').on('change', function () {
+                        $(g.currentEditCell).data('lineEnding', this.value);
                     });
                 }
 

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -943,11 +943,6 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                     }
                     var crlfTemplateEl = document.getElementById('crlf-div-template-' + t.dataset.uniqueid);
                     var $crlfDiv = $(crlfTemplateEl.content.cloneNode(true));
-                    $crlfDiv.find('.line-ending-text').text(Messages.strLineEnding);
-                    $crlfDiv.find('img').attr({
-                        'title': Messages.strLineEndingDetected,
-                        'alt': Messages.strLineEndingDetected
-                    });
                     $editArea.append($crlfDiv);
                     var detectedEnding = $(g.currentEditCell).data('lineEnding');
                     $editArea.find('.line-ending-select').val(detectedEnding);

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -934,10 +934,10 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         '<div class="crlf_div">' +
                             '<label>' +
                                 '<span class="line-ending-label">' +
-                                    'Line endings' +
+                                    'Line ending:' +
                                     '<span>' +
                                         '<img src="themes/dot.gif" title="The suggested value was detected from your existing data." alt="The suggested value was detected from your existing data." class="icon ic_b_help">' +
-                                    '</span>:' +
+                                    '</span>' +
                                 '</span>' +
                                 '<select class="line-ending-select">' +
                                     '<option value="LF">LF</option>' +

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -701,7 +701,6 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                     if (isNull) {
                         $thisField.find('span').html('NULL');
                         $thisField.addClass('null');
-                        // todo: set original value to null & remove data-line-ending attribute
                         $thisField.data('originalValue', null);
                         if ($thisField.is('[data-line-ending]')) {
                             $thisField
@@ -711,8 +710,8 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                     } else {
                         $thisField.removeClass('null');
                         var value = data.isNeedToRecheck
-                            ? data.truncatableFieldValue.replace(/\r\n/g, '\n')
-                            : $thisField.data('value').replace(/\r\n/g, '\n');
+                            ? Functions.normalizeNewlines(data.truncatableFieldValue)
+                            : Functions.normalizeNewlines($thisField.data('value'));
 
                         // Truncates the text.
                         $thisField.removeClass('truncated');
@@ -937,9 +936,12 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         '<div class="crlf_div">' +
                             '<label>' +
                                 '<span class="line-ending-label">' +
-                                    'Line ending:' +
+                                    Messages.strLineEnding +
                                     '<span>' +
-                                        '<img src="themes/dot.gif" title="The suggested value was detected from your existing data." alt="The suggested value was detected from your existing data." class="icon ic_b_help">' +
+                                        '<img src="themes/dot.gif" ' +
+                                        'title="' + Functions.escapeHtml(Messages.strLineEndingDetected) + '" ' +
+                                        'alt="' + Functions.escapeHtml(Messages.strLineEndingDetected) + '" ' +
+                                        'class="icon ic_b_help">' +
                                     '</span>' +
                                 '</span>' +
                                 '<select class="line-ending-select">' +
@@ -1603,7 +1605,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         canonicalOldValue = String(Functions.normalizeNewlines(Functions.getCellValue(g.currentEditCell)));
                     }
                     // Normalizing to LFs only for text comparison.
-                    canonicalNewValue = (String(canonicalNewValue)).replace(/\r\n/g, '\n');
+                    canonicalNewValue = Functions.normalizeNewlines(String(canonicalNewValue));
                     isValueUpdated = (canonicalNewValue !== canonicalOldValue) || ($(g.currentEditCell).data('lineEnding') !== $(g.currentEditCell).attr('data-line-ending'));
                 } else {
                     const JSONString = Functions.stringifyJSON(thisFieldParams[fieldName]);

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -931,26 +931,14 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         );
                         $(g.currentEditCell).data('originalValue', originalValue);
                     }
-                    // Cache it once
-                    $editArea.append(
-                        '<div class="crlf_div">' +
-                            '<label>' +
-                                '<span class="line-ending-label">' +
-                                    Messages.strLineEnding +
-                                    '<span>' +
-                                        '<img src="themes/dot.gif" ' +
-                                        'title="' + Functions.escapeHtml(Messages.strLineEndingDetected) + '" ' +
-                                        'alt="' + Functions.escapeHtml(Messages.strLineEndingDetected) + '" ' +
-                                        'class="icon ic_b_help">' +
-                                    '</span>' +
-                                '</span>' +
-                                '<select class="line-ending-select">' +
-                                    '<option value="LF">LF</option>' +
-                                    '<option value="CRLF">CRLF</option>' +
-                                '</select>' +
-                            '</label>' +
-                        '</div>'
-                    );
+                    var crlfTemplateEl = document.getElementById('crlf-div-template-' + t.dataset.uniqueid);
+                    var $crlfDiv = $(crlfTemplateEl.content.cloneNode(true));
+                    $crlfDiv.find('.line-ending-text').text(Messages.strLineEnding);
+                    $crlfDiv.find('img').attr({
+                        'title': Messages.strLineEndingDetected,
+                        'alt': Messages.strLineEndingDetected
+                    });
+                    $editArea.append($crlfDiv);
                     var detectedEnding = $(g.currentEditCell).data('lineEnding');
                     $editArea.find('.line-ending-select').val(detectedEnding);
                     // handle change of line ending selection

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -750,8 +750,18 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                             $target.html(newHtml);
                         }
                         $thisField.data('originalValue', value);
-                        if ($thisField.data('lineEnding') !== $thisField.attr('data-line-ending')) {
-                            $thisField.attr('data-line-ending', $thisField.data('lineEnding'));
+                        if (value.indexOf('\n') !== -1) {
+                            // Value contains line breaks: ensure the attribute exists
+                            if (!$thisField.is('[data-line-ending]')) {
+                                $thisField.data('lineEnding', 'LF');
+                                $thisField.attr('data-line-ending', 'LF');
+                            } else if ($thisField.data('lineEnding') !== $thisField.attr('data-line-ending')) {
+                                $thisField.attr('data-line-ending', $thisField.data('lineEnding'));
+                            }
+                        } else if ($thisField.is('[data-line-ending]')) {
+                            // Value no longer has line breaks: remove the attribute
+                            $thisField.removeData('lineEnding');
+                            $thisField.removeAttr('data-line-ending');
                         }
                     }
                     if ($thisField.is('.bit')) {

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -1536,7 +1536,8 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
 
                 let isValueUpdated;
                 if ($thisField.attr('data-type') !== 'json') {
-                    isValueUpdated = thisFieldParams[fieldName] !== Functions.getCellValue(g.currentEditCell);
+                    let normalizedCellVal = Functions.normalizeNewlines(Functions.getCellValue(g.currentEditCell));
+                    isValueUpdated = thisFieldParams[fieldName] !== normalizedCellVal;
                 } else {
                     const JSONString = Functions.stringifyJSON(thisFieldParams[fieldName]);
                     isValueUpdated = JSONString !== Functions.stringifyJSON(Functions.getCellValue(g.currentEditCell));

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -713,7 +713,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         var value = data.isNeedToRecheck
                             ? data.truncatableFieldValue.replace(/\r\n/g, '\n')
                             : $thisField.data('value').replace(/\r\n/g, '\n');
-                        
+
                         // Truncates the text.
                         $thisField.removeClass('truncated');
                         if (CommonParams.get('pftext') === 'P' && value.length > g.maxTruncatedLen) {
@@ -919,15 +919,15 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                     });
                 }
 
-                if (hasLineEnding) {   
+                if (hasLineEnding) {
                     // Canonical server truth (preferred)
-                    let originalValue = $td.data('originalValue');  
+                    let originalValue = $td.data('originalValue');
                     // Fallback ONLY if not present (AJAX-fetched truncated case)
                     if (originalValue === undefined) {
                         originalValue = Functions.normalizeNewlines(
                             Functions.getCellValue(g.currentEditCell)
                         );
-                        $td.data('originalValue', originalValue);           
+                        $td.data('originalValue', originalValue);
                     }
                     // Cache it once
                     $editArea.append(
@@ -1596,7 +1596,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                     // Normalizing to LFs only for text comparison.
                     canonicalNewValue = canonicalNewValue.replace(/\r\n/g, '\n');
                     isValueUpdated = (canonicalNewValue !== canonicalOldValue) || ($(g.currentEditCell).data('lineEnding') !== $(g.currentEditCell).attr('data-line-ending'));
-                    
+
                     $(g.currentEditCell).attr('data-line-ending', selectedEnding);
                 } else {
                     const JSONString = Functions.stringifyJSON(thisFieldParams[fieldName]);

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -750,7 +750,10 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         if (!Functions.updateCode($target, newHtml, value)) {
                             $target.html(newHtml);
                         }
-                        $thisField.data('originalValue', value)
+                        $thisField.data('originalValue', value);
+                        if ($(g.currentEditCell).data('lineEnding') !== $(g.currentEditCell).attr('data-line-ending')) {
+                            $(g.currentEditCell).attr('data-line-ending', $(g.currentEditCell).data('lineEnding'));
+                        }
                     }
                     if ($thisField.is('.bit')) {
                         $thisField.find('span').text($thisField.data('value'));
@@ -1593,16 +1596,15 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                 if ($thisField.attr('data-type') !== 'json') {
                     let canonicalOldValue;
                     if ((! $(g.currentEditCell).hasClass('truncated')) && $(g.currentEditCell).data('originalValue') !== null && $(g.currentEditCell).data('originalValue') !== undefined) {
-                        canonicalOldValue = $(g.currentEditCell).data('originalValue');
+                        let raw = $(g.currentEditCell).data('originalValue');
+                        canonicalOldValue = (typeof raw === 'object') ? Functions.stringifyJSON(raw) : String(raw);
                     } else {
                         // Fallback: DOM value
-                        canonicalOldValue = Functions.normalizeNewlines(Functions.getCellValue(g.currentEditCell));
+                        canonicalOldValue = String(Functions.normalizeNewlines(Functions.getCellValue(g.currentEditCell)));
                     }
                     // Normalizing to LFs only for text comparison.
-                    canonicalNewValue = canonicalNewValue.replace(/\r\n/g, '\n');
+                    canonicalNewValue = (String(canonicalNewValue)).replace(/\r\n/g, '\n');
                     isValueUpdated = (canonicalNewValue !== canonicalOldValue) || ($(g.currentEditCell).data('lineEnding') !== $(g.currentEditCell).attr('data-line-ending'));
-
-                    $(g.currentEditCell).attr('data-line-ending', selectedEnding);
                 } else {
                     const JSONString = Functions.stringifyJSON(thisFieldParams[fieldName]);
                     isValueUpdated = JSONString !== Functions.stringifyJSON(Functions.getCellValue(g.currentEditCell));

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -713,6 +713,20 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                             ? Functions.normalizeNewlines(data.truncatableFieldValue)
                             : Functions.normalizeNewlines($thisField.data('value'));
 
+                        if (value.indexOf('\n') !== -1) {
+                            // Value contains line breaks: ensure the attribute exists
+                            if (!$thisField.is('[data-line-ending]')) {
+                                $thisField.data('lineEnding', 'LF');
+                                $thisField.attr('data-line-ending', 'LF');
+                            } else if ($thisField.data('lineEnding') !== $thisField.attr('data-line-ending')) {
+                                $thisField.attr('data-line-ending', $thisField.data('lineEnding'));
+                            }
+                        } else if ($thisField.is('[data-line-ending]')) {
+                            // Value no longer has line breaks: remove the attribute
+                            $thisField.removeData('lineEnding');
+                            $thisField.removeAttr('data-line-ending');
+                        }
+
                         // Truncates the text.
                         $thisField.removeClass('truncated');
                         if (CommonParams.get('pftext') === 'P' && value.length > g.maxTruncatedLen) {
@@ -750,19 +764,6 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                             $target.html(newHtml);
                         }
                         $thisField.data('originalValue', value);
-                        if (value.indexOf('\n') !== -1) {
-                            // Value contains line breaks: ensure the attribute exists
-                            if (!$thisField.is('[data-line-ending]')) {
-                                $thisField.data('lineEnding', 'LF');
-                                $thisField.attr('data-line-ending', 'LF');
-                            } else if ($thisField.data('lineEnding') !== $thisField.attr('data-line-ending')) {
-                                $thisField.attr('data-line-ending', $thisField.data('lineEnding'));
-                            }
-                        } else if ($thisField.is('[data-line-ending]')) {
-                            // Value no longer has line breaks: remove the attribute
-                            $thisField.removeData('lineEnding');
-                            $thisField.removeAttr('data-line-ending');
-                        }
                     }
                     if ($thisField.is('.bit')) {
                         $thisField.find('span').text($thisField.data('value'));

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -701,12 +701,19 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                     if (isNull) {
                         $thisField.find('span').html('NULL');
                         $thisField.addClass('null');
+                        // todo: set original value to null & remove data-line-ending attribute
+                        $thisField.data('originalValue', null);
+                        if ($thisField.is('[data-line-ending]')) {
+                            $thisField
+                                .removeData('lineEnding')
+                                .removeAttr('data-line-ending');
+                        }
                     } else {
                         $thisField.removeClass('null');
                         var value = data.isNeedToRecheck
-                            ? data.truncatableFieldValue
-                            : $thisField.data('value');
-
+                            ? data.truncatableFieldValue.replace(/\r\n/g, '\n')
+                            : $thisField.data('value').replace(/\r\n/g, '\n');
+                        
                         // Truncates the text.
                         $thisField.removeClass('truncated');
                         if (CommonParams.get('pftext') === 'P' && value.length > g.maxTruncatedLen) {
@@ -743,6 +750,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         if (!Functions.updateCode($target, newHtml, value)) {
                             $target.html(newHtml);
                         }
+                        $thisField.data('originalValue', value)
                     }
                     if ($thisField.is('.bit')) {
                         $thisField.find('span').text($thisField.data('value'));
@@ -795,6 +803,10 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                  * @var $td current edited cell
                  */
                 var $td = $(g.currentEditCell);
+                /**
+                 * @var hasLineEnding boolean, true if the edited cell has line-ending data option
+                 */
+                var hasLineEnding = ($td.is('[data-line-ending]'));
                 /**
                  * @var $editArea the editing area
                  */
@@ -904,6 +916,36 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                             $editArea.find('textarea').val('');
                         }
                         $(g.cEdit).find('.edit_box').val('');
+                    });
+                }
+
+                if (hasLineEnding) {   
+                    // Canonical server truth (preferred)
+                    let originalValue = $td.data('originalValue');  
+                    // Fallback ONLY if not present (AJAX-fetched truncated case)
+                    if (originalValue === undefined) {
+                        originalValue = Functions.normalizeNewlines(
+                            Functions.getCellValue(g.currentEditCell)
+                        );
+                        $td.data('originalValue', originalValue);           
+                    }
+                    // Cache it once
+                    $editArea.append(
+                        '<div class="crlf_div">' +
+                            '<label>' +
+                                '<span class="line-ending-label">Line endings:</span>' +
+                                '<select class="line-ending-select">' +
+                                    '<option value="LF">LF</option>' +
+                                    '<option value="CRLF">CRLF</option>' +
+                                '</select>' +
+                            '</label>' +
+                        '</div>'
+                    );
+                    var detectedEnding = $td.data('lineEnding');
+                    $editArea.find('.line-ending-select').val(detectedEnding);
+                    // handle change of line ending selection
+                    $editArea.on('change', '.line-ending-select', function () {
+                        $td.data('lineEnding', this.value);
                     });
                 }
 
@@ -1531,13 +1573,31 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         thisFieldParams[fieldName] = Functions.getCellValue(g.currentEditCell);
                     }
                 } else {
-                    thisFieldParams[fieldName] = $(g.cEdit).find('.edit_box').val();
+                    let inputValue = $(g.cEdit).find('.edit_box').val();
+                    var canonicalNewValue = inputValue;
+                    var selectedEnding = $(g.currentEditCell).data('lineEnding');
+                    // browser always gives LF.
+                    if (selectedEnding === 'CRLF') {
+                        canonicalNewValue = canonicalNewValue.replace(/\n/g, '\r\n');
+                    }
+                    // new value that will be saved in the database.
+                    thisFieldParams[fieldName] = canonicalNewValue;
                 }
 
                 let isValueUpdated;
                 if ($thisField.attr('data-type') !== 'json') {
-                    let normalizedCellVal = Functions.normalizeNewlines(Functions.getCellValue(g.currentEditCell));
-                    isValueUpdated = thisFieldParams[fieldName] !== normalizedCellVal;
+                    let canonicalOldValue;
+                    if ((! $(g.currentEditCell).hasClass('truncated')) && $(g.currentEditCell).data('originalValue') !== null) {
+                        canonicalOldValue = $(g.currentEditCell).data('originalValue');
+                    } else {
+                        // Fallback: DOM value
+                        canonicalOldValue = Functions.normalizeNewlines(Functions.getCellValue(g.currentEditCell));
+                    }
+                    // Normalizing to LFs only for text comparison.
+                    canonicalNewValue = canonicalNewValue.replace(/\r\n/g, '\n');
+                    isValueUpdated = (canonicalNewValue !== canonicalOldValue) || ($(g.currentEditCell).data('lineEnding') !== $(g.currentEditCell).attr('data-line-ending'));
+                    
+                    $(g.currentEditCell).attr('data-line-ending', selectedEnding);
                 } else {
                     const JSONString = Functions.stringifyJSON(thisFieldParams[fieldName]);
                     isValueUpdated = JSONString !== Functions.stringifyJSON(Functions.getCellValue(g.currentEditCell));

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -1592,7 +1592,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                 let isValueUpdated;
                 if ($thisField.attr('data-type') !== 'json') {
                     let canonicalOldValue;
-                    if ((! $(g.currentEditCell).hasClass('truncated')) && $(g.currentEditCell).data('originalValue') !== null) {
+                    if ((! $(g.currentEditCell).hasClass('truncated')) && $(g.currentEditCell).data('originalValue') !== null && $(g.currentEditCell).data('originalValue') !== undefined) {
                         canonicalOldValue = $(g.currentEditCell).data('originalValue');
                     } else {
                         // Fallback: DOM value

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -933,7 +933,12 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                     $editArea.append(
                         '<div class="crlf_div">' +
                             '<label>' +
-                                '<span class="line-ending-label">Line endings:</span>' +
+                                '<span class="line-ending-label">' +
+                                    'Line endings' +
+                                    '<span>' +
+                                        '<img src="themes/dot.gif" title="The suggested value was detected from your existing data." alt="The suggested value was detected from your existing data." class="icon ic_b_help">' +
+                                    '</span>:' +
+                                '</span>' +
                                 '<select class="line-ending-select">' +
                                     '<option value="LF">LF</option>' +
                                     '<option value="CRLF">CRLF</option>' +

--- a/libraries/classes/Controllers/JavaScriptMessagesController.php
+++ b/libraries/classes/Controllers/JavaScriptMessagesController.php
@@ -570,6 +570,10 @@ final class JavaScriptMessagesController
             ),
             'strOriginalLength' => __('Original length'),
 
+            /* For makegrid.js (CRLF/LF handling) */
+            'strLineEnding' => __('Line ending:'),
+            'strLineEndingDetected' => __('The suggested value was detected from your existing data.'),
+
             /* Drag & Drop sql import messages */
             'dropImportMessageCancel' => __('cancel'),
             'dropImportMessageAborted' => __('Aborted'),

--- a/libraries/classes/Controllers/JavaScriptMessagesController.php
+++ b/libraries/classes/Controllers/JavaScriptMessagesController.php
@@ -570,10 +570,6 @@ final class JavaScriptMessagesController
             ),
             'strOriginalLength' => __('Original length'),
 
-            /* For makegrid.js (CRLF/LF handling) */
-            'strLineEnding' => __('Line ending:'),
-            'strLineEndingDetected' => __('The suggested value was detected from your existing data.'),
-
             /* Drag & Drop sql import messages */
             'dropImportMessageCancel' => __('cancel'),
             'dropImportMessageAborted' => __('Aborted'),

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -51,7 +51,6 @@ use function in_array;
 use function intval;
 use function is_array;
 use function is_numeric;
-use function is_string;
 use function json_encode;
 use function max;
 use function mb_check_encoding;
@@ -4419,8 +4418,8 @@ class Results
         array $analyzedSqlResults,
         FieldMetadata $meta,
         array $map,
-        $data,
-        $displayedData,
+        string $data,
+        string $displayedData,
         ?TransformationsPlugin $transformationPlugin,
         string $nowrap,
         string $whereComparison,
@@ -4441,10 +4440,7 @@ class Results
             $transformationPlugin !== null
         );
 
-        $canonicalValue = null;
-        if (is_string($data)) {
-            $canonicalValue = str_replace(["\r\n", "\r"], "\n", $data);
-        }
+        $canonicalValue = str_replace(["\r\n", "\r"], "\n", $data);
 
         if (! empty($analyzedSqlResults['statement']->expr)) {
             foreach ($analyzedSqlResults['statement']->expr as $expr) {
@@ -4561,7 +4557,7 @@ class Results
      *
      * @param string $value The string whose line endings should be detected
      *
-     * @return string|null  Returns 'CRLF', 'LF', or null if no line breaks exist
+     * @psalm-return 'CRLF'|'LF'|null
      */
     private function detectLineEnding(string $value): ?string
     {
@@ -4585,8 +4581,7 @@ class Results
      *
      * @param string $str string to be truncated
      *
-     * @return array
-     * @psalm-return array{bool, string, int}
+     * @psalm-return array{bool, string, int, 'CRLF'|'LF'|null}
      */
     private function getPartialText($str): array
     {

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -51,6 +51,7 @@ use function in_array;
 use function intval;
 use function is_array;
 use function is_numeric;
+use function is_string;
 use function json_encode;
 use function max;
 use function mb_check_encoding;
@@ -3373,11 +3374,12 @@ class Results
             && str_contains($transformationPlugin->getName(), 'Link'))
             && ! $meta->isBinary()
         ) {
-            [
-                $isFieldTruncated,
-                $column,
-                $originalLength,
-            ] = $this->getPartialText($column);
+                        [
+                            $isFieldTruncated,
+                            $column,
+                            $originalLength,
+                            $lineEnding,
+                        ] = $this->getPartialText($column);
         }
 
         if ($meta->isMappedTypeBit) {
@@ -3446,7 +3448,8 @@ class Results
             $whereComparison,
             $transformOptions,
             $isFieldTruncated,
-            (string) $originalLength
+            (string) $originalLength,
+            $lineEnding ?? null
         );
     }
 
@@ -4423,7 +4426,8 @@ class Results
         string $whereComparison,
         array $transformOptions,
         bool $isFieldTruncated = false,
-        string $originalLength = ''
+        string $originalLength = '',
+        ?string $lineEnding = null
     ) {
         $relationalDisplay = $_SESSION['tmpval']['relational_display'];
         $printView = $this->properties['printview'];
@@ -4436,6 +4440,11 @@ class Results
             $isFieldTruncated,
             $transformationPlugin !== null
         );
+
+        $canonicalValue = null;
+        if (is_string($data)) {
+            $canonicalValue = str_replace(["\r\n", "\r"], "\n", $data);
+        }
 
         if (! empty($analyzedSqlResults['statement']->expr)) {
             foreach ($analyzedSqlResults['statement']->expr as $expr) {
@@ -4532,7 +4541,39 @@ class Results
             'decimals' => $meta->decimals,
             'type' => $meta->getMappedType(),
             'original_length' => $originalLength,
+            'line_ending' => $lineEnding,
+            'canonical_value' => $canonicalValue,
         ]);
+    }
+
+    /**
+     * Detects the line-ending style used in a string.
+     *
+     * Determines whether the given string contains CRLF (\r\n) or LF (\n)
+     * line endings. CRLF is given precedence if both are present.
+     * Returns null if no line breaks are found.
+     *
+     * This is used to preserve line-ending semantics of textual data,
+     * especially when values may later be truncated or normalized
+     * for display or editing.
+     *
+     * @see getPartialText()
+     *
+     * @param string $value The string whose line endings should be detected
+     *
+     * @return string|null  Returns 'CRLF', 'LF', or null if no line breaks exist
+     */
+    private function detectLineEnding(string $value): ?string
+    {
+        if (strpos($value, "\r\n") !== false) {
+            return 'CRLF';
+        }
+
+        if (strpos($value, "\n") !== false) {
+            return 'LF';
+        }
+
+        return null;
     }
 
     /**
@@ -4550,6 +4591,7 @@ class Results
     private function getPartialText($str): array
     {
         $originalLength = mb_strlen($str);
+        $lineEnding = $this->detectLineEnding($str);
         if (
             $originalLength > $GLOBALS['cfg']['LimitChars']
             && $_SESSION['tmpval']['pftext'] === self::DISPLAY_PARTIAL_TEXT
@@ -4564,6 +4606,7 @@ class Results
             $truncated,
             $str,
             $originalLength,
+            $lineEnding,
         ];
     }
 }

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -3374,12 +3374,12 @@ class Results
             && str_contains($transformationPlugin->getName(), 'Link'))
             && ! $meta->isBinary()
         ) {
-                        [
-                            $isFieldTruncated,
-                            $column,
-                            $originalLength,
-                            $lineEnding,
-                        ] = $this->getPartialText($column);
+            [
+                $isFieldTruncated,
+                $column,
+                $originalLength,
+                $lineEnding,
+            ] = $this->getPartialText($column);
         }
 
         if ($meta->isMappedTypeBit) {

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -3377,9 +3377,10 @@ class Results
                 $isFieldTruncated,
                 $column,
                 $originalLength,
-                $lineEnding,
             ] = $this->getPartialText($column);
         }
+
+        $lineEnding = $this->detectLineEnding($originalDataForWhereClause);
 
         if ($meta->isMappedTypeBit) {
             $displayedColumn = Util::printableBitValue((int) $displayedColumn, (int) $meta->length);
@@ -3448,7 +3449,7 @@ class Results
             $transformOptions,
             $isFieldTruncated,
             (string) $originalLength,
-            $lineEnding ?? null
+            $lineEnding
         );
     }
 
@@ -4426,7 +4427,7 @@ class Results
         array $transformOptions,
         bool $isFieldTruncated = false,
         string $originalLength = '',
-        ?string $lineEnding = null
+        ?string $lineEnding = ''
     ) {
         $relationalDisplay = $_SESSION['tmpval']['relational_display'];
         $printView = $this->properties['printview'];
@@ -4547,29 +4548,29 @@ class Results
      *
      * Determines whether the given string contains CRLF (\r\n) or LF (\n)
      * line endings. CRLF is given precedence if both are present.
-     * Returns null if no line breaks are found.
+     * Returns an empty string if no line breaks are found.
      *
      * This is used to preserve line-ending semantics of textual data,
      * especially when values may later be truncated or normalized
      * for display or editing.
      *
-     * @see getPartialText()
+     * @see getDataCellForNonNumericColumns()
      *
      * @param string $value The string whose line endings should be detected
      *
-     * @psalm-return 'CRLF'|'LF'|null
+     * @psalm-return 'CRLF'|'LF'|''
      */
-    private function detectLineEnding(string $value): ?string
+    private function detectLineEnding(string $value): string
     {
-        if (strpos($value, "\r\n") !== false) {
+        if (str_contains($value, "\r\n")) {
             return 'CRLF';
         }
 
-        if (strpos($value, "\n") !== false) {
+        if (str_contains($value, "\n")) {
             return 'LF';
         }
 
-        return null;
+        return '';
     }
 
     /**
@@ -4581,12 +4582,11 @@ class Results
      *
      * @param string $str string to be truncated
      *
-     * @psalm-return array{bool, string, int, 'CRLF'|'LF'|null}
+     * @psalm-return array{bool, string, int}
      */
     private function getPartialText($str): array
     {
         $originalLength = mb_strlen($str);
-        $lineEnding = $this->detectLineEnding($str);
         if (
             $originalLength > $GLOBALS['cfg']['LimitChars']
             && $_SESSION['tmpval']['pftext'] === self::DISPLAY_PARTIAL_TEXT
@@ -4601,7 +4601,6 @@ class Results
             $truncated,
             $str,
             $originalLength,
-            $lineEnding,
         ];
     }
 }

--- a/templates/display/results/row_data.twig
+++ b/templates/display/results/row_data.twig
@@ -1,3 +1,3 @@
-<td data-decimals="{{ decimals }}" data-type="{{ type }}"{% if original_length is not empty %} data-originallength="{{ original_length }}"{% endif %} class="{{ td_class }}"{% if line_ending is not null %} data-line-ending="{{ line_ending }}"{% endif %}{% if canonical_value is not null %} data-original-value="{{ canonical_value|e('html_attr') }}"{% endif %}>
+<td data-decimals="{{ decimals }}" data-type="{{ type }}"{% if original_length is not empty %} data-originallength="{{ original_length }}"{% endif %} class="{{ td_class }}"{% if line_ending is not empty %} data-line-ending="{{ line_ending }}"{% endif %}{% if canonical_value is not null %} data-original-value="{{ canonical_value|e('html_attr') }}"{% endif %}>
   {{- value|raw -}}
 </td>

--- a/templates/display/results/row_data.twig
+++ b/templates/display/results/row_data.twig
@@ -1,3 +1,3 @@
-<td data-decimals="{{ decimals }}" data-type="{{ type }}"{% if original_length is not empty %} data-originallength="{{ original_length }}"{% endif %} class="{{ td_class }}">
+<td data-decimals="{{ decimals }}" data-type="{{ type }}"{% if original_length is not empty %} data-originallength="{{ original_length }}"{% endif %} class="{{ td_class }}"{% if line_ending is not null %} data-line-ending="{{ line_ending }}"{% endif %}{% if canonical_value is not null %} data-original-value="{{ canonical_value|e('html_attr') }}"{% endif %}>
   {{- value|raw -}}
 </td>

--- a/templates/display/results/table.twig
+++ b/templates/display/results/table.twig
@@ -204,6 +204,23 @@
     <input type="hidden" name="goto" value="{{ url('/sql') }}">
 {% endif %}
 
+  <template id="crlf-div-template-{{ unique_id }}">
+    <div class="crlf_div">
+      <label>
+        <span class="line-ending-label">
+          <span class="line-ending-text"></span>
+          <span>
+            <img src="themes/dot.gif" class="icon ic_b_help">
+          </span>
+        </span>
+        <select class="line-ending-select">
+          <option value="LF">LF</option>
+          <option value="CRLF">CRLF</option>
+        </select>
+      </label>
+    </div>
+  </template>
+
   <div class="table-responsive-md">
     <table class="table table-striped table-hover table-sm table_results data ajax w-auto" data-uniqueId="{{ unique_id }}">
 

--- a/templates/display/results/table.twig
+++ b/templates/display/results/table.twig
@@ -208,9 +208,9 @@
     <div class="crlf_div">
       <label>
         <span class="line-ending-label">
-          <span class="line-ending-text"></span>
+          <span class="line-ending-text">{% trans 'Line ending:' %}</span>
           <span>
-            <img src="themes/dot.gif" class="icon ic_b_help">
+            <img src="themes/dot.gif" class="icon ic_b_help" title="{% trans 'The suggested value was detected from your existing data.' %}" alt="{% trans 'The suggested value was detected from your existing data.' %}">
           </span>
         </span>
         <select class="line-ending-select">

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -457,6 +457,7 @@ class ResultsTest extends AbstractTestCase
                     false,
                     'foo',
                     3,
+                    null,
                 ],
             ],
             [
@@ -467,6 +468,7 @@ class ResultsTest extends AbstractTestCase
                     true,
                     'f...',
                     3,
+                    null,
                 ],
             ],
             [
@@ -477,6 +479,7 @@ class ResultsTest extends AbstractTestCase
                     false,
                     'foo',
                     3,
+                    null,
                 ],
             ],
             [
@@ -487,6 +490,7 @@ class ResultsTest extends AbstractTestCase
                     false,
                     'foo',
                     3,
+                    null,
                 ],
             ],
         ];
@@ -1587,25 +1591,25 @@ class ResultsTest extends AbstractTestCase
                 'column_at_right_side' => "\n" . '<td class="d-print-none"></td>',
             ],
             'body' => '<tr><td data-decimals="0" data-type="real" class="'
-                . 'text-end data not_null text-nowrap">1</td>' . "\n"
+                . 'text-end data not_null text-nowrap" data-original-value="1">1</td>' . "\n"
                 . '<td data-decimals="0" data-type="string" data-originallength="4" class="'
-                . 'data not_null text pre_wrap">abcd</td>' . "\n"
+                . 'data not_null text pre_wrap" data-original-value="abcd">abcd</td>' . "\n"
                 . '<td data-decimals="0" data-type="datetime" data-originallength="19" class="'
-                . 'data not_null datetimefield text-nowrap">2011-01-20 02:00:02</td>' . "\n"
+                . 'data not_null datetimefield text-nowrap" data-original-value="2011-01-20&#x20;02&#x3A;00&#x3A;02">2011-01-20 02:00:02</td>' . "\n"
                 . '</tr>' . "\n"
                 . '<tr><td data-decimals="0" data-type="real" class="'
-                . 'text-end data not_null text-nowrap">2</td>' . "\n"
+                . 'text-end data not_null text-nowrap" data-original-value="2">2</td>' . "\n"
                 . '<td data-decimals="0" data-type="string" data-originallength="3" class="'
-                . 'data not_null text pre_wrap">foo</td>' . "\n"
+                . 'data not_null text pre_wrap" data-original-value="foo">foo</td>' . "\n"
                 . '<td data-decimals="0" data-type="datetime" data-originallength="19" class="'
-                . 'data not_null datetimefield text-nowrap">2010-01-20 02:00:02</td>' . "\n"
+                . 'data not_null datetimefield text-nowrap" data-original-value="2010-01-20&#x20;02&#x3A;00&#x3A;02">2010-01-20 02:00:02</td>' . "\n"
                 . '</tr>' . "\n"
                 . '<tr><td data-decimals="0" data-type="real" class="'
-                . 'text-end data not_null text-nowrap">3</td>' . "\n"
+                . 'text-end data not_null text-nowrap" data-original-value="3">3</td>' . "\n"
                 . '<td data-decimals="0" data-type="string" data-originallength="4" class="'
-                . 'data not_null text pre_wrap">Abcd</td>' . "\n"
+                . 'data not_null text pre_wrap" data-original-value="Abcd">Abcd</td>' . "\n"
                 . '<td data-decimals="0" data-type="datetime" data-originallength="19" class="'
-                . 'data not_null datetimefield text-nowrap">2012-01-20 02:00:02</td>' . "\n"
+                . 'data not_null datetimefield text-nowrap" data-original-value="2012-01-20&#x20;02&#x3A;00&#x3A;02">2012-01-20 02:00:02</td>' . "\n"
                 . '</tr>' . "\n",
             'bulk_links' => [],
             'operations' => [

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -457,7 +457,7 @@ class ResultsTest extends AbstractTestCase
                     false,
                     'foo',
                     3,
-                    null,
+                    '',
                 ],
             ],
             [
@@ -468,7 +468,7 @@ class ResultsTest extends AbstractTestCase
                     true,
                     'f...',
                     3,
-                    null,
+                    '',
                 ],
             ],
             [
@@ -479,7 +479,7 @@ class ResultsTest extends AbstractTestCase
                     false,
                     'foo',
                     3,
-                    null,
+                    '',
                 ],
             ],
             [
@@ -490,7 +490,7 @@ class ResultsTest extends AbstractTestCase
                     false,
                     'foo',
                     3,
-                    null,
+                    '',
                 ],
             ],
         ];

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -1595,21 +1595,27 @@ class ResultsTest extends AbstractTestCase
                 . '<td data-decimals="0" data-type="string" data-originallength="4" class="'
                 . 'data not_null text pre_wrap" data-original-value="abcd">abcd</td>' . "\n"
                 . '<td data-decimals="0" data-type="datetime" data-originallength="19" class="'
-                . 'data not_null datetimefield text-nowrap" data-original-value="2011-01-20&#x20;02&#x3A;00&#x3A;02">2011-01-20 02:00:02</td>' . "\n"
+                . 'data not_null datetimefield text-nowrap" '
+                . 'data-original-value="2011-01-20&#x20;02&#x3A;00&#x3A;02">2011-01-20 02:00:02</td>'
+                . "\n"
                 . '</tr>' . "\n"
                 . '<tr><td data-decimals="0" data-type="real" class="'
                 . 'text-end data not_null text-nowrap" data-original-value="2">2</td>' . "\n"
                 . '<td data-decimals="0" data-type="string" data-originallength="3" class="'
                 . 'data not_null text pre_wrap" data-original-value="foo">foo</td>' . "\n"
                 . '<td data-decimals="0" data-type="datetime" data-originallength="19" class="'
-                . 'data not_null datetimefield text-nowrap" data-original-value="2010-01-20&#x20;02&#x3A;00&#x3A;02">2010-01-20 02:00:02</td>' . "\n"
+                . 'data not_null datetimefield text-nowrap" '
+                . 'data-original-value="2010-01-20&#x20;02&#x3A;00&#x3A;02">2010-01-20 02:00:02</td>'
+                . "\n"
                 . '</tr>' . "\n"
                 . '<tr><td data-decimals="0" data-type="real" class="'
                 . 'text-end data not_null text-nowrap" data-original-value="3">3</td>' . "\n"
                 . '<td data-decimals="0" data-type="string" data-originallength="4" class="'
                 . 'data not_null text pre_wrap" data-original-value="Abcd">Abcd</td>' . "\n"
                 . '<td data-decimals="0" data-type="datetime" data-originallength="19" class="'
-                . 'data not_null datetimefield text-nowrap" data-original-value="2012-01-20&#x20;02&#x3A;00&#x3A;02">2012-01-20 02:00:02</td>' . "\n"
+                . 'data not_null datetimefield text-nowrap" '
+                . 'data-original-value="2012-01-20&#x20;02&#x3A;00&#x3A;02">2012-01-20 02:00:02</td>'
+                . "\n"
                 . '</tr>' . "\n",
             'bulk_links' => [],
             'operations' => [

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -759,7 +759,8 @@ class ResultsTest extends AbstractTestCase
                 [],
                 '<td data-decimals="0" data-type="string" '
                 . 'data-originallength="11" '
-                . 'class="grid_edit pre_wrap">foo bar baz</td>' . "\n",
+                . 'class="grid_edit pre_wrap" data-original-value="foo&#x20;bar&#x20;baz">'
+                . 'foo bar baz</td>' . "\n",
             ],
             [
                 'all',
@@ -774,7 +775,8 @@ class ResultsTest extends AbstractTestCase
                 [],
                 '<td data-decimals="0" data-type="string" '
                 . 'data-originallength="11" '
-                . 'class="grid_edit text-nowrap transformed">foo bar baz</td>' . "\n",
+                . 'class="grid_edit text-nowrap transformed" data-original-value="foo&#x20;bar&#x20;baz">'
+                . 'foo bar baz</td>' . "\n",
             ],
             [
                 'all',
@@ -789,7 +791,9 @@ class ResultsTest extends AbstractTestCase
                 [],
                 '<td data-decimals="0" data-type="datetime" '
                 . 'data-originallength="19" '
-                . 'class="grid_edit text-nowrap">2020-09-20 16:35:00</td>' . "\n",
+                . 'class="grid_edit text-nowrap" '
+                . 'data-original-value="2020-09-20&#x20;16&#x3A;35&#x3A;00">'
+                . '2020-09-20 16:35:00</td>' . "\n",
             ],
         ];
     }

--- a/themes/bootstrap/scss/_common.scss
+++ b/themes/bootstrap/scss/_common.scss
@@ -136,7 +136,6 @@ div.crlf_div label {
   display: flex;
   align-items: center;
   gap: 6px;
-
   flex-wrap: wrap;
   width: 100%;
   min-width: 0;

--- a/themes/bootstrap/scss/_common.scss
+++ b/themes/bootstrap/scss/_common.scss
@@ -128,28 +128,28 @@ div.null_div {
 }
 
 div.crlf_div {
-    font-style: normal;
-    max-width: 100%;
+  font-style: normal;
+  max-width: 100%;
 }
 
 div.crlf_div label {
-    display: flex;
-    align-items: center;
-    gap: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 
-    flex-wrap: wrap;
-    width: 100%;        /* 🔑 constrain to edit-area */
-    min-width: 0;       /* 🔑 allow shrinking */
+  flex-wrap: wrap;
+  width: 100%;
+  min-width: 0;
 }
 
 div.crlf_div .line-ending-label {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 
 div.crlf_div select {
-    box-sizing: border-box;
-    max-width: 100%;
-    flex: 1 1 auto;     /* 🔑 shrink when needed */
+  box-sizing: border-box;
+  max-width: 100%;
+  flex: 1 1 auto;
 }
 
 .pma-fieldset {

--- a/themes/bootstrap/scss/_common.scss
+++ b/themes/bootstrap/scss/_common.scss
@@ -127,6 +127,31 @@ div.null_div {
   min-width: 50px;
 }
 
+div.crlf_div {
+    font-style: normal;
+    max-width: 100%;
+}
+
+div.crlf_div label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    flex-wrap: wrap;
+    width: 100%;        /* 🔑 constrain to edit-area */
+    min-width: 0;       /* 🔑 allow shrinking */
+}
+
+div.crlf_div .line-ending-label {
+    white-space: nowrap;
+}
+
+div.crlf_div select {
+    box-sizing: border-box;
+    max-width: 100%;
+    flex: 1 1 auto;     /* 🔑 shrink when needed */
+}
+
 .pma-fieldset {
   .formelement {
     float: left;

--- a/themes/metro/scss/_common.scss
+++ b/themes/metro/scss/_common.scss
@@ -420,7 +420,6 @@ div.crlf_div label {
   display: flex;
   align-items: center;
   gap: 6px;
-
   flex-wrap: wrap;
   width: 100%;
   min-width: 0;

--- a/themes/metro/scss/_common.scss
+++ b/themes/metro/scss/_common.scss
@@ -411,6 +411,31 @@ div.null_div {
   min-width: 50px;
 }
 
+div.crlf_div {
+    font-style: normal;
+    max-width: 100%;
+}
+
+div.crlf_div label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    flex-wrap: wrap;
+    width: 100%;        /* 🔑 constrain to edit-area */
+    min-width: 0;       /* 🔑 allow shrinking */
+}
+
+div.crlf_div .line-ending-label {
+    white-space: nowrap;
+}
+
+div.crlf_div select {
+    box-sizing: border-box;
+    max-width: 100%;
+    flex: 1 1 auto;     /* 🔑 shrink when needed */
+}
+
 .pma-fieldset {
   .formelement {
     float: left;

--- a/themes/metro/scss/_common.scss
+++ b/themes/metro/scss/_common.scss
@@ -412,28 +412,28 @@ div.null_div {
 }
 
 div.crlf_div {
-    font-style: normal;
-    max-width: 100%;
+  font-style: normal;
+  max-width: 100%;
 }
 
 div.crlf_div label {
-    display: flex;
-    align-items: center;
-    gap: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 
-    flex-wrap: wrap;
-    width: 100%;        /* 🔑 constrain to edit-area */
-    min-width: 0;       /* 🔑 allow shrinking */
+  flex-wrap: wrap;
+  width: 100%;
+  min-width: 0;
 }
 
 div.crlf_div .line-ending-label {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 
 div.crlf_div select {
-    box-sizing: border-box;
-    max-width: 100%;
-    flex: 1 1 auto;     /* 🔑 shrink when needed */
+  box-sizing: border-box;
+  max-width: 100%;
+  flex: 1 1 auto;
 }
 
 .pma-fieldset {

--- a/themes/original/scss/_common.scss
+++ b/themes/original/scss/_common.scss
@@ -132,6 +132,31 @@ div.null_div {
   min-width: 50px;
 }
 
+div.crlf_div {
+    font-style: normal;
+    max-width: 100%;
+}
+
+div.crlf_div label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    flex-wrap: wrap;
+    width: 100%;        /* 🔑 constrain to edit-area */
+    min-width: 0;       /* 🔑 allow shrinking */
+}
+
+div.crlf_div .line-ending-label {
+    white-space: nowrap;
+}
+
+div.crlf_div select {
+    box-sizing: border-box;
+    max-width: 100%;
+    flex: 1 1 auto;     /* 🔑 shrink when needed */
+}
+
 .pma-fieldset {
   .formelement {
     float: left;

--- a/themes/original/scss/_common.scss
+++ b/themes/original/scss/_common.scss
@@ -141,7 +141,6 @@ div.crlf_div label {
   display: flex;
   align-items: center;
   gap: 6px;
-
   flex-wrap: wrap;
   width: 100%;
   min-width: 0;

--- a/themes/original/scss/_common.scss
+++ b/themes/original/scss/_common.scss
@@ -133,28 +133,28 @@ div.null_div {
 }
 
 div.crlf_div {
-    font-style: normal;
-    max-width: 100%;
+  font-style: normal;
+  max-width: 100%;
 }
 
 div.crlf_div label {
-    display: flex;
-    align-items: center;
-    gap: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 
-    flex-wrap: wrap;
-    width: 100%;        /* 🔑 constrain to edit-area */
-    min-width: 0;       /* 🔑 allow shrinking */
+  flex-wrap: wrap;
+  width: 100%;
+  min-width: 0;
 }
 
 div.crlf_div .line-ending-label {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 
 div.crlf_div select {
-    box-sizing: border-box;
-    max-width: 100%;
-    flex: 1 1 auto;     /* 🔑 shrink when needed */
+  box-sizing: border-box;
+  max-width: 100%;
+  flex: 1 1 auto;
 }
 
 .pma-fieldset {

--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -312,6 +312,31 @@ div.null_div {
   min-width: 50px;
 }
 
+div.crlf_div {
+    font-style: normal;
+    max-width: 100%;
+}
+
+div.crlf_div label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    flex-wrap: wrap;
+    width: 100%;        /* 🔑 constrain to edit-area */
+    min-width: 0;       /* 🔑 allow shrinking */
+}
+
+div.crlf_div .line-ending-label {
+    white-space: nowrap;
+}
+
+div.crlf_div select {
+    box-sizing: border-box;
+    max-width: 100%;
+    flex: 1 1 auto;     /* 🔑 shrink when needed */
+}
+
 .pma-fieldset {
   .formelement {
     float: left;

--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -321,7 +321,6 @@ div.crlf_div label {
   display: flex;
   align-items: center;
   gap: 6px;
-
   flex-wrap: wrap;
   width: 100%;
   min-width: 0;

--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -313,28 +313,28 @@ div.null_div {
 }
 
 div.crlf_div {
-    font-style: normal;
-    max-width: 100%;
+  font-style: normal;
+  max-width: 100%;
 }
 
 div.crlf_div label {
-    display: flex;
-    align-items: center;
-    gap: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 
-    flex-wrap: wrap;
-    width: 100%;        /* 🔑 constrain to edit-area */
-    min-width: 0;       /* 🔑 allow shrinking */
+  flex-wrap: wrap;
+  width: 100%;
+  min-width: 0;
 }
 
 div.crlf_div .line-ending-label {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 
 div.crlf_div select {
-    box-sizing: border-box;
-    max-width: 100%;
-    flex: 1 1 auto;     /* 🔑 shrink when needed */
+  box-sizing: border-box;
+  max-width: 100%;
+  flex: 1 1 auto;
 }
 
 .pma-fieldset {


### PR DESCRIPTION
### Description

This pull request adds explicit line ending (CRLF / LF) handling to inline grid editing for text-like fields.
Browsers normalize textarea input to LF, which previously made it impossible for users to reliably view, preserve, or intentionally change the original line-ending format stored in the database. This PR addresses that gap by:

- Detecting the original line-ending format (CRLF or LF) on the server
- Exposing a line-ending selector in the inline edit area for applicable text fields
- Allowing users to preserve or intentionally change the line-ending format
- Ensuring idempotent behavior to avoid duplicated line breaks on repeated edits
- Keeping rendering and comparison logic consistent across truncated and non-truncated values
The implementation follows existing phpMyAdmin patterns and avoids altering behavior for non-textual field types.

Fixes #19368 - \r\n is replaced with \n when clicking on a value

Before submitting pull request, please review the following checklist:

- [ X ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ X ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ X ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ X ] Every commit has a descriptive commit message.
- [ X ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
