### PR TITLE
Clean up setUserValue

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -970,12 +970,6 @@ parameters:
 			path: src/Config/UserPreferencesHandler.php
 
 		-
-			message: '#^Only booleans are allowed in &&, string\|null given on the right side\.$#'
-			identifier: booleanAnd.rightNotBoolean
-			count: 1
-			path: src/Config/UserPreferencesHandler.php
-
-		-
 			message: '#^Parameter \#1 \$code of method PhpMyAdmin\\I18n\\LanguageManager\:\:getLanguage\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -916,27 +916,9 @@ parameters:
 			path: src/Config/UserPreferencesHandler.php
 
 		-
-			message: '#^Cannot access offset ''Server'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Config/UserPreferencesHandler.php
-
-		-
-			message: '#^Cannot access offset ''ThemeDefault'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Config/UserPreferencesHandler.php
-
-		-
 			message: '#^Cannot access offset ''config_mtime'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
-			path: src/Config/UserPreferencesHandler.php
-
-		-
-			message: '#^Cannot access offset ''lang'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
 			path: src/Config/UserPreferencesHandler.php
 
 		-
@@ -971,12 +953,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$code of method PhpMyAdmin\\I18n\\LanguageManager\:\:getLanguage\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Config/UserPreferencesHandler.php
-
-		-
-			message: '#^Parameter \#2 \.\.\.\$replacements of function array_replace_recursive expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Config/UserPreferencesHandler.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -439,9 +439,6 @@
     <PossiblyInvalidArgument>
       <code><![CDATA[$defaultValue]]></code>
     </PossiblyInvalidArgument>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$cookieName]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Config/Validator.php">
     <DeprecatedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -408,7 +408,6 @@
   </file>
   <file src="src/Config/UserPreferencesHandler.php">
     <MixedArgument>
-      <code><![CDATA[$configData]]></code>
       <code><![CDATA[$configData['lang']]]></code>
       <code><![CDATA[$defaultValue]]></code>
     </MixedArgument>
@@ -416,7 +415,6 @@
       <code><![CDATA[$_SESSION['cache'][$cacheKey]['userprefs']]]></code>
       <code><![CDATA[$_SESSION['cache'][$cacheKey]['userprefs']['LoginCookieValidity']]]></code>
       <code><![CDATA[$_SESSION['cache'][$cacheKey]['userprefs_type']]]></code>
