### PR TITLE
Fix #20195 - error when generating charts for columns with int column names

### DIFF
--- a/libraries/classes/Controllers/Table/ChartController.php
+++ b/libraries/classes/Controllers/Table/ChartController.php
@@ -216,7 +216,7 @@ class ChartController extends AbstractController
             $tmp_row = [];
             foreach ($data_row as $data_column => $data_value) {
                 $escaped_value = $data_value === null ? null : htmlspecialchars($data_value);
-                $tmp_row[htmlspecialchars($data_column)] = $escaped_value;
+                $tmp_row[htmlspecialchars((string) $data_column)] = $escaped_value;
             }
 
             $sanitized_data[] = $tmp_row;

--- a/libraries/classes/Dbal/MysqliResult.php
+++ b/libraries/classes/Dbal/MysqliResult.php
@@ -112,7 +112,8 @@ final class MysqliResult implements ResultInterface
     /**
      * Returns all rows of the result
      *
-     * @return array<int, array<string,string|null>>
+     * @return array<int, array<string|null>>
+     * @psalm-return list<array<array-key, string|null>>
      */
     public function fetchAllAssoc(): array
     {

--- a/libraries/classes/Dbal/ResultInterface.php
+++ b/libraries/classes/Dbal/ResultInterface.php
@@ -52,7 +52,8 @@ interface ResultInterface extends IteratorAggregate
     /**
      * Returns all rows of the result
      *
-     * @return array<int, array<string,string|null>>
+     * @return array<int, array<string|null>>
+     * @psalm-return list<array<array-key, string|null>>
      */
     public function fetchAllAssoc(): array;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2816,7 +2816,7 @@ parameters:
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getForeignData\\(\\) should return array\\{foreign_link\\: bool, the_total\\: mixed, foreign_display\\: string, disp_row\\: array\\<int, non\\-empty\\-array\\>\\|null, foreign_field\\: mixed\\} but returns array\\{foreign_link\\: bool, the_total\\: mixed, foreign_display\\: string, disp_row\\: array\\<int, array\\<string, string\\|null\\>\\>\\|null, foreign_field\\: mixed\\}\\.$#"
+			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getForeignData\\(\\) should return array\\{foreign_link\\: bool, the_total\\: mixed, foreign_display\\: string, disp_row\\: array\\<int, non\\-empty\\-array\\>\\|null, foreign_field\\: mixed\\} but returns array\\{foreign_link\\: bool, the_total\\: mixed, foreign_display\\: string, disp_row\\: array\\<int, array\\<string\\|null\\>\\>\\|null, foreign_field\\: mixed\\}\\.$#"
 			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
 
@@ -15521,12 +15521,12 @@ parameters:
 			path: libraries/classes/Dbal/MysqliResult.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\MysqliResult\\:\\:fetchAllAssoc\\(\\) should return array\\<int, array\\<string, string\\|null\\>\\> but returns array\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Dbal\\\\MysqliResult\\:\\:fetchAllAssoc\\(\\) should return array\\<int, array\\<string\\|null\\>\\> but returns array\\.$#"
 			count: 1
 			path: libraries/classes/Dbal/MysqliResult.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\MysqliResult\\:\\:fetchAllAssoc\\(\\) should return array\\<int, array\\<string, string\\|null\\>\\> but returns array\\<int\\<0, max\\>, array\\<string, float\\|int\\|string\\|null\\>\\>\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Dbal\\\\MysqliResult\\:\\:fetchAllAssoc\\(\\) should return array\\<int, array\\<string\\|null\\>\\> but returns array\\<int\\<0, max\\>, array\\<string, float\\|int\\|string\\|null\\>\\>\\.$#"
 			count: 1
 			path: libraries/classes/Dbal/MysqliResult.php
 
@@ -40661,8 +40661,21 @@ parameters:
 			path: test/classes/AbstractNetworkTestCase.php
 
 		-
+			message: """
+				#^Call to deprecated method assertRegExp\\(\\) of class PHPUnit\\\\Framework\\\\Assert\\:
+				https\\://github\\.com/sebastianbergmann/phpunit/issues/4086$#
+			"""
+			count: 1
+			path: test/classes/AbstractTestCase.php
+
+		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 2
+			path: test/classes/AbstractTestCase.php
+
+		-
+			message: "#^Call to function method_exists\\(\\) with 'PHPUnit\\\\\\\\Framework\\\\\\\\TestCase' and 'assertMatchesRegula…' will always evaluate to true\\.$#"
+			count: 1
 			path: test/classes/AbstractTestCase.php
 
 		-
@@ -40934,6 +40947,11 @@ parameters:
 			message: "#^Parameter \\#1 \\$array_arg of function sort expects TArray of array\\<T\\>, mixed given\\.$#"
 			count: 2
 			path: test/classes/Command/TwigLintCommandTest.php
+
+		-
+			message: "#^Call to deprecated method withConsecutive\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\Builder\\\\InvocationMocker\\.$#"
+			count: 1
+			path: test/classes/Command/WriteGitRevisionCommandTest.php
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestSkipped\\(\\)\\.$#"
@@ -41301,6 +41319,11 @@ parameters:
 			path: test/classes/Config/SettingsTest.php
 
 		-
+			message: "#^Call to deprecated method withConsecutive\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\Builder\\\\InvocationMocker\\.$#"
+			count: 4
+			path: test/classes/ConfigStorage/RelationCleanupTest.php
+
+		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:equalTo\\(\\)\\.$#"
 			count: 32
 			path: test/classes/ConfigStorage/RelationCleanupTest.php
@@ -41481,6 +41504,11 @@ parameters:
 			path: test/classes/ConfigStorage/RelationTest.php
 
 		-
+			message: "#^Call to deprecated method withConsecutive\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\Builder\\\\InvocationMocker\\.$#"
+			count: 1
+			path: test/classes/ConfigStorage/UserGroupsTest.php
+
+		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:equalTo\\(\\)\\.$#"
 			count: 2
 			path: test/classes/ConfigStorage/UserGroupsTest.php
@@ -41514,6 +41542,22 @@ parameters:
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:returnValue\\(\\)\\.$#"
 			count: 3
 			path: test/classes/ConfigStorage/UserGroupsTest.php
+
+		-
+			message: """
+				#^Call to deprecated method expectError\\(\\) of class PHPUnit\\\\Framework\\\\TestCase\\:
+				https\\://github\\.com/sebastianbergmann/phpunit/issues/5062$#
+			"""
+			count: 1
+			path: test/classes/ConfigTest.php
+
+		-
+			message: """
+				#^Call to deprecated method expectErrorMessage\\(\\) of class PHPUnit\\\\Framework\\\\TestCase\\:
+				https\\://github\\.com/sebastianbergmann/phpunit/issues/5062$#
+			"""
+			count: 1
+			path: test/classes/ConfigTest.php
 
 		-
 			message: "#^Cannot access offset 'ProxyUrl' on mixed\\.$#"
@@ -45766,6 +45810,22 @@ parameters:
 			path: test/classes/Navigation/NavigationTreeTest.php
 
 		-
+			message: """
+				#^Call to deprecated method expectError\\(\\) of class PHPUnit\\\\Framework\\\\TestCase\\:
+				https\\://github\\.com/sebastianbergmann/phpunit/issues/5062$#
+			"""
+			count: 2
+			path: test/classes/Navigation/NodeFactoryTest.php
+
+		-
+			message: """
+				#^Call to deprecated method expectErrorMessage\\(\\) of class PHPUnit\\\\Framework\\\\TestCase\\:
+				https\\://github\\.com/sebastianbergmann/phpunit/issues/5062$#
+			"""
+			count: 2
+			path: test/classes/Navigation/NodeFactoryTest.php
+
+		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array\\{text\\: array\\{route\\: string, params\\: array\\<string, mixed\\>\\}, icon\\: array\\{route\\: string, params\\: array\\<string, mixed\\>\\}, second_icon\\?\\: array\\{route\\: string, params\\: array\\<string, mixed\\>\\}, title\\?\\: string\\} will always evaluate to true\\.$#"
 			count: 1
 			path: test/classes/Navigation/Nodes/NodeColumnContainerTest.php
@@ -46616,6 +46676,11 @@ parameters:
 			path: test/classes/Plugins/Export/ExportPdfTest.php
 
 		-
+			message: "#^Call to deprecated method withConsecutive\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\Builder\\\\InvocationMocker\\.$#"
+			count: 2
+			path: test/classes/Plugins/Export/ExportSqlTest.php
+
+		-
 			message: "#^Cannot access offset 'DisableIS' on mixed\\.$#"
 			count: 8
 			path: test/classes/Plugins/Export/ExportSqlTest.php
@@ -47296,6 +47361,11 @@ parameters:
 			path: test/classes/Server/PluginsTest.php
 
 		-
+			message: "#^Call to deprecated method withConsecutive\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\Builder\\\\InvocationMocker\\.$#"
+			count: 4
+			path: test/classes/Server/Privileges/AccountLockingTest.php
+
+		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:equalTo\\(\\)\\.$#"
 			count: 12
 			path: test/classes/Server/Privileges/AccountLockingTest.php
@@ -47314,6 +47384,11 @@ parameters:
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:once\\(\\)\\.$#"
 			count: 18
 			path: test/classes/Server/Privileges/AccountLockingTest.php
+
+		-
+			message: "#^Call to deprecated method withConsecutive\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\Builder\\\\InvocationMocker\\.$#"
+			count: 1
+			path: test/classes/Server/PrivilegesTest.php
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\) with null will always evaluate to true\\.$#"
@@ -48261,6 +48336,11 @@ parameters:
 			path: test/classes/ThemeTest.php
 
 		-
