### PR TITLE
Replace getRealSize with ini_parse_quantity

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1978,12 +1978,6 @@ parameters:
 			path: src/Controllers/Import/ImportController.php
 
 		-
-			message: '#^Casting to string something that''s already string\.$#'
-			identifier: cast.useless
-			count: 1
-			path: src/Controllers/Import/ImportController.php
-
-		-
 			message: '#^Comparison operation "\<\=" between 0 and int\<1, max\> is always true\.$#'
 			identifier: smallerOrEqual.alwaysTrue
 			count: 1
@@ -5776,12 +5770,6 @@ parameters:
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
 			count: 2
-			path: src/Export/Export.php
-
-		-
-			message: '#^Casting to string something that''s already string\.$#'
-			identifier: cast.useless
-			count: 1
 			path: src/Export/Export.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3925,12 +3925,6 @@ parameters:
 			path: src/Core.php
 
 		-
-			message: '#^Only booleans are allowed in a negated boolean, int\|string given\.$#'
-			identifier: booleanNot.exprNotBoolean
-			count: 1
-			path: src/Core.php
-
-		-
 			message: '#^Parameter \#1 \$value of function count expects array\|Countable, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1319,9 +1319,6 @@
     </UnusedVariable>
   </file>
   <file src="src/Controllers/Import/ImportController.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$memoryLimit]]></code>
-    </ArgumentTypeCoercion>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[UrlParams::$params]]></code>
     </MixedArgumentTypeCoercion>
@@ -4059,9 +4056,6 @@
     </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Export/Export.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[(string) ini_get('memory_limit')]]></code>
-    </ArgumentTypeCoercion>
     <MixedArgument>
       <code><![CDATA[$dbAlias]]></code>
       <code><![CDATA[$dbAlias]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2967,9 +2967,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
-    <InvalidOperand>
-      <code><![CDATA[$matches[1]]]></code>
-    </InvalidOperand>
     <MixedArgument>
       <code><![CDATA[$path[$depth + 1]]]></code>
     </MixedArgument>

--- a/src/Controllers/Import/ImportController.php
+++ b/src/Controllers/Import/ImportController.php
@@ -36,7 +36,6 @@ use function __;
 use function _ngettext;
 use function in_array;
 use function ini_get;
-use function ini_parse_quantity;
 use function ini_set;
 use function is_array;
 use function is_link;
@@ -343,8 +342,7 @@ final readonly class ImportController implements InvocableController
 
         // We can not read all at once, otherwise we can run out of memory
         // Calculate value of the limit
-        $memoryLimit = (string) ini_get('memory_limit');
-        $memoryLimit = ini_parse_quantity($memoryLimit);
+        $memoryLimit = Util::getRealSize(ini_get('memory_limit'));
         // 2 MB as default
         if ($memoryLimit === 0) {
             $memoryLimit = 2 * 1024 * 1024;

--- a/src/Core.php
+++ b/src/Core.php
@@ -120,38 +120,6 @@ class Core
     }
 
     /**
-     * Converts numbers like 10M into bytes
-     * Used with permission from Moodle (https://moodle.org) by Martin Dougiamas
-     * (renamed with PMA prefix to avoid double definition when embedded
-     * in Moodle)
-     *
-     * @param string|int $size size (Default = 0)
-     */
-    public static function getRealSize(string|int $size = 0): int
-    {
-        if (! $size) {
-            return 0;
-        }
-
-        $binaryprefixes = [
-            'T' => 1099511627776,
-            't' => 1099511627776,
-            'G' => 1073741824,
-            'g' => 1073741824,
-            'M' => 1048576,
-            'm' => 1048576,
-            'K' => 1024,
-            'k' => 1024,
-        ];
-
-        if (preg_match('/^([0-9]+)([KMGT])/i', (string) $size, $matches) === 1) {
-            return (int) ($matches[1] * $binaryprefixes[$matches[2]]);
-        }
-
-        return (int) $size;
-    }
-
-    /**
      * Checks if the given $page is index.php and returns true if valid.
      * It ignores query parameters in $page (script.php?ignored)
      */

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -32,7 +32,6 @@ use function http_build_query;
 use function implode;
 use function in_array;
 use function ini_get;
-use function ini_parse_quantity;
 use function is_array;
 use function is_numeric;
 use function mb_strlen;
@@ -114,7 +113,7 @@ class Export
      */
     public function getMemoryLimit(): int
     {
-        $memoryLimit = ini_parse_quantity((string) ini_get('memory_limit'));
+        $memoryLimit = Util::getRealSize(ini_get('memory_limit'));
 
         // Some of memory is needed for other things and as threshold.
         // During export I had allocated (see memory_get_usage function)

--- a/src/Util.php
+++ b/src/Util.php
@@ -40,6 +40,7 @@ use function htmlspecialchars_decode;
 use function implode;
 use function in_array;
 use function ini_get;
+use function ini_parse_quantity;
 use function is_array;
 use function is_object;
 use function is_scalar;
@@ -1742,11 +1743,11 @@ class Util
             $fileSize = '5M';
         }
 
-        $size = Core::getRealSize($fileSize);
+        $size = ini_parse_quantity($fileSize);
         $postSize = ini_get('post_max_size');
 
         if ($postSize !== '' && $postSize !== false) {
-            $size = min($size, Core::getRealSize($postSize));
+            $size = min($size, ini_parse_quantity($postSize));
         }
 
         return $size;

--- a/src/Util.php
+++ b/src/Util.php
@@ -1743,15 +1743,27 @@ class Util
             $fileSize = '5M';
         }
 
