### PR TITLE
Fix #19891 - invalid $cfg['Export']['format'] defaulting to sql in dropdown

### DIFF
--- a/libraries/classes/Export/Options.php
+++ b/libraries/classes/Export/Options.php
@@ -132,6 +132,12 @@ final class Options
         }
 
         $default = isset($_GET['what']) ? (string) $_GET['what'] : Plugins::getDefault('Export', 'format');
+        $validNames = array_map(static function ($plugin) {
+            return $plugin->getName();
+        }, $exportList);
+        if (! in_array($default, $validNames, true)) {
+            $default = 'sql';
+        }
         $dropdown = Plugins::getChoice($exportList, $default);
         $tableObject = new Table($table, $db);
         $rows = [];


### PR DESCRIPTION
## Summary
When `$cfg['Export']['format']` is set to an invalid value (e.g. `'garbage'`), the Export page showed **CodeGen** selected instead of **sql**. This PR validates the default format against the export plugin list and uses **sql** when the config value is invalid.

Fixes #19891

## Changes
- **libraries/classes/Export/Options.php** (QA_5_2): After resolving `$default` from `$_GET['what']` or `Plugins::getDefault('Export', 'format')`, validate that it exists in the export plugin list; if not, set `$default = 'sql'` before calling `Plugins::getChoice()`.

## Verification
Single commit with proper DCO sign-off.