### PR TITLE
Fix gis export to pdf and svg

### DIFF
--- a/libraries/classes/Gis/GisGeometry.php
+++ b/libraries/classes/Gis/GisGeometry.php
@@ -227,6 +227,7 @@ abstract class GisGeometry
      * @param bool       $linear     if true, as a 1D array, else as a 2D array
      *
      * @return array scaled points
+     * @psalm-return ($linear is true? list<float> : list<array{float,float}>)
      */
     protected function extractPoints($point_set, $scale_data, $linear = false): array
     {
@@ -249,8 +250,8 @@ abstract class GisGeometry
                     $y = floatval($scale_data['height'] - ($y - $scale_data['y']) * $scale_data['scale']);
                 }
             } else {
-                $x = 0;
-                $y = 0;
+                $x = 0.0;
+                $y = 0.0;
             }
 
             if (! $linear) {

--- a/libraries/classes/Gis/GisLineString.php
+++ b/libraries/classes/Gis/GisLineString.php
@@ -136,12 +136,14 @@ class GisLineString extends GisGeometry
         $red = hexdec(mb_substr($line_color, 1, 2));
         $green = hexdec(mb_substr($line_color, 3, 2));
         $blue = hexdec(mb_substr($line_color, 4, 2));
-        $line = [
-            'width' => 1.5,
-            'color' => [
-                $red,
-                $green,
-                $blue,
+        $lineStyle = [
+            'all' => [
+                'width' => 1.5,
+                'color' => [
+                    $red,
+                    $green,
+                    $blue,
+                ],
             ],
         ];
 
@@ -149,20 +151,12 @@ class GisLineString extends GisGeometry
 
         // Trim to remove leading 'LINESTRING(' and trailing ')'
         $linesrting = mb_substr($spatial, 11, -1);
-        $points_arr = $this->extractPoints($linesrting, $scale_data);
-
-        foreach ($points_arr as $point) {
-            if (isset($temp_point)) {
-                // draw line section
-                $pdf->Line($temp_point[0], $temp_point[1], $point[0], $point[1], $line);
-            }
-
-            $temp_point = $point;
-        }
+        $points_arr = $this->extractPoints($linesrting, $scale_data, true);
+        $pdf->PolyLine($points_arr, 'S', $lineStyle);
 
         // print label
         if ($label !== '') {
-            $pdf->setXY($points_arr[1][0], $points_arr[1][1]);
+            $pdf->setXY($points_arr[2], $points_arr[3]);
             $pdf->setFontSize(5);
             $pdf->Cell(0, 0, $label);
         }

--- a/libraries/classes/Gis/GisMultiLineString.php
+++ b/libraries/classes/Gis/GisMultiLineString.php
@@ -153,12 +153,14 @@ class GisMultiLineString extends GisGeometry
         $red = hexdec(mb_substr($line_color, 1, 2));
         $green = hexdec(mb_substr($line_color, 3, 2));
         $blue = hexdec(mb_substr($line_color, 4, 2));
-        $line = [
-            'width' => 1.5,
-            'color' => [
-                $red,
-                $green,
-                $blue,
+        $lineStyle = [
+            'all' => [
+                'width' => 1.5,
+                'color' => [
+                    $red,
+                    $green,
+                    $blue,
+                ],
             ],
         ];
 
@@ -169,27 +171,18 @@ class GisMultiLineString extends GisGeometry
         // Separate each linestring
         $linestirngs = explode('),(', $multilinestirng);
 
-        $first_line = true;
         foreach ($linestirngs as $linestring) {
-            $points_arr = $this->extractPoints($linestring, $scale_data);
-            foreach ($points_arr as $point) {
-                if (isset($temp_point)) {
-                    // draw line section
-                    $pdf->Line($temp_point[0], $temp_point[1], $point[0], $point[1], $line);
-                }
+            $points_arr = $this->extractPoints($linestring, $scale_data, true);
+            $pdf->PolyLine($points_arr, 'S', $lineStyle);
 
-                $temp_point = $point;
-            }
-
-            unset($temp_point);
             // print label
-            if ($label !== '' && $first_line) {
-                $pdf->setXY($points_arr[1][0], $points_arr[1][1]);
-                $pdf->setFontSize(5);
-                $pdf->Cell(0, 0, $label);
+            if ($label === '') {
+                continue;
             }
 
-            $first_line = false;
+            $pdf->setXY($points_arr[2], $points_arr[3]);
+            $pdf->setFontSize(5);
+            $pdf->Cell(0, 0, $label);
         }
 
         return $pdf;

--- a/libraries/classes/Gis/GisMultiLineString.php
+++ b/libraries/classes/Gis/GisMultiLineString.php
@@ -209,7 +209,7 @@ class GisMultiLineString extends GisGeometry
     {
         $line_options = [
             'data-label' => $label,
-            'class' => 'linestring vector',
+            'class' => 'multilinestring vector',
             'fill' => 'none',
             'stroke' => $line_color,
             'stroke-width' => 2,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17921,11 +17921,6 @@ parameters:
 			path: libraries/classes/Gis/GisGeometry.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisGeometry\\:\\:extractPoints\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisGeometry.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisGeometry\\:\\:generateParams\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisGeometry.php
@@ -18246,16 +18241,6 @@ parameters:
 			path: libraries/classes/Gis/GisLineString.php
 
 		-
-			message: "#^Cannot access offset 0 on mixed\\.$#"
-			count: 8
-			path: libraries/classes/Gis/GisLineString.php
-
-		-
-			message: "#^Cannot access offset 1 on mixed\\.$#"
-			count: 8
-			path: libraries/classes/Gis/GisLineString.php
-
-		-
 			message: "#^Cannot access offset int\\<0, max\\> on mixed\\.$#"
 			count: 4
 			path: libraries/classes/Gis/GisLineString.php
@@ -18301,42 +18286,7 @@ parameters:
 			path: libraries/classes/Gis/GisLineString.php
 
 		-
-			message: "#^Parameter \\#1 \\$number of function round expects float, mixed given\\.$#"
-			count: 6
-			path: libraries/classes/Gis/GisLineString.php
-
-		-
 			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisLineString.php
-
-		-
-			message: "#^Parameter \\#1 \\$x of method TCPDF\\:\\:setXY\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisLineString.php
-
-		-
-			message: "#^Parameter \\#1 \\$x1 of method TCPDF\\:\\:Line\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisLineString.php
-
-		-
-			message: "#^Parameter \\#2 \\$y of method TCPDF\\:\\:setXY\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisLineString.php
-
-		-
-			message: "#^Parameter \\#2 \\$y1 of method TCPDF\\:\\:Line\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisLineString.php
-
-		-
-			message: "#^Parameter \\#3 \\$x2 of method TCPDF\\:\\:Line\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisLineString.php
-
-		-
-			message: "#^Parameter \\#4 \\$y2 of method TCPDF\\:\\:Line\\(\\) expects float, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisLineString.php
 
@@ -18396,16 +18346,6 @@ parameters:
 			path: libraries/classes/Gis/GisMultiLineString.php
 
 		-
-			message: "#^Cannot access offset 0 on mixed\\.$#"
-			count: 8
-			path: libraries/classes/Gis/GisMultiLineString.php
-
-		-
-			message: "#^Cannot access offset 1 on mixed\\.$#"
-			count: 8
-			path: libraries/classes/Gis/GisMultiLineString.php
-
-		-
 			message: "#^Cannot access offset int\\<0, max\\> on mixed\\.$#"
 			count: 11
 			path: libraries/classes/Gis/GisMultiLineString.php
@@ -18456,42 +18396,7 @@ parameters:
 			path: libraries/classes/Gis/GisMultiLineString.php
 
 		-
-			message: "#^Parameter \\#1 \\$number of function round expects float, mixed given\\.$#"
-			count: 6
-			path: libraries/classes/Gis/GisMultiLineString.php
-
-		-
 			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiLineString.php
-
-		-
-			message: "#^Parameter \\#1 \\$x of method TCPDF\\:\\:setXY\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiLineString.php
-
-		-
-			message: "#^Parameter \\#1 \\$x1 of method TCPDF\\:\\:Line\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiLineString.php
-
-		-
-			message: "#^Parameter \\#2 \\$y of method TCPDF\\:\\:setXY\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiLineString.php
-
-		-
-			message: "#^Parameter \\#2 \\$y1 of method TCPDF\\:\\:Line\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiLineString.php
-
-		-
-			message: "#^Parameter \\#3 \\$x2 of method TCPDF\\:\\:Line\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiLineString.php
-
-		-
-			message: "#^Parameter \\#4 \\$y2 of method TCPDF\\:\\:Line\\(\\) expects float, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisMultiLineString.php
 
@@ -18537,12 +18442,12 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 0 on mixed\\.$#"
-			count: 8
+			count: 1
 			path: libraries/classes/Gis/GisMultiPoint.php
 
 		-
 			message: "#^Cannot access offset 1 on mixed\\.$#"
-			count: 8
+			count: 1
 			path: libraries/classes/Gis/GisMultiPoint.php
 
 		-
@@ -18551,12 +18456,12 @@ parameters:
 			path: libraries/classes/Gis/GisMultiPoint.php
 
 		-
-			message: "#^Cannot cast mixed to float\\.$#"
+			message: "#^Cannot cast mixed to string\\.$#"
 			count: 2
 			path: libraries/classes/Gis/GisMultiPoint.php
 
 		-
-			message: "#^Cannot cast mixed to string\\.$#"
+			message: "#^Casting to float something that's already float\\.$#"
 			count: 2
 			path: libraries/classes/Gis/GisMultiPoint.php
 
@@ -18606,37 +18511,12 @@ parameters:
 			path: libraries/classes/Gis/GisMultiPoint.php
 
 		-
-			message: "#^Parameter \\#1 \\$number of function round expects float, mixed given\\.$#"
-			count: 4
-			path: libraries/classes/Gis/GisMultiPoint.php
-
-		-
 			message: "#^Parameter \\#1 \\$point of method PhpMyAdmin\\\\Gis\\\\GisGeometry\\:\\:getPointForOpenLayers\\(\\) expects array, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisMultiPoint.php
 
 		-
 			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiPoint.php
-
-		-
-			message: "#^Parameter \\#1 \\$x of method TCPDF\\:\\:setXY\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiPoint.php
-
-		-
-			message: "#^Parameter \\#1 \\$x0 of method TCPDF\\:\\:Circle\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiPoint.php
-
-		-
-			message: "#^Parameter \\#2 \\$y of method TCPDF\\:\\:setXY\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiPoint.php
-
-		-
-			message: "#^Parameter \\#2 \\$y0 of method TCPDF\\:\\:Circle\\(\\) expects float, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisMultiPoint.php
 
@@ -18722,12 +18602,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 0 on mixed\\.$#"
-			count: 7
-			path: libraries/classes/Gis/GisMultiPolygon.php
-
-		-
-			message: "#^Cannot access offset 1 on mixed\\.$#"
-			count: 4
+			count: 3
 			path: libraries/classes/Gis/GisMultiPolygon.php
 
 		-
@@ -18791,11 +18666,6 @@ parameters:
 			path: libraries/classes/Gis/GisMultiPolygon.php
 
 		-
-			message: "#^Parameter \\#1 \\$number of function round expects float, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Gis/GisMultiPolygon.php
-
-		-
 			message: "#^Parameter \\#1 \\$point of static method PhpMyAdmin\\\\Gis\\\\GisPolygon\\:\\:isPointInsidePolygon\\(\\) expects array, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisMultiPolygon.php
@@ -18816,22 +18686,12 @@ parameters:
 			path: libraries/classes/Gis/GisMultiPolygon.php
 
 		-
-			message: "#^Parameter \\#1 \\$x of method TCPDF\\:\\:setXY\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiPolygon.php
-
-		-
 			message: "#^Parameter \\#2 \\$color of method PhpMyAdmin\\\\Image\\\\ImageWrapper\\:\\:filledPolygon\\(\\) expects int, int\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisMultiPolygon.php
 
 		-
 			message: "#^Parameter \\#2 \\$polygon of static method PhpMyAdmin\\\\Gis\\\\GisPolygon\\:\\:isPointInsidePolygon\\(\\) expects array, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiPolygon.php
-
-		-
-			message: "#^Parameter \\#2 \\$y of method TCPDF\\:\\:setXY\\(\\) expects float, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisMultiPolygon.php
 
@@ -18866,22 +18726,12 @@ parameters:
 			path: libraries/classes/Gis/GisPoint.php
 
 		-
-			message: "#^Cannot access offset 0 on mixed\\.$#"
-			count: 6
-			path: libraries/classes/Gis/GisPoint.php
-
-		-
-			message: "#^Cannot access offset 1 on mixed\\.$#"
-			count: 6
-			path: libraries/classes/Gis/GisPoint.php
-
-		-
-			message: "#^Cannot cast mixed to float\\.$#"
+			message: "#^Cannot cast mixed to string\\.$#"
 			count: 2
 			path: libraries/classes/Gis/GisPoint.php
 
 		-
-			message: "#^Cannot cast mixed to string\\.$#"
+			message: "#^Casting to float something that's already float\\.$#"
 			count: 2
 			path: libraries/classes/Gis/GisPoint.php
 
@@ -18926,37 +18776,7 @@ parameters:
 			path: libraries/classes/Gis/GisPoint.php
 
 		-
-			message: "#^Parameter \\#1 \\$number of function round expects float, mixed given\\.$#"
-			count: 4
-			path: libraries/classes/Gis/GisPoint.php
-
-		-
-			message: "#^Parameter \\#1 \\$point of method PhpMyAdmin\\\\Gis\\\\GisGeometry\\:\\:getPointForOpenLayers\\(\\) expects array, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisPoint.php
-
-		-
 			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisPoint.php
-
-		-
-			message: "#^Parameter \\#1 \\$x of method TCPDF\\:\\:setXY\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisPoint.php
-
-		-
-			message: "#^Parameter \\#1 \\$x0 of method TCPDF\\:\\:Circle\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisPoint.php
-
-		-
-			message: "#^Parameter \\#2 \\$y of method TCPDF\\:\\:setXY\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisPoint.php
-
-		-
-			message: "#^Parameter \\#2 \\$y0 of method TCPDF\\:\\:Circle\\(\\) expects float, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisPoint.php
 
@@ -19003,16 +18823,6 @@ parameters:
 		-
 			message: "#^Cannot access offset 'y' on mixed\\.$#"
 			count: 21
-			path: libraries/classes/Gis/GisPolygon.php
-
-		-
-			message: "#^Cannot access offset 0 on mixed\\.$#"
-			count: 3
-			path: libraries/classes/Gis/GisPolygon.php
-
-		-
-			message: "#^Cannot access offset 1 on mixed\\.$#"
-			count: 3
 			path: libraries/classes/Gis/GisPolygon.php
 
 		-
@@ -19096,27 +18906,12 @@ parameters:
 			path: libraries/classes/Gis/GisPolygon.php
 
 		-
-			message: "#^Parameter \\#1 \\$number of function round expects float, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Gis/GisPolygon.php
-
-		-
 			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisPolygon.php
 
 		-
-			message: "#^Parameter \\#1 \\$x of method TCPDF\\:\\:setXY\\(\\) expects float, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisPolygon.php
-
-		-
 			message: "#^Parameter \\#2 \\$color of method PhpMyAdmin\\\\Image\\\\ImageWrapper\\:\\:filledPolygon\\(\\) expects int, int\\|false given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisPolygon.php
-
-		-
-			message: "#^Parameter \\#2 \\$y of method TCPDF\\:\\:setXY\\(\\) expects float, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisPolygon.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6810,38 +6810,14 @@
     </RedundantPropertyInitializationCheck>
   </file>
   <file src="libraries/classes/Gis/GisLineString.php">
-    <MixedArgument occurrences="13">
-      <code>$point[0]</code>
-      <code>$point[0]</code>
-      <code>$point[1]</code>
-      <code>$point[1]</code>
-      <code>$points_arr[1][0]</code>
-      <code>$points_arr[1][0]</code>
-      <code>$points_arr[1][1]</code>
-      <code>$points_arr[1][1]</code>
+    <MixedArgument occurrences="3">
       <code>$temp_point[0]</code>
-      <code>$temp_point[0]</code>
-      <code>$temp_point[1]</code>
       <code>$temp_point[1]</code>
       <code>$wkt</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="17">
+    <MixedArrayAccess occurrences="3">
       <code>$gis_data[$index]['LINESTRING']['no_of_points']</code>
-      <code>$point[0]</code>
-      <code>$point[0]</code>
-      <code>$point[0]</code>
-      <code>$point[1]</code>
-      <code>$point[1]</code>
-      <code>$point[1]</code>
-      <code>$points_arr[$i][0]</code>
-      <code>$points_arr[$i][1]</code>
-      <code>$points_arr[1][0]</code>
-      <code>$points_arr[1][0]</code>
-      <code>$points_arr[1][1]</code>
-      <code>$points_arr[1][1]</code>
       <code>$temp_point[0]</code>
-      <code>$temp_point[0]</code>
-      <code>$temp_point[1]</code>
       <code>$temp_point[1]</code>
     </MixedArrayAccess>
     <MixedArrayAssignment occurrences="3">
@@ -6849,22 +6825,12 @@
       <code>$params[$index]['LINESTRING']</code>
       <code>$params[$index]['LINESTRING']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="10">
+    <MixedAssignment occurrences="3">
       <code>$no_of_points</code>
-      <code>$params[$index]['LINESTRING'][$i]['x']</code>
-      <code>$params[$index]['LINESTRING'][$i]['y']</code>
       <code>$params['srid']</code>
-      <code>$point</code>
-      <code>$point</code>
-      <code>$point</code>
-      <code>$temp_point</code>
-      <code>$temp_point</code>
       <code>$wkt</code>
     </MixedAssignment>
-    <MixedOperand occurrences="4">
-      <code>$point[0]</code>
-      <code>$point[1]</code>
-    </MixedOperand>
+    <MixedOperand occurrences="2"/>
     <ParamNameMismatch occurrences="4">
       <code>$line_color</code>
       <code>$line_color</code>
@@ -6880,42 +6846,18 @@
     </RedundantPropertyInitializationCheck>
   </file>
   <file src="libraries/classes/Gis/GisMultiLineString.php">
-    <MixedArgument occurrences="13">
-      <code>$point[0]</code>
-      <code>$point[0]</code>
-      <code>$point[1]</code>
-      <code>$point[1]</code>
-      <code>$points_arr[1][0]</code>
-      <code>$points_arr[1][0]</code>
-      <code>$points_arr[1][1]</code>
-      <code>$points_arr[1][1]</code>
+    <MixedArgument occurrences="3">
       <code>$temp_point[0]</code>
-      <code>$temp_point[0]</code>
-      <code>$temp_point[1]</code>
       <code>$temp_point[1]</code>
       <code>$wkt</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="21">
+    <MixedArrayAccess occurrences="7">
       <code>$data_row[$i]</code>
       <code>$data_row['no_of_lines']</code>
       <code>$point['x']</code>
       <code>$point['y']</code>
-      <code>$point[0]</code>
-      <code>$point[0]</code>
-      <code>$point[0]</code>
-      <code>$point[1]</code>
-      <code>$point[1]</code>
-      <code>$point[1]</code>
-      <code>$points_arr[$i][0]</code>
-      <code>$points_arr[$i][1]</code>
-      <code>$points_arr[1][0]</code>
-      <code>$points_arr[1][0]</code>
-      <code>$points_arr[1][1]</code>
-      <code>$points_arr[1][1]</code>
       <code>$row_data['parts'][$i]</code>
       <code>$temp_point[0]</code>
-      <code>$temp_point[0]</code>
-      <code>$temp_point[1]</code>
       <code>$temp_point[1]</code>
     </MixedArrayAccess>
     <MixedArrayAssignment occurrences="4">
@@ -6924,26 +6866,17 @@
       <code>$params[$index]['MULTILINESTRING']</code>
       <code>$params[$index]['MULTILINESTRING']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="13">
+    <MixedAssignment occurrences="6">
       <code>$data_row</code>
       <code>$no_of_lines</code>
       <code>$no_of_points</code>
-      <code>$params[$index]['MULTILINESTRING'][$j][$i]['x']</code>
-      <code>$params[$index]['MULTILINESTRING'][$j][$i]['y']</code>
       <code>$params['srid']</code>
       <code>$point</code>
-      <code>$point</code>
-      <code>$point</code>
-      <code>$point</code>
-      <code>$temp_point</code>
-      <code>$temp_point</code>
       <code>$wkt</code>
     </MixedAssignment>
-    <MixedOperand occurrences="6">
+    <MixedOperand occurrences="4">
       <code>$point['x']</code>
       <code>$point['y']</code>
-      <code>$point[0]</code>
-      <code>$point[1]</code>
     </MixedOperand>
     <ParamNameMismatch occurrences="4">
       <code>$line_color</code>
@@ -6964,40 +6897,14 @@
     </RedundantPropertyInitializationCheck>
   </file>
   <file src="libraries/classes/Gis/GisMultiPoint.php">
-    <MixedArgument occurrences="10">
+    <MixedArgument occurrences="2">
       <code>$point</code>
-      <code>$point[0]</code>
-      <code>$point[0]</code>
-      <code>$point[1]</code>
-      <code>$point[1]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][1]</code>
-      <code>$points_arr[0][1]</code>
       <code>$wkt</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="23">
+    <MixedArrayAccess occurrences="5">
       <code>$gis_data[$index]['MULTIPOINT']['no_of_points']</code>
       <code>$point[0]</code>
-      <code>$point[0]</code>
-      <code>$point[0]</code>
-      <code>$point[0]</code>
-      <code>$point[0]</code>
-      <code>$point[0]</code>
-      <code>$point[0]</code>
       <code>$point[1]</code>
-      <code>$point[1]</code>
-      <code>$point[1]</code>
-      <code>$point[1]</code>
-      <code>$point[1]</code>
-      <code>$point[1]</code>
-      <code>$point[1]</code>
-      <code>$points_arr[$i][0]</code>
-      <code>$points_arr[$i][1]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][1]</code>
-      <code>$points_arr[0][1]</code>
       <code>$row_data['points'][$i]</code>
       <code>$row_data['points'][$i]</code>
     </MixedArrayAccess>
@@ -7006,20 +6913,13 @@
       <code>$params[$index]['MULTIPOINT']</code>
       <code>$params[$index]['MULTIPOINT']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment occurrences="4">
       <code>$no_of_points</code>
-      <code>$params[$index]['MULTIPOINT'][$i]['x']</code>
-      <code>$params[$index]['MULTIPOINT'][$i]['y']</code>
       <code>$params['srid']</code>
-      <code>$point</code>
-      <code>$point</code>
-      <code>$point</code>
       <code>$point</code>
       <code>$wkt</code>
     </MixedAssignment>
-    <MixedOperand occurrences="6">
-      <code>$point[0]</code>
-      <code>$point[1]</code>
+    <MixedOperand occurrences="4">
       <code>$row_data['points'][$i]['x']</code>
       <code>$row_data['points'][$i]['y']</code>
     </MixedOperand>
@@ -7033,6 +6933,10 @@
       <code>$black</code>
       <code>$color</code>
     </PossiblyFalseArgument>
+    <RedundantCastGivenDocblockType occurrences="2">
+      <code>(float) $point[0]</code>
+      <code>(float) $point[1]</code>
+    </RedundantCastGivenDocblockType>
     <RedundantPropertyInitializationCheck occurrences="1">
       <code>isset(self::$instance)</code>
     </RedundantPropertyInitializationCheck>
@@ -7049,7 +6953,7 @@
       <code>$ring['points']</code>
       <code>$wkt</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="37">
+    <MixedArrayAccess occurrences="29">
       <code>$data_row[$k]</code>
       <code>$data_row[$k]</code>
       <code>$data_row['no_of_polygons']</code>
@@ -7068,14 +6972,6 @@
       <code>$params[$index]['MULTIPOLYGON']</code>
       <code>$point['x']</code>
       <code>$point['y']</code>
-      <code>$point[0]</code>
-      <code>$point[1]</code>
-      <code>$points_arr[$i][0]</code>
-      <code>$points_arr[$i][0]</code>
-      <code>$points_arr[$i][1]</code>
-      <code>$points_arr[$i][1]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][1]</code>
       <code>$ring1['isOuter']</code>
       <code>$ring1['pointOnSurface']</code>
       <code>$ring2['isOuter']</code>
@@ -7110,7 +7006,7 @@
       <code>$row_data['parts'][$k]</code>
       <code>$row_data['parts'][$k]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="25">
+    <MixedAssignment occurrences="20">
       <code>$data_row</code>
       <code>$i</code>
       <code>$i</code>
@@ -7122,12 +7018,7 @@
       <code>$no_of_points</code>
       <code>$no_of_polygons</code>
       <code>$param_row</code>
-      <code>$param_row[$k][$j][$i]['x']</code>
-      <code>$param_row[$k][$j][$i]['y']</code>
-      <code>$param_row[$k][0][$i]['x']</code>
-      <code>$param_row[$k][0][$i]['y']</code>
       <code>$params['srid']</code>
-      <code>$point</code>
       <code>$point</code>
       <code>$ring</code>
       <code>$ring</code>
@@ -7137,15 +7028,11 @@
       <code>$row_data['parts'][$k]['inner'][]</code>
       <code>$wkt</code>
     </MixedAssignment>
-    <MixedOperand occurrences="10">
+    <MixedOperand occurrences="6">
       <code>$innerPoint['x']</code>
       <code>$innerPoint['y']</code>
       <code>$point['x']</code>
       <code>$point['y']</code>
-      <code>$point[0]</code>
-      <code>$point[1]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][1]</code>
     </MixedOperand>
     <ParamNameMismatch occurrences="4">
       <code>$fill_color</code>
@@ -7167,49 +7054,24 @@
     </RedundantPropertyInitializationCheck>
   </file>
   <file src="libraries/classes/Gis/GisPoint.php">
-    <MixedArgument occurrences="10">
-      <code>$points_arr[0]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][1]</code>
-      <code>$points_arr[0][1]</code>
-      <code>$points_arr[0][1]</code>
-      <code>$points_arr[0][1]</code>
+    <MixedArgument occurrences="1">
       <code>$wkt</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="16">
+    <MixedArrayAccess occurrences="4">
       <code>$gis_data[$index]['POINT']['x']</code>
       <code>$gis_data[$index]['POINT']['x']</code>
       <code>$gis_data[$index]['POINT']['y']</code>
       <code>$gis_data[$index]['POINT']['y']</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][1]</code>
-      <code>$points_arr[0][1]</code>
-      <code>$points_arr[0][1]</code>
-      <code>$points_arr[0][1]</code>
-      <code>$points_arr[0][1]</code>
-      <code>$points_arr[0][1]</code>
     </MixedArrayAccess>
     <MixedArrayAssignment occurrences="2">
       <code>$params[$index]['POINT']</code>
       <code>$params[$index]['POINT']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="4">
-      <code>$params[$index]['POINT']['x']</code>
-      <code>$params[$index]['POINT']['y']</code>
+    <MixedAssignment occurrences="2">
       <code>$params['srid']</code>
       <code>$wkt</code>
     </MixedAssignment>
-    <MixedOperand occurrences="6">
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][1]</code>
+    <MixedOperand occurrences="4">
       <code>$row_data['x'] ?? ''</code>
       <code>$row_data['y'] ?? ''</code>
     </MixedOperand>
@@ -7223,20 +7085,20 @@
       <code>$black</code>
       <code>$color</code>
     </PossiblyFalseArgument>
+    <RedundantCastGivenDocblockType occurrences="2">
+      <code>(float) $points_arr[0][0]</code>
+      <code>(float) $points_arr[0][1]</code>
+    </RedundantCastGivenDocblockType>
     <RedundantPropertyInitializationCheck occurrences="1">
       <code>isset(self::$instance)</code>
     </RedundantPropertyInitializationCheck>
   </file>
   <file src="libraries/classes/Gis/GisPolygon.php">
-    <MixedArgument occurrences="6">
-      <code>$points_arr[2]</code>
-      <code>$points_arr[2]</code>
-      <code>$points_arr[3]</code>
-      <code>$points_arr[3]</code>
+    <MixedArgument occurrences="2">
       <code>$wkt</code>
       <code>($y1 - $y0) ** 2 + ($x0 - $x1) ** 2</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="42">
+    <MixedArrayAccess occurrences="36">
       <code>$gis_data[$index]['POLYGON']</code>
       <code>$gis_data[$index]['POLYGON']['no_of_lines']</code>
       <code>$p1['x']</code>
@@ -7255,12 +7117,6 @@
       <code>$p2['y']</code>
       <code>$p2['y']</code>
       <code>$p2['y']</code>
-      <code>$point[0]</code>
-      <code>$point[1]</code>
-      <code>$points_arr[$i][0]</code>
-      <code>$points_arr[$i][1]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][1]</code>
       <code>$polygon[$last]['x']</code>
       <code>$polygon[$last]['y']</code>
       <code>$polygon[0]['x']</code>
