### PR TITLE
Fix #20068 - Fix HTML special chars encoding on triggers and events

### DIFF
--- a/src/Controllers/Database/EventsController.php
+++ b/src/Controllers/Database/EventsController.php
@@ -24,6 +24,8 @@ use function mb_strtoupper;
 use function sprintf;
 use function trim;
 
+use const ENT_NOQUOTES;
+
 #[Route('/database/events', ['GET', 'POST'])]
 final class EventsController implements InvocableController
 {
@@ -205,14 +207,14 @@ final class EventsController implements InvocableController
                 $title = sprintf(__('Export of event %s'), $itemName);
 
                 if ($request->isAjax()) {
-					$exportData = htmlspecialchars(trim($exportData));	
-					$this->response->addJSON('message', $exportData);
+                    $exportData = htmlspecialchars(trim($exportData));
+                    $this->response->addJSON('message', $exportData);
                     $this->response->addJSON('title', $title);
 
                     return $this->response->response();
-				} else {
-					$exportData = htmlspecialchars(trim($exportData),ENT_NOQUOTES);
-				}
+                }
+
+                $exportData = htmlspecialchars(trim($exportData), ENT_NOQUOTES);
 
                 $output = '<div class="container">';
                 $output .= '<h2>' . $title . '</h2>';

--- a/src/Controllers/Database/EventsController.php
+++ b/src/Controllers/Database/EventsController.php
@@ -202,15 +202,17 @@ final class EventsController implements InvocableController
 
             $itemName = htmlspecialchars(Util::backquote($itemName));
             if ($exportData !== false) {
-                $exportData = htmlspecialchars(trim($exportData));
                 $title = sprintf(__('Export of event %s'), $itemName);
 
                 if ($request->isAjax()) {
-                    $this->response->addJSON('message', $exportData);
+					$exportData = htmlspecialchars(trim($exportData));	
+					$this->response->addJSON('message', $exportData);
                     $this->response->addJSON('title', $title);
 
                     return $this->response->response();
-                }
+				} else {
+					$exportData = htmlspecialchars(trim($exportData),ENT_NOQUOTES);
+				}
 
                 $output = '<div class="container">';
                 $output .= '<h2>' . $title . '</h2>';


### PR DESCRIPTION
### Description

Newbie here just trying to learn how this all works. Sorry, I obviously don't know what I'm doing! I thought I saw I was supposed to submit pull requests to the QA branch, but I just got an email saying that I should do it for the master branch. I am trying to learn and I gave my best shot at solving issue #20068 


Fixes #20068

Added ENT_NOQUOTES flag to htmlspecialchars so single and double quotes are ignored. The change should remain secure, as I understand that <textarea> is only vulnerable to a </textarea> in its contents, but single and double quotes will be fine.

Signed-off-by: Bryan Hoffman <bryanhoffman1@gmail.com>