### PR TITLE
Migrate $_REQUEST to ServerRequest in 6 controllers

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1010,9 +1010,6 @@
       <code><![CDATA[Current::$database]]></code>
       <code><![CDATA[Current::$database]]></code>
     </MixedArgument>
-    <PossiblyInvalidCast>
-      <code><![CDATA[$parameters['table']]]></code>
-    </PossiblyInvalidCast>
     <PossiblyUnusedReturnValue>
       <code><![CDATA[Response]]></code>
     </PossiblyUnusedReturnValue>

--- a/src/Controllers/Database/ImportController.php
+++ b/src/Controllers/Database/ImportController.php
@@ -25,6 +25,7 @@ use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Routing\Route;
 use PhpMyAdmin\Util;
 use PhpMyAdmin\Utils\ForeignKey;
+use Webmozart\Assert\Assert;
 
 use function __;
 use function is_numeric;
@@ -80,12 +81,14 @@ final readonly class ImportController implements InvocableController
         }
 
         $offset = null;
-        if (isset($_REQUEST['offset']) && is_numeric($_REQUEST['offset'])) {
-            $offset = (int) $_REQUEST['offset'];
+        if ($request->has('offset') && is_numeric($request->getParam('offset'))) {
+            $offset = (int) $request->getParam('offset');
         }
 
-        $timeoutPassed = $_REQUEST['timeout_passed'] ?? null;
-        $localImportFile = $_REQUEST['local_import_file'] ?? null;
+        $timeoutPassed = $request->getParam('timeout_passed');
+        Assert::nullOrString($timeoutPassed);
+        $localImportFile = $request->getParam('local_import_file');
+        Assert::nullOrString($localImportFile);
         $compressions = Import::getCompressions($this->config);
 
         $charsets = Charsets::getCharsets($this->dbi, $this->config->selectedServer['DisableIS']);

--- a/src/Controllers/Database/Structure/FavoriteTableController.php
+++ b/src/Controllers/Database/Structure/FavoriteTableController.php
@@ -73,13 +73,13 @@ final readonly class FavoriteTableController implements InvocableController
         $favoriteTable = new RecentFavoriteTable($databaseName, TableName::from($favoriteTableName));
         $alreadyFavorite = $favoriteInstance->contains($favoriteTable);
 
-        if (isset($_REQUEST['remove_favorite'])) {
+        if ($request->has('remove_favorite')) {
             if ($alreadyFavorite) {
                 // If already in favorite list, remove it.
                 $favoriteInstance->remove($favoriteTable);
                 $alreadyFavorite = false; // for favorite_anchor template
             }
-        } elseif (isset($_REQUEST['add_favorite'])) {
+        } elseif ($request->has('add_favorite')) {
             if (! $alreadyFavorite) {
                 $numTables = count($favoriteInstance->getTables());
                 if ($numTables === $this->config->settings['NumFavoriteTables']) {

--- a/src/Controllers/Database/Structure/RealRowCountController.php
+++ b/src/Controllers/Database/Structure/RealRowCountController.php
@@ -34,8 +34,8 @@ final readonly class RealRowCountController implements InvocableController
     public function __invoke(ServerRequest $request): Response
     {
         $parameters = [
-            'real_row_count_all' => $_REQUEST['real_row_count_all'] ?? null,
-            'table' => $_REQUEST['table'] ?? null,
+            'real_row_count_all' => $request->getParam('real_row_count_all'),
+            'table' => $request->getParam('table'),
         ];
 
         if (Current::$database === '') {

--- a/src/Controllers/Database/StructureController.php
+++ b/src/Controllers/Database/StructureController.php
@@ -36,6 +36,7 @@ use PhpMyAdmin\Tracking\TrackingChecker;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
 use Throwable;
+use Webmozart\Assert\Assert;
 
 use function __;
 use function array_search;
@@ -144,7 +145,9 @@ final class StructureController implements InvocableController
 
     public function __invoke(ServerRequest $request): Response
     {
-        $parameters = ['sort' => $_REQUEST['sort'] ?? null, 'sort_order' => $_REQUEST['sort_order'] ?? null];
+        $parameters = ['sort' => $request->getParam('sort'), 'sort_order' => $request->getParam('sort_order')];
+        Assert::nullOrString($parameters['sort']);
+        Assert::nullOrString($parameters['sort_order']);
 
         if (Current::$database === '') {
             return $this->response->missingParameterError('db');

--- a/src/Controllers/Operations/DatabaseController.php
+++ b/src/Controllers/Operations/DatabaseController.php
@@ -79,7 +79,7 @@ final readonly class DatabaseController implements InvocableController
             }
 
             if ($newDatabaseName !== null) {
-                if ($newDatabaseName->getName() === $_REQUEST['db']) {
+                if ($newDatabaseName->getName() === $request->getParam('db')) {
                     Current::$message = Message::error(
                         __('Cannot copy database to the same name. Change the name and try again.'),
                     );

--- a/src/Controllers/Server/ImportController.php
+++ b/src/Controllers/Server/ImportController.php
@@ -23,6 +23,7 @@ use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Routing\Route;
 use PhpMyAdmin\Util;
 use PhpMyAdmin\Utils\ForeignKey;
+use Webmozart\Assert\Assert;
 
 use function __;
 use function is_numeric;
@@ -65,12 +66,14 @@ final readonly class ImportController implements InvocableController
         }
 
         $offset = null;
-        if (isset($_REQUEST['offset']) && is_numeric($_REQUEST['offset'])) {
-            $offset = (int) $_REQUEST['offset'];
+        if ($request->has('offset') && is_numeric($request->getParam('offset'))) {
+            $offset = (int) $request->getParam('offset');
         }
 
-        $timeoutPassed = $_REQUEST['timeout_passed'] ?? null;
-        $localImportFile = $_REQUEST['local_import_file'] ?? null;
+        $timeoutPassed = $request->getParam('timeout_passed');
+        Assert::nullOrString($timeoutPassed);
+        $localImportFile = $request->getParam('local_import_file');
+        Assert::nullOrString($localImportFile);
         $compressions = Import::getCompressions($this->config);
 
         $charsets = Charsets::getCharsets($this->dbi, $this->config->selectedServer['DisableIS']);

--- a/tests/unit/Controllers/Database/Structure/RealRowCountControllerTest.php
+++ b/tests/unit/Controllers/Database/Structure/RealRowCountControllerTest.php
@@ -21,7 +21,6 @@ class RealRowCountControllerTest extends AbstractTestCase
     {
         Config::getInstance()->selectedServer['DisableIS'] = true;
         Current::$database = 'world';
-        $_REQUEST['table'] = 'City';
 
         $dbiDummy = $this->createDbiDummy();
         $dbiDummy->addSelectDb('world');
@@ -31,7 +30,8 @@ class RealRowCountControllerTest extends AbstractTestCase
 
         $response = new ResponseStub();
 
-        $request = ServerRequestFactory::create()->createServerRequest('GET', 'http://example.com/')
+        $requestFactory = ServerRequestFactory::create();
+        $request = $requestFactory->createServerRequest('GET', 'http://example.com/')
             ->withQueryParams(['db' => 'world', 'table' => 'City', 'ajax_request' => '1']);
 
         (new RealRowCountController($response, $dbi, new DbTableExists($dbi)))($request);
@@ -39,9 +39,15 @@ class RealRowCountControllerTest extends AbstractTestCase
         $json = $response->getJSONResult();
         self::assertSame('4,079', $json['real_row_count']);
 
-        $_REQUEST['real_row_count_all'] = 'on';
+        $requestAll = $requestFactory->createServerRequest('GET', 'http://example.com/')
+            ->withQueryParams([
+                'db' => 'world',
+                'table' => 'City',
+                'ajax_request' => '1',
+                'real_row_count_all' => 'on',
+            ]);
 
-        (new RealRowCountController($response, $dbi, new DbTableExists($dbi)))($request);
+        (new RealRowCountController($response, $dbi, new DbTableExists($dbi)))($requestAll);
 
         $json = $response->getJSONResult();
         $expected = [


### PR DESCRIPTION
Continues the ongoing $_REQUEST migration (refs #16276, #17769). Replaces direct superglobal access with ServerRequest methods in 6 controllers where $request is already in scope:

- Server/ImportController + Database/ImportController
- Operations/DatabaseController
- Database/StructureController
- Database/Structure/FavoriteTableController
- Database/Structure/RealRowCountController

Follows the same patterns established in #20122. Auth-related files and non-controller code left for separate PRs.