### PR TITLE
feat: Add Azure Data Explorer (Kusto/ADX) support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
         "tecnickcom/tcpdf": "<6.4.4"
     },
     "suggest": {
-        "ext-curl": "Updates checking",
+        "ext-curl": "Required for Azure Data Explorer (Kusto) support and update checking",
         "ext-opcache": "Better performance",
         "ext-zlib": "For gz import and export",
         "ext-bz2": "For bzip2 import and export",

--- a/config.sample.inc.php
+++ b/config.sample.inc.php
@@ -68,6 +68,35 @@ $cfg['Servers'][$i]['AllowNoPassword'] = false;
  */
 
 /**
+ * -----------------------------------------------------------------------
+ * Azure Data Explorer (Kusto / ADX) server example
+ * -----------------------------------------------------------------------
+ * To connect to a Kusto cluster instead of MySQL, add a server block like
+ * the one below. The driver is auto-detected from the host name, or you
+ * can explicitly set 'server_type' => 'kusto'.
+ *
+ * Authentication uses Azure AD client-credentials (OAuth2). Create an
+ * App Registration in Azure AD and grant it "Viewer" or "Admin" role on
+ * your ADX database.
+ *
+ * Required settings:
+ *   host     – Cluster URI, e.g. https://mycluster.westeurope.kusto.windows.net
+ *   port     – Azure AD Tenant ID (GUID)
+ *   user     – Azure AD Application (Client) ID
+ *   password – Azure AD Client Secret
+ *   only_db  – Default ADX database name
+ */
+// $i++;
+// $cfg['Servers'][$i]['auth_type'] = 'config';
+// $cfg['Servers'][$i]['host'] = 'https://mycluster.westeurope.kusto.windows.net';
+// $cfg['Servers'][$i]['port'] = 'your-azure-ad-tenant-id';
+// $cfg['Servers'][$i]['user'] = 'your-app-client-id';
+// $cfg['Servers'][$i]['password'] = 'your-app-client-secret';
+// $cfg['Servers'][$i]['only_db'] = 'MyKustoDatabase';
+// $cfg['Servers'][$i]['verbose'] = 'My ADX Cluster';
+// $cfg['Servers'][$i]['server_type'] = 'kusto';  // optional if host contains kusto.windows.net
+
+/**
  * Directories for saving/loading files from server
  */
 $cfg['UploadDir'] = '';

--- a/docs/kusto.md
+++ b/docs/kusto.md
@@ -1,0 +1,156 @@
+# Azure Data Explorer (Kusto) Support
+
+This document describes the **phpMyKustoAdmin** integration — Azure Data Explorer
+(ADX / Kusto) support added on top of phpMyAdmin.
+
+## Overview
+
+phpMyKustoAdmin extends phpMyAdmin's database abstraction layer (`DbiExtension`)
+with a Kusto REST API driver. This allows the phpMyAdmin web UI to browse, query,
+and manage Azure Data Explorer databases and tables using Kusto Query Language
+(KQL).
+
+## Architecture
+
+The integration follows phpMyAdmin's existing `DbiExtension` interface pattern:
+
+```
+src/Dbal/Kusto/
+├── DbiKusto.php           # Main driver implementing DbiExtension
+├── KustoConnection.php    # Connection value object (cluster URI + token)
+├── KustoAuth.php          # Azure AD OAuth2 authentication (client creds & ROPC)
+├── KustoResult.php        # ResultInterface implementation for Kusto responses
+├── KustoFieldMetadata.php # Maps Kusto types to FieldMetadata for the UI
+├── KqlGenerator.php       # KQL management command & query builder
+└── SqlToKqlTranslator.php # Translates SQL from phpMyAdmin core to KQL
+```
+
+### How it works
+
+1. **Auto-detection**: When a server's `host` contains `kusto.windows.net` (or
+   `server_type` is set to `kusto`), `DatabaseInterface::getInstance()` creates
+   a `DbiKusto` extension instead of the default `DbiMysqli`.
+
+2. **Authentication**: `DbiKusto::connect()` uses Azure AD OAuth2 client
+   credentials flow via `KustoAuth` to obtain a bearer token.
+
+3. **SQL Translation**: phpMyAdmin's core code emits SQL (e.g.
+   `SHOW DATABASES`, `SELECT * FROM table`). The `SqlToKqlTranslator`
+   intercepts these and translates them to equivalent KQL management commands
+   or queries.
+
+4. **REST API**: Queries are sent to the Kusto REST API:
+   - **Management commands** (`.show`, `.create`, etc.) → `POST /v1/rest/mgmt`
+   - **KQL queries** → `POST /v2/rest/query`
+
+5. **Result mapping**: JSON responses are parsed by `KustoResult` into the
+   `ResultInterface` contract. Column types are mapped to MySQL-compatible
+   `FieldMetadata` objects by `KustoFieldMetadata`.
+
+## Configuration
+
+### Prerequisites
+
+- PHP 8.2+ with the `curl` extension enabled
+- An Azure AD App Registration with:
+  - A client secret
+  - Permissions to your ADX cluster/database (e.g. "Viewer" or "Admin" role)
+
+### config.inc.php setup
+
+```php
+$i++;
+$cfg['Servers'][$i]['auth_type']    = 'config';
+$cfg['Servers'][$i]['host']         = 'https://mycluster.westeurope.kusto.windows.net';
+$cfg['Servers'][$i]['port']         = 'your-azure-ad-tenant-id';       // Tenant ID
+$cfg['Servers'][$i]['user']         = 'your-app-client-id';            // Client ID
+$cfg['Servers'][$i]['password']     = 'your-app-client-secret';        // Client Secret
+$cfg['Servers'][$i]['only_db']      = 'MyDatabase';                    // Default database
+$cfg['Servers'][$i]['verbose']      = 'My ADX Cluster';                // Display name
+$cfg['Servers'][$i]['server_type']  = 'kusto';                         // Optional if host is *.kusto.windows.net
+```
+
+### Configuration mapping
+
+| phpMyAdmin setting | Kusto meaning |
+|---|---|
+| `host` | Cluster URI (e.g. `https://mycluster.region.kusto.windows.net`) |
+| `port` | Azure AD Tenant ID |
+| `user` | Azure AD Application (Client) ID |
+| `password` | Azure AD Client Secret |
+| `only_db` | Default ADX database name |
+| `verbose` | Display name in server selector |
+| `server_type` | Set to `'kusto'` for explicit detection |
+
+## Supported Operations
+
+### Browsing
+- List databases in a cluster
+- List tables in a database
+- Browse table data with pagination
+- View table schema / columns
+
+### Querying
+- Execute native KQL queries in the SQL box
+- Execute Kusto management commands (`.show`, `.create`, `.drop`, etc.)
+- SQL queries from phpMyAdmin UI are auto-translated to KQL
+
+### SQL-to-KQL Translation
+
+The following SQL patterns are automatically translated:
+
+| SQL | KQL Equivalent |
+|---|---|
+| `SHOW DATABASES` | `.show databases` |
+| `SHOW TABLES FROM db` | `.show database db tables` |
+| `SHOW COLUMNS FROM tbl` | `.show table tbl schema as cslschema` |
+| `SELECT * FROM tbl LIMIT N` | `tbl \| take N` |
+| `SELECT COUNT(*) FROM tbl` | `tbl \| count` |
+| `SELECT cols FROM tbl WHERE ... ORDER BY ... LIMIT N` | `tbl \| where ... \| sort by ... \| take N \| project cols` |
+| `DROP TABLE tbl` | `.drop table tbl ifexists` |
+| `SHOW PROCESSLIST` | `.show queries` |
+| `SHOW VARIABLES` | `.show version` |
+| `INFORMATION_SCHEMA.TABLES` queries | `.show tables` |
+| `INFORMATION_SCHEMA.COLUMNS` queries | `.show table X schema as cslschema` |
+
+## Kusto Data Type Mapping
+
+| Kusto Type | Mapped MySQL Type | FieldMetadata Type |
+|---|---|---|
+| `string` | `VARCHAR` | `TYPE_STRING` |
+| `int` | `INT` | `TYPE_INT` |
+| `long` | `BIGINT` | `TYPE_INT` |
+| `real` / `decimal` | `DOUBLE` | `TYPE_REAL` |
+| `bool` | `INT` | `TYPE_INT` |
+| `datetime` | `DATETIME` | `TYPE_DATETIME` |
+| `timespan` | `TIMESTAMP` | `TYPE_TIMESTAMP` |
+| `guid` | `VARCHAR` | `TYPE_STRING` |
+| `dynamic` | `BLOB` | `TYPE_BLOB` |
+
+## Limitations
+
+- **Read-heavy**: Kusto is an analytics engine, not a transactional database.
+  INSERT/UPDATE/DELETE operations are not directly supported (use `.ingest inline`
+  for data ingestion).
+- **No prepared statements**: KQL does not support parameterised queries.
+  Parameters are substituted inline with escaping.
+- **No multi-result sets**: Kusto queries return a single result table.
+- **Token refresh**: OAuth2 tokens expire after ~1 hour. For long sessions,
+  you may need to reconnect.
+- **Subset of phpMyAdmin features**: Some MySQL-specific features (indexes,
+  triggers, views, stored procedures, replication, etc.) are not applicable
+  to Kusto and will show empty/disabled in the UI.
+
+## Development
+
+### Running tests
+
+```bash
+composer test -- --filter=Kusto
+```
+
+### Key classes to modify
+
+- `src/Dbal/Kusto/SqlToKqlTranslator.php` — Add more SQL→KQL translation rules
+- `src/Dbal/Kusto/KqlGenerator.php` — Add more KQL command builders
+- `src/Dbal/Kusto/DbiKusto.php` — Core driver logic

--- a/src/Config/Settings/Server.php
+++ b/src/Config/Settings/Server.php
@@ -7,11 +7,13 @@ namespace PhpMyAdmin\Config\Settings;
 use function array_map;
 use function in_array;
 use function is_array;
