### PR TITLE
Fix #17451 - fetchValue call with connection parameter

### DIFF
--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -1824,7 +1824,7 @@ class Table implements Stringable
         // Remove some old rows in table_uiprefs if it exceeds the configured
         // maximum rows
         $sqlQuery = 'SELECT COUNT(*) FROM ' . $table;
-        $rowsCount = (int) $this->dbi->fetchValue($sqlQuery);
+        $rowsCount = (int) $this->dbi->fetchValue($sqlQuery, 0, DatabaseInterface::CONNECT_CONTROL)
         $maxRows = (int) $GLOBALS['cfg']['Server']['MaxTableUiprefs'];
         if ($rowsCount > $maxRows) {
             $numRowsToDelete = $rowsCount - $maxRows;


### PR DESCRIPTION
### Description

A regular user cannot read the table "table_uiprefs", so table rows cannot be counted to check if they exceed MaxTableUiprefs. Rows count must be fetched as controluser, not as logged in user.

Fixes #17451

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.

Signed-off-by: Guido Selva <guido.selva@gmail.com>