### PR TITLE
Fix #20153: Handle missing database tag in XML import

### DIFF
--- a/src/Plugins/Import/ImportXml.php
+++ b/src/Plugins/Import/ImportXml.php
@@ -167,7 +167,7 @@ class ImportXml extends ImportPlugin
         $databaseName = (string) $databaseXml['name'];
 
         /** @var SimpleXMLElement $tableRowXml */
-        foreach ($databaseXml->table as $tableRowXml) {
+        foreach ($databaseXml->table ?? [] as $tableRowXml) {
             $tableName = (string) $tableRowXml['name'];
 
             $table = $tables[$tableName] ?? new ImportTable($tableName);


### PR DESCRIPTION
### Description

This pull request fixes a fatal `ErrorException` that occurs during XML imports when the `<database>` tag is missing from the file.

Fixes #20153

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
