### PR TITLE
Fix #20171 - Retrieval of the default storage engine

### DIFF
--- a/src/Controllers/Database/StructureController.php
+++ b/src/Controllers/Database/StructureController.php
@@ -457,12 +457,11 @@ final class StructureController implements InvocableController
 
         $defaultStorageEngine = '';
         if ($this->config->config->PropertiesNumColumns < 2) {
-            // MySQL <= 5.5.2
-            $defaultStorageEngine = $this->dbi->fetchValue('SELECT @@storage_engine;');
-            if (! is_string($defaultStorageEngine) || $defaultStorageEngine === '') {
-                // MySQL >= 5.5.3
-                $defaultStorageEngine = $this->dbi->fetchValue('SELECT @@default_storage_engine;');
-            }
+            $default_storage_engine_var = (
+                ($this->dbi->isMySql() && $this->dbi->getVersion() >= 050503)
+                || ($this->dbi->isMariaDb() && $this->dbi->getVersion() >= 120000)
+            ) ? '@@default_storage_engine' : '@@storage_engine';
+            $defaultStorageEngine = $this->dbi->fetchValue("SELECT $default_storage_engine_var");
         }
 
         return $html . $this->template->render('database/structure/table_header', [


### PR DESCRIPTION
### Description

The variable name of the default storage engine changed in MySQL from v5.5.3, and in MariaDB from v12.0.0

Fixes #20171

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [] Any new functionality is covered by tests.

```
Signed-off-by: Guido Selva <guido.selva@gmail.com>
```