### PR TITLE
Skip tables that cannot be read

### DIFF
--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -841,6 +841,11 @@ class Export
                 $tableObj = new Table($table, $db);
                 $nonGeneratedCols = $tableObj->getNonGeneratedColumns(true);
 
+                // Skip tables that cannot be read
+                if ($nonGeneratedCols === []) {
+                    continue;
+                }
+
                 $localQuery = 'SELECT ' . implode(', ', $nonGeneratedCols)
                     . ' FROM ' . Util::backquote($db)
                     . '.' . Util::backquote($table);
@@ -1109,6 +1114,11 @@ class Export
                 // Data is exported only for Non-generated columns
                 $tableObj = new Table($table, $db);
                 $nonGeneratedCols = $tableObj->getNonGeneratedColumns(true);
+
+                // Skip tables that cannot be read
+                if ($nonGeneratedCols === []) {
+                    return;
+                }
 
                 $localQuery = 'SELECT ' . implode(', ', $nonGeneratedCols)
                     . ' FROM ' . Util::backquote($db)


### PR DESCRIPTION
### Description

This should fix the export for all other formats, except `SQL`, when tables cannot be read. Previously `HTML` content was added to the exported file. Now, it will skip the tables and only export what can be read.

Something similar was done here:

https://github.com/phpmyadmin/phpmyadmin/blob/559587a6a4160911fec4a3b15b4b4f2ecffabf43/libraries/classes/Table.php#L1303-L1304
https://github.com/phpmyadmin/phpmyadmin/blob/2f4a40d2082b04a8c53d35e19f21ffc85749c279/src/Table/TableMover.php#L452-L455

**Before:**

https://github.com/user-attachments/assets/07b35dbf-e761-40da-b09c-ffe23bde7aeb

**After:**

https://github.com/user-attachments/assets/1934ac86-db8c-491f-b0ce-8033e06f42e4

Related #18028, #18183, #20160

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
