### PR TITLE
Fix failing unit tests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15417,7 +15417,7 @@ parameters:
 				Use dependency injection instead\.$#
 			'''
 			identifier: staticMethod.deprecated
-			count: 9
+			count: 7
 			path: tests/unit/Display/ResultsTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9850,8 +9850,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
-      <code><![CDATA[Config::getInstance()]]></code>
-      <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
     <DocblockTypeContradiction>
       <code><![CDATA[assertSame]]></code>

--- a/tests/unit/AbstractTestCase.php
+++ b/tests/unit/AbstractTestCase.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Cache;
+use PhpMyAdmin\Charsets;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Container\ContainerBuilder;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Dbal\DbiExtension;
+use PhpMyAdmin\Encoding;
 use PhpMyAdmin\I18n\LanguageManager;
 use PhpMyAdmin\Plugins\Export\ExportSql;
 use PhpMyAdmin\Sql;
@@ -68,11 +70,14 @@ abstract class AbstractTestCase extends TestCase
         Cache::purge();
         Tracker::disable();
 
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
         ContainerBuilder::$container = null;
         DatabaseInterface::$instance = null;
         Config::$instance = null;
         (new ReflectionProperty(Template::class, 'twig'))->setValue(null, null);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
+        (new ReflectionProperty(Charsets::class, 'charsets'))->setValue(null, []);
+        (new ReflectionProperty(Charsets::class, 'collations'))->setValue(null, []);
+        (new ReflectionProperty(Encoding::class, 'engine'))->setValue(null, null);
     }
 
     protected function createDatabaseInterface(

--- a/tests/unit/AbstractTestCase.php
+++ b/tests/unit/AbstractTestCase.php
@@ -70,6 +70,9 @@ abstract class AbstractTestCase extends TestCase
 
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
         ContainerBuilder::$container = null;
+        DatabaseInterface::$instance = null;
+        Config::$instance = null;
+        (new ReflectionProperty(Template::class, 'twig'))->setValue(null, null);
     }
 
     protected function createDatabaseInterface(
@@ -101,18 +104,6 @@ abstract class AbstractTestCase extends TestCase
     protected function setProxySettings(): void
     {
         HttpRequest::setProxySettingsFromEnv();
-    }
-
-    /**
-     * Destroys the environment built for the test.
-     * Clean all variables
-     */
-    protected function tearDown(): void
-    {
-        ContainerBuilder::$container = null;
-        DatabaseInterface::$instance = null;
-        Config::$instance = null;
-        (new ReflectionProperty(Template::class, 'twig'))->setValue(null, null);
     }
 
     /**

--- a/tests/unit/Display/ResultsTest.php
+++ b/tests/unit/Display/ResultsTest.php
@@ -73,14 +73,14 @@ class ResultsTest extends AbstractTestCase
 
         $this->setLanguage();
 
-        $this->dummyDbi = $this->createDbiDummy();
-        $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
-        DatabaseInterface::$instance = $this->dbi;
         Current::$server = 2;
         Current::$database = 'db';
         Current::$table = 'table';
-        $config = Config::getInstance();
+        $config = Config::$instance = new Config();
         $config->selectedServer['DisableIS'] = false;
+        $this->dummyDbi = $this->createDbiDummy();
+        $this->dbi = $this->createDatabaseInterface($this->dummyDbi, $config);
+        DatabaseInterface::$instance = $this->dbi;
         $this->object = new DisplayResults($this->dbi, $config, 'as', '', 2, '', '');
         $_SESSION[' HMAC_secret '] = 'test';
     }
@@ -1118,8 +1118,9 @@ class ResultsTest extends AbstractTestCase
 
     public function testGetTable(): void
     {
-        $config = Config::getInstance();
+        $config = Config::$instance = new Config();
         $config->selectedServer['DisableIS'] = true;
+        $this->dbi = $this->createDatabaseInterface($this->dummyDbi, $config);
 
         Current::$server = 2;
         Current::$database = 'test_db';


### PR DESCRIPTION
Clears `DatabaseInterface` and `Config` instances in `AbstractTestCase::setUp()`.

- https://github.com/phpmyadmin/phpmyadmin/actions/runs/22231785350/job/64313114297#step:8:109
- https://github.com/phpmyadmin/phpmyadmin/actions/runs/22207217878/job/64233731128#step:8:109
- https://github.com/phpmyadmin/phpmyadmin/actions/runs/22233310543/job/64318456213#step:6:579
- https://github.com/phpmyadmin/phpmyadmin/actions/runs/22235675033/job/64326536870?pr=20146#step:8:107