@@ -7286,7 +7142,7 @@
       <code>$params[$index]['POLYGON']</code>
       <code>$params[$index]['POLYGON']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="27">
+    <MixedAssignment occurrences="24">
       <code>$area</code>
       <code>$area</code>
       <code>$area</code>
@@ -7298,10 +7154,7 @@
       <code>$p1</code>
       <code>$p1</code>
       <code>$p2</code>
-      <code>$params[$index]['POLYGON'][$j][$i]['x']</code>
-      <code>$params[$index]['POLYGON'][$j][$i]['y']</code>
       <code>$params['srid']</code>
-      <code>$point</code>
       <code>$pointA['x']</code>
       <code>$pointA['y']</code>
       <code>$pointB['x']</code>
@@ -7318,7 +7171,7 @@
     <MixedInferredReturnType occurrences="1">
       <code>float</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="35">
+    <MixedOperand occurrences="31">
       <code>$area</code>
       <code>$area</code>
       <code>$epsilon * ($y1 - $y0)</code>
@@ -7328,10 +7181,6 @@
       <code>$pointA['x']</code>
       <code>$pointB['x']</code>
       <code>$point['y']</code>
-      <code>$point[0]</code>
-      <code>$point[1]</code>
-      <code>$points_arr[0][0]</code>
-      <code>$points_arr[0][1]</code>
       <code>$ring[$i]['x']</code>
       <code>$ring[$i]['y']</code>
       <code>$x0</code>