-        // Using error suppression operator because ini_parse_quantity() can throw a warning if the value is invalid
-        $size = @ini_parse_quantity($fileSize);
+        $size = self::getRealSize($fileSize);
         $postSize = ini_get('post_max_size');
 
         if ($postSize !== '' && $postSize !== false) {
-            $size = min($size, @ini_parse_quantity($postSize));
+            $size = min($size, self::getRealSize($postSize));
         }
 
         return $size;
+    }
+
+    /**
+     * Converts numbers like 10M into bytes
+     */
+    public static function getRealSize(string $size): int
+    {
+        if ($size === '') {
+            return 0;
+        }
+
+        // Using error suppression operator because ini_parse_quantity() can throw a warning if the value is invalid
+        return @ini_parse_quantity($size);
     }
 
     public static function unquoteDefaultValue(string $value): string

--- a/src/Util.php
+++ b/src/Util.php
@@ -1743,11 +1743,12 @@ class Util
             $fileSize = '5M';
         }
 
-        $size = ini_parse_quantity($fileSize);
+        // Using error suppression operator because ini_parse_quantity() can throw a warning if the value is invalid
+        $size = @ini_parse_quantity($fileSize);
         $postSize = ini_get('post_max_size');
 
         if ($postSize !== '' && $postSize !== false) {
-            $size = min($size, ini_parse_quantity($postSize));
+            $size = min($size, @ini_parse_quantity($postSize));
         }
 
         return $size;

--- a/tests/unit/CoreTest.php
+++ b/tests/unit/CoreTest.php
@@ -14,7 +14,6 @@ use PhpMyAdmin\Tests\Clock\MockClock;
 use PhpMyAdmin\Url;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 
 use function _pgettext;
@@ -255,42 +254,6 @@ class CoreTest extends AbstractTestCase
             ['shell.php?sql.php&test=true', false],
             ['index.php%3Fsql.php%26test%3Dtrue', true],
             ['shell.php%3Fsql.php%26test%3Dtrue', false],
-        ];
-    }
-
-    /**
-     * Test for Core::getRealSize
-     *
-     * @param string $size     Size
-     * @param int    $expected Expected value
-     */
-    #[DataProvider('providerTestGetRealSize')]
-    #[Group('32bit-incompatible')]
-    public function testGetRealSize(string $size, int $expected): void
-    {
-        self::assertSame($expected, Core::getRealSize($size));
-    }
-
-    /**
-     * Data provider for testGetRealSize
-     *
-     * @return array<array{string, int}>
-     */
-    public static function providerTestGetRealSize(): array
-    {
-        return [
-            ['0', 0],
-            ['1kb', 1024],
-            ['1024k', 1024 * 1024],
-            ['8m', 8 * 1024 * 1024],
-            ['12gb', 12 * 1024 * 1024 * 1024],
-            ['1024', 1024],
-            ['8000m', 8 * 1000 * 1024 * 1024],
-            ['8G', 8 * 1024 * 1024 * 1024],
-            ['2048', 2048],
-            ['2048K', 2048 * 1024],
-            ['2048K', 2048 * 1024],
-            ['102400K', 102400 * 1024],
         ];
     }
 

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -700,6 +700,7 @@ class UtilTest extends AbstractTestCase
     public static function providerTestGetRealSize(): array
     {
         return [
+            ['', 0],
             ['0', 0],
             ['1kb', 1],
             ['1024k', 1024 * 1024],

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -16,6 +16,7 @@ use PhpMyAdmin\Utils\SessionCache;
 use PhpMyAdmin\Version;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 use function __;
@@ -675,6 +676,42 @@ class UtilTest extends AbstractTestCase
                 __('MiB'),
                 '100',
             ],
+        ];
+    }
+
+    /**
+     * Test for Util::getRealSize
+     *
+     * @param string $size     Size
+     * @param int    $expected Expected value
+     */
+    #[DataProvider('providerTestGetRealSize')]
+    #[Group('32bit-incompatible')]
+    public function testGetRealSize(string $size, int $expected): void
+    {
+        self::assertSame($expected, Util::getRealSize($size));
+    }
+
+    /**
+     * Data provider for testGetRealSize
+     *
+     * @return array<array{string, int}>
+     */
+    public static function providerTestGetRealSize(): array
+    {
+        return [
+            ['0', 0],
+            ['1kb', 1],
+            ['1024k', 1024 * 1024],
+            ['8m', 8 * 1024 * 1024],
+            ['12gb', 12],
+            ['1024', 1024],
+            ['8000m', 8 * 1000 * 1024 * 1024],
+            ['8G', 8 * 1024 * 1024 * 1024],
+            ['2048', 2048],
+            ['2048K', 2048 * 1024],
+            ['2048K', 2048 * 1024],
+            ['102400K', 102400 * 1024],
         ];
     }
 


### PR DESCRIPTION
Fixes #20115

There are two commits here. First removes the obsolete function and replaces it with `ini_parse_quantity`. The second fixes the mentioned bug, although I think not fixing the bug would also be ok. 