+			message: "#^Call to deprecated method withConsecutive\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\Builder\\\\InvocationMocker\\.$#"
+			count: 1
+			path: test/classes/TrackerTest.php
+
+		-
 			message: "#^Cannot access offset 'DisableIS' on mixed\\.$#"
 			count: 1
 			path: test/classes/TrackerTest.php
@@ -48851,6 +48931,11 @@ parameters:
 			path: test/classes/UserPreferencesTest.php
 
 		-
+			message: "#^Call to deprecated method withConsecutive\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\Builder\\\\InvocationMocker\\.$#"
+			count: 4
+			path: test/classes/UtilTest.php
+
+		-
 			message: "#^Cannot access offset 'AllowThirdPartyFram…' on mixed\\.$#"
 			count: 1
 			path: test/classes/UtilTest.php
@@ -49181,6 +49266,11 @@ parameters:
 			path: test/classes/Utils/SessionCacheTest.php
 
 		-
+			message: "#^Call to deprecated method withConsecutive\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\Builder\\\\InvocationMocker\\.$#"
+			count: 4
+			path: test/classes/VersionInformationTest.php
+
+		-
 			message: "#^Cannot access offset 'Servers' on mixed\\.$#"
 			count: 4
 			path: test/classes/VersionInformationTest.php
