### PR TITLE
Fix #19330 - Show original value instead of negative value

### DIFF
--- a/resources/js/server/status/monitor.ts
+++ b/resources/js/server/status/monitor.ts
@@ -1491,6 +1491,11 @@ AJAX.registerOnload('server/status/monitor.js', function () {
                             }
 
                             value -= oldChartData[key][j][0].value;
+
+                            // Show original value instead of negative value when database server is restarted
+                            if (value < 0) {
+                                value = parseFloat(chartData[key][j][0].value);
+                            }
                         }
 
                         if (elem.nodes[j].valueDivisor) {


### PR DESCRIPTION
### Description

Show original value instead of negative value when database server is restarted.

If original value is `1` (after server restart) and old value is `10`, results in `-9` being shown. Instead of `-9` now it will show `1`.

https://github.com/user-attachments/assets/3f8cbe5d-b970-490b-884f-a49b3e33dfe1

Fixes #19330

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
