### PR TITLE
Fix #20152 - XML import when structure is present

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9469,18 +9469,6 @@ parameters:
 			path: src/Plugins/Import/ImportXml.php
 
 		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/Plugins/Import/ImportXml.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between list\<array\<PhpMyAdmin\\Import\\AnalysedColumn\>\> and null will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: src/Plugins/Import/ImportXml.php
-
-		-
 			message: '#^Method PhpMyAdmin\\Plugins\\Import\\ShapeFileImport\:\:readSHP\(\) never returns false so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9469,6 +9469,18 @@ parameters:
 			path: src/Plugins/Import/ImportXml.php
 
 		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: src/Plugins/Import/ImportXml.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between list\<array\<PhpMyAdmin\\Import\\AnalysedColumn\>\> and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: src/Plugins/Import/ImportXml.php
+
+		-
 			message: '#^Method PhpMyAdmin\\Plugins\\Import\\ShapeFileImport\:\:readSHP\(\) never returns false so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1

--- a/src/Plugins/Import/ImportXml.php
+++ b/src/Plugins/Import/ImportXml.php
@@ -202,11 +202,11 @@ class ImportXml extends ImportPlugin
         }
 
         /**
-         * Only build SQL from data if there is data present.
+         * Only build SQL from data if there is data present and no structure.
          * Set values to NULL if they were not present
          * to maintain Import::buildSql() call integrity
          */
-        if ($tables !== [] && $analyses === null) {
+        if (! $structPresent && $tables !== [] && $analyses === null) {
             $create = null;
         }
 

--- a/src/Plugins/Import/ImportXml.php
+++ b/src/Plugins/Import/ImportXml.php
@@ -206,7 +206,7 @@ class ImportXml extends ImportPlugin
          * Set values to NULL if they were not present
          * to maintain Import::buildSql() call integrity
          */
-        if (! $structPresent && $tables !== [] && $analyses === null) {
+        if (! $structPresent && $tables !== []) {
             $create = null;
         }
 

--- a/tests/unit/Plugins/Import/ImportXmlTest.php
+++ b/tests/unit/Plugins/Import/ImportXmlTest.php
@@ -95,27 +95,23 @@ final class ImportXmlTest extends AbstractTestCase
         $importXml = $this->getImportXml($dbi);
         $importXml->doImport($importHandle);
 
-        // If import successfully, PMA will show all databases and tables
-        // imported as following HTML Page
-        /*
-           The following structures have either been created or altered. Here you
-           can:
-           View a structure's contents by clicking on its name
-           Change any of its settings by clicking the corresponding "Options" link
-           Edit structure by following the "Structure" link
-
-           phpmyadmintest (Options)
-           pma_bookmarktest (Structure) (Options)
-        */
-
-        self::assertStringContainsString(
-            'The following structures have either been created or altered.',
-            ImportSettings::$importNotice,
+        //assert that all sql are executed
+        self::assertSame(
+            'CREATE DATABASE IF NOT EXISTS `phpmyadmintest` DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;'
+            . 'USE `phpmyadmintest`;' . "\n"
+            . 'CREATE TABLE IF NOT EXISTS `pma_bookmarktest` (' . "\n"
+            . '  `id` int(11) NOT NULL AUTO_INCREMENT,' . "\n"
+            . '  `dbase` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT \'\',' . "\n"
+            . '  `user` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT \'\',' . "\n"
+            . '  `label` varchar(255) CHARACTER SET utf8 NOT NULL DEFAULT \'\',' . "\n"
+            . '  `query` text COLLATE utf8_bin NOT NULL,' . "\n"
+            . '  PRIMARY KEY (`id`)' . "\n"
+            . ') ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT=\'Bookmarks\';' . "\n"
+            . '            ;'
+            . 'INSERT INTO `phpmyadmintest`.`pma_bookmarktest` (`id`, `dbase`, `user`, `label`, `query`) VALUES (1, , , , );',
+            Current::$sqlQuery,
         );
-        self::assertStringContainsString('Go to database: `phpmyadmintest`', ImportSettings::$importNotice);
-        self::assertStringContainsString('Edit settings for `phpmyadmintest`', ImportSettings::$importNotice);
-        self::assertStringContainsString('Go to table: `pma_bookmarktest`', ImportSettings::$importNotice);
-        self::assertStringContainsString('Edit settings for `pma_bookmarktest`', ImportSettings::$importNotice);
+
         self::assertTrue(ImportSettings::$finished);
     }
 

--- a/tests/unit/Plugins/Import/ImportXmlTest.php
+++ b/tests/unit/Plugins/Import/ImportXmlTest.php
@@ -108,7 +108,8 @@ final class ImportXmlTest extends AbstractTestCase
             . '  PRIMARY KEY (`id`)' . "\n"
             . ') ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT=\'Bookmarks\';' . "\n"
             . '            ;'
-            . 'INSERT INTO `phpmyadmintest`.`pma_bookmarktest` (`id`, `dbase`, `user`, `label`, `query`) VALUES (1, , , , );',
+            . 'INSERT INTO `phpmyadmintest`.`pma_bookmarktest` (`id`, `dbase`, `user`, `label`, `query`) '
+            . 'VALUES (1, , , , );',
             Current::$sqlQuery,
         );
 


### PR DESCRIPTION
### Description

The problem was `$create` being overwritten with `null` everytime, even if structure was present.

Fixes #20152

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