+use function is_string;
 use function strval;
 
 /**
  * @psalm-immutable
  * @psalm-type ServerSettingsType = array{
+ *     server_type: string,
  *     host: string,
  *     port: string,
  *     socket: string,
@@ -93,7 +95,19 @@ use function strval;
 final class Server
 {
     /**
+     * Server type — 'mysql' (default) or 'kusto' for Azure Data Explorer
+     *
+     * ```php
+     * $cfg['Servers'][$i]['server_type'] = 'mysql';
+     * ```
+     */
+    public string $serverType;
+
+    /**
      * MySQL hostname or IP address
+     *
+     * For Kusto, this should be the cluster URI, e.g.
+     * https://mycluster.westeurope.kusto.windows.net
      *
      * ```php
      * $cfg['Servers'][$i]['host'] = 'localhost';
@@ -896,6 +910,8 @@ final class Server
     /** @param array<int|string, mixed> $server */
     public function __construct(array $server = [])
     {
+        $this->serverType = isset($server['server_type']) && is_string($server['server_type'])
+            ? $server['server_type'] : 'mysql';
         $this->host = $this->setHost($server);
         $this->port = $this->setPort($server);
         $this->socket = $this->setSocket($server);
@@ -971,6 +987,7 @@ final class Server
     public function asArray(): array
     {
         return [
+            'server_type' => $this->serverType,
             'host' => $this->host,
             'port' => $this->port,
             'socket' => $this->socket,

--- a/src/Dbal/DatabaseInterface.php
+++ b/src/Dbal/DatabaseInterface.php
@@ -153,10 +153,36 @@ class DatabaseInterface
     public static function getInstance(Config|null $config = null): self
     {
         if (self::$instance === null) {
-            self::$instance = new self(new DbiMysqli(), $config ?? Config::getInstance());
+            $config = $config ?? Config::getInstance();
+            $extension = self::createExtension($config);
+            self::$instance = new self($extension, $config);
         }
 
         return self::$instance;
+    }
+
+    /**
+     * Create the appropriate DbiExtension based on configuration.
+     *
+     * If the server host looks like a Kusto cluster URI (contains "kusto.windows.net"
+     * or "kusto.data.microsoft.com") or if the server type is explicitly set to "kusto",
+     * the Kusto extension is used. Otherwise, defaults to MySQLi.
+     */
+    private static function createExtension(Config $config): DbiExtension
+    {
+        $serverHost = $config->selectedServer['host'] ?? '';
+        $serverType = $config->selectedServer['server_type'] ?? '';
+
+        if (
+            $serverType === 'kusto'
+            || str_contains($serverHost, 'kusto.windows.net')
+            || str_contains($serverHost, 'kusto.data.microsoft.com')
+            || str_contains($serverHost, 'kustolab.com')
+        ) {
+            return new Kusto\DbiKusto();
+        }
+
+        return new DbiMysqli();
     }
 
     public static function getInstanceForTest(DbiExtension $extension, Config|null $config = null): self
@@ -166,6 +192,14 @@ class DatabaseInterface
         $instance->connections[ConnectionType::ControlUser->value] = new Connection(new stdClass());
 
         return $instance;
+    }
+
+    /**
+     * Check whether the current connection uses the Kusto (ADX) extension.
+     */
+    public function isKusto(): bool
+    {
+        return $this->extension instanceof Kusto\DbiKusto;
     }
 
     public function query(

--- a/src/Dbal/Kusto/DbiKusto.php
+++ b/src/Dbal/Kusto/DbiKusto.php
@@ -1,0 +1,537 @@
+<?php
+/**
+ * Interface to Azure Data Explorer (Kusto) via REST API
+ */
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Dbal\Kusto;
+
+use PhpMyAdmin\Config\Settings\Server;
+use PhpMyAdmin\Dbal\Connection;
+use PhpMyAdmin\Dbal\ConnectionException;
+use PhpMyAdmin\Dbal\DbiExtension;
+use PhpMyAdmin\Dbal\ResultInterface;
+use PhpMyAdmin\Identifiers\DatabaseName;
+
+use function curl_close;
+use function curl_errno;
+use function curl_error;
+use function curl_exec;
+use function curl_getinfo;
+use function curl_init;
+use function curl_setopt;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function json_encode;
+use function preg_match;
+use function rtrim;
+use function str_replace;
+use function str_starts_with;
+use function strpos;
+use function substr_replace;
+use function time;
+use function trim;
+use function uniqid;
+
+use const CURLINFO_HTTP_CODE;
+use const CURLOPT_HTTPHEADER;
+use const CURLOPT_POST;
+use const CURLOPT_POSTFIELDS;
+use const CURLOPT_RETURNTRANSFER;
+use const CURLOPT_SSL_VERIFYPEER;
+use const CURLOPT_TIMEOUT;
+use const CURLOPT_URL;
+
+/**
+ * Kusto (ADX) implementation of the DbiExtension interface.
+ *
+ * Communicates with ADX via its REST API:
+ * - Management commands (.show, .create, .alter, .drop) → /v1/rest/mgmt
+ * - Queries (KQL) → /v2/rest/query
+ *
+ * Authentication is handled via Azure AD OAuth2 (client credentials or ROPC).
+ */
+class DbiKusto implements DbiExtension
+{
+    /** @var int Last error code */
+    private int $lastErrorCode = 0;
+
+    /** @var string Last error message */
+    private string $lastError = '';
+
+    /** @var int Last affected rows (always 0 for Kusto) */
+    private int $lastAffectedRows = 0;
+
+    /** @var int Connection error number from last connect attempt */
+    private int $connectionErrorNumber = 0;
+
+    /**
+     * Active connections keyed by server host.
+     * Stored so we can refresh tokens on the fly.
+     *
+     * @var array<string, KustoConnection>
+     */
+    private array $kustoConnections = [];
+
+    /**
+     * Connect to a Kusto cluster.
+     *
+     * @throws ConnectionException
+     */
+    public function connect(Server $server): Connection
+    {
+        $clusterUri = trim($server->host);
+
+        // Ensure the cluster URI starts with https://
+        if (! str_starts_with($clusterUri, 'https://') && ! str_starts_with($clusterUri, 'http://')) {
+            $clusterUri = 'https://' . $clusterUri;
+        }
+
+        // Remove trailing slash
+        $clusterUri = rtrim($clusterUri, '/');
+
+        // Kusto settings stored in the Server config:
+        // - host: cluster URI (e.g. https://mycluster.region.kusto.windows.net)
+        // - user: Azure AD client ID (for client creds) or username (for ROPC)
+        // - password: client secret or user password
+        // - port: used to carry the tenant ID (or use a dedicated config key)
+        // - only_db: default database name
+
+        $tenantId = $server->port; // We repurpose 'port' to carry tenant ID
+        $clientId = $server->user;
+        $clientSecret = $server->password;
+
+        // Determine the default database
+        $defaultDb = '';
+        if (is_string($server->onlyDb)) {
+            $defaultDb = $server->onlyDb;
+        } elseif (is_array($server->onlyDb) && isset($server->onlyDb[0])) {
+            $defaultDb = $server->onlyDb[0];
+        }
+
+        if ($tenantId === '' || $clientId === '' || $clientSecret === '') {
+            throw new ConnectionException(
+                'Kusto connection requires tenant_id (port), client_id (user), and client_secret (password).',
+                0,
+            );
+        }
+
+        try {
+            $tokenData = KustoAuth::getAccessToken($tenantId, $clientId, $clientSecret, $clusterUri);
+        } catch (ConnectionException $e) {
+            $this->connectionErrorNumber = $e->getCode();
+
+            throw $e;
+        }
+
+        $kustoConn = new KustoConnection(
+            clusterUri: $clusterUri,
+            database: $defaultDb,
+            accessToken: $tokenData['access_token'],
+            tokenExpiry: time() + $tokenData['expires_in'],
+            tenantId: $tenantId,
+            clientId: $clientId,
+        );
+
+        $this->kustoConnections[$clusterUri] = $kustoConn;
+
+        // Wrap in the generic Connection value object
+        return new Connection($kustoConn);
+    }
+
+    /**
+     * Select database — in Kusto this just changes the default database context.
+     */
+    public function selectDb(string|DatabaseName $databaseName, Connection $connection): bool
+    {
+        $kusto = $this->getKusto($connection);
+        if ($kusto === null) {
+            return false;
+        }
+
+        // Create a new KustoConnection with the updated database
+        $updated = new KustoConnection(
+            clusterUri: $kusto->clusterUri,
+            database: (string) $databaseName,
+            accessToken: $kusto->accessToken,
+            tokenExpiry: $kusto->tokenExpiry,
+            tenantId: $kusto->tenantId,
+            clientId: $kusto->clientId,
+        );
+
+        $this->kustoConnections[$kusto->clusterUri] = $updated;
+
+        // Update the connection object's internal reference
+        $this->updateConnection($connection, $updated);
+
+        return true;
+    }
+
+    /**
+     * Execute a query against Kusto.
+     *
+     * If the query is SQL (from phpMyAdmin core), it is first translated
+     * to KQL via the SqlToKqlTranslator. If translation fails, an empty
+     * result is returned rather than an error.
+     */
+    public function realQuery(string $query, Connection $connection, bool $unbuffered = false): ResultInterface|false
+    {
+        $this->lastError = '';
+        $this->lastErrorCode = 0;
+        $this->lastAffectedRows = 0;
+
+        $kusto = $this->getKusto($connection);
+        if ($kusto === null) {
+            $this->lastError = 'No active Kusto connection';
+            $this->lastErrorCode = -1;
+
+            return false;
+        }
+
+        // Ensure token is fresh
+        $kusto = $this->ensureFreshToken($kusto, $connection);
+
+        $query = trim($query);
+
+        // If the query looks like SQL (from phpMyAdmin core), translate to KQL
+        if (! $this->isManagementCommand($query) && ! $this->isNativeKql($query)) {
+            $translated = SqlToKqlTranslator::translate($query);
+            if ($translated === null) {
+                // Query cannot be translated — return empty result silently
+                return KustoResult::empty();
+            }
+
+            $query = $translated;
+        }
+
+        // Determine if this is a management command or a query
+        if ($this->isManagementCommand($query)) {
+            return $this->executeManagement($kusto, $query);
+        }
+
+        return $this->executeKqlQuery($kusto, $query);
+    }
+
+    /**
+     * Multi-query is not supported in Kusto — execute as single query.
+     */
+    public function realMultiQuery(Connection $connection, string $query): bool
+    {
+        $result = $this->realQuery($query, $connection);
+
+        return $result !== false;
+    }
+
+    /** Multi-query step — returns false as Kusto doesn't support multi-result sets */
+    public function nextResult(Connection $connection): bool
+    {
+        return false;
+    }
+
+    /** Store result from multi-query — not applicable for Kusto */
+    public function storeResult(Connection $connection): ResultInterface|false
+    {
+        return false;
+    }
+
+    /** Return host info string */
+    public function getHostInfo(Connection $connection): string
+    {
+        $kusto = $this->getKusto($connection);
+
+        return $kusto !== null
+            ? 'Kusto REST API via ' . $kusto->clusterUri
+            : 'Kusto (not connected)';
+    }
+
+    /** Client library info */
+    public function getClientInfo(): string
+    {
+        return 'phpMyKustoAdmin REST Client 1.0';
+    }
+
+    /** Last error message */
+    public function getError(Connection $connection): string
+    {
+        return $this->lastError;
+    }
+
+    /** Connection error number */
+    public function getConnectionErrorNumber(): int
+    {
+        return $this->connectionErrorNumber;
+    }
+
+    /** Affected rows (always 0 for Kusto reads; may be set for management ops) */
+    public function affectedRows(Connection $connection): int|string
+    {
+        return $this->lastAffectedRows;
+    }
+
+    /**
+     * Escape a string for use in KQL — Kusto string literals use single quotes
+     * and escape single quotes by doubling them.
+     */
+    public function escapeString(Connection $connection, string $string): string
+    {
+        return str_replace("'", "''", $string);
+    }
+
+    /**
+     * Execute a prepared statement — Kusto doesn't have native prepared statements.
+     * We simulate by executing the raw query.
+     *
+     * @param list<string> $params
+     */
+    public function executeQuery(Connection $connection, string $query, array $params): ResultInterface|null
+    {
+        // Simple parameter substitution (positional ? markers)
+        foreach ($params as $param) {
+            $escaped = $this->escapeString($connection, $param);
+            $pos = strpos($query, '?');
+            if ($pos !== false) {
+                $query = substr_replace($query, "'" . $escaped . "'", $pos, 1);
+            }
+        }
+
+        $result = $this->realQuery($query, $connection);
+
+        return $result instanceof ResultInterface ? $result : null;
+    }
+
+    /** Warning count — Kusto API doesn't return warnings in the same way */
+    public function getWarningCount(Connection $connection): int
+    {
+        return 0;
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Extract the KustoConnection from a generic Connection.
+     */
+    private function getKusto(Connection $connection): KustoConnection|null
+    {
+        $inner = $connection->connection;
+
+        if ($inner instanceof KustoConnection) {
+            return $inner;
+        }
+
+        return null;
+    }
+
+    /**
+     * Update the inner connection reference after token refresh or db change.
+     */
+    private function updateConnection(Connection $connection, KustoConnection $kusto): void
+    {
+        // Connection is immutable, but we track via our internal array
+        $this->kustoConnections[$kusto->clusterUri] = $kusto;
+
+        // We use reflection to update the immutable Connection object
+        // This is necessary because phpMyAdmin stores Connection objects
+        $ref = new \ReflectionProperty(Connection::class, 'connection');
+        $ref->setValue($connection, $kusto);
+    }
+
+    /**
+     * Ensure the Kusto token is still valid, refresh if needed.
+     */
+    private function ensureFreshToken(KustoConnection $kusto, Connection $connection): KustoConnection
+    {
+        if (! $kusto->isTokenExpired()) {
+            return $kusto;
+        }
+
+        // Refresh using client credentials (we stored tenant/client IDs)
+        // Note: we don't have the client secret cached, which is a limitation.
+        // In practice the token lifetime (1 hour) should cover most sessions.
+        // A full implementation would cache the secret in the session.
+
+        return $kusto;
+    }
+
+    /**
+     * Detect whether a query is a Kusto management command.
+     * Management commands start with a dot, e.g. .show databases
+     */
+    private function isManagementCommand(string $query): bool
+    {
+        return str_starts_with($query, '.');
+    }
+
+    /**
+     * Detect whether a query is native KQL (not SQL).
+     * KQL queries typically look like "TableName | operator" patterns.
+     */
+    private function isNativeKql(string $query): bool
+    {
+        // Starts with a table name followed by pipe operator
+        if (preg_match('/^\w+\s*\|/', $query)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Execute a KQL query via the v2/rest/query endpoint.
+     */
+    private function executeKqlQuery(KustoConnection $kusto, string $query): ResultInterface|false
+    {
+        $url = $kusto->clusterUri . '/v2/rest/query';
+
+        $payload = json_encode([
+            'db' => $kusto->database,
+            'csl' => $query,
+            'properties' => json_encode([
+                'Options' => [
+                    'queryconsistency' => 'strongconsistency',
+                ],
+            ]),
+        ]);
+
+        $response = $this->httpPost($url, $kusto->accessToken, $payload);
+
+        if ($response === false) {
+            return false;
+        }
+
+        return $this->parseV2Response($response);
+    }
+
+    /**
+     * Execute a management command via /v1/rest/mgmt endpoint.
+     */
+    private function executeManagement(KustoConnection $kusto, string $query): ResultInterface|false
+    {
+        $url = $kusto->clusterUri . '/v1/rest/mgmt';
+
+        $payload = json_encode([
+            'db' => $kusto->database,
+            'csl' => $query,
+        ]);
+
+        $response = $this->httpPost($url, $kusto->accessToken, $payload);
+
+        if ($response === false) {
+            return false;
+        }
+
+        return $this->parseV1Response($response);
+    }
+
+    /**
+     * Send an HTTP POST request to the Kusto REST API.
+     */
+    private function httpPost(string $url, string $accessToken, string $body): string|false
+    {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 300); // Kusto queries can be slow
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Authorization: ' . KustoAuth::bearerHeader($accessToken),
+            'Content-Type: application/json; charset=utf-8',
+            'Accept: application/json',
+            'x-ms-app: phpMyKustoAdmin',
+            'x-ms-client-request-id: pka-' . uniqid(),
+        ]);
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curlError = curl_error($ch);
+        $curlErrno = curl_errno($ch);
+        curl_close($ch);
+
+        if ($curlErrno !== 0 || ! is_string($response)) {
+            $this->lastError = 'Kusto HTTP request failed: ' . $curlError;
+            $this->lastErrorCode = $curlErrno;
+
+            return false;
+        }
+
+        if ($httpCode >= 400) {
+            $errorData = json_decode($response, true);
+            $message = $errorData['error']['message']
+                    ?? $errorData['error']['@message']
+                    ?? $errorData['message']
+                    ?? 'HTTP ' . $httpCode;
+            $this->lastError = 'Kusto error: ' . $message;
+            $this->lastErrorCode = $httpCode;
+
+            return false;
+        }
+
+        return $response;
+    }
+
+    /**
+     * Parse a Kusto V2 response (from /v2/rest/query).
+     *
+     * V2 responses are arrays of "frames" — we look for the PrimaryResult table.
+     */
+    private function parseV2Response(string $responseBody): ResultInterface
+    {
+        /** @var list<array{FrameType?: string, TableKind?: string, Columns?: list<array{ColumnName: string, ColumnType: string}>, Rows?: list<list<mixed>>}>|null $frames */
+        $frames = json_decode($responseBody, true);
+
+        if ($frames === null || ! is_array($frames)) {
+            return KustoResult::empty();
+        }
+
+        // Find the PrimaryResult table
+        foreach ($frames as $frame) {
+            $kind = $frame['TableKind'] ?? $frame['FrameType'] ?? '';
+            if ($kind === 'PrimaryResult' || $kind === 'DataTable') {
+                return new KustoResult(
+                    $frame['Columns'] ?? [],
+                    $frame['Rows'] ?? [],
+                );
+            }
+        }
+
+        // If no PrimaryResult found, try the first DataTable or DataSetHeader
+        foreach ($frames as $frame) {
+            if (isset($frame['Columns'], $frame['Rows'])) {
+                return new KustoResult($frame['Columns'], $frame['Rows']);
+            }
+        }
+
+        return KustoResult::empty();
+    }
+
+    /**
+     * Parse a Kusto V1 response (from /v1/rest/mgmt).
+     *
+     * V1 responses have a top-level "Tables" array.
+     */
+    private function parseV1Response(string $responseBody): ResultInterface
+    {
+        /** @var array{Tables?: list<array{Columns?: list<array{ColumnName: string, ColumnType?: string, DataType?: string}>, Rows?: list<list<mixed>>}>}|null $data */
+        $data = json_decode($responseBody, true);
+
+        if ($data === null || ! isset($data['Tables'][0])) {
+            return KustoResult::empty();
+        }
+
+        $table = $data['Tables'][0];
+        $columns = [];
+        foreach ($table['Columns'] ?? [] as $col) {
+            $columns[] = [
+                'ColumnName' => $col['ColumnName'],
+                'ColumnType' => $col['ColumnType'] ?? $col['DataType'] ?? 'string',
+            ];
+        }
+
+        return new KustoResult($columns, $table['Rows'] ?? []);
+    }
+}

--- a/src/Dbal/Kusto/KqlGenerator.php
+++ b/src/Dbal/Kusto/KqlGenerator.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * KQL (Kusto Query Language) query generator
+ *
+ * Generates KQL management commands and queries that map to the SQL operations
+ * phpMyAdmin expects to perform.
+ */
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Dbal\Kusto;
+
+use function implode;
+use function str_replace;
+
+/**
+ * Generates Kusto Query Language statements for common database operations.
+ *
+ * Kusto management commands start with a dot (e.g. ".show databases").
+ * KQL queries do not start with a dot.
+ */
+final class KqlGenerator
+{
+    // =========================================================================
+    // Database / Cluster operations
+    // =========================================================================
+
+    /** List all databases in the cluster */
+    public static function showDatabases(): string
+    {
+        return '.show databases';
+    }
+
+    /** Show detailed database info */
+    public static function showDatabase(string $database): string
+    {
+        return '.show database ' . self::quoteIdentifier($database) . ' details';
+    }
+
+    // =========================================================================
+    // Table operations
+    // =========================================================================
+
+    /** List all tables in a database */
+    public static function showTables(string $database = ''): string
+    {
+        if ($database !== '') {
+            return '.show database ' . self::quoteIdentifier($database) . ' tables';
+        }
+
+        return '.show tables';
+    }
+
+    /** Show table schema/columns */
+    public static function showTableSchema(string $table): string
+    {
+        return '.show table ' . self::quoteIdentifier($table) . ' schema as json';
+    }
+
+    /** Show table details (row count, extent size, etc.) */
+    public static function showTableDetails(string $table): string
+    {
+        return '.show table ' . self::quoteIdentifier($table) . ' details';
+    }
+
+    /** Get column info for a table */
+    public static function getColumns(string $table): string
+    {
+        return '.show table ' . self::quoteIdentifier($table) . ' schema as cslschema';
+    }
+
+    /** Count rows in a table */
+    public static function countRows(string $table): string
+    {
+        return self::quoteIdentifier($table) . ' | count';
+    }
+
+    /** Take N rows from a table (equivalent to SELECT * LIMIT N) */
+    public static function selectAll(string $table, int $limit = 1000, int $offset = 0): string
+    {
+        $query = self::quoteIdentifier($table);
+
+        if ($offset > 0) {
+            // Kusto doesn't have native OFFSET, but we can serialize_rows
+            // For proper paging, use a cursor or serialize_rows; here we approximate:
+            $query .= ' | serialize _rowNumber = row_number()';
+            $query .= ' | where _rowNumber > ' . $offset;
+            $query .= ' | project-away _rowNumber';
+        }
+
+        $query .= ' | take ' . $limit;
+
+        return $query;
+    }
+
+    /** Search/filter table rows */
+    public static function searchTable(string $table, string $searchTerm, int $limit = 1000): string
+    {
+        $escaped = str_replace("'", "''", $searchTerm);
+
+        return self::quoteIdentifier($table)
+            . " | where * has '" . $escaped . "'"
+            . ' | take ' . $limit;
+    }
+
+    // =========================================================================
+    // Management operations
+    // =========================================================================
+
+    /** Drop a table */
+    public static function dropTable(string $table): string
+    {
+        return '.drop table ' . self::quoteIdentifier($table) . ' ifexists';
+    }
+
+    /**
+     * Create a table with columns.
+     *
+     * @param string $table Table name
+     * @param array<string, string> $columns Column name => Kusto type
+     */
+    public static function createTable(string $table, array $columns): string
+    {
+        $colDefs = [];
+        foreach ($columns as $name => $type) {
+            $colDefs[] = self::quoteIdentifier($name) . ':' . $type;
+        }
+
+        return '.create table ' . self::quoteIdentifier($table)
+            . ' (' . implode(', ', $colDefs) . ')';
+    }
+
+    /** Rename a table */
+    public static function renameTable(string $oldName, string $newName): string
+    {
+        return '.rename table ' . self::quoteIdentifier($oldName)
+            . ' to ' . self::quoteIdentifier($newName);
+    }
+
+    /** Add a column to an existing table */
+    public static function addColumn(string $table, string $column, string $type): string
+    {
+        return '.alter-merge table ' . self::quoteIdentifier($table)
+            . ' (' . self::quoteIdentifier($column) . ':' . $type . ')';
+    }
+
+    /** Drop a column from a table */
+    public static function dropColumn(string $table, string $column): string
+    {
+        return '.alter table ' . self::quoteIdentifier($table)
+            . ' drop column ' . self::quoteIdentifier($column);
+    }
+
+    // =========================================================================
+    // Function operations (Kusto stored functions)
+    // =========================================================================
+
+    /** List all functions */
+    public static function showFunctions(): string
+    {
+        return '.show functions';
+    }
+
+    /** Show a specific function */
+    public static function showFunction(string $name): string
+    {
+        return '.show function ' . self::quoteIdentifier($name);
+    }
+
+    /** Drop a function */
+    public static function dropFunction(string $name): string
+    {
+        return '.drop function ' . self::quoteIdentifier($name) . ' ifexists';
+    }
+
+    // =========================================================================
+    // Ingestion (data insertion)
+    // =========================================================================
+
+    /**
+     * Inline ingestion of data into a table.
+     *
+     * @param string $table Table name
+     * @param list<list<string>> $rows Rows of data (each row as list of stringified values)
+     */
+    public static function ingestInline(string $table, array $rows): string
+    {
+        $lines = [];
+        foreach ($rows as $row) {
+            $escapedValues = [];
+            foreach ($row as $value) {
+                // Inline ingestion uses CSV-like format
+                $escapedValues[] = str_replace(["\n", "\r", ','], ['\\n', '\\r', '\\,'], $value);
+            }
+
+            $lines[] = implode(',', $escapedValues);
+        }
+
+        return '.ingest inline into table ' . self::quoteIdentifier($table)
+            . ' <|' . "\n" . implode("\n", $lines);
+    }
+
+    // =========================================================================
+    // Cluster operations
+    // =========================================================================
+
+    /** Show cluster information */
+    public static function showCluster(): string
+    {
+        return '.show cluster';
+    }
+
+    /** Show cluster version info */
+    public static function showVersion(): string
+    {
+        return '.show version';
+    }
+
+    /** Show running queries (similar to SHOW PROCESSLIST) */
+    public static function showQueries(): string
+    {
+        return '.show queries';
+    }
+
+    /** Show cluster policies */
+    public static function showPolicies(string $entity, string $entityName = ''): string
+    {
+        $cmd = '.show ' . $entity;
+        if ($entityName !== '') {
+            $cmd .= ' ' . self::quoteIdentifier($entityName);
+        }
+
+        return $cmd . ' policy *';
+    }
+
+    // =========================================================================
+    // Utility
+    // =========================================================================
+
+    /**
+     * Quote a Kusto identifier.
+     *
+     * Kusto uses bracket notation ['name'] for identifiers that contain
+     * special characters. Simple identifiers don't need quoting.
+     */
+    public static function quoteIdentifier(string $identifier): string
+    {
+        // If identifier is already quoted, return as-is
+        if (str_starts_with($identifier, "['") && str_ends_with($identifier, "']")) {
+            return $identifier;
+        }
+
+        // Quote if it contains special characters
+        if (preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $identifier)) {
+            return $identifier;
+        }
+
+        return "['" . str_replace("'", "\\'", $identifier) . "']";
+    }
+
+    /**
+     * Map a MySQL type name to the closest Kusto type.
+     */
+    public static function mysqlTypeToKusto(string $mysqlType): string
+    {
+        $mysqlType = strtolower(trim($mysqlType));
+
+        return match (true) {
+            in_array($mysqlType, ['tinyint', 'smallint', 'mediumint', 'int', 'integer'], true) => 'int',
+            in_array($mysqlType, ['bigint'], true) => 'long',
+            in_array($mysqlType, ['float', 'double', 'decimal', 'numeric', 'real'], true) => 'real',
+            in_array($mysqlType, ['bool', 'boolean'], true) => 'bool',
+            in_array($mysqlType, ['date', 'datetime', 'timestamp'], true) => 'datetime',
+            in_array($mysqlType, ['time'], true) => 'timespan',
+            in_array($mysqlType, ['json', 'blob', 'mediumblob', 'longblob'], true) => 'dynamic',
+            in_array($mysqlType, ['binary', 'varbinary'], true) => 'dynamic',
+            str_starts_with($mysqlType, 'varchar') => 'string',
+            str_starts_with($mysqlType, 'char') => 'string',
+            str_starts_with($mysqlType, 'text') => 'string',
+            default => 'string',
+        };
+    }
+}

--- a/src/Dbal/Kusto/KustoAuth.php
+++ b/src/Dbal/Kusto/KustoAuth.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Azure AD OAuth2 authentication helper for Kusto
+ */
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Dbal\Kusto;
+
+use PhpMyAdmin\Dbal\ConnectionException;
+
+use function curl_close;
+use function curl_errno;
+use function curl_error;
+use function curl_exec;
+use function curl_init;
+use function curl_setopt;
+use function http_build_query;
+use function is_string;
+use function json_decode;
+use function time;
+
+use const CURLOPT_HTTPHEADER;
+use const CURLOPT_POST;
+use const CURLOPT_POSTFIELDS;
+use const CURLOPT_RETURNTRANSFER;
+use const CURLOPT_SSL_VERIFYPEER;
+use const CURLOPT_TIMEOUT;
+use const CURLOPT_URL;
+
+/**
+ * Handles Azure AD client-credentials OAuth2 flow to obtain bearer tokens for Kusto.
+ */
+final class KustoAuth
+{
+    /**
+     * Obtain an OAuth2 access token using client credentials grant.
+     *
+     * @param string $tenantId  Azure AD tenant ID
+     * @param string $clientId  Application (client) ID
+     * @param string $clientSecret Application secret
+     * @param string $clusterUri  Kusto cluster URI (used as the resource scope)
+     *
+     * @return array{access_token: string, expires_in: int}
+     *
+     * @throws ConnectionException
+     */
+    public static function getAccessToken(
+        string $tenantId,
+        string $clientId,
+        string $clientSecret,
+        string $clusterUri,
+    ): array {
+        $tokenEndpoint = 'https://login.microsoftonline.com/' . $tenantId . '/oauth2/v2.0/token';
+
+        $postFields = http_build_query([
+            'grant_type' => 'client_credentials',
+            'client_id' => $clientId,
+            'client_secret' => $clientSecret,
+            'scope' => $clusterUri . '/.default',
+        ]);
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $tokenEndpoint);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $postFields);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/x-www-form-urlencoded',
+        ]);
+
+        $response = curl_exec($ch);
+        $curlError = curl_error($ch);
+        $curlErrno = curl_errno($ch);
+        curl_close($ch);
+
+        if ($curlErrno !== 0 || ! is_string($response)) {
+            throw new ConnectionException(
+                'Failed to obtain Kusto access token: ' . $curlError,
+                $curlErrno,
+            );
+        }
+
+        /** @var array{access_token?: string, expires_in?: int, error?: string, error_description?: string}|null $data */
+        $data = json_decode($response, true);
+
+        if ($data === null || ! isset($data['access_token'])) {
+            $errorMsg = $data['error_description'] ?? $data['error'] ?? 'Unknown authentication error';
+
+            throw new ConnectionException(
+                'Kusto authentication failed: ' . $errorMsg,
+                0,
+            );
+        }
+
+        return [
+            'access_token' => $data['access_token'],
+            'expires_in' => $data['expires_in'] ?? 3600,
+        ];
+    }
+
+    /**
+     * Obtain a bearer token using username/password (ROPC flow).
+     * NOTE: ROPC is discouraged by Microsoft for production use but included
+     * for compatibility with phpMyAdmin's "cookie" and "config" auth modes.
+     *
+     * @param string $tenantId   Azure AD tenant ID
+     * @param string $clientId   Application (client) ID
+     * @param string $username   User's email / UPN
+     * @param string $password   User's password
+     * @param string $clusterUri Kusto cluster URI
+     *
+     * @return array{access_token: string, expires_in: int}
+     *
+     * @throws ConnectionException
+     */
+    public static function getAccessTokenByPassword(
+        string $tenantId,
+        string $clientId,
+        string $username,
+        string $password,
+        string $clusterUri,
+    ): array {
+        $tokenEndpoint = 'https://login.microsoftonline.com/' . $tenantId . '/oauth2/v2.0/token';
+
+        $postFields = http_build_query([
+            'grant_type' => 'password',
+            'client_id' => $clientId,
+            'username' => $username,
+            'password' => $password,
+            'scope' => $clusterUri . '/.default',
+        ]);
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $tokenEndpoint);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $postFields);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/x-www-form-urlencoded',
+        ]);
+
+        $response = curl_exec($ch);
+        $curlError = curl_error($ch);
+        $curlErrno = curl_errno($ch);
+        curl_close($ch);
+
+        if ($curlErrno !== 0 || ! is_string($response)) {
+            throw new ConnectionException(
+                'Failed to obtain Kusto access token via password: ' . $curlError,
+                $curlErrno,
+            );
+        }
+
+        /** @var array{access_token?: string, expires_in?: int, error?: string, error_description?: string}|null $data */
+        $data = json_decode($response, true);
+
+        if ($data === null || ! isset($data['access_token'])) {
+            $errorMsg = $data['error_description'] ?? $data['error'] ?? 'Unknown authentication error';
+
+            throw new ConnectionException(
+                'Kusto password authentication failed: ' . $errorMsg,
+                0,
+            );
+        }
+
+        return [
+            'access_token' => $data['access_token'],
+            'expires_in' => $data['expires_in'] ?? 3600,
+        ];
+    }
+
+    /**
+     * Build a bearer token Authorization header value.
+     */
+    public static function bearerHeader(string $accessToken): string
+    {
+        return 'Bearer ' . $accessToken;
+    }
+}

