### PR TITLE
Fix CodeMirror.runMode is not a function

### DIFF
--- a/js/src/console.js
+++ b/js/src/console.js
@@ -538,7 +538,7 @@ var ConsoleInput = {
         if (ConsoleInput.inputs !== null) {
             return;
         }
-        if (typeof CodeMirror !== 'undefined') {
+        if (typeof CodeMirror !== 'undefined' && typeof CodeMirror.runMode === 'function') {
             ConsoleInput.codeMirror = true;
         }
         ConsoleInput.inputs = [];

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -1720,7 +1720,7 @@ Functions.highlightSql = function ($base) {
         if ($pre.is(':visible')) {
             var $highlight = $('<div class="sql-highlight cm-s-default"></div>');
             $sql.append($highlight);
-            if (typeof CodeMirror !== 'undefined') {
+            if (typeof CodeMirror !== 'undefined' && typeof CodeMirror.runMode === 'function') {
                 CodeMirror.runMode($sql.text(), 'text/x-mysql', $highlight[0]);
                 $pre.hide();
                 $highlight.find('.cm-keyword').each(Functions.documentationKeyword);
@@ -1791,7 +1791,7 @@ Functions.updateCode = function ($base, htmlValue, rawValue) {
     var $notHighlighted = $('<pre>' + htmlValue + '</pre>');
 
     // Tries to highlight code using CodeMirror.
-    if (typeof CodeMirror !== 'undefined') {
+    if (typeof CodeMirror !== 'undefined' && typeof CodeMirror.runMode === 'function') {
         var $highlighted = $('<div class="' + type + '-highlight cm-s-default"></div>');
         CodeMirror.runMode(rawValue, mode, $highlighted[0]);
         $notHighlighted.hide();


### PR DESCRIPTION
### Description

This is an attempt to fix `CodeMirror.runMode is not a function`. This type of check was already added for `JSON` here:

https://github.com/phpmyadmin/phpmyadmin/blob/3f658b8e15f1268161778efd55fce0344223b3cf/js/src/functions.js#L1747-L1750

For first commit:

https://reports.phpmyadmin.net/reports/view/88391
https://reports.phpmyadmin.net/reports/view/88843

For the second commit:

https://reports.phpmyadmin.net/reports/view/88417

From what I've found it seems there are extensions probably using CodeMirror that interfere with.

https://stackoverflow.com/questions/76595307/problems-when-querying-mysql-tables-in-phpmyadmin-from-google-chrome-browser

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
