### PR TITLE
Improve design in structure snapshot page

### DIFF
--- a/resources/templates/table/tracking/structure_snapshot_columns.twig
+++ b/resources/templates/table/tracking/structure_snapshot_columns.twig
@@ -1,56 +1,60 @@
-<h3>{{ t('Structure') }}</h3>
-<table id="tablestructure" class="table table-striped table-hover w-auto">
-    <thead>
-        <tr>
-            <th>{{ t('#', context = 'Number') }}</th>
-            <th>{{ t('Column') }}</th>
-            <th>{{ t('Type') }}</th>
-            <th>{{ t('Collation') }}</th>
-            <th>{{ t('Null') }}</th>
-            <th>{{ t('Default') }}</th>
-            <th>{{ t('Extra') }}</th>
-            <th>{{ t('Comment') }}</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% set index = 1 %}
-        {% for field in columns %}
-            <tr class="noclick">
-                <td>{{ index }}</td>
-                {% set index = index + 1 %}
-                <td>
-                    <strong>
-                        {{ field['Field'] }}
-                        {% if field['Key'] == 'PRI' %}
-                            {{ get_image('b_primary', t('Primary')) }}
-                        {% elseif field['Key'] is not empty %}
-                            {{ get_image('bd_primary', t('Index')) }}
-                        {% endif %}
-                    </strong>
-                </td>
-                <td>{{ field['Type'] }}</td>
-                <td>{{ field['Collation'] }}</td>
-                <td>{{ field['Null'] == 'YES' ? t('Yes') : t('No') }}</td>
-                <td>
-                    {% if field['Default'] is defined %}
-                        {% set extracted_columnspec = extract_column_spec(field['Type']) %}
-                        {% if extracted_columnspec['type'] == 'bit' %}
-                            {# here, $field['Default'] contains something like b'010' #}
-                            {{ field['Default']|convert_bit_default_value }}
-                        {% else %}
-                            {{ field['Default'] }}
-                        {% endif %}
-                    {% else %}
-                        {% if field['Null'] == 'YES' %}
-                            <em>NULL</em>
-                        {% else %}
-                            <em>{{ t('None', context = 'None for default') }}</em>
-                        {% endif %}
-                    {% endif %}
-                </td>
-                <td>{{ field['Extra'] }}</td>
-                <td>{{ field['Comment'] }}</td>
-            </tr>
-        {% endfor %}
-    </tbody>
-</table>
+<div class="card mb-3">
+    <div class="card-header">{{ t('Structure') }}</div>
+    <div class="card-body">
+        <table id="tablestructure" class="table table-striped table-hover w-auto">
+            <thead>
+                <tr>
+                    <th>{{ t('#', context = 'Number') }}</th>
+                    <th>{{ t('Column') }}</th>
+                    <th>{{ t('Type') }}</th>
+                    <th>{{ t('Collation') }}</th>
+                    <th>{{ t('Null') }}</th>
+                    <th>{{ t('Default') }}</th>
+                    <th>{{ t('Extra') }}</th>
+                    <th>{{ t('Comment') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% set index = 1 %}
+                {% for field in columns %}
+                    <tr class="noclick">
+                        <td>{{ index }}</td>
+                        {% set index = index + 1 %}
+                        <td>
+                            <strong>
+                                {{ field['Field'] }}
+                                {% if field['Key'] == 'PRI' %}
+                                    {{ get_image('b_primary', t('Primary')) }}
+                                {% elseif field['Key'] is not empty %}
+                                    {{ get_image('bd_primary', t('Index')) }}
+                                {% endif %}
+                            </strong>
+                        </td>
+                        <td>{{ field['Type'] }}</td>
+                        <td>{{ field['Collation'] }}</td>
+                        <td>{{ field['Null'] == 'YES' ? t('Yes') : t('No') }}</td>
+                        <td>
+                            {% if field['Default'] is defined %}
+                                {% set extracted_columnspec = extract_column_spec(field['Type']) %}
+                                {% if extracted_columnspec['type'] == 'bit' %}
+                                    {# here, $field['Default'] contains something like b'010' #}
+                                    {{ field['Default']|convert_bit_default_value }}
+                                {% else %}
+                                    {{ field['Default'] }}
+                                {% endif %}
+                            {% else %}
+                                {% if field['Null'] == 'YES' %}
+                                    <em>NULL</em>
+                                {% else %}
+                                    <em>{{ t('None', context = 'None for default') }}</em>
+                                {% endif %}
+                            {% endif %}
+                        </td>
+                        <td>{{ field['Extra'] }}</td>
+                        <td>{{ field['Comment'] }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/resources/templates/table/tracking/structure_snapshot_indexes.twig
+++ b/resources/templates/table/tracking/structure_snapshot_indexes.twig
@@ -1,33 +1,40 @@
-<h3>{{ t('Indexes') }}</h3>
-<table id="tablestructure_indexes" class="table table-striped table-hover">
-    <thead>
-        <tr>
-            <th>{{ t('Keyname') }}</th>
-            <th>{{ t('Type') }}</th>
-            <th>{{ t('Unique') }}</th>
-            <th>{{ t('Packed') }}</th>
-            <th>{{ t('Column') }}</th>
-            <th>{{ t('Cardinality') }}</th>
-            <th>{{ t('Collation') }}</th>
-            <th>{{ t('Null') }}</th>
-            <th>{{ t('Comment') }}</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for index in indexes %}
-            <tr class="noclick">
-                <td>
-                    <strong>{{ index['Key_name'] }}</strong>
-                </td>
-                <td>{{ index['Index_type'] }}</td>
-                <td>{{ index['Non_unique'] == 0 ? t('Yes') : t('No') }}</td>
-                <td>{{ index['Packed'] != '' ? t('Yes') : t('No') }}</td>
-                <td>{{ index['Column_name'] }}</td>
-                <td>{{ index['Cardinality'] }}</td>
-                <td>{{ index['Collation'] }}</td>
-                <td>{{ index['Null'] }}</td>
-                <td>{{ index['Comment'] }}</td>
-            </tr>
-        {% endfor %}
-    </tbody>
-</table>
+<div class="card">
+    <div class="card-header">
+        {{ t('Indexes') }}
+        {{ show_mysql_docu('optimizing-database-structure') }}
+    </div>
+    <div class="card-body">
+        <table id="tablestructure_indexes" class="table table-striped table-hover w-auto">
+            <thead>
+                <tr>
+                    <th>{{ t('Keyname') }}</th>
+                    <th>{{ t('Type') }}</th>
+                    <th>{{ t('Unique') }}</th>
+                    <th>{{ t('Packed') }}</th>
+                    <th>{{ t('Column') }}</th>
+                    <th>{{ t('Cardinality') }}</th>
+                    <th>{{ t('Collation') }}</th>
+                    <th>{{ t('Null') }}</th>
+                    <th>{{ t('Comment') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for index in indexes %}
+                    <tr class="noclick">
+                        <td>
+                            <strong>{{ index['Key_name'] }}</strong>
+                        </td>
+                        <td>{{ index['Index_type'] }}</td>
+                        <td>{{ index['Non_unique'] == 0 ? t('Yes') : t('No') }}</td>
+                        <td>{{ index['Packed'] != '' ? t('Yes') : t('No') }}</td>
+                        <td>{{ index['Column_name'] }}</td>
+                        <td>{{ index['Cardinality'] }}</td>
+                        <td>{{ index['Collation'] }}</td>
+                        <td>{{ index['Null'] }}</td>
+                        <td>{{ index['Comment'] }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>


### PR DESCRIPTION
### Description

Improve design in structure snapshot page. Also, `w-auto` was missing from indexes table. Table structure has it.

**Before:**

https://github.com/user-attachments/assets/609e44a3-bbf1-4dd8-b2b2-c7d9c243e7b9

**After:**

https://github.com/user-attachments/assets/3d707171-55ae-4233-86e2-ffb8411565a9

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