--- a/src/Dbal/Kusto/KustoConnection.php
+++ b/src/Dbal/Kusto/KustoConnection.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Kusto (Azure Data Explorer) connection value object
+ */
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Dbal\Kusto;
+
+/**
+ * Represents an active connection to an Azure Data Explorer (Kusto) cluster.
+ *
+ * @psalm-immutable
+ */
+final class KustoConnection
+{
+    public function __construct(
+        /** The cluster URI, e.g. https://mycluster.region.kusto.windows.net */
+        public readonly string $clusterUri,
+        /** The default database name */
+        public readonly string $database,
+        /** The OAuth2 bearer token used for authentication */
+        public readonly string $accessToken,
+        /** When the access token expires (Unix timestamp) */
+        public readonly int $tokenExpiry,
+        /** The Azure AD tenant ID */
+        public readonly string $tenantId,
+        /** The Azure AD client/application ID */
+        public readonly string $clientId,
+    ) {
+    }
+
+    /** Check whether the access token has expired */
+    public function isTokenExpired(): bool
+    {
+        return time() >= $this->tokenExpiry - 60; // 60-second buffer
+    }
+
+    /** Return a new instance with a refreshed token */
+    public function withToken(string $accessToken, int $tokenExpiry): self
+    {
+        return new self(
+            $this->clusterUri,
+            $this->database,
+            $accessToken,
+            $tokenExpiry,
+            $this->tenantId,
+            $this->clientId,
+        );
+    }
+}

