### PR TITLE
Rework GIS file export

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2866,12 +2866,6 @@ parameters:
 			path: src/Controllers/Table/GisVisualizationController.php
 
 		-
-			message: '#^Parameter \#2 \$format of method PhpMyAdmin\\Gis\\GisVisualization\:\:toFile\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Controllers/Table/GisVisualizationController.php
-
-		-
 			message: '#^Cannot access offset ''handler'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2199,12 +2199,6 @@
       <code><![CDATA[$_SESSION['tmpval']['max_rows']]]></code>
       <code><![CDATA[$_SESSION['tmpval']['pos']]]></code>
     </MixedArrayAccess>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$_GET['fileFormat']]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyInvalidCast>
-      <code><![CDATA[$_GET['fileFormat']]]></code>
-    </PossiblyInvalidCast>
     <RiskyCast>
       <code><![CDATA[$_POST['pos'] ?? $_GET['pos'] ?? $_SESSION['tmpval']['pos']]]></code>
       <code><![CDATA[$_POST['session_max_rows'] ?? $_GET['session_max_rows']]]></code>

--- a/src/Controllers/Table/GisVisualizationController.php
+++ b/src/Controllers/Table/GisVisualizationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Table;
 
+use Fig\Http\Message\StatusCodeInterface;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Controllers\InvocableController;
 use PhpMyAdmin\Core;
@@ -33,11 +34,11 @@ use function __;
 use function array_search;
 use function class_exists;
 use function extension_loaded;
+use function implode;
 use function in_array;
 use function is_array;
 use function is_string;
