### PR TITLE
Improve the way phpMyAdmin uses the user-agent

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -109,7 +109,7 @@ $.ajaxPrefilter(function (options, originalOptions) {
 Functions.userAgent = function () {
     try {
         return navigator.userAgent;
-    } catch {
+    } catch (e) {
         return '';
     }
 };

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -104,6 +104,17 @@ $.ajaxPrefilter(function (options, originalOptions) {
 });
 
 /**
+ * Get an empty string for user-agent, if undefined
+ */
+Functions.userAgent = function () {
+    try {
+        return navigator.userAgent;
+    } catch {
+        return '';
+    }
+};
+
+/**
  * Adds a date/time picker to an element
  *
  * @param {object} $thisElement a jQuery object pointing to the element
@@ -1095,7 +1106,7 @@ AJAX.registerOnload('functions.js', function () {
     /**
      * Add attribute to text boxes for iOS devices (based on bugID: 3508912)
      */
-    if (navigator.userAgent.match(/(iphone|ipod|ipad)/i)) {
+    if (Functions.userAgent().match(/(iphone|ipod|ipad)/i)) {
         $('input[type=text]').attr('autocapitalize', 'off').attr('autocorrect', 'off');
     }
 });

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -112,6 +112,7 @@ Functions.userAgent = function () {
     try {
         return navigator.userAgent;
     } catch (e) {
+        console.error(e);
         return '';
     }
 };

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -105,6 +105,8 @@ $.ajaxPrefilter(function (options, originalOptions) {
 
 /**
  * Get an empty string for user-agent, if undefined
+ *
+ * @return {string}
  */
 Functions.userAgent = function () {
     try {

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -260,7 +260,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
             for (var n = 0, l = $firstRowCols.length; n < l; n++) {
                 var $col = $($firstRowCols[n]);
                 var colWidth;
-                if (navigator.userAgent.toLowerCase().indexOf('safari') !== -1) {
+                if (Functions.userAgent().toLowerCase().indexOf('safari') !== -1) {
                     colWidth = $col.outerWidth();
                 } else {
                     colWidth = $col.outerWidth(true);
@@ -2317,10 +2317,10 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
     $.fn.noSelect = function (p) { // no select plugin by Paulo P.Marinas
         var prevent = (p === null) ? true : p;
         /* eslint-disable compat/compat */
-        var isMsie = navigator.userAgent.indexOf('MSIE') > -1 || !!window.navigator.userAgent.match(/Trident.*rv:11\./);
-        var isFirefox = navigator.userAgent.indexOf('Firefox') > -1;
-        var isSafari = navigator.userAgent.indexOf('Safari') > -1;
-        var isOpera = navigator.userAgent.indexOf('Presto') > -1;
+        var isMsie = Functions.userAgent().indexOf('MSIE') > -1 || !!Functions.userAgent().match(/Trident.*rv:11\./);
+        var isFirefox = Functions.userAgent().indexOf('Firefox') > -1;
+        var isSafari = Functions.userAgent().indexOf('Safari') > -1;
+        var isOpera = Functions.userAgent().indexOf('Presto') > -1;
         /* eslint-enable compat/compat */
         if (prevent) {
             return this.each(function () {

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -334,7 +334,8 @@ class Header
 
         // The user preferences have been merged at this point
         // so we can conditionally add CodeMirror, other scripts and settings
-        if ($GLOBALS['cfg']['CodemirrorEnable']) {
+        // See #20159, why we need to check for HTTP_USER_AGENT here
+        if ($GLOBALS['cfg']['CodemirrorEnable'] && isset($_SERVER['HTTP_USER_AGENT'])) {
             $this->scripts->addFile('vendor/codemirror/lib/codemirror.js');
             $this->scripts->addFile('vendor/codemirror/mode/sql/sql.js');
             $this->scripts->addFile('vendor/codemirror/addon/runmode/runmode.js');


### PR DESCRIPTION
### Description

Since this won't be improved any time soon in CodeMirror at least, the first commit will block CodeMirror from loading.

The second commit will return an empty string if `userAgent` is not in `navigator`. This was the only working solution to check for it.

With those changes, will make phpMyAdmin usable. Login will work, edit/insert/browse, it just needs a refresh and the second time works.

I'm not trying to find edge cases here, but I reproduced the bug report from reporting server, which lead me to those issues.

Related #20159

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