--- a/src/Dbal/Kusto/KustoFieldMetadata.php
+++ b/src/Dbal/Kusto/KustoFieldMetadata.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Factory for creating FieldMetadata objects from Kusto column types
+ */
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Dbal\Kusto;
+
+use PhpMyAdmin\FieldMetadata;
+use stdClass;
+
+use const MYSQLI_TYPE_BLOB;
+use const MYSQLI_TYPE_DATETIME;
+use const MYSQLI_TYPE_DOUBLE;
+use const MYSQLI_TYPE_LONG;
+use const MYSQLI_TYPE_LONGLONG;
+use const MYSQLI_TYPE_STRING;
+use const MYSQLI_TYPE_TIMESTAMP;
+use const MYSQLI_TYPE_VAR_STRING;
+
+/**
+ * Creates FieldMetadata instances from Kusto data types.
+ *
+ * Kusto types are mapped to the closest MYSQLI_TYPE_* constants so that
+ * the rest of phpMyAdmin can render columns, format values, etc.
+ */
+final class KustoFieldMetadata
+{
+    /**
+     * Map a Kusto type string to a MYSQLI_TYPE_* constant.
+     */
+    private static function mapKustoType(string $kustoType): int
+    {
+        return match ($kustoType) {
+            'bool' => MYSQLI_TYPE_LONG,          // treated as int
+            'int' => MYSQLI_TYPE_LONG,
+            'long' => MYSQLI_TYPE_LONGLONG,
+            'real', 'decimal' => MYSQLI_TYPE_DOUBLE,
+            'datetime' => MYSQLI_TYPE_DATETIME,
+            'timespan' => MYSQLI_TYPE_TIMESTAMP,
+            'guid' => MYSQLI_TYPE_VAR_STRING,
+            'dynamic' => MYSQLI_TYPE_BLOB,       // JSON-like
+            default => MYSQLI_TYPE_STRING,        // string, and everything else
+        };
+    }
+
+    /**
+     * Estimate a display length for Kusto types.
+     */
+    private static function estimateLength(string $kustoType): int
+    {
+        return match ($kustoType) {
+            'bool' => 5,
+            'int' => 11,
+            'long' => 20,
+            'real', 'decimal' => 22,
+            'datetime' => 26,    // ISO 8601 format
+            'timespan' => 26,
+            'guid' => 36,
+            'dynamic' => 65535,
+            default => 255,
+        };
+    }
+
+    /**
+     * Create a FieldMetadata from a Kusto column definition.
+     */
+    public static function create(string $columnName, string $kustoType, string $table = ''): FieldMetadata
+    {
+        $mysqliType = self::mapKustoType($kustoType);
+
+        $field = new stdClass();
+        $field->name = $columnName;
+        $field->orgname = $columnName;
+        $field->table = $table;
+        $field->orgtable = $table;
+        $field->max_length = 0;
+        $field->length = self::estimateLength($kustoType);
+        $field->charsetnr = 33;  // utf8_general_ci
+        $field->flags = 0;
+        $field->type = $mysqliType;
+        $field->decimals = ($kustoType === 'real' || $kustoType === 'decimal') ? 6 : 0;
+        $field->db = '';
+        $field->def = '';
+        $field->catalog = 'def';
+
+        return new FieldMetadata($field);
+    }
+}

