### PR TITLE
Fix #20155 - Fix Call to a member function count() on null

### DIFF
--- a/libraries/classes/Plugins/Import/ImportXml.php
+++ b/libraries/classes/Plugins/Import/ImportXml.php
@@ -229,7 +229,7 @@ class ImportXml extends ImportPlugin
         /**
          * Only attempt to analyze/collect data if there is data present
          */
-        if ($xml && $xml->children()->count()) {
+        if ($xml && $xml->count()) {
             $data_present = true;
 
             /**


### PR DESCRIPTION
### Description

See line https://github.com/phpmyadmin/phpmyadmin/blob/3f658b8e15f1268161778efd55fce0344223b3cf/libraries/classes/Plugins/Import/ImportXml.php#L224-L225

This resulted in `$xml->children()->children()->children()->count()`

There's no need to merge anything in `master`, since the bug is not present there.

Fixes #20155

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
