### PR TITLE
Fix: Text copying while editing a cell

### DIFF
--- a/resources/js/makegrid.ts
+++ b/resources/js/makegrid.ts
@@ -2666,7 +2666,7 @@ const makeGrid = function (t, enableResize = undefined, enableReorder = undefine
 
             // Copy handler
             $(document).on('copy', function (e) {
-                if (!document.body.contains(g.t)) {
+                if (!document.body.contains(g.t) || g.isCellEditActive) {
                     return;
                 }
 


### PR DESCRIPTION
## Summary

Added a check to verify if a cell is currently being edited before intercepting the copy event. This ensures that standard text selection/copying works as expected while in edit mode.


Bug details - https://github.com/phpmyadmin/phpmyadmin/pull/20036#issuecomment-3970208682

