### PR TITLE
fix: migrate $_REQUEST to ServerRequest in DesignerController

### DIFF
--- a/src/Controllers/Database/DesignerController.php
+++ b/src/Controllers/Database/DesignerController.php
@@ -66,7 +66,7 @@ final class DesignerController implements InvocableController
 
                 $html = $this->template->render('database/designer/database_tables', [
                     'db' => Current::$database,
-                    'has_query' => isset($_REQUEST['query']),
+                    'has_query' => $request->has('query'),
                     'tab_pos' => [],
                     'display_page' => -1,
                     'tab_column' => $tableColumn,


### PR DESCRIPTION
Migrates `$_REQUEST['query']` to `$request->has('query')` in DesignerController, matching the pattern used in other controllers.

Single-line mechanical substitution — `$request` is already in scope as a method parameter.