-      <code><![CDATA[$configData['lang']]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
       <code><![CDATA[$_SESSION['cache'][$cacheKey]]]></code>
@@ -427,7 +425,6 @@
       <code><![CDATA[$_SESSION['cache'][$cacheKey]['userprefs_type']]]></code>
     </MixedArrayAssignment>
     <MixedAssignment>
-      <code><![CDATA[$configData]]></code>
       <code><![CDATA[$defaultValue]]></code>
       <code><![CDATA[$defaultValue]]></code>
       <code><![CDATA[$this->storageType]]></code>

--- a/src/Config.php
+++ b/src/Config.php
@@ -307,8 +307,12 @@ class Config
     private function setValueRecursive(array &$array, array $parts, mixed $value): bool
     {
         $part = array_shift($parts);
+        if (! isset($array[$part])) {
+            throw new ConfigException('Configuration option "' . $part . '" does not exist.');
+        }
+
         if ($parts === []) {
-            if (isset($array[$part]) && $array[$part] === $value) {
+            if ($array[$part] === $value) {
                 return false;
             }
 
@@ -318,7 +322,7 @@ class Config
         }
 
         if (! is_array($array[$part])) {
-            throw new ConfigException('Failed to set configuration value.');
+            throw new ConfigException('Configuration option "' . $part . '" is not an array.');
         }
 
         return $this->setValueRecursive($array[$part], $parts, $value);

--- a/src/Config/UserPreferencesHandler.php
+++ b/src/Config/UserPreferencesHandler.php
@@ -88,7 +88,6 @@ class UserPreferencesHandler
                 && $configData['ThemeDefault'] !== $this->themeManager->theme->getId()
             ) {
                 $this->setUserValue(
-                    null,
                     'ThemeDefault',
                     $this->themeManager->theme->getId(),
                     'original',
@@ -111,7 +110,7 @@ class UserPreferencesHandler
                 || isset($configData['lang'])
                 && Current::$lang !== $configData['lang']
             ) {
-                $this->setUserValue(null, 'lang', Current::$lang, 'en');
+                $this->setUserValue('lang', Current::$lang, 'en');
             }
         } elseif (isset($configData['lang'])) {
             // read language from settings
@@ -151,17 +150,12 @@ class UserPreferencesHandler
      * If user preferences are not yet initialized, option is applied to
      * global config and added to a update queue, which is processed
      * by {@link loadUserPreferences()}
-     *
-     * @param string|null $cookieName   can be null
-     * @param string      $cfgPath      configuration path
-     * @param mixed       $newCfgValue  new value
-     * @param string|null $defaultValue default value
      */
     public function setUserValue(
-        string|null $cookieName,
         string $cfgPath,
         mixed $newCfgValue,
         string|null $defaultValue = null,
+        string $cookieName = '',
     ): true|Message {
         $result = true;
         // use permanent user preferences if possible
@@ -173,7 +167,7 @@ class UserPreferencesHandler
             $result = $this->userPreferences->persistOption($cfgPath, $newCfgValue, $defaultValue);
         }
 
-        if ($this->storageType !== 'db' && $cookieName) {
+        if ($this->storageType !== 'db' && $cookieName !== '') {
             // fall back to cookies
             if ($defaultValue === null) {
                 $defaultValue = Core::arrayRead($cfgPath, $this->config->settings);

--- a/src/Config/UserPreferencesHandler.php
+++ b/src/Config/UserPreferencesHandler.php
@@ -92,6 +92,7 @@ class UserPreferencesHandler
                     $this->themeManager->theme->getId(),
                     'original',
                 );
+                $this->updateConfigValue('ThemeDefault', $this->themeManager->theme->getId());
             }
         } elseif (
             $this->config->config->ThemeDefault !== $this->themeManager->theme->getId()
@@ -176,9 +177,12 @@ class UserPreferencesHandler
             $this->config->setCookie($cookieName, (string) $newCfgValue, $defaultValue);
         }
 
-        $this->config->set($cfgPath, $newCfgValue);
-
         return $result;
+    }
+
+    public function updateConfigValue(string $cfgPath, mixed $newCfgValue): void
+    {
+        $this->config->set($cfgPath, $newCfgValue);
     }
 
     /**

--- a/src/Config/UserPreferencesHandler.php
+++ b/src/Config/UserPreferencesHandler.php
@@ -58,6 +58,7 @@ class UserPreferencesHandler
             return;
         }
 
+        /** @var mixed[] $configData */
         $configData = $_SESSION['cache'][$cacheKey]['userprefs'];
         // type is 'db' or 'session'
         $this->storageType = $_SESSION['cache'][$cacheKey]['userprefs_type'];

--- a/src/Controllers/CollationConnectionController.php
+++ b/src/Controllers/CollationConnectionController.php
@@ -27,6 +27,10 @@ final readonly class CollationConnectionController implements InvocableControlle
             $request->getParsedBodyParam('collation_connection'),
             'utf8mb4_unicode_ci',
         );
+        $this->userPreferencesHandler->updateConfigValue(
+            'DefaultConnectionCollation',
+            $request->getParsedBodyParam('collation_connection'),
+        );
 
         $this->response->redirect('index.php?route=/' . Url::getCommonRaw([], '&'));
 

--- a/src/Controllers/CollationConnectionController.php
+++ b/src/Controllers/CollationConnectionController.php
@@ -23,7 +23,6 @@ final readonly class CollationConnectionController implements InvocableControlle
     public function __invoke(ServerRequest $request): Response
     {
         $this->userPreferencesHandler->setUserValue(
-            null,
             'DefaultConnectionCollation',
             $request->getParsedBodyParam('collation_connection'),
             'utf8mb4_unicode_ci',

--- a/src/Controllers/Console/UpdateConfigController.php
+++ b/src/Controllers/Console/UpdateConfigController.php
@@ -39,7 +39,7 @@ final readonly class UpdateConfigController implements InvocableController
             return $this->response->response();
         }
 
-        $result = $this->userPreferencesHandler->setUserValue(null, 'Console/' . $key, $value);
+        $result = $this->userPreferencesHandler->setUserValue('Console/' . $key, $value);
         if ($result !== true) {
             $this->response->setStatusCode(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
             $this->response->setRequestStatus(false);

--- a/src/Controllers/Console/UpdateConfigController.php
+++ b/src/Controllers/Console/UpdateConfigController.php
@@ -48,6 +48,8 @@ final readonly class UpdateConfigController implements InvocableController
             return $this->response->response();
         }
 
+        $this->userPreferencesHandler->updateConfigValue('Console/' . $key, $value);
+
         $this->response->addJSON('message', __('Console settings has been updated successfully.'));
 
         return $this->response->response();

--- a/src/Controllers/Navigation/UpdateNavWidthConfigController.php
+++ b/src/Controllers/Navigation/UpdateNavWidthConfigController.php
@@ -35,6 +35,7 @@ final readonly class UpdateNavWidthConfigController implements InvocableControll
         }
 
         $result = $this->userPreferencesHandler->setUserValue('NavigationWidth', (int) $value);
+        $this->userPreferencesHandler->updateConfigValue('NavigationWidth', (int) $value);
         if ($result === true) {
             return $this->response->response();
         }

--- a/src/Controllers/Navigation/UpdateNavWidthConfigController.php
+++ b/src/Controllers/Navigation/UpdateNavWidthConfigController.php
@@ -34,7 +34,7 @@ final readonly class UpdateNavWidthConfigController implements InvocableControll
             return $this->response->response();
         }
 
-        $result = $this->userPreferencesHandler->setUserValue(null, 'NavigationWidth', (int) $value);
+        $result = $this->userPreferencesHandler->setUserValue('NavigationWidth', (int) $value);
         if ($result === true) {
             return $this->response->response();
         }

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -179,13 +179,7 @@ class Export
                 $filenameTemplate,
                 cookieName: 'pma_db_filename_template',
             );