@@ -49423,6 +49513,14 @@ parameters:
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestSkipped\\(\\)\\.$#"
 			count: 8
+			path: test/selenium/TestBase.php
+
+		-
+			message: """
+				#^Fetching deprecated class constant CAPABILITY_W3C of class Facebook\\\\WebDriver\\\\Chrome\\\\ChromeOptions\\:
+				Use CAPABILITY instead$#
+			"""
+			count: 1
 			path: test/selenium/TestBase.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5969,11 +5969,11 @@
       <code>is_array($row) ? $row : []</code>
     </InvalidReturnStatement>
     <InvalidReturnType occurrences="5">
-      <code>array&lt;int, array&lt;string,string|null&gt;&gt;</code>
       <code>array&lt;int, string|null&gt;</code>
       <code>array&lt;int,string|null&gt;</code>
       <code>array&lt;string, string|null&gt;</code>
       <code>array&lt;string,string|null&gt;</code>
+      <code>list&lt;array&lt;array-key, string|null&gt;&gt;</code>
     </InvalidReturnType>
     <MixedArgument occurrences="2">
       <code>$field-&gt;flags</code>
@@ -12924,7 +12924,7 @@
       <code>$arrInstance[$name]</code>
       <code>$arrInstance[$name]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="21">
+    <MixedAssignment occurrences="20">
       <code>$arrInstance[$name]</code>
       <code>$arrProp</code>
       <code>$arrWEBMCol</code>
@@ -12938,7 +12938,6 @@
       <code>$mem['SwapUsed']</code>
       <code>$name</code>
       <code>$objItem</code>
-      <code>$objLocator</code>
       <code>$objWEBM</code>
       <code>$propItem</code>
       <code>$sum</code>
@@ -12947,8 +12946,7 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="2">
-      <code>ConnectServer</code>
+    <MixedMethodCall occurrences="1">
       <code>Instances_</code>
     </MixedMethodCall>
     <MixedOperand occurrences="7">
@@ -12968,10 +12966,10 @@
     <PossiblyNullReference occurrences="1">
       <code>Get</code>
     </PossiblyNullReference>
-    <UndefinedDocblockClass occurrences="2">
-      <code>$this-&gt;wmi</code>
-      <code>COM|null</code>
-    </UndefinedDocblockClass>
+    <UndefinedMagicMethod occurrences="2">
+      <code>ConnectServer</code>
+      <code>Get</code>
+    </UndefinedMagicMethod>
   </file>
   <file src="libraries/classes/Session.php">
     <MixedArgument occurrences="3">
