### PR TITLE
Fixes #19912 - remove the dead Suhosin warning

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -122,6 +122,10 @@ Basic settings
     :type: boolean
     :default: false
 
+    .. deprecated:: 6.0.0
+
+        This setting has been removed. The Suhosin extension is no longer supported.
+
     A warning is displayed on the main page if Suhosin is detected.
 
     You can set this parameter to ``true`` to stop this message from appearing.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -532,65 +532,8 @@ extension which works fine in this case.
 
 .. _faq1_38:
 
-1.38 Can I use phpMyAdmin on a server on which Suhosin is enabled?
-------------------------------------------------------------------
-
-Yes but the default configuration values of Suhosin are known to cause
-problems with some operations, for example editing a table with many
-columns and no :term:`primary key` or with textual :term:`primary key`.
-
-Suhosin configuration might lead to malfunction in some cases and it
-can not be fully avoided as phpMyAdmin is kind of application which
-needs to transfer big amounts of columns in single HTTP request, what
-is something what Suhosin tries to prevent. Generally all
-``suhosin.request.*``, ``suhosin.post.*`` and ``suhosin.get.*``
-directives can have negative effect on phpMyAdmin usability. You can
-always find in your error logs which limit did cause dropping of
-variable, so you can diagnose the problem and adjust matching
-configuration variable.
-
-The default values for most Suhosin configuration options will work in
-most scenarios, however you might want to adjust at least following
-parameters:
-
-* `suhosin.request.max\_vars <https://suhosin5.suhosin.org/stories/configuration.html#suhosin-request-max-vars>`_ should
-  be increased (eg. 2048)
-* `suhosin.post.max\_vars <https://suhosin5.suhosin.org/stories/configuration.html#suhosin-post-max-vars>`_ should be
-  increased (eg. 2048)
-* `suhosin.request.max\_array\_index\_length <https://suhosin5.suhosin.org/stories/configuration.html#suhosin-request-max-array-index-length>`_
-  should be increased (eg. 256)
-* `suhosin.post.max\_array\_index\_length <https://suhosin5.suhosin.org/stories/configuration.html#suhosin-post-max-array-index-length>`_
-  should be increased (eg. 256)
-* `suhosin.request.max\_totalname\_length <https://suhosin5.suhosin.org/stories/configuration.html#suhosin-request-max-totalname-length>`_
-  should be increased (eg. 8192)
-* `suhosin.post.max\_totalname\_length <https://suhosin5.suhosin.org/stories/configuration.html#suhosin-post-max-totalname-length>`_ should be
-  increased (eg. 8192)
-* `suhosin.get.max\_value\_length <https://suhosin5.suhosin.org/stories/configuration.html#suhosin-get-max-value-length>`_
-  should be increased (eg. 1024)
-* `suhosin.sql.bailout\_on\_error <https://suhosin5.suhosin.org/stories/configuration.html#suhosin-sql-bailout-on-error>`_
-  needs to be disabled (the default)
-* `suhosin.log.\* <https://suhosin5.suhosin.org/stories/configuration.html#logging-configuration>`_ should not
-  include :term:`SQL`, otherwise you get big
-  slowdown
-* `suhosin.sql.union <https://suhosin5.suhosin.org/stories/configuration.html#suhosin-
-  sql-union>`_ must be disabled (which is the default).
-* `suhosin.sql.multiselect <https://suhosin5.suhosin.org/stories/configuration.html#
-  suhosin-sql-multiselect>`_ must be disabled (which is the default).
-* `suhosin.sql.comment <https://suhosin5.suhosin.org/stories/configuration.html#suhosin-
-  sql-comment>`_ must be disabled (which is the default).
-
-To further improve security, we also recommend these modifications:
-
-* `suhosin.executor.include.max\_traversal <https://suhosin5.suhosin.org/stories/
-  configuration.html#suhosin-executor-include-max-traversal>`_ should be
-  enabled as a mitigation against local file inclusion attacks. We suggest
-  setting this to 2 as ``../`` is used with the ReCaptcha library.
-* `suhosin.cookie.encrypt <https://suhosin5.suhosin.org/stories/configuration.html#
-  suhosin-cookie-encrypt>`_ should be enabled.
-* `suhosin.executor.disable_emodifier <https://suhosin5.suhosin.org/stories/config
-  uration.html#suhosin-executor-disable-emodifier>`_ should be enabled.
-
-You can also disable the warning using the :config:option:`$cfg['SuhosinDisableWarning']`.
+1.38 (withdrawn).
+-----------------
 
 .. _faq1_39:
 
@@ -871,8 +814,6 @@ Here are a few points to check:
   Dorninger for the hint).
 * In the :file:`php.ini` directive ``arg_separator.input``, a value of ";"
   will cause this error. Replace it with "&;".