-        } elseif ($exportType === ExportType::Raw) {
-            $userPreferencesHandler->setUserValue(
-                'Export/file_template_raw',
-                $filenameTemplate,
-                cookieName: 'pma_raw_filename_template',
-            );
-        } else {
+        } elseif ($exportType === ExportType::Table) {
             $userPreferencesHandler->setUserValue(
                 'Export/file_template_table',
                 $filenameTemplate,

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -169,27 +169,27 @@ class Export
     ): void {
         if ($exportType === ExportType::Server) {
             $userPreferencesHandler->setUserValue(
-                'pma_server_filename_template',
                 'Export/file_template_server',
                 $filenameTemplate,
+                cookieName: 'pma_server_filename_template',
             );
         } elseif ($exportType === ExportType::Database) {
             $userPreferencesHandler->setUserValue(
-                'pma_db_filename_template',
                 'Export/file_template_database',
                 $filenameTemplate,
+                cookieName: 'pma_db_filename_template',
             );
         } elseif ($exportType === ExportType::Raw) {
             $userPreferencesHandler->setUserValue(
-                'pma_raw_filename_template',
                 'Export/file_template_raw',
                 $filenameTemplate,
+                cookieName: 'pma_raw_filename_template',
             );
         } else {
             $userPreferencesHandler->setUserValue(
-                'pma_table_filename_template',
                 'Export/file_template_table',
                 $filenameTemplate,
+                cookieName: 'pma_table_filename_template',
             );
         }
     }

--- a/tests/unit/Config/UserPreferencesHandlerTest.php
+++ b/tests/unit/Config/UserPreferencesHandlerTest.php
@@ -29,10 +29,10 @@ final class UserPreferencesHandlerTest extends AbstractTestCase
             new LanguageManager($config),
             new ThemeManager(),
         );