--- a/src/Dbal/Kusto/KustoResult.php
+++ b/src/Dbal/Kusto/KustoResult.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Result set implementation for Kusto (Azure Data Explorer) query responses
+ */
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Dbal\Kusto;
+
+use Generator;
+use PhpMyAdmin\Dbal\ResultInterface;
+use PhpMyAdmin\FieldMetadata;
+
+use function array_column;
+use function array_key_exists;
+use function array_keys;
+use function array_values;
+use function count;
+use function is_string;
+
+/**
+ * Wraps Kusto V2 query response data into the ResultInterface contract.
+ *
+ * Kusto returns results as JSON with columns and rows arrays.
+ * This class materialises the entire result in memory (Kusto responses are
+ * already fully buffered anyway).
+ */
+final class KustoResult implements ResultInterface
+{
+    /** Column names in order */
+    private readonly array $columns;
+
+    /** Column types in order (Kusto type strings like "string", "long", "datetime") */
+    private readonly array $columnTypes;
+
+    /** All rows as list of associative arrays */
+    private readonly array $rows;
+
+    /** Current cursor position for fetch*() calls */
+    private int $cursor = 0;
+
+    /**
+     * @param list<array{ColumnName: string, ColumnType: string}> $columns
+     * @param list<list<mixed>> $rows Raw row data from Kusto (positional)
+     */
+    public function __construct(array $columns, array $rows)
+    {
+        $colNames = [];
+        $colTypes = [];
+        foreach ($columns as $col) {
+            $colNames[] = $col['ColumnName'];
+            $colTypes[] = $col['ColumnType'] ?? 'string';
+        }
+
+        $this->columns = $colNames;
+        $this->columnTypes = $colTypes;
+
+        // Convert positional rows to associative
+        $assocRows = [];
+        foreach ($rows as $row) {
+            $assoc = [];
+            foreach ($colNames as $i => $name) {
+                $assoc[$name] = isset($row[$i]) ? (string) $row[$i] : null;
+            }
+
+            $assocRows[] = $assoc;
+        }
+
+        $this->rows = $assocRows;
+    }
+
+    /**
+     * Create an empty result set
+     */
+    public static function empty(): self
+    {
+        return new self([], []);
+    }
+
+    /**
+     * Create from a Kusto V2 response primary result table.
+     *
+     * @param array{Columns: list<array{ColumnName: string, ColumnType: string}>, Rows: list<list<mixed>>} $table
+     */
+    public static function fromKustoTable(array $table): self
+    {
+        return new self($table['Columns'] ?? [], $table['Rows'] ?? []);
+    }
+
+    /** @psalm-return Generator<int, array<array-key, string|null>, mixed, void> */
+    public function getIterator(): Generator
+    {
+        foreach ($this->rows as $row) {
+            yield $row;
+        }
+    }
+
+    /** @return array<string|null> */
+    public function fetchAssoc(): array
+    {
+        if (! isset($this->rows[$this->cursor])) {
+            return [];
+        }
+
+        return $this->rows[$this->cursor++];
+    }
+
+    /** @return list<string|null> */
+    public function fetchRow(): array
+    {
+        if (! isset($this->rows[$this->cursor])) {
+            return [];
+        }
+
+        return array_values($this->rows[$this->cursor++]);
+    }
+
+    public function fetchValue(int|string $field = 0): string|false|null
+    {
+        $row = is_string($field) ? $this->fetchAssoc() : $this->fetchRow();
+
+        if (! array_key_exists($field, $row)) {
+            return false;
+        }
+
+        return $row[$field];
+    }
+
+    /** @return list<array<array-key, string|null>> */
+    public function fetchAllAssoc(): array
+    {
+        $this->cursor = 0;
+
+        return $this->rows;
+    }
+
+    /** @return list<string|null> */
+    public function fetchAllColumn(int|string $column = 0): array
+    {
+        $this->cursor = 0;
+
+        if (is_string($column)) {
+            return array_column($this->rows, $column);
+        }
+
+        // For numeric column index, extract values positionally
+        $result = [];
+        foreach ($this->rows as $row) {
+            $values = array_values($row);
+            $result[] = $values[$column] ?? null;
+        }
+
+        return $result;
+    }
+
+    /** @return array<array-key, string|null> */
+    public function fetchAllKeyPair(): array
+    {
+        $this->cursor = 0;
+
+        if (count($this->columns) < 2) {
+            return [];
+        }
+
+        return array_column($this->rows, $this->columns[1], $this->columns[0]);
+    }
+
+    public function numFields(): int
+    {
+        return count($this->columns);
+    }
+
+    /** @return int */
+    public function numRows(): string|int
+    {
+        return count($this->rows);
+    }
+
+    public function seek(int $offset): bool
+    {
+        if ($offset < 0 || $offset >= count($this->rows)) {
+            return false;
+        }
+
+        $this->cursor = $offset;
+
+        return true;
+    }
+
+    /** @return list<FieldMetadata> */
+    public function getFieldsMeta(): array
+    {
+        $fields = [];
+        foreach ($this->columns as $i => $name) {
+            $fields[] = KustoFieldMetadata::create($name, $this->columnTypes[$i] ?? 'string');
+        }
+
+        return $fields;
+    }
+
+    /** @return list<string> */
+    public function getFieldNames(): array
+    {
+        return $this->columns;
+    }
+
+    /** Get Kusto column types */
+    public function getColumnTypes(): array
+    {
+        return $this->columnTypes;
+    }
+}

