### PR TITLE
Don't show invalid Gis download options

### DIFF
--- a/libraries/classes/Controllers/Table/GisVisualizationController.php
+++ b/libraries/classes/Controllers/Table/GisVisualizationController.php
@@ -16,9 +16,12 @@ use PhpMyAdmin\SqlParser\Statements\SelectStatement;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
+use TCPDF;
 
 use function __;
 use function array_merge;
+use function class_exists;
+use function extension_loaded;
 use function is_array;
 
 /**
@@ -115,6 +118,8 @@ final class GisVisualizationController extends AbstractController
 
         $this->visualization = GisVisualization::get($sqlQuery, $visualizationSettings, $rows, $pos);
 
+        $downloadOptions = $this->getDownloadOptions();
+
         if (isset($_GET['saveToFile'])) {
             $this->saveToFile($visualizationSettings['spatialColumn'], $_GET['fileFormat']);
 
@@ -172,9 +177,27 @@ final class GisVisualizationController extends AbstractController
             'start_and_number_of_rows_fieldset' => $startAndNumberOfRowsFieldset,
             'visualization' => $this->visualization->toImage('svg'),
             'draw_ol' => $this->visualization->asOl(),
+            'download_options' => $downloadOptions,
         ]);
 
         $this->response->addHTML($html);
+    }
+
+    /** @return list<'svg'|'png'|'pdf'> */
+    private function getDownloadOptions(): array
+    {
+        $downloadOptions = [];
+        if (class_exists(TCPDF::class)) {
+            $downloadOptions[] = 'pdf';
+        }
+
+        if (extension_loaded('gd')) {
+            $downloadOptions[] = 'png';
+        }
+
+        $downloadOptions[] = 'svg';
+
+        return $downloadOptions;
     }
 
     /**

--- a/templates/table/gis_visualization/gis_visualization.twig
+++ b/templates/table/gis_visualization/gis_visualization.twig
@@ -40,9 +40,9 @@
               {{ get_icon('b_saveimage', 'Save'|trans) }}
             </button>
             <ul class="dropdown-menu" aria-labelledby="saveImageButton">
-              <li><a class="dropdown-item disableAjax" href="{{ download_url|raw }}&fileFormat=png">PNG</a></li>
-              <li><a class="dropdown-item disableAjax" href="{{ download_url|raw }}&fileFormat=pdf">PDF</a></li>
-              <li><a class="dropdown-item disableAjax" href="{{ download_url|raw }}&fileFormat=svg">SVG</a></li>
+            {% for fileType in download_options %}
+              <li><a class="dropdown-item disableAjax" download href="{{ download_url|raw }}&amp;fileFormat={{ fileType }}">{{ fileType|upper }}</a></li>
+            {% endfor %}
             </ul>
           </div>
         </div>


### PR DESCRIPTION
### Description

Backport these options from #20208:
- Add `download` attribute to download links so, in case of download error the current page is not replaced with the error message, instead it opens in a new tab.
- Remove invalid options:
If gd extension is missing, png can't be created.
If TCPDF is not installed, pdf can't be created.