### PR TITLE
Fix #20157 - Set user-agent to null if not defined

### DIFF
--- a/libraries/classes/ErrorReport.php
+++ b/libraries/classes/ErrorReport.php
@@ -86,7 +86,7 @@ class ErrorReport
             'browser_version' => $this->config->get('PMA_USR_BROWSER_VER'),
             'user_os' => $this->config->get('PMA_USR_OS'),
             'server_software' => $_SERVER['SERVER_SOFTWARE'] ?? null,
-            'user_agent_string' => $_SERVER['HTTP_USER_AGENT'],
+            'user_agent_string' => $_SERVER['HTTP_USER_AGENT'] ?? null,
             'locale' => $this->config->getCookie('pma_lang'),
             'configuration_storage' => $relationParameters->db === null ? 'disabled' : 'enabled',
             'php_version' => PHP_VERSION,


### PR DESCRIPTION
### Description

It will show `null` for `user_agent_string`:

```JSON
{
    "pma_version": "5.2.4-dev",
    "browser_name": "OTHER",
    "browser_version": 0,
    "user_os": "Other",
    "server_software": "nginx/1.29.5",
    "user_agent_string": null,
    "locale": "en",
    "configuration_storage": "enabled",
    "php_version": "8.5.3",
    "script_name": "index.php",
    "exception_type": "js"
}
```

Fixes #20157

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