@@ -14672,6 +14670,11 @@
       <code>$filesInfos</code>
     </MixedAssignment>
   </file>
+  <file src="test/classes/Command/WriteGitRevisionCommandTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
+  </file>
   <file src="test/classes/CommonTest.php">
     <DocblockTypeContradiction occurrences="2">
       <code>assertFalse</code>
@@ -14767,6 +14770,12 @@
     </MixedAssignment>
   </file>
   <file src="test/classes/ConfigStorage/RelationCleanupTest.php">
+    <DeprecatedMethod occurrences="4">
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$dbi</code>
     </NonInvariantDocblockPropertyType>
@@ -14798,7 +14807,16 @@
       <code>assertSame</code>
     </TypeDoesNotContainType>
   </file>
+  <file src="test/classes/ConfigStorage/UserGroupsTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
+  </file>
   <file src="test/classes/ConfigTest.php">
+    <DeprecatedMethod occurrences="2">
+      <code>expectError</code>
+      <code>expectErrorMessage</code>
+    </DeprecatedMethod>
     <MixedInferredReturnType occurrences="8">
       <code>array</code>
       <code>array</code>
@@ -15637,6 +15655,14 @@
       <code>array</code>
     </MixedInferredReturnType>
   </file>
+  <file src="test/classes/Navigation/NodeFactoryTest.php">
+    <DeprecatedMethod occurrences="4">
+      <code>expectError</code>
+      <code>expectError</code>
+      <code>expectErrorMessage</code>
+      <code>expectErrorMessage</code>
+    </DeprecatedMethod>
+  </file>
   <file src="test/classes/Navigation/Nodes/NodeColumnContainerTest.php">
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>assertIsArray</code>
@@ -15957,6 +15983,10 @@
     </MixedAssignment>
   </file>
   <file src="test/classes/Plugins/Export/ExportSqlTest.php">
+    <DeprecatedMethod occurrences="2">
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
     <InvalidArrayOffset occurrences="1">
       <code>$GLOBALS['sql_constraints']</code>
     </InvalidArrayOffset>
@@ -16162,7 +16192,18 @@
       <code>assertIsArray</code>
     </RedundantCondition>
   </file>
+  <file src="test/classes/Server/Privileges/AccountLockingTest.php">
+    <DeprecatedMethod occurrences="4">
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
+  </file>
   <file src="test/classes/Server/PrivilegesTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
     <MixedArgument occurrences="5">
       <code>$export</code>
       <code>$extra_data['new_privileges']</code>
@@ -16318,6 +16359,9 @@
     </MixedReturnStatement>
   </file>
   <file src="test/classes/Stubs/DummyResult.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array&lt;int, array&lt;string,string|null&gt;&gt;</code>
+    </LessSpecificImplementedReturnType>
     <MixedReturnTypeCoercion occurrences="6">
       <code>$this-&gt;link-&gt;fetchAssoc($this-&gt;result) ?? []</code>
       <code>$this-&gt;link-&gt;fetchRow($this-&gt;result) ?? []</code>
@@ -16398,6 +16442,9 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/classes/TrackerTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
     <MixedAssignment occurrences="1">
       <code>$result</code>
     </MixedAssignment>
@@ -16468,6 +16515,12 @@
     </TypeDoesNotContainType>
   </file>
   <file src="test/classes/UtilTest.php">
+    <DeprecatedMethod occurrences="4">
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
     <MixedArgument occurrences="3">
       <code>$_SESSION['cache']['server_server']</code>
       <code>$_SESSION['cache']['server_server']</code>
@@ -16575,6 +16628,12 @@
     </MixedArrayAccess>
   </file>
   <file src="test/classes/VersionInformationTest.php">
+    <DeprecatedMethod occurrences="4">
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
     <MixedArrayAccess occurrences="1">
       <code>$_SESSION['cache']['version_check']</code>
     </MixedArrayAccess>
@@ -16618,6 +16677,9 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/selenium/TestBase.php">
+    <DeprecatedConstant occurrences="1">
+      <code>ChromeOptions::CAPABILITY_W3C</code>
+    </DeprecatedConstant>
     <DocblockTypeContradiction occurrences="1">
       <code>$this-&gt;webDriver === null</code>
     </DocblockTypeContradiction>


### PR DESCRIPTION
Fix #20195

I don't know what's up with the baselines. 