-* If you are using `Suhosin <https://suhosin5.suhosin.org/stories/index.html>`_, you
-  might want to increase `request limits <https://suhosin5.suhosin.org/stories/faq.html>`_.
 * The directory specified in the :file:`php.ini` directive
   ``session.save_path`` does not exist or is read-only (this can be caused
   by `bug in the PHP installer <https://bugs.php.net/bug.php?id=39842>`_).

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -313,7 +313,7 @@ parameters:
 			path: src/Config.php
 
 		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\<mixed\>\.$#'
+			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\<mixed\>\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/Config.php
@@ -970,7 +970,7 @@ parameters:
 			path: src/Config/UserPreferencesHandler.php
 
 		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\.$#'
+			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/Config/UserPreferencesHandler.php
@@ -1915,18 +1915,6 @@ parameters:
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
 			count: 5
-			path: src/Controllers/HomeController.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 1
-			path: src/Controllers/HomeController.php
-
-		-
-			message: '#^Only booleans are allowed in &&, string\|false given on the right side\.$#'
-			identifier: booleanAnd.rightNotBoolean
-			count: 1
 			path: src/Controllers/HomeController.php
 
 		-
@@ -14230,7 +14218,7 @@ parameters:
 			path: tests/unit/Config/UserPreferencesTest.php
 
 		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\{''Server/hide_db''\: ''testval123'', ''Server/port''\: ''213''\}\.$#'
+			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\{''Server/hide_db''\: ''testval123'', ''Server/port''\: ''213''\}\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: tests/unit/Config/UserPreferencesTest.php
@@ -16108,7 +16096,7 @@ parameters:
 			path: tests/unit/Plugins/Auth/AuthenticationConfigTest.php
 
 		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\.$#'
+			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: tests/unit/Plugins/Auth/AuthenticationConfigTest.php
@@ -16165,7 +16153,7 @@ parameters:
 			path: tests/unit/Plugins/Auth/AuthenticationCookieTest.php
 
 		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\.$#'
+			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\.$#'
 			identifier: assign.propertyType
 			count: 6
 			path: tests/unit/Plugins/Auth/AuthenticationCookieTest.php
@@ -16186,7 +16174,7 @@ parameters:
 			path: tests/unit/Plugins/Auth/AuthenticationHttpTest.php
 
 		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\.$#'
+			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\.$#'
 			identifier: assign.propertyType
 			count: 2
 			path: tests/unit/Plugins/Auth/AuthenticationHttpTest.php
@@ -16387,7 +16375,7 @@ parameters:
 			path: tests/unit/PluginsTest.php
 
 		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\.$#'
+			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: tests/unit/PluginsTest.php
@@ -16516,7 +16504,7 @@ parameters:
 			path: tests/unit/Server/SelectTest.php
 
 		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\.$#'
+			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: tests/unit/Server/SelectTest.php
@@ -16930,7 +16918,7 @@ parameters:
 			path: tests/unit/VersionInformationTest.php
 
 		-
-			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, SuhosinDisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\.$#'
+			message: '#^Property PhpMyAdmin\\Config\:\:\$settings \(array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\) does not accept array\{PmaAbsoluteUri\: string, AuthLog\: string, AuthLogSuccess\: bool, PmaNoRelation_DisableWarning\: bool, LoginCookieValidityDisableWarning\: bool, ReservedWordDisableWarning\: bool, TranslationWarningThreshold\: int, \.\.\.\}\.$#'
 			identifier: assign.propertyType
 			count: 3
 			path: tests/unit/VersionInformationTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5739,7 +5739,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''alias'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 6
+			count: 4
 			path: src/Export/Export.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1255,7 +1255,6 @@
       <code><![CDATA[empty($this->config->selectedServer['verbose'])]]></code>
       <code><![CDATA[empty($this->config->settings['Servers'][Current::$server]['pmadb'])]]></code>
       <code><![CDATA[ini_get('allow_url_fopen')]]></code>
-      <code><![CDATA[ini_get('suhosin.request.max_value_length')]]></code>
     </RiskyTruthyFalsyComparison>
     <UnusedVariable>
       <code><![CDATA[$collationsList]]></code>

--- a/src/Config/Descriptions.php
+++ b/src/Config/Descriptions.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Verbose descriptions for settings.
  */

--- a/src/Config/Descriptions.php
+++ b/src/Config/Descriptions.php
@@ -490,9 +490,6 @@ class Descriptions
             'SkipLockedTables_desc' => __(
                 'Mark used tables and make it possible to show databases with locked tables.',
             ),
