### PR TITLE
Add Skip Explain SQL button for queries with FORMAT

### DIFF
--- a/src/Html/Generator.php
+++ b/src/Html/Generator.php
@@ -486,6 +486,9 @@ class Generator
         $isSelect = preg_match('@^SELECT[[:space:]]+@i', $sqlQuery) === 1;
         if (! empty($config->settings['SQLQuery']['Explain']) && ! $queryTooBig) {
             $explainParams = $urlParams;
+            $explainRegex = '@^EXPLAIN[[:space:]]+(?:ANALYZE[[:space:]]+)?'
+                . '(?:FORMAT=(?:JSON|TREE|TRADITIONAL)[[:space:]]+)?';
+
             if ($isSelect) {
                 $explainParams['sql_query'] = 'EXPLAIN ' . $sqlQuery;
                 $explainLink = '<div class="col-auto">'
@@ -495,8 +498,8 @@ class Generator
                         __('Explain SQL'),
                         ['class' => 'btn btn-link'],
                     ) . '</div>' . "\n";
-            } elseif (preg_match('@^EXPLAIN[[:space:]]+SELECT[[:space:]]+@i', $sqlQuery) === 1) {
-                $explainParams['sql_query'] = mb_substr($sqlQuery, 8);
+            } elseif (preg_match($explainRegex . 'SELECT[[:space:]]+@i', $sqlQuery) === 1) {
+                $explainParams['sql_query'] = preg_replace($explainRegex . '@i', '', $sqlQuery, 1);
                 $explainLink = '<div class="col-auto">'
                     . self::linkOrButton(
                         Url::getFromRoute('/import', $explainParams),

--- a/src/Html/Generator.php
+++ b/src/Html/Generator.php
@@ -488,6 +488,7 @@ class Generator
             $explainParams = $urlParams;
             $explainRegex = '@^EXPLAIN[[:space:]]+(?:ANALYZE[[:space:]]+)?'
                 . '(?:FORMAT=(?:JSON|TREE|TRADITIONAL)[[:space:]]+)?';
+            $analyzeRegex = '@^ANALYZE[[:space:]]+(?:FORMAT=(?:JSON|TRADITIONAL)[[:space:]]+)?';
 
             if ($isSelect) {
                 $explainParams['sql_query'] = 'EXPLAIN ' . $sqlQuery;
@@ -505,6 +506,16 @@ class Generator
                         Url::getFromRoute('/import', $explainParams),
                         null,
                         __('Skip Explain SQL'),
+                        ['class' => 'btn btn-link'],
+                    ) . '</div>' . "\n";
+            } elseif (preg_match($analyzeRegex . 'SELECT[[:space:]]+@i', $sqlQuery) === 1) {
+                $explainParams['sql_query'] = preg_replace($analyzeRegex . '@i', '', $sqlQuery, 1);
+
+                $explainLink = '<div class="col-auto">'
+                    . self::linkOrButton(
+                        Url::getFromRoute('/import', $explainParams),
+                        null,
+                        __('Skip Analyze SQL'),
                         ['class' => 'btn btn-link'],
                     ) . '</div>' . "\n";
             }


### PR DESCRIPTION
### Description

`Skip Explain SQL` was missing if the query had `FORMAT`.

This should support:

```SQL
EXPLAIN SELECT 1;
EXPLAIN FORMAT=JSON SELECT 1;
EXPLAIN FORMAT=TRADITIONAL SELECT 1;
EXPLAIN FORMAT=TREE SELECT 1;
EXPLAIN ANALYZE SELECT 1;
ANALYZE FORMAT=JSON SELECT 1;
ANALYZE FORMAT=TRADITIONAL SELECT 1;
```

https://github.com/user-attachments/assets/ab3c62e6-c463-49e5-ab9a-f520ebfea3dc

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
