### PR TITLE
Fix #20102 - Show grid edit hint for truncated values

### DIFF
--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -1031,7 +1031,6 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         $(g.cEdit).on('keyup', '.edit_box', function () {
                             $editArea.find('textarea').val($(this).val());
                         });
-                        $editArea.append('<div class="cell_edit_hint">' + g.cellEditHint + '</div>');
                     } else {
                         // handle truncated/transformed values values
                         $editArea.addClass('edit_area_loading');
@@ -1066,6 +1065,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         }); // end $.post()
                     }
                     g.isEditCellTextEditable = true;
+                    $editArea.append('<div class="cell_edit_hint">' + g.cellEditHint + '</div>');
                 } else if ($td.is('.timefield, .datefield, .datetimefield, .timestampfield')) {
                     var $inputField = $(g.cEdit).find('.edit_box');
 


### PR DESCRIPTION
### Description

Displayed the grid edit hint for truncated values which was not being displayed before when edit area was showing up.

Fixes #20102 

Before submitting pull request, please review the following checklist:

- [ X ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ X ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ X ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ X ] Every commit has a descriptive commit message.
- [ X ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ X ] Any new functionality is covered by tests.

### Video Demonstration of the fix:
[Screencast from 2026-02-22 19-02-17.webm](https://github.com/user-attachments/assets/126b3875-5fc7-47c5-9af0-6a3ecd65ee56)
