### PR TITLE
Add str_replace(DIRECTORY_SEPARATOR, '/'

### DIFF
--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -238,7 +238,7 @@ class Error extends Message
      */
     public function getFile(): string
     {
-        return $this->file;
+        return str_replace(DIRECTORY_SEPARATOR, '/', $this->file);
     }
 
     /**

--- a/tests/unit/Error/ErrorTest.php
+++ b/tests/unit/Error/ErrorTest.php
@@ -9,9 +9,6 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-use function str_replace;
-
-use const DIRECTORY_SEPARATOR;
 use const E_COMPILE_ERROR;
 use const E_COMPILE_WARNING;
 use const E_CORE_ERROR;
@@ -81,9 +78,7 @@ class ErrorTest extends AbstractTestCase
     {
         $this->object->setFile($file);
         $filePath = $this->object->getFile();
-        self::assertStringStartsWith('.' . DIRECTORY_SEPARATOR, $filePath);
-        /** @psalm-var non-empty-string $expected */
-        $expected = str_replace('/', DIRECTORY_SEPARATOR, $expected);
+        self::assertStringStartsWith('./', $filePath);
         self::assertStringEndsWith($expected, $filePath);
     }
 


### PR DESCRIPTION
Makes it so that the path reported on Windows and Linux is the same. 