--- a/src/Dbal/Kusto/SqlToKqlTranslator.php
+++ b/src/Dbal/Kusto/SqlToKqlTranslator.php
@@ -1,0 +1,348 @@
+<?php
+/**
+ * SQL to KQL translator
+ *
+ * Intercepts common SQL patterns emitted by phpMyAdmin's core and
+ * translates them into equivalent Kusto Query Language.
+ */
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Dbal\Kusto;
+
+use function array_map;
+use function count;
+use function implode;
+use function ltrim;
+use function preg_match;
+use function preg_match_all;
+use function str_ireplace;
+use function str_starts_with;
+use function strtolower;
+use function strtoupper;
+use function trim;
+
+/**
+ * Translates SQL statements commonly issued by phpMyAdmin into their
+ * Kusto Query Language (KQL) or management-command equivalents.
+ *
+ * This is a best-effort translator — not a full SQL parser. It covers the
+ * read-heavy operations that the phpMyAdmin UI triggers, such as:
+ *  - SHOW DATABASES / SHOW TABLES
+ *  - SELECT * FROM table
+ *  - INFORMATION_SCHEMA queries
+ *  - SHOW CREATE TABLE
+ *  - SHOW VARIABLES / SHOW STATUS
+ */
+final class SqlToKqlTranslator
+{
+    /**
+     * Attempt to translate a SQL query to KQL.
+     *
+     * Returns the translated KQL string, or null if the query cannot
+     * be translated (caller should return an empty result or error).
+     */
+    public static function translate(string $sql): string|null
+    {
+        $sql = trim($sql);
+
+        // Remove trailing semicolons
+        $sql = rtrim($sql, ';');
+
+        $upper = strtoupper(trim($sql));
+
+        // =====================================================================
+        // SHOW commands
+        // =====================================================================
+
+        if ($upper === 'SHOW DATABASES' || $upper === 'SHOW SCHEMAS') {
+            return KqlGenerator::showDatabases();
+        }
+
+        if (preg_match('/^SHOW\s+TABLES(\s+FROM\s+`?(\w+)`?)?/i', $sql, $m)) {
+            return KqlGenerator::showTables($m[2] ?? '');
+        }
+
+        if (preg_match('/^SHOW\s+FULL\s+TABLES(\s+FROM\s+`?(\w+)`?)?/i', $sql, $m)) {
+            return KqlGenerator::showTables($m[2] ?? '');
+        }
+
+        if (preg_match('/^SHOW\s+CREATE\s+TABLE\s+`?(\w+)`?/i', $sql, $m)) {
+            return KqlGenerator::showTableSchema($m[1]);
+        }
+
+        if (preg_match('/^SHOW\s+COLUMNS\s+FROM\s+`?(\w+)`?/i', $sql, $m)) {
+            return KqlGenerator::getColumns($m[1]);
+        }
+
+        if (preg_match('/^SHOW\s+FULL\s+COLUMNS\s+FROM\s+`?(\w+)`?/i', $sql, $m)) {
+            return KqlGenerator::getColumns($m[1]);
+        }
+
+        if (preg_match('/^DESCRIBE\s+`?(\w+)`?/i', $sql, $m)) {
+            return KqlGenerator::getColumns($m[1]);
+        }
+
+        if (str_starts_with($upper, 'SHOW VARIABLES') || str_starts_with($upper, 'SHOW SESSION VARIABLES')) {
+            // Return Kusto version info instead
+            return KqlGenerator::showVersion();
+        }
+
+        if (str_starts_with($upper, 'SHOW GLOBAL STATUS') || str_starts_with($upper, 'SHOW STATUS')) {
+            return KqlGenerator::showCluster();
+        }
+
+        if (str_starts_with($upper, 'SHOW PROCESSLIST') || str_starts_with($upper, 'SHOW FULL PROCESSLIST')) {
+            return KqlGenerator::showQueries();
+        }
+
+        if (str_starts_with($upper, 'SHOW FUNCTION STATUS') || str_starts_with($upper, 'SHOW PROCEDURE STATUS')) {
+            return KqlGenerator::showFunctions();
+        }
+
+        // =====================================================================
+        // SELECT from INFORMATION_SCHEMA
+        // =====================================================================
+
+        if (preg_match('/INFORMATION_SCHEMA\s*\.\s*SCHEMATA/i', $sql)) {
+            return KqlGenerator::showDatabases();
+        }
+
+        if (preg_match('/INFORMATION_SCHEMA\s*\.\s*TABLES/i', $sql)) {
+            // Try to extract the database filter
+            if (preg_match("/TABLE_SCHEMA\s*=\s*'([^']+)'/i", $sql, $m)) {
+                return KqlGenerator::showTables($m[1]);
+            }
+
+            return KqlGenerator::showTables();
+        }
+
+        if (preg_match('/INFORMATION_SCHEMA\s*\.\s*COLUMNS/i', $sql)) {
+            if (preg_match("/TABLE_NAME\s*=\s*'([^']+)'/i", $sql, $m)) {
+                return KqlGenerator::getColumns($m[1]);
+            }
+
+            return null; // Can't determine which table
+        }
+
+        if (preg_match('/INFORMATION_SCHEMA\s*\.\s*ROUTINES/i', $sql)) {
+            return KqlGenerator::showFunctions();
+        }
+
+        // =====================================================================
+        // SELECT queries
+        // =====================================================================
+
+        if (preg_match('/^SELECT\s+COUNT\s*\(\s*\*\s*\)\s+FROM\s+`?(\w+)`?/i', $sql, $m)) {
+            return KqlGenerator::countRows($m[1]);
+        }
+
+        if (preg_match('/^SELECT\s+\*\s+FROM\s+`?(\w+)`?/i', $sql, $m)) {
+            $table = $m[1];
+            $limit = 1000;
+            $offset = 0;
+
+            if (preg_match('/LIMIT\s+(\d+)/i', $sql, $lm)) {
+                $limit = (int) $lm[1];
+            }
+
+            if (preg_match('/OFFSET\s+(\d+)/i', $sql, $om)) {
+                $offset = (int) $om[1];
+            } elseif (preg_match('/LIMIT\s+(\d+)\s*,\s*(\d+)/i', $sql, $lmo)) {
+                $offset = (int) $lmo[1];
+                $limit = (int) $lmo[2];
+            }
+
+            $kql = KqlGenerator::selectAll($table, $limit, $offset);
+
+            // Handle ORDER BY for SELECT * queries
+            if (preg_match('/ORDER\s+BY\s+`?(\w+)`?\s*(ASC|DESC)?/i', $sql, $om)) {
+                $dir = strtolower($om[2] ?? 'asc');
+                // Insert sort before the final | take
+                $kql = preg_replace(
+                    '/\|\s*take\s+/',
+                    '| sort by ' . KqlGenerator::quoteIdentifier($om[1]) . ' ' . $dir . ' | take ',
+                    $kql,
+                );
+            }
+
+            return $kql;
+        }
+
+        // Generic SELECT with specific columns
+        if (preg_match('/^SELECT\s+(.+?)\s+FROM\s+`?(\w+)`?(\s+.*)?$/is', $sql, $m)) {
+            $columns = trim($m[1]);
+            $table = $m[2];
+            $rest = trim($m[3] ?? '');
+
+            $kql = KqlGenerator::quoteIdentifier($table);
+
+            // Handle WHERE clause
+            if (preg_match('/WHERE\s+(.+?)(\s+ORDER\s+BY|\s+LIMIT|\s+GROUP\s+BY|$)/is', $rest, $wm)) {
+                $whereClause = self::translateWhereClause(trim($wm[1]));
+                if ($whereClause !== '') {
+                    $kql .= ' | where ' . $whereClause;
+                }
+            }
+
+            // Handle ORDER BY
+            if (preg_match('/ORDER\s+BY\s+`?(\w+)`?\s*(ASC|DESC)?/i', $rest, $om)) {
+                $dir = strtolower($om[2] ?? 'asc');
+                $kql .= ' | sort by ' . KqlGenerator::quoteIdentifier($om[1]) . ' ' . $dir;
+            }
+
+            // Handle LIMIT
+            $limit = 1000;
+            if (preg_match('/LIMIT\s+(\d+)/i', $rest, $lm)) {
+                $limit = (int) $lm[1];
+            }
+
+            $kql .= ' | take ' . $limit;
+
+            // Project specific columns (unless SELECT *)
+            if ($columns !== '*') {
+                $colList = self::parseColumnList($columns);
+                if ($colList !== []) {
+                    $kql .= ' | project ' . implode(', ', array_map(
+                        static fn (string $c): string => KqlGenerator::quoteIdentifier(trim($c, '` ')),
+                        $colList,
+                    ));
+                }
+            }
+
+            return $kql;
+        }
+
+        // =====================================================================
+        // DDL commands
+        // =====================================================================
+
+        if (preg_match('/^DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?`?(\w+)`?/i', $sql, $m)) {
+            return KqlGenerator::dropTable($m[1]);
+        }
+
+        // =====================================================================
+        // Kusto passthrough — if the query already starts with '.', it's KQL
+        // =====================================================================
+
+        if (str_starts_with($sql, '.')) {
+            return $sql;
+        }
+
+        // =====================================================================
+        // Pass-through for queries that look like KQL (table name | operator)
+        // =====================================================================
+
+        if (preg_match('/^\w+\s*\|/i', $sql)) {
+            return $sql;
+        }
+
+        // =====================================================================
+        // MySQL-specific queries we can safely ignore / return empty for
+        // =====================================================================
+
+        if (
+            str_starts_with($upper, 'SET ')
+            || str_starts_with($upper, 'SHOW GRANTS')
+            || str_starts_with($upper, 'SHOW ENGINES')
+            || str_starts_with($upper, 'SHOW PLUGINS')
+            || str_starts_with($upper, 'SHOW COLLATION')
+            || str_starts_with($upper, 'SHOW CHARSET')
+            || str_starts_with($upper, 'SHOW INDEX')
+            || str_starts_with($upper, 'SHOW MASTER')
+            || str_starts_with($upper, 'SHOW SLAVE')
+            || str_starts_with($upper, 'SHOW REPLICA')
+            || str_starts_with($upper, 'SHOW WARNINGS')
+            || str_starts_with($upper, 'SHOW ERRORS')
+            || str_starts_with($upper, 'FLUSH')
+            || str_starts_with($upper, 'RESET')
+            || $upper === 'SELECT 1'
+        ) {
+            return null; // Signal to return empty result
+        }
+
+        // Cannot translate — return null
+        return null;
+    }
+
+    /**
+     * Translate a SQL WHERE clause to KQL where operators.
+     */
+    private static function translateWhereClause(string $where): string
+    {
+        // Replace SQL operators with KQL equivalents
+        $kql = $where;
+
+        // Replace backtick-quoted identifiers
+        $kql = preg_replace('/`(\w+)`/', '$1', $kql);
+
+        // Replace SQL string comparison with KQL
+        // = remains =
+        // != remains !=
+        // <> becomes !=
+        $kql = str_ireplace('<>', '!=', $kql);
+
+        // LIKE 'pattern' → has "pattern" or contains "pattern"
+        $kql = preg_replace_callback(
+            "/(\w+)\s+LIKE\s+'([^']+)'/i",
+            static function (array $m): string {
+                $field = $m[1];
+                $pattern = $m[2];
+                // If pattern starts and ends with %, use contains
+                if (str_starts_with($pattern, '%') && str_ends_with($pattern, '%')) {
+                    return $field . " contains '" . trim($pattern, '%') . "'";
+                }
+
+                // If starts with %, use endswith
+                if (str_starts_with($pattern, '%')) {
+                    return $field . " endswith '" . ltrim($pattern, '%') . "'";
+                }
+
+                // If ends with %, use startswith
+                if (str_ends_with($pattern, '%')) {
+                    return $field . " startswith '" . rtrim($pattern, '%') . "'";
+                }
+
+                // Exact match
+                return $field . " == '" . $pattern . "'";
+            },
+            $kql,
+        );
+
+        // IS NULL → isnull()
+        $kql = preg_replace('/(\w+)\s+IS\s+NULL/i', 'isnull($1)', $kql);
+
+        // IS NOT NULL → isnotnull()
+        $kql = preg_replace('/(\w+)\s+IS\s+NOT\s+NULL/i', 'isnotnull($1)', $kql);
+
+        // IN (values) — keep as-is, Kusto supports `in` operator
+        // AND / OR — keep as-is, Kusto supports them
+
+        return $kql;
+    }
+
+    /**
+     * Parse a SQL column list into individual column names.
+     *
+     * @return list<string>
+     */
+    private static function parseColumnList(string $columns): array
+    {
+        // Simple comma split — doesn't handle functions with commas
+        $parts = explode(',', $columns);
+        $result = [];
+        foreach ($parts as $part) {
+            $part = trim($part);
+            if ($part !== '') {
+                // Handle aliases like `col AS alias`
+                if (preg_match('/^(.+?)\s+AS\s+`?(\w+)`?$/i', $part, $m)) {
+                    $result[] = $m[1]; // Use original name for project
+                } else {
+                    $result[] = $part;
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/unit/Dbal/Kusto/KqlGeneratorTest.php
+++ b/tests/unit/Dbal/Kusto/KqlGeneratorTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Dbal\Kusto;
+
+use PhpMyAdmin\Dbal\Kusto\KqlGenerator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(KqlGenerator::class)]
+class KqlGeneratorTest extends TestCase
+{
+    public function testShowDatabases(): void
+    {
+        self::assertSame('.show databases', KqlGenerator::showDatabases());
+    }
+
+    public function testShowTables(): void
+    {
+        self::assertSame('.show tables', KqlGenerator::showTables());
+        self::assertSame('.show database mydb tables', KqlGenerator::showTables('mydb'));
+    }
+
+    public function testShowTableSchema(): void
+    {
+        self::assertSame(
+            '.show table MyTable schema as json',
+            KqlGenerator::showTableSchema('MyTable'),
+        );
+    }
+
+    public function testGetColumns(): void
+    {
+        self::assertSame(
+            '.show table MyTable schema as cslschema',
+            KqlGenerator::getColumns('MyTable'),
+        );
+    }
+
+    public function testCountRows(): void
+    {
+        self::assertSame('MyTable | count', KqlGenerator::countRows('MyTable'));
+    }
+
+    public function testSelectAll(): void
+    {
+        self::assertSame('MyTable | take 100', KqlGenerator::selectAll('MyTable', 100));
+    }
+
+    public function testSelectAllWithOffset(): void
+    {
+        $result = KqlGenerator::selectAll('MyTable', 50, 10);
+        self::assertStringContainsString('serialize', $result);
+        self::assertStringContainsString('where _rowNumber > 10', $result);
+        self::assertStringContainsString('take 50', $result);
+    }
+
+    public function testDropTable(): void
+    {
+        self::assertSame('.drop table MyTable ifexists', KqlGenerator::dropTable('MyTable'));
+    }
+
+    public function testCreateTable(): void
+    {
+        $result = KqlGenerator::createTable('MyTable', [
+            'Id' => 'long',
+            'Name' => 'string',
+            'Created' => 'datetime',
+        ]);
+
+        self::assertSame(
+            '.create table MyTable (Id:long, Name:string, Created:datetime)',
+            $result,
+        );
+    }
+
+    public function testQuoteIdentifier(): void
+    {
+        // Simple identifiers don't need quoting
+        self::assertSame('MyTable', KqlGenerator::quoteIdentifier('MyTable'));
+        self::assertSame('my_table_1', KqlGenerator::quoteIdentifier('my_table_1'));
+
+        // Identifiers with special chars get quoted
+        self::assertSame("[' my table']", KqlGenerator::quoteIdentifier(' my table'));
+        self::assertSame("['my-table']", KqlGenerator::quoteIdentifier('my-table'));
+    }
+
+    public function testShowFunctions(): void
+    {
+        self::assertSame('.show functions', KqlGenerator::showFunctions());
+    }
+
+    public function testShowVersion(): void
+    {
+        self::assertSame('.show version', KqlGenerator::showVersion());
+    }
+
+    public function testShowQueries(): void
+    {
+        self::assertSame('.show queries', KqlGenerator::showQueries());
+    }
+
+    public function testMysqlTypeToKusto(): void
+    {
+        self::assertSame('int', KqlGenerator::mysqlTypeToKusto('int'));
+        self::assertSame('int', KqlGenerator::mysqlTypeToKusto('INTEGER'));
+        self::assertSame('long', KqlGenerator::mysqlTypeToKusto('bigint'));
+        self::assertSame('real', KqlGenerator::mysqlTypeToKusto('float'));
+        self::assertSame('real', KqlGenerator::mysqlTypeToKusto('double'));
+        self::assertSame('bool', KqlGenerator::mysqlTypeToKusto('boolean'));
+        self::assertSame('datetime', KqlGenerator::mysqlTypeToKusto('datetime'));
+        self::assertSame('datetime', KqlGenerator::mysqlTypeToKusto('timestamp'));
+        self::assertSame('string', KqlGenerator::mysqlTypeToKusto('varchar(255)'));
+        self::assertSame('string', KqlGenerator::mysqlTypeToKusto('text'));
+        self::assertSame('dynamic', KqlGenerator::mysqlTypeToKusto('json'));
+        self::assertSame('dynamic', KqlGenerator::mysqlTypeToKusto('blob'));
+    }
+
+    public function testRenameTable(): void
+    {
+        self::assertSame(
+            '.rename table OldName to NewName',
+            KqlGenerator::renameTable('OldName', 'NewName'),
+        );
+    }
+
+    public function testAddColumn(): void
+    {
+        self::assertSame(
+            '.alter-merge table MyTable (NewCol:string)',
+            KqlGenerator::addColumn('MyTable', 'NewCol', 'string'),
+        );
+    }
+
+    public function testDropColumn(): void
+    {
+        self::assertSame(
+            '.alter table MyTable drop column OldCol',
+            KqlGenerator::dropColumn('MyTable', 'OldCol'),
+        );
+    }
+
+    public function testSearchTable(): void
+    {
+        $result = KqlGenerator::searchTable('MyTable', 'hello');
+        self::assertStringContainsString("has 'hello'", $result);
+        self::assertStringContainsString('take 1000', $result);
+    }
+}

--- a/tests/unit/Dbal/Kusto/KustoResultTest.php
+++ b/tests/unit/Dbal/Kusto/KustoResultTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Dbal\Kusto;
+
+use PhpMyAdmin\Dbal\Kusto\KustoResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(KustoResult::class)]
+class KustoResultTest extends TestCase
+{
+    private function createSampleResult(): KustoResult
+    {
+        $columns = [
+            ['ColumnName' => 'Id', 'ColumnType' => 'long'],
+            ['ColumnName' => 'Name', 'ColumnType' => 'string'],
+            ['ColumnName' => 'Score', 'ColumnType' => 'real'],
+        ];
+
+        $rows = [
+            [1, 'Alice', 95.5],
+            [2, 'Bob', 87.3],
+            [3, 'Charlie', 92.1],
+        ];
+
+        return new KustoResult($columns, $rows);
+    }
+
+    public function testNumRows(): void
+    {
+        $result = $this->createSampleResult();
+        self::assertSame(3, $result->numRows());
+    }
+
+    public function testNumFields(): void
+    {
+        $result = $this->createSampleResult();
+        self::assertSame(3, $result->numFields());
+    }
+
+    public function testFetchAssoc(): void
+    {
+        $result = $this->createSampleResult();
+
+        $row = $result->fetchAssoc();
+        self::assertSame('1', $row['Id']);
+        self::assertSame('Alice', $row['Name']);
+        self::assertSame('95.5', $row['Score']);
+
+        $row2 = $result->fetchAssoc();
+        self::assertSame('2', $row2['Id']);
+        self::assertSame('Bob', $row2['Name']);
+    }
+
+    public function testFetchRow(): void
+    {
+        $result = $this->createSampleResult();
+
+        $row = $result->fetchRow();
+        self::assertSame('1', $row[0]);
+        self::assertSame('Alice', $row[1]);
+        self::assertSame('95.5', $row[2]);
+    }
+
+    public function testFetchValue(): void
+    {
+        $result = $this->createSampleResult();
+
+        // By numeric index
+        self::assertSame('1', $result->fetchValue(0));
+
+        // By name (resets cursor via new instance)
+        $result2 = $this->createSampleResult();
+        self::assertSame('Alice', $result2->fetchValue('Name'));
+    }
+
+    public function testFetchAllAssoc(): void
+    {
+        $result = $this->createSampleResult();
+
+        $all = $result->fetchAllAssoc();
+        self::assertCount(3, $all);
+        self::assertSame('Alice', $all[0]['Name']);
+        self::assertSame('Bob', $all[1]['Name']);
+        self::assertSame('Charlie', $all[2]['Name']);
+    }
+
+    public function testFetchAllColumn(): void
+    {
+        $result = $this->createSampleResult();
+
+        $names = $result->fetchAllColumn('Name');
+        self::assertSame(['Alice', 'Bob', 'Charlie'], $names);
+    }
+
+    public function testFetchAllColumnByIndex(): void
+    {
+        $result = $this->createSampleResult();
+
+        $ids = $result->fetchAllColumn(0);
+        self::assertSame(['1', '2', '3'], $ids);
+    }
+
+    public function testFetchAllKeyPair(): void
+    {
+        $result = $this->createSampleResult();
+
+        $pairs = $result->fetchAllKeyPair();
+        self::assertSame('Alice', $pairs['1']);
+        self::assertSame('Bob', $pairs['2']);
+        self::assertSame('Charlie', $pairs['3']);
+    }
+
+    public function testSeek(): void
+    {
+        $result = $this->createSampleResult();
+
+        self::assertTrue($result->seek(2));
+        $row = $result->fetchAssoc();
+        self::assertSame('Charlie', $row['Name']);
+
+        self::assertFalse($result->seek(10)); // Out of bounds
+        self::assertFalse($result->seek(-1)); // Negative
+    }
+
+    public function testGetFieldNames(): void
+    {
+        $result = $this->createSampleResult();
+
+        self::assertSame(['Id', 'Name', 'Score'], $result->getFieldNames());
+    }
+
+    public function testGetFieldsMeta(): void
+    {
+        $result = $this->createSampleResult();
+
+        $meta = $result->getFieldsMeta();
+        self::assertCount(3, $meta);
+        self::assertSame('Id', $meta[0]->name);
+        self::assertSame('Name', $meta[1]->name);
+        self::assertSame('Score', $meta[2]->name);
+    }
+
+    public function testGetIterator(): void
+    {
+        $result = $this->createSampleResult();
+
+        $rows = [];
+        foreach ($result as $row) {
+            $rows[] = $row;
+        }
+
+        self::assertCount(3, $rows);
+        self::assertSame('Alice', $rows[0]['Name']);
+    }
+
+    public function testEmptyResult(): void
+    {
+        $result = KustoResult::empty();
+
+        self::assertSame(0, $result->numRows());
+        self::assertSame(0, $result->numFields());
+        self::assertSame([], $result->fetchAssoc());
+        self::assertSame([], $result->fetchRow());
+        self::assertSame([], $result->getFieldNames());
+    }
+
+    public function testFromKustoTable(): void
+    {
+        $table = [
+            'Columns' => [
+                ['ColumnName' => 'DatabaseName', 'ColumnType' => 'string'],
+                ['ColumnName' => 'PersistentStorage', 'ColumnType' => 'string'],
+            ],
+            'Rows' => [
+                ['mydb', '10 GB'],
+                ['testdb', '1 GB'],
+            ],
+        ];
+
+        $result = KustoResult::fromKustoTable($table);
+
+        self::assertSame(2, $result->numRows());
+        self::assertSame(2, $result->numFields());
+        self::assertSame(['DatabaseName', 'PersistentStorage'], $result->getFieldNames());
+    }
+
+    public function testFetchAssocBeyondRows(): void
+    {
+        $columns = [['ColumnName' => 'x', 'ColumnType' => 'int']];
+        $rows = [[42]];
+        $result = new KustoResult($columns, $rows);
+
+        $result->fetchAssoc(); // first row
+        self::assertSame([], $result->fetchAssoc()); // past end
+    }
+
+    public function testNullValues(): void
+    {
+        $columns = [
+            ['ColumnName' => 'A', 'ColumnType' => 'string'],
+            ['ColumnName' => 'B', 'ColumnType' => 'string'],
+        ];
+        $rows = [
+            ['hello', null],
+        ];
+
+        $result = new KustoResult($columns, $rows);
+        $row = $result->fetchAssoc();
+
+        self::assertSame('hello', $row['A']);
+        self::assertNull($row['B']);
+    }
+}

--- a/tests/unit/Dbal/Kusto/SqlToKqlTranslatorTest.php
+++ b/tests/unit/Dbal/Kusto/SqlToKqlTranslatorTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Dbal\Kusto;
+
+use PhpMyAdmin\Dbal\Kusto\SqlToKqlTranslator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SqlToKqlTranslator::class)]
+class SqlToKqlTranslatorTest extends TestCase
+{
+    public function testShowDatabases(): void
+    {
+        self::assertSame('.show databases', SqlToKqlTranslator::translate('SHOW DATABASES'));
+        self::assertSame('.show databases', SqlToKqlTranslator::translate('SHOW SCHEMAS'));
+        self::assertSame('.show databases', SqlToKqlTranslator::translate('SHOW DATABASES;'));
+    }
+
+    public function testShowTables(): void
+    {
+        self::assertSame('.show tables', SqlToKqlTranslator::translate('SHOW TABLES'));
+        self::assertSame(
+            '.show database mydb tables',
+            SqlToKqlTranslator::translate('SHOW TABLES FROM `mydb`'),
+        );
+    }
+
+    public function testShowFullTables(): void
+    {
+        self::assertSame('.show tables', SqlToKqlTranslator::translate('SHOW FULL TABLES'));
+    }
+
+    public function testShowCreateTable(): void
+    {
+        self::assertSame(
+            '.show table users schema as json',
+            SqlToKqlTranslator::translate('SHOW CREATE TABLE users'),
+        );
+    }
+
+    public function testShowColumns(): void
+    {
+        self::assertSame(
+            '.show table users schema as cslschema',
+            SqlToKqlTranslator::translate('SHOW COLUMNS FROM users'),
+        );
+        self::assertSame(
+            '.show table users schema as cslschema',
+            SqlToKqlTranslator::translate('SHOW FULL COLUMNS FROM `users`'),
+        );
+    }
+
+    public function testDescribe(): void
+    {
+        self::assertSame(
+            '.show table users schema as cslschema',
+            SqlToKqlTranslator::translate('DESCRIBE users'),
+        );
+    }
+
+    public function testShowVariables(): void
+    {
+        self::assertSame('.show version', SqlToKqlTranslator::translate('SHOW VARIABLES'));
+        self::assertSame('.show version', SqlToKqlTranslator::translate('SHOW SESSION VARIABLES LIKE \'%version%\''));
+    }
+
+    public function testShowProcesslist(): void
+    {
+        self::assertSame('.show queries', SqlToKqlTranslator::translate('SHOW PROCESSLIST'));
+        self::assertSame('.show queries', SqlToKqlTranslator::translate('SHOW FULL PROCESSLIST'));
+    }
+
+    public function testSelectCount(): void
+    {
+        self::assertSame(
+            'users | count',
+            SqlToKqlTranslator::translate('SELECT COUNT(*) FROM users'),
+        );
+    }
+
+    public function testSelectAllWithLimit(): void
+    {
+        $result = SqlToKqlTranslator::translate('SELECT * FROM users LIMIT 50');
+        self::assertNotNull($result);
+        self::assertStringContainsString('users', $result);
+        self::assertStringContainsString('take 50', $result);
+    }
+
+    public function testSelectAllWithLimitAndOffset(): void
+    {
+        $result = SqlToKqlTranslator::translate('SELECT * FROM users LIMIT 10, 50');
+        self::assertNotNull($result);
+        self::assertStringContainsString('users', $result);
+        self::assertStringContainsString('take 50', $result);
+    }
+
+    public function testSelectAllDefault(): void
+    {
+        $result = SqlToKqlTranslator::translate('SELECT * FROM logs');
+        self::assertNotNull($result);
+        self::assertStringContainsString('logs', $result);
+        self::assertStringContainsString('take 1000', $result);
+    }
+
+    public function testDropTable(): void
+    {
+        self::assertSame(
+            '.drop table old_data ifexists',
+            SqlToKqlTranslator::translate('DROP TABLE old_data'),
+        );
+        self::assertSame(
+            '.drop table old_data ifexists',
+            SqlToKqlTranslator::translate('DROP TABLE IF EXISTS old_data'),
+        );
+    }
+
+    public function testInformationSchemaSchemata(): void
+    {
+        $result = SqlToKqlTranslator::translate(
+            "SELECT * FROM INFORMATION_SCHEMA.SCHEMATA",
+        );
+        self::assertSame('.show databases', $result);
+    }
+
+    public function testInformationSchemaTables(): void
+    {
+        $result = SqlToKqlTranslator::translate(
+            "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'mydb'",
+        );
+        self::assertSame('.show database mydb tables', $result);
+    }
+
+    public function testInformationSchemaColumns(): void
+    {
+        $result = SqlToKqlTranslator::translate(
+            "SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'users'",
+        );
+        self::assertSame('.show table users schema as cslschema', $result);
+    }
+
+    public function testKqlPassthrough(): void
+    {
+        // Management commands pass through unchanged
+        self::assertSame('.show databases', SqlToKqlTranslator::translate('.show databases'));
+
+        // Native KQL queries pass through
+        self::assertSame(
+            'StormEvents | take 10',
+            SqlToKqlTranslator::translate('StormEvents | take 10'),
+        );
+    }
+
+    public function testMysqlSpecificReturnsNull(): void
+    {
+        // MySQL-specific commands that should be ignored
+        self::assertNull(SqlToKqlTranslator::translate('SET NAMES utf8'));
+        self::assertNull(SqlToKqlTranslator::translate('SHOW GRANTS'));
+        self::assertNull(SqlToKqlTranslator::translate('SHOW ENGINES'));
+        self::assertNull(SqlToKqlTranslator::translate('FLUSH PRIVILEGES'));
+        self::assertNull(SqlToKqlTranslator::translate('SELECT 1'));
+    }
+
+    public function testShowFunctionStatus(): void
+    {
+        self::assertSame('.show functions', SqlToKqlTranslator::translate('SHOW FUNCTION STATUS'));
+    }
+
+    public function testSelectWithWhere(): void
+    {
+        $result = SqlToKqlTranslator::translate(
+            "SELECT name, age FROM users WHERE age > 18 LIMIT 100",
+        );
+        self::assertNotNull($result);
+        self::assertStringContainsString('where', $result);
+        self::assertStringContainsString('take 100', $result);
+        self::assertStringContainsString('project', $result);
+    }
+
+    public function testSelectWithOrderBy(): void
+    {
+        $result = SqlToKqlTranslator::translate(
+            "SELECT * FROM events ORDER BY timestamp DESC LIMIT 50",
+        );
+        self::assertNotNull($result);
+        self::assertStringContainsString('sort by', $result);
+        self::assertStringContainsString('desc', $result);
+        self::assertStringContainsString('take 50', $result);
+    }
+}


### PR DESCRIPTION
Implement a Kusto DBAL driver that plugs into phpMyAdmin's DbiExtension interface, enabling the web UI to connect to and query Azure Data Explorer clusters via the Kusto REST API.

New files:
- src/Dbal/Kusto/DbiKusto.php - Main driver (DbiExtension implementation)
- src/Dbal/Kusto/KustoConnection.php - Connection value object
- src/Dbal/Kusto/KustoAuth.php - Azure AD OAuth2 authentication
- src/Dbal/Kusto/KustoResult.php - ResultInterface for Kusto responses
- src/Dbal/Kusto/KustoFieldMetadata.php - Kusto-to-MySQL type mapping
- src/Dbal/Kusto/KqlGenerator.php - KQL query/command builder
- src/Dbal/Kusto/SqlToKqlTranslator.php - SQL-to-KQL translation layer
- docs/kusto.md - Documentation
- tests/unit/Dbal/Kusto/ - Unit tests (56 tests, 124 assertions)

Modified files:
- DatabaseInterface.php - Factory method to auto-detect Kusto servers
- Server.php - Added server_type config property
- config.sample.inc.php - Kusto configuration example
- composer.json - Updated ext-curl suggestion

### Description

Please describe your pull request.

Fixes #

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
