### PR TITLE
Unset route - $getParams is never empty

### DIFF
--- a/src/Controllers/Import/ImportController.php
+++ b/src/Controllers/Import/ImportController.php
@@ -157,6 +157,9 @@ final readonly class ImportController implements InvocableController
         // upload limit has been reached, let's assume the second possibility.
         $getParams = $request->getQueryParams();
         $postParams = $request->getParsedBody();
+
+        unset($getParams['route']);
+
         if ($postParams === [] && $getParams === []) {
             Current::$message = Message::error(
                 __(

--- a/src/Controllers/Import/ImportController.php
+++ b/src/Controllers/Import/ImportController.php
@@ -155,9 +155,8 @@ final readonly class ImportController implements InvocableController
 
         // If we didn't get any parameters, either user called this directly, or
         // upload limit has been reached, let's assume the second possibility.
-        $getParams = $request->getQueryParams();
         $postParams = $request->getParsedBody();
-        if ($postParams === [] && $getParams === []) {
+        if ($postParams === []) {
             Current::$message = Message::error(
                 __(
                     'You probably tried to upload a file that is too large. Please refer ' .

--- a/src/Controllers/Import/ImportController.php
+++ b/src/Controllers/Import/ImportController.php
@@ -155,8 +155,9 @@ final readonly class ImportController implements InvocableController
 
         // If we didn't get any parameters, either user called this directly, or
         // upload limit has been reached, let's assume the second possibility.
+        $getParams = $request->getQueryParams();
         $postParams = $request->getParsedBody();
-        if ($postParams === []) {
+        if ($postParams === [] && $getParams === []) {
             Current::$message = Message::error(
                 __(
                     'You probably tried to upload a file that is too large. Please refer ' .


### PR DESCRIPTION
### Description

`$getParams` is never empty, it has atleast the route. Removing it has the same result, if I access the page directly, and will make this code to evaluate.

Before:

https://github.com/user-attachments/assets/a2689de2-63e2-4526-9bc1-43927f179b5b

After:

https://github.com/user-attachments/assets/2c8ece48-5309-46e3-a3a8-119183bba5f3

Related to #20059

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