-use function ob_get_clean;
-use function ob_start;
+use function strlen;
 
 /**
  * Handles creation of the GIS visualizations.
@@ -111,14 +112,28 @@ final readonly class GisVisualizationController implements InvocableController
 
         $downloadOptions = $this->getDownloadOptions();
 
-        if (isset($_GET['saveToFile'])) {
-            $response = $this->responseFactory->createResponse();
-            $filename = $visualization->getSpatialColumn();
-            ob_start();
-            $visualization->toFile($filename, $_GET['fileFormat']);
-            $output = ob_get_clean();
+        if ($request->hasQueryParam('saveToFile')) {
+            $fileFormat = $request->getQueryParam('fileFormat');
+            if (! in_array($fileFormat, $downloadOptions, true)) {
+                return $this->responseFactory->createResponse(
+                    StatusCodeInterface::STATUS_BAD_REQUEST,
+                    __('Invalid file format, expected one of: ') . implode(', ', $downloadOptions),
+                );
+            }
 
-            return $response->write((string) $output);
+            $data = $visualization->toFile($fileFormat);
+            if ($data === null) {
+                return $this->responseFactory->createResponse(
+                    StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR,
+                    __('Failed to create image'),
+                );
+            }
+
+            $fileName = $visualization->getSpatialColumn() . '.' . $data->extension;
+            $response = $this->responseFactory->createResponse();
+            Core::downloadHeader($fileName, $data->mime, strlen($data->blob));
+
+            return $response->write($data->blob);
         }
 
         $this->response->addScriptFiles(['vendor/openlayers/openlayers.js', 'table/gis_visualization.js']);

--- a/src/Gis/Ds/Extent.php
+++ b/src/Gis/Ds/Extent.php
@@ -9,7 +9,7 @@ use function min;
 
 use const INF;
 
-class Extent
+final readonly class Extent
 {
     public static function empty(): Extent
     {
@@ -17,10 +17,10 @@ class Extent
     }
 
     public function __construct(
-        public readonly float $minX,
-        public readonly float $minY,
-        public readonly float $maxX,
-        public readonly float $maxY,
+        public float $minX,
+        public float $minY,
+        public float $maxX,
+        public float $maxY,
     ) {
     }
 

--- a/src/Gis/Ds/FileDownload.php
+++ b/src/Gis/Ds/FileDownload.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Gis\Ds;
+
+final readonly class FileDownload
+{
+    public function __construct(
+        public string $blob,
+        public string $mime,
+        public string $extension,
+    ) {
+    }
+}

--- a/src/Gis/Ds/ScaleData.php
+++ b/src/Gis/Ds/ScaleData.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Gis\Ds;
 
-class ScaleData
+final readonly class ScaleData
 {
     public function __construct(
-        public readonly float $scale,
-        public readonly float $offsetX,
-        public readonly float $offsetY,
-        public readonly int $height,
+        public float $scale,
+        public float $offsetX,
+        public float $offsetY,
+        public int $height,
     ) {
     }
 }

--- a/src/Gis/GisVisualization.php
+++ b/src/Gis/GisVisualization.php
@@ -8,12 +8,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Gis;
 
 use PhpMyAdmin\Config;
-use PhpMyAdmin\Core;
 use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Gis\Ds\Extent;
+use PhpMyAdmin\Gis\Ds\FileDownload;
 use PhpMyAdmin\Gis\Ds\ScaleData;
 use PhpMyAdmin\Image\ImageWrapper;
-use PhpMyAdmin\Sanitize;
 use PhpMyAdmin\Util;
 use TCPDF;
 
@@ -22,9 +21,8 @@ use function count;
 use function htmlspecialchars;
 use function is_string;
 use function max;
-use function mb_strlen;
-use function mb_strtolower;
-use function mb_substr;
+use function ob_get_clean;
+use function ob_start;
 use function rtrim;
 use function trim;
 
@@ -247,43 +245,6 @@ class GisVisualization
     }
 
     /**
-     * Sanitizes the file name.
-     *
-     * @param string $fileName file name
-     * @param string $ext      extension of the file
-     *
-     * @return string the sanitized file name
-     */
-    private function sanitizeName(string $fileName, string $ext): string
-    {
-        $fileName = Sanitize::sanitizeFilename($fileName);
-
-        // Check if the user already added extension;
-        // get the substring where the extension would be if it was included
-        $requiredExtension = '.' . $ext;
-        $extensionLength = mb_strlen($requiredExtension);
-        $userExtension = mb_substr($fileName, -$extensionLength);
-        if (mb_strtolower($userExtension) !== $requiredExtension) {
-            $fileName .= $requiredExtension;
-        }
-
-        return $fileName;
-    }
-
-    /**
-     * Handles common tasks of writing the visualization to file for various formats.
-     *
-     * @param string $fileName file name
-     * @param string $type     mime type
-     * @param string $ext      extension of the file
-     */
-    private function writeToFile(string $fileName, string $type, string $ext): void
-    {
-        $fileName = $this->sanitizeName($fileName, $ext);
-        Core::downloadHeader($fileName, $type);
-    }
-
-    /**
      * Generate the visualization in SVG format.
      *
      * @return string the generated image resource
@@ -312,16 +273,10 @@ class GisVisualization
         return $this->svg();
     }
 
-    /**
-     * Saves as a SVG image to a file.
-     *
-     * @param string $fileName File name
-     */
-    public function toFileAsSvg(string $fileName): void
+    /** Get SVG image as string + type infos. */
+    private function asSvgFile(): FileDownload
     {
-        $img = $this->svg();
-        $this->writeToFile($fileName, 'image/svg+xml', 'svg');
-        echo $img;
+        return new FileDownload(mime: 'image/svg+xml', extension: 'svg', blob: $this->svg());
     }
 
     /**
@@ -345,20 +300,22 @@ class GisVisualization
         return $image;
     }
 
-    /**
-     * Saves as a PNG image to a file.
-     *
-     * @param string $fileName File name
-     */
-    public function toFileAsPng(string $fileName): void
+    /** Get PNG image as string (blob) + type infos. */
+    private function asPngFile(): FileDownload|null
     {
         $image = $this->png();
         if ($image === null) {
-            return;
+            return null;
         }
 
-        $this->writeToFile($fileName, 'image/png', 'png');
-        $image->png(null, 9, PNG_ALL_FILTERS);
+        ob_start();
+        $ok = $image->png(null, 9, PNG_ALL_FILTERS);
+        $output = ob_get_clean();
+        if (! $ok || $output === false) {
+            return null;
+        }
+
+        return new FileDownload(mime: 'image/png', extension: 'png', blob: $output);
     }
 
     /**
@@ -371,18 +328,15 @@ class GisVisualization
         return $this->prepareDataSet($this->data, 'ol');
     }
 
-    /**
-     * Saves as a PDF to a file.
-     *
-     * @param string $fileName File name
-     */
-    public function toFileAsPdf(string $fileName): void
+    /** Get image PDF as string (blob) + type infos. */
+    private function asPdfFile(): FileDownload
     {
-        $fileName = $this->sanitizeName($fileName, 'pdf');
         $pdf = $this->createEmptyPdf(Config::getInstance()->config->PDFDefaultPageSize ?? 'A4');
         $this->prepareDataSet($this->data, 'pdf', $pdf);
 
-        $pdf->Output($fileName, 'D');
+        $blob = $pdf->Output('', 'S');
+
+        return new FileDownload(mime: 'application/pdf', extension: 'pdf', blob: $blob);
     }
 
     private function createEmptyPdf(string $format): TCPDF
