### PR TITLE
Fix #17452 - Binary logs fetching for super users only

### DIFF
--- a/libraries/classes/Menu.php
+++ b/libraries/classes/Menu.php
@@ -463,11 +463,13 @@ class Menu
 
         $isSuperUser = $this->dbi->isSuperUser();
         $isCreateOrGrantUser = $this->dbi->isGrantUser() || $this->dbi->isCreateUser();
-        if (SessionCache::has('binary_logs')) {
-            $binaryLogs = SessionCache::get('binary_logs');
-        } else {
-            $binaryLogs = $this->dbi->fetchResult('SHOW BINARY LOGS', 'Log_name');
-            SessionCache::set('binary_logs', $binaryLogs);
+        if ($isSuperUser) {
+            if (SessionCache::has('binary_logs')) {
+                $binaryLogs = SessionCache::get('binary_logs');
+            } else {
+                $binaryLogs = $this->dbi->fetchResult('SHOW BINARY LOGS', 'Log_name');
+                SessionCache::set('binary_logs', $binaryLogs);
+            }
         }
 
         $tabs = [];


### PR DESCRIPTION
### Description

Prevent a regular user to try to fetch binalry logs, generating useless errors in the SQL errors log file.

Fixes #17452

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.

Signed-off-by: Guido Selva <guido.selva@gmail.com>