### PR TITLE
FIX #20171 - Refactor default engine retrieval logic in Twig template

### DIFF
--- a/templates/database/structure/body_for_table_summary.twig
+++ b/templates/database/structure/body_for_table_summary.twig
@@ -36,12 +36,10 @@
     {% endif %}
     <th class="value tbl_rows font-monospace text-end">{{ cell_text }}</th>
     {% if not (properties_num_columns > 1) %}
-        {# MySQL <= 5.5.2 #}
-        {% set default_engine = dbi.fetchValue('SELECT @@storage_engine;') %}
-        {% if default_engine is empty %}
-            {# MySQL >= 5.5.3 #}
-            {% set default_engine = dbi.fetchValue('SELECT @@default_storage_engine;') %}
-        {% endif %}
+    {% $default_storage_engine = $this->dbi->getVersion() >= 050503
+                ? '@@default_storage_engine'
+                : '@@storage_engine'; %}
+    {% set default_engine = dbi.fetchValue("SELECT $default_storage_engine;") %}
         <th class="text-center">
             <dfn title="{{ '%s is the default storage engine on this MySQL server.'|trans|format(default_engine) }}">
                 {{ default_engine }}

--- a/templates/database/structure/body_for_table_summary.twig
+++ b/templates/database/structure/body_for_table_summary.twig
@@ -36,10 +36,8 @@
     {% endif %}
     <th class="value tbl_rows font-monospace text-end">{{ cell_text }}</th>
     {% if not (properties_num_columns > 1) %}
-    {% $default_storage_engine = $this->dbi->getVersion() >= 050503
-                ? '@@default_storage_engine'
-                : '@@storage_engine'; %}
-    {% set default_engine = dbi.fetchValue("SELECT $default_storage_engine;") %}
+    {% set default_storage_engine_var = dbi.getVersion() >= 050503 ? '@@default_storage_engine' : '@@storage_engine' %}
+    {% set default_engine = dbi.fetchValue("SELECT #{default_storage_engine_var};") %}
         <th class="text-center">
             <dfn title="{{ '%s is the default storage engine on this MySQL server.'|trans|format(default_engine) }}">
                 {{ default_engine }}


### PR DESCRIPTION
### Description

Use the correct variable to retrieve the default storage engine, based on MySQL/MariaDB version.

Fixes #20171

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.

Signed-off-by: Guido Selva <guido.selva@gmail.com>