--- a/test/classes/Gis/GisMultiLineStringTest.php
+++ b/test/classes/Gis/GisMultiLineStringTest.php
@@ -349,9 +349,9 @@ class GisMultiLineStringTest extends GisGeomTestCase
                     'height' => 150,
                 ],
                 '/^(<polyline points="48,260 70,242 100,138 " data-label="svg" '
-                . 'class="linestring vector" fill="none" stroke="#B02EE0" '
+                . 'class="multilinestring vector" fill="none" stroke="#B02EE0" '
                 . 'stroke-width="2" id="svg)(\d+)("\/><polyline points="48,268 10,'
-                . '242 332,182 " data-label="svg" class="linestring vector" fill="none" '
+                . '242 332,182 " data-label="svg" class="multilinestring vector" fill="none" '
                 . 'stroke="#B02EE0" stroke-width="2" id="svg)(\d+)("\/>)$/',
             ],
         ];


### PR DESCRIPTION
### Description

In exported svg files geometries have class names according to their geometry type, e. g. `point`, `linestring`, and `polygon`, but also `multipoint`, and `multipolygon`, only for MultiLineString it was `linestring` instead `multilinestring`.
This class is not used by phpmyadmin, so it doesn't really matter...

In exported pdf files each linestring segment was drawn with a new call to the `Line` function which caused each segment to have a line cap, drawing as a polyline fixes this.

```sql
SELECT ST_GeomFromText('LINESTRING(120 20,170 60,140 10)') AS geom UNION ALL
SELECT ST_GeomFromText('MULTILINESTRING((120 60,165 60,120 59),(170 10,170 55,160 10),(120 62,172 62,172 10))');
```
Visualize GIS data -> Save -> PDF

Before pdf:
<img width="527" height="284" alt="image" src="https://github.com/user-attachments/assets/ef794667-ae8f-4677-9086-f8cf4d2c0528" />

After pdf:
<img width="527" height="284" alt="image" src="https://github.com/user-attachments/assets/0385da7a-f89a-41ee-aa5a-b0a649943902" />