-            'SuhosinDisableWarning_desc' => __(
-                'Disable the default warning that is displayed on the main page if Suhosin is detected.',
-            ),
             'LoginCookieValidityDisableWarning_desc' => __(
                 'Disable the default warning that is displayed on the main page if the value ' .
                 'of the PHP setting session.gc_maxlifetime is less than the value of ' .
@@ -927,7 +924,6 @@ class Descriptions
             'SQLQuery_Explain_name' => __('Explain SQL'),
             'SQLQuery_Refresh_name' => __('Refresh'),
             'SQLQuery_ShowAsPHP_name' => __('Create PHP code'),
-            'SuhosinDisableWarning_name' => __('Suhosin warning'),
             'LoginCookieValidityDisableWarning_name' => __('Login cookie validity warning'),
             'TextareaCols_name' => __('Textarea columns'),
             'TextareaRows_name' => __('Textarea rows'),

--- a/src/Config/Forms/User/FeaturesForm.php
+++ b/src/Config/Forms/User/FeaturesForm.php
@@ -51,7 +51,6 @@ class FeaturesForm extends BaseForm
             'Page_titles' => ['TitleDefault', 'TitleTable', 'TitleDatabase', 'TitleServer'],
             'Warnings' => [
                 'PmaNoRelation_DisableWarning',
-                'SuhosinDisableWarning',
                 'LoginCookieValidityDisableWarning',
                 'ReservedWordDisableWarning',
             ],

--- a/src/Config/Forms/User/FeaturesForm.php
+++ b/src/Config/Forms/User/FeaturesForm.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * User preferences form
  */

--- a/src/Config/Settings.php
+++ b/src/Config/Settings.php
@@ -48,7 +48,6 @@ use const VERSION_CHECK_DEFAULT;
  *     AuthLog: string,
  *     AuthLogSuccess: bool,
  *     PmaNoRelation_DisableWarning: bool,
- *     SuhosinDisableWarning: bool,
  *     LoginCookieValidityDisableWarning: bool,
  *     ReservedWordDisableWarning: bool,
  *     TranslationWarningThreshold: int,
@@ -296,17 +295,6 @@ final class Settings
      * @link https://docs.phpmyadmin.net/en/latest/config.html#cfg_PmaNoRelation_DisableWarning
      */
     public bool $PmaNoRelation_DisableWarning;
-
-    /**
-     * Disable the default warning that is displayed if Suhosin is detected
-     *
-     * ```php
-     * $cfg['SuhosinDisableWarning'] = false;
-     * ```
-     *
-     * @link https://docs.phpmyadmin.net/en/latest/config.html#cfg_SuhosinDisableWarning
-     */
-    public bool $SuhosinDisableWarning;
 
     /**
      * Disable the default warning that is displayed if session.gc_maxlifetime
@@ -2633,7 +2621,6 @@ final class Settings
         $this->authLog = $this->setAuthLog($settings);
         $this->authLogSuccess = $this->setAuthLogSuccess($settings);
         $this->PmaNoRelation_DisableWarning = $this->setPmaNoRelationDisableWarning($settings);
-        $this->SuhosinDisableWarning = $this->setSuhosinDisableWarning($settings);
         $this->LoginCookieValidityDisableWarning = $this->setLoginCookieValidityDisableWarning($settings);
         $this->ReservedWordDisableWarning = $this->setReservedWordDisableWarning($settings);
         $this->TranslationWarningThreshold = $this->setTranslationWarningThreshold($settings);
@@ -2831,7 +2818,6 @@ final class Settings
             'AuthLog' => $this->authLog,
             'AuthLogSuccess' => $this->authLogSuccess,
             'PmaNoRelation_DisableWarning' => $this->PmaNoRelation_DisableWarning,
-            'SuhosinDisableWarning' => $this->SuhosinDisableWarning,
             'LoginCookieValidityDisableWarning' => $this->LoginCookieValidityDisableWarning,
             'ReservedWordDisableWarning' => $this->ReservedWordDisableWarning,
             'TranslationWarningThreshold' => $this->TranslationWarningThreshold,
@@ -3062,15 +3048,6 @@ final class Settings
         return (bool) $settings['PmaNoRelation_DisableWarning'];
     }
 
-    /** @param array<int|string, mixed> $settings */
-    private function setSuhosinDisableWarning(array $settings): bool
-    {
-        if (! isset($settings['SuhosinDisableWarning'])) {
-            return false;
-        }
-
-        return (bool) $settings['SuhosinDisableWarning'];
-    }
 
     /** @param array<int|string, mixed> $settings */
     private function setLoginCookieValidityDisableWarning(array $settings): bool

--- a/src/Controllers/HomeController.php
+++ b/src/Controllers/HomeController.php
@@ -390,26 +390,6 @@ final class HomeController implements InvocableController
             ];
         }
 