-        $userPreferencesHandler->setUserValue(null, 'Lang', 'cs', 'en');
-        $userPreferencesHandler->setUserValue('TEST_COOKIE_USER_VAL', 'Servers/1/hide_db', 'cfg_val_1');
+        $userPreferencesHandler->setUserValue('Lang', 'cs', 'en');
+        $userPreferencesHandler->setUserValue('Servers/1/hide_db', 'cfg_val_1', cookieName: 'TEST_COOKIE_USER_VAL');
         self::assertSame('cfg_val_1', $userPreferencesHandler->getUserValue('TEST_COOKIE_USER_VAL', 'fail'));
-        $userPreferencesHandler->setUserValue(null, 'NavigationWidth', 300);
+        $userPreferencesHandler->setUserValue('NavigationWidth', 300);
         self::assertSame(300, $config->settings['NavigationWidth']);
     }
 

--- a/tests/unit/Config/UserPreferencesHandlerTest.php
+++ b/tests/unit/Config/UserPreferencesHandlerTest.php
@@ -32,8 +32,21 @@ final class UserPreferencesHandlerTest extends AbstractTestCase
         $userPreferencesHandler->setUserValue('Lang', 'cs', 'en');
         $userPreferencesHandler->setUserValue('Servers/1/hide_db', 'cfg_val_1', cookieName: 'TEST_COOKIE_USER_VAL');
         self::assertSame('cfg_val_1', $userPreferencesHandler->getUserValue('TEST_COOKIE_USER_VAL', 'fail'));
-        $userPreferencesHandler->setUserValue('NavigationWidth', 300);
-        self::assertSame(300, $config->settings['NavigationWidth']);
+    }
+
+    public function testUpdateConfigValue(): void
+    {
+        $config = new Config();
+        $dbi = $this->createDatabaseInterface();
+        $userPreferencesHandler = new UserPreferencesHandler(
+            $config,
+            $dbi,
+            new UserPreferences($dbi, new Relation($dbi, $config), new Template($config), $config, new Clock()),
+            new LanguageManager($config),
+            new ThemeManager(),
+        );
+        $userPreferencesHandler->updateConfigValue('NavigationWidth', 300);
+        self::assertSame(300, $config->config->NavigationWidth);
     }
 
     public function testGetUserValue(): void

--- a/tests/unit/Controllers/CollationConnectionControllerTest.php
+++ b/tests/unit/Controllers/CollationConnectionControllerTest.php
@@ -29,6 +29,8 @@ class CollationConnectionControllerTest extends AbstractTestCase
         $userPreferencesHandler = self::createMock(UserPreferencesHandler::class);
         $userPreferencesHandler->expects(self::once())->method('setUserValue')
             ->with('DefaultConnectionCollation', 'utf8mb4_general_ci', 'utf8mb4_unicode_ci');
+        $userPreferencesHandler->expects(self::once())->method('updateConfigValue')
+            ->with('DefaultConnectionCollation', 'utf8mb4_general_ci');
 
         (new CollationConnectionController($response, $userPreferencesHandler))($request);
     }

--- a/tests/unit/Controllers/CollationConnectionControllerTest.php
+++ b/tests/unit/Controllers/CollationConnectionControllerTest.php
@@ -28,7 +28,7 @@ class CollationConnectionControllerTest extends AbstractTestCase
 
         $userPreferencesHandler = self::createMock(UserPreferencesHandler::class);
         $userPreferencesHandler->expects(self::once())->method('setUserValue')
-            ->with(null, 'DefaultConnectionCollation', 'utf8mb4_general_ci', 'utf8mb4_unicode_ci');
+            ->with('DefaultConnectionCollation', 'utf8mb4_general_ci', 'utf8mb4_unicode_ci');
 
         (new CollationConnectionController($response, $userPreferencesHandler))($request);
     }


### PR DESCRIPTION
The goal is to try and separate the Config and UserPreferences. `lang` and Export preferences have not used the Config so that's why I decided to split that method in two. It is now a lot clearer which preferences affect the Config. 