### PR TITLE
Fix #20171 - Refactor default engine retrieval logic

### DIFF
--- a/libraries/classes/Controllers/Database/StructureController.php
+++ b/libraries/classes/Controllers/Database/StructureController.php
@@ -66,6 +66,9 @@ class StructureController extends AbstractController
     /** @var bool whether stats show or not */
     protected $isShowStats;
 
+    /** @var bool whether database details show or not */
+    protected $isShowDbDetails;
+
     /** @var Relation */
     private $relation;
 
@@ -105,6 +108,8 @@ class StructureController extends AbstractController
         $this->operations = $operations;
         $this->dbi = $dbi;
         $this->flash = $flash;
+
+        $this->isShowDbDetails = $GLOBALS['cfg']['PropertiesNumColumns'] < 2;
 
         $this->replicationInfo = new ReplicationInfo($this->dbi);
     }
@@ -380,6 +385,7 @@ class StructureController extends AbstractController
                     'replication' => $replicaInfo['status'],
                     'properties_num_columns' => $GLOBALS['cfg']['PropertiesNumColumns'],
                     'is_show_stats' => $this->isShowStats,
+                    'is_show_db_details' => $this->isShowDbDetails,
                     'show_charset' => $GLOBALS['cfg']['ShowDbStructureCharset'],
                     'show_comment' => $GLOBALS['cfg']['ShowDbStructureComment'],
                     'show_creation' => $GLOBALS['cfg']['ShowDbStructureCreation'],
@@ -440,6 +446,7 @@ class StructureController extends AbstractController
                 'already_favorite' => $this->checkFavoriteTable($currentTable['TABLE_NAME']),
                 'num_favorite_tables' => $GLOBALS['cfg']['NumFavoriteTables'],
                 'properties_num_columns' => $GLOBALS['cfg']['PropertiesNumColumns'],
+                'is_show_db_details' => $this->isShowDbDetails,
                 'limit_chars' => $GLOBALS['cfg']['LimitChars'],
                 'show_charset' => $GLOBALS['cfg']['ShowDbStructureCharset'],
                 'show_comment' => $GLOBALS['cfg']['ShowDbStructureComment'],
@@ -468,11 +475,20 @@ class StructureController extends AbstractController
 
         $relationParameters = $this->relation->getRelationParameters();
 
+        $defaultStorageEngine = '';
+        if ($this->isShowDbDetails) {
+            $defaultStorageEngineVar = $this->dbi->getVersion() >= 50503
+                ? '@@default_storage_engine'
+                : '@@storage_engine';
+            $defaultStorageEngine = $this->dbi->fetchValue(sprintf('SELECT %s;', $defaultStorageEngineVar));
+        }
+
         return $html . $this->template->render('database/structure/table_header', [
             'db' => $this->db,
             'db_is_system_schema' => $this->dbIsSystemSchema,
             'replication' => $replicaInfo['status'],
             'properties_num_columns' => $GLOBALS['cfg']['PropertiesNumColumns'],
+            'is_show_db_details' => $this->isShowDbDetails,
             'is_show_stats' => $this->isShowStats,
             'show_charset' => $GLOBALS['cfg']['ShowDbStructureCharset'],
             'show_comment' => $GLOBALS['cfg']['ShowDbStructureComment'],
@@ -498,6 +514,8 @@ class StructureController extends AbstractController
                 'num_favorite_tables' => $GLOBALS['cfg']['NumFavoriteTables'],
                 'db' => $GLOBALS['db'],
                 'properties_num_columns' => $GLOBALS['cfg']['PropertiesNumColumns'],
+                'is_show_db_details' => $this->isShowDbDetails,
+                'default_storage_engine' => $defaultStorageEngine,
                 'dbi' => $this->dbi,
                 'show_charset' => $GLOBALS['cfg']['ShowDbStructureCharset'],
                 'show_comment' => $GLOBALS['cfg']['ShowDbStructureComment'],

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5037,7 +5037,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'PropertiesNumColumns' on mixed\\.$#"
-			count: 1
+			count: 2
 			path: libraries/classes/Controllers/Database/StructureController.php
 
 		-

--- a/templates/database/structure/body_for_table_summary.twig
+++ b/templates/database/structure/body_for_table_summary.twig
@@ -35,16 +35,10 @@
         {% set cell_text = row_count_sum %}
     {% endif %}
     <th class="value tbl_rows font-monospace text-end">{{ cell_text }}</th>
-    {% if not (properties_num_columns > 1) %}
-        {# MySQL <= 5.5.2 #}
-        {% set default_engine = dbi.fetchValue('SELECT @@storage_engine;') %}
-        {% if default_engine is empty %}
-            {# MySQL >= 5.5.3 #}
-            {% set default_engine = dbi.fetchValue('SELECT @@default_storage_engine;') %}
-        {% endif %}
+    {% if is_show_db_details %}
         <th class="text-center">
-            <dfn title="{{ '%s is the default storage engine on this MySQL server.'|trans|format(default_engine) }}">
-                {{ default_engine }}
+            <dfn title="{{ '%s is the default storage engine on this MySQL server.'|trans|format(default_storage_engine) }}">
+                {{ default_storage_engine }}
             </dfn>
         </th>
         <th>

--- a/templates/database/structure/structure_table_row.twig
+++ b/templates/database/structure/structure_table_row.twig
@@ -114,7 +114,7 @@
             {{ show_superscript|raw }}
         </td>
 
-        {% if not (properties_num_columns > 1) %}
+        {% if is_show_db_details %}
             <td class="text-nowrap">
                 {% if current_table['ENGINE'] is not empty %}
                     {{ current_table['ENGINE'] }}

--- a/templates/database/structure/table_header.twig
+++ b/templates/database/structure/table_header.twig
@@ -26,7 +26,7 @@
                 {{ sortable_table_header('Rows'|trans, 'records', 'DESC') }}
                 {{ show_hint('May be approximate. Click on the number to get the exact count. See [doc@faq3-11]FAQ 3.11[/doc].'|trans|sanitize) }}
             </th>
-            {% if not (properties_num_columns > 1) %}
+            {% if is_show_db_details %}
                 <th>{{ sortable_table_header('Type'|trans, 'type') }}</th>
                 <th>{{ sortable_table_header('Collation'|trans, 'collation') }}</th>
             {% endif %}


### PR DESCRIPTION
### Description

Use the correct variable to retrieve the default storage engine, based on MySQL/MariaDB version.

Fixes #20171

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.

Signed-off-by: Guido Selva <guido.selva@gmail.com>