-        /**
-         * Warning about Suhosin only if its simulation mode is not enabled
-         */
-        if (
-            ! $this->config->settings['SuhosinDisableWarning']
-            && ini_get('suhosin.request.max_value_length')
-            && ini_get('suhosin.simulation') == '0'
-        ) {
-            $this->errors[] = [
-                'message' => sprintf(
-                    __(
-                        'Server running with Suhosin. Please refer to %sdocumentation%s for possible issues.',
-                    ),
-                    '[doc@faq1-38]',
-                    '[/doc]',
-                ),
-                'severity' => 'warning',
-            ];
-        }
-
         /* Missing template cache */
         if ($this->config->getTempDir('twig') === null) {
             $this->errors[] = [

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * function for the main export logic
  */

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This class includes various sanitization methods that can be called statically
  */

--- a/src/Types.php
+++ b/src/Types.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SQL data types definition
  */

--- a/tests/unit/Config/Forms/Setup/FeaturesFormTest.php
+++ b/tests/unit/Config/Forms/Setup/FeaturesFormTest.php
@@ -106,7 +106,6 @@ final class FeaturesFormTest extends AbstractTestCase
         self::assertSame(
             [
                 'PmaNoRelation_DisableWarning' => 'PmaNoRelation_DisableWarning',
-                'SuhosinDisableWarning' => 'SuhosinDisableWarning',
                 'LoginCookieValidityDisableWarning' => 'LoginCookieValidityDisableWarning',
                 'ReservedWordDisableWarning' => 'ReservedWordDisableWarning',
             ],
@@ -236,7 +235,6 @@ final class FeaturesFormTest extends AbstractTestCase
                 'TitleDatabase',
                 'TitleServer',
                 'PmaNoRelation_DisableWarning',
-                'SuhosinDisableWarning',
                 'LoginCookieValidityDisableWarning',
                 'ReservedWordDisableWarning',
                 'Console/Mode',

--- a/tests/unit/Config/Forms/User/FeaturesFormTest.php
+++ b/tests/unit/Config/Forms/User/FeaturesFormTest.php
@@ -112,7 +112,6 @@ final class FeaturesFormTest extends AbstractTestCase
         self::assertSame(
             [
                 'PmaNoRelation_DisableWarning' => 'PmaNoRelation_DisableWarning',
-                'SuhosinDisableWarning' => 'SuhosinDisableWarning',
                 'LoginCookieValidityDisableWarning' => 'LoginCookieValidityDisableWarning',
                 'ReservedWordDisableWarning' => 'ReservedWordDisableWarning',
             ],
@@ -181,7 +180,6 @@ final class FeaturesFormTest extends AbstractTestCase
                 'TitleDatabase',
                 'TitleServer',
                 'PmaNoRelation_DisableWarning',
-                'SuhosinDisableWarning',
                 'LoginCookieValidityDisableWarning',
                 'ReservedWordDisableWarning',
                 'Console/Mode',

--- a/tests/unit/Config/SettingsTest.php
+++ b/tests/unit/Config/SettingsTest.php
@@ -709,15 +709,6 @@ class SettingsTest extends TestCase
     }
 
     #[DataProvider('booleanWithDefaultFalseProvider')]
-    public function testSuhosinDisableWarning(mixed $actual, bool $expected): void
-    {
-        $settings = new Settings(['SuhosinDisableWarning' => $actual]);
-        $settingsArray = $settings->asArray();
-        self::assertSame($expected, $settings->SuhosinDisableWarning);
-        self::assertSame($expected, $settingsArray['SuhosinDisableWarning']);
-    }
-
-    #[DataProvider('booleanWithDefaultFalseProvider')]
     public function testLoginCookieValidityDisableWarning(mixed $actual, bool $expected): void
     {
         $settings = new Settings(['LoginCookieValidityDisableWarning' => $actual]);


### PR DESCRIPTION
## Summary

- Remove the Suhosin extension check from HomeController (dead code on PHP 8+)
- Remove SuhosinDisableWarning from user-facing settings form and descriptions
- Add `deprecated:: 6.0.0` directive to `docs/config.rst`, keeping original description text
- Withdraw FAQ 1.38 in `docs/faq.rst`
- Remove 2 stale PHPStan baseline entries for removed HomeController code
- Keep `SuhosinDisableWarning` property in Settings.php as deprecated no-op to avoid a 540-entry Psalm baseline cascade from the type shape change

Replaces #20123 which had a corrupted branch push.

Fixes #19912

## Test plan

- [x] `phpunit tests/unit/Controllers/HomeControllerTest.php` passes
- [x] `phpstan analyse` -- no errors
- [x] `psalm --no-diff` -- no errors