### PR TITLE
Fix #20142 - Unregister all click events when the modal is hidden

### DIFF
--- a/js/src/designer/move.js
+++ b/js/src/designer/move.js
@@ -662,6 +662,11 @@ DesignerMove.addTableToTablesList = function (index, tableDom) {
  */
 DesignerMove.displayModal = function (form, heading, type) {
     var modal = $(type);
+
+    modal.one('hidden.bs.modal', function () {
+        modal.find('*').off('click'); // Unregister all click events when the modal is hidden
+    });
+
     modal.modal('show');
     modal.find('.modal-body').first().html(form);
     $(type + 'Label').first().html(heading);
@@ -726,7 +731,6 @@ DesignerMove.addOtherDbTables = function () {
             }
         });
 
-        $('#designerModalGoButton').off('click');// Unregister the event for other modals to not call this one
         modal.modal('hide');
     });
     $('#add_table_from').on('change', function () {
@@ -898,7 +902,6 @@ DesignerMove.save3 = function (callback) {
             var $form = $('#save_page');
             $form.trigger('submit');
 
-            $('#designerModalGoButton').off('click');// Unregister the event for other modals to not call this one
             modal.modal('hide');
         });
     }
@@ -933,7 +936,6 @@ DesignerMove.editPages = function () {
                         return;
                     }
 
-                    $('#designerModalGoButton').off('click');// Unregister the event for other modals to not call this one
                     modal.modal('hide');
                     DesignerMove.loadPage(selected);
                 });
@@ -1003,7 +1005,6 @@ DesignerMove.deletePages = function () {
                     });
                 }
 
-                $('#designerModalGoButton').off('click');// Unregister the event for other modals to not call this one
                 modal.modal('hide');
             });
         }
@@ -1090,7 +1091,6 @@ DesignerMove.saveAs = function () {
                     }
                 }
 
-                $('#designerModalGoButton').off('click');// Unregister the event for other modals to not call this one
                 modal.modal('hide');
             });
             // select current page by default
@@ -1156,7 +1156,6 @@ DesignerMove.exportPages = function () {
             var modal = DesignerMove.displayModal($form, Messages.strExportRelationalSchema, '#designerGoModal');
             $('#designerModalGoButton').on('click', function () {
                 $('#id_export_pages').trigger('submit');
-                $('#designerModalGoButton').off('click');// Unregister the event for other modals to not call this one
                 modal.modal('hide');
             });
         }


### PR DESCRIPTION
### Description

The events weren't unregistered when the modals were closed without clicking on `Go` (`Cancel` or `X`).

To check that, you can see in the console with:

```JS
console.log(jQuery._data($('#designerModalGoButton')[0], 'events'));
```

**Before:**

https://github.com/user-attachments/assets/10e4affe-d0e1-4e44-8ba7-40c918a45fdf

**After:**

https://github.com/user-attachments/assets/7d1db121-70ae-4a03-b000-5250decb0948

Fixes #20142

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
