### PR TITLE
Fixes #18557 - Drag & drop difference between Firefox & Chromium browsers

### DIFF
--- a/js/src/drag_drop_import.js
+++ b/js/src/drag_drop_import.js
@@ -27,6 +27,10 @@ var DragDropImport = {
      */
     importStatus: [],
     /**
+     * @var {boolean}, true when drag was initiated from current document DOM
+     */
+    internalDomDrag: false,
+    /**
      * Checks if any dropped file has valid extension or not
      *
      * @param {string} file filename
@@ -164,6 +168,32 @@ var DragDropImport = {
         $('.pma_drop_handler').fadeIn();
     },
     /**
+     * Marks drag as internal if it starts from current page DOM.
+     *
+     * @param {MouseEvent} event obj
+     *
+     * @return {void}
+     */
+    markInternalDrag: function (event) {
+        var dataTransfer = event.originalEvent && event.originalEvent.dataTransfer;
+
+        // OS file drags do not trigger dragstart on current document.
+        // If we can already detect real file payload here, do not mark internal.
+        if (dataTransfer && dataTransfer.types && $.inArray('Files', dataTransfer.types) >= 0) {
+            return;
+        }
+
+        DragDropImport.internalDomDrag = true;
+    },
+    /**
+     * Clears internal drag marker.
+     *
+     * @return {void}
+     */
+    clearInternalDrag: function () {
+        DragDropImport.internalDomDrag = false;
+    },
+    /**
      * Check if dragged element contains Files
      *
      * @param event the event object
@@ -171,12 +201,37 @@ var DragDropImport = {
      * @return {boolean}
      */
     hasFiles: function (event) {
-        return !(typeof event.originalEvent.dataTransfer.types === 'undefined' ||
-            $.inArray('Files', event.originalEvent.dataTransfer.types) < 0 ||
-            $.inArray(
-                'application/x-moz-nativeimage',
-                event.originalEvent.dataTransfer.types
-            ) >= 0);
+        var dataTransfer = event.originalEvent.dataTransfer;
+        var types = dataTransfer.types;
+
+        // Chrome/Edge may expose browser-internal drags as 'Files'.
+        if (DragDropImport.internalDomDrag) {
+            return false;
+        }
+
+        if (typeof types === 'undefined') {
+            return false;
+        }
+
+        // Not a file drag at all
+        if ($.inArray('Files', types) < 0) {
+            return false;
+        }
+
+        // Firefox native image drag - exclude it
+        if ($.inArray('application/x-moz-nativeimage', types) >= 0) {
+            return false;
+        }
+
+        // Chromium browsers (Chrome, Edge, Brave, Opera) include 'Files' even when
+        // dragging browser-internal elements like images or icons. These drags also
+        // include 'text/uri-list' and/or 'text/html', which are not present when
+        // the user is dragging a real file from the OS filesystem.
+        if ($.inArray('text/uri-list', types) >= 0 || $.inArray('text/html', types) >= 0) {
+            return false;
+        }
+
+        return true;
     },
     /**
      * Triggered when dragged file is being dragged over PMA UI
@@ -281,6 +336,14 @@ var DragDropImport = {
         var dbname = CommonParams.get('db');
         var server = CommonParams.get('server');
 
+        if (!DragDropImport.hasFiles(event)) {
+            DragDropImport.clearInternalDrag();
+            $('.pma_drop_handler').fadeOut();
+            event.stopPropagation();
+            event.preventDefault();
+            return;
+        }
+
         // if no database is selected -- no
         if (dbname !== '') {
             var files = event.originalEvent.dataTransfer.files;
@@ -344,6 +407,7 @@ var DragDropImport = {
                 }
             }
         }
+        DragDropImport.clearInternalDrag();
         $('.pma_drop_handler').fadeOut();
         event.stopPropagation();
         event.preventDefault();
@@ -359,6 +423,8 @@ var DragDropImport = {
 $(document).on('dragenter', DragDropImport.dragEnter);
 $(document).on('dragover', DragDropImport.dragOver);
 $(document).on('dragleave', '.pma_drop_handler', DragDropImport.dragLeave);
+$(document).on('dragstart', DragDropImport.markInternalDrag);
+$(document).on('dragend drop', DragDropImport.clearInternalDrag);
 
 // when file is dropped to PMA UI
 $(document).on('drop', 'body', DragDropImport.drop);


### PR DESCRIPTION
### Description

Fix the drag-and-drop import overlay being incorrectly activated on Chromium-based browsers (Chrome, Edge, Brave, Opera) when users drag internal page elements such as the phpMyAdmin logo, icons, or links. Firefox is not affected because it does not expose Files in `dataTransfer.types` for in-page drags.

#### Changes (single file: js/src/drag_drop_import.js)
**1. New `internalDomDrag` flag (property)**

Added a boolean property `internalDomDrag` to the `DragDropImport `object.
Tracks whether the current drag operation was initiated from within the page DOM (i.e., user dragged a page element, not an OS file).

**2. New `markInternalDrag(event)` method**

Bound to the dragstart event on document.
Since OS file drags never trigger `dragstart` on the page, this reliably distinguishes internal DOM drags from external file drags.

**3. New `clearInternalDrag()` method**

Resets `internalDomDrag` to `false`.
Bound to `dragend` and `drop` events to ensure the flag is always cleaned up.

**4. Rewritten `hasFiles(event)` method (core fix)**

The original one-liner:
```js
return !(typeof event.originalEvent.dataTransfer.types === 'undefined' ||
    $.inArray('Files', event.originalEvent.dataTransfer.types) < 0 ||
    $.inArray('application/x-moz-nativeimage', event.originalEvent.dataTransfer.types) >= 0);
```
was replaced with a multi-layered detection approach:

- **Internal DOM drag check**: If `internalDomDrag` is `true`, returns `false` immediately
- `**undefined**` **types guard**: Returns `false` when `dataTransfer.types` is undefined.
- **`Files` type presence**: Returns `false` if `Files` is not in the types list.
- **Firefox native image exclusion**: Returns `false` if `application/x-moz-nativeimage` is present (retained from original logic).
- **Chromium internal element heuristic (new)**: Returns `false` if `text/uri-list` or `text/html` are present — these accompany in-page element drags on Chromium but are absent when dragging real OS files.

**5. Updated `drop(event)` handler**

Added an early `hasFiles()` guard at the top of the `drop` handler to reject non-file drops cleanly.
Added `clearInternalDrag()` call at the end of the handler to reset state.

**6. New event listeners**
```js
$(document).on('dragstart', DragDropImport.markInternalDrag);
$(document).on('dragend drop', DragDropImport.clearInternalDrag);
```

Fixes #18557 

Before submitting pull request, please review the following checklist:

- [ X ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ X ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ X ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ X ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.

### Demo

https://github.com/user-attachments/assets/ea258f1a-fbbc-4add-891c-cce2619e1642