@@ -406,18 +360,15 @@ class GisVisualization
     /**
      * Convert file to given format
      *
-     * @param string $filename Filename
-     * @param string $format   Output format
+     * @param 'svg'|'png'|'pdf' $format Output format
      */
-    public function toFile(string $filename, string $format): void
+    public function toFile(string $format): FileDownload|null
     {
-        if ($format === 'svg') {
-            $this->toFileAsSvg($filename);
-        } elseif ($format === 'png') {
-            $this->toFileAsPng($filename);
-        } elseif ($format === 'pdf') {
-            $this->toFileAsPdf($filename);
-        }
+        return match ($format) {
+            'svg' => $this->asSvgFile(),
+            'png' => $this->asPngFile(),
+            'pdf' => $this->asPdfFile(),
+        };
     }
 
     /**

--- a/tests/unit/Controllers/Table/GisVisualizationControllerTest.php
+++ b/tests/unit/Controllers/Table/GisVisualizationControllerTest.php
@@ -20,6 +20,7 @@ use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\UrlParams;
 use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionMethod;
 
 use const MYSQLI_TYPE_GEOMETRY;
 use const MYSQLI_TYPE_VAR_STRING;
@@ -79,6 +80,19 @@ class GisVisualizationControllerTest extends AbstractTestCase
 
         $config = new Config();
         $template = new Template($config);
+        $responseRenderer = new ResponseRenderer();
+        $controller = new GisVisualizationController(
+            $responseRenderer,
+            $template,
+            $dbi,
+            new DbTableExists($dbi),
+            ResponseFactory::create(),
+            $config,
+        );
+
+        /** @var list<string> $downloadOptions */
+        $downloadOptions = (new ReflectionMethod(GisVisualizationController::class, 'getDownloadOptions'))
+            ->invoke($controller);
         $expected = $template->render('table/gis_visualization/gis_visualization', [
             'url_params' => $params,
             'download_url' => $downloadUrl,
@@ -110,25 +124,12 @@ class GisVisualizationControllerTest extends AbstractTestCase
                     ],
                 ],
             ],
-            'download_options' => [
-                'pdf',
-                'png',
-                'svg',
-            ],
+            'download_options' => $downloadOptions,
         ]);
 
         $request = ServerRequestFactory::create()->createServerRequest('POST', 'http://example.com/')
             ->withQueryParams(['db' => 'test_db', 'table' => 'test_table']);
 
-        $responseRenderer = new ResponseRenderer();
-        $controller = new GisVisualizationController(
-            $responseRenderer,
-            $template,
-            $dbi,
-            new DbTableExists($dbi),
-            ResponseFactory::create(),
-            $config,
-        );
         $response = $controller($request);
 
         self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());


### PR DESCRIPTION
### Description

- Move the download logic from GisVisualization to GisVisualizationController.
- Get the file blob directly without going through the output buffer for svg and pdf file download.
- Fix test when gd or TCPDF is not available
- Remove sanitizing of the download file name, it is done in `Core::downloadHeader` function, and the check for double filename extension was unnecessary as the file name is the column name, so in all likelihood does not contain an extension.
- Add Content-Size header with the file size.
- Send an error message in case the file export fails

<img width="777" height="417" alt="image" src="https://github.com/user-attachments/assets/dc5488f3-f59b-4756-999e-e0afc5caedd1" />
