### PR TITLE
Cleanup Content-Security-Policy header

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9915,17 +9915,6 @@
       <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>
     </DeprecatedMethod>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[testGetHttpHeaders]]></code>
-      <code><![CDATA[testGetHttpHeaders]]></code>
-      <code><![CDATA[testGetHttpHeaders]]></code>
-      <code><![CDATA[testGetHttpHeaders]]></code>
-      <code><![CDATA[testGetHttpHeaders]]></code>
-      <code><![CDATA[testGetHttpHeaders]]></code>
-      <code><![CDATA[testGetHttpHeaders]]></code>
-      <code><![CDATA[testGetHttpHeaders]]></code>
-      <code><![CDATA[testGetHttpHeaders]]></code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="tests/unit/Html/GeneratorTest.php">
     <DeprecatedMethod>

--- a/src/Header.php
+++ b/src/Header.php
@@ -22,9 +22,9 @@ use Psr\Clock\ClockInterface;
 
 use function array_merge;
 use function htmlspecialchars;
+use function implode;
 use function ini_get;
 use function json_encode;
-use function sprintf;
 
 use const JSON_HEX_TAG;
 
@@ -332,7 +332,49 @@ class Header
     /** @return array<string, string> */
     public function getHttpHeaders(ClockInterface|null $clock = null): array
     {
-        $headers = [];
+        $headers = [
+            'Referrer-Policy' => 'same-origin',
+
+            'Content-Security-Policy' => $this->getCspHeader(),
+
+            /**
+             * Re-enable possible disabled XSS filters.
+             *
+             * @see https://developer.mozilla.org/docs/Web/HTTP/Headers/X-XSS-Protection
+             */
+            'X-XSS-Protection' => '1; mode=block',
+
+            /**
+             * "nosniff", prevents Internet Explorer and Google Chrome from MIME-sniffing
+             * a response away from the declared content-type.
+             *
+             * @see https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Content-Type-Options
+             */
+            'X-Content-Type-Options' => 'nosniff',
+
+            /**
+             * Adobe cross-domain-policies.
+             *
+             * @see https://www.sentrium.co.uk/labs/application-security-101-http-headers
+             */
+            'X-Permitted-Cross-Domain-Policies' => 'none',
+
+            /**
+             * Robots meta tag.
+             *
+             * @see https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag
+             */
+            'X-Robots-Tag' => 'noindex, nofollow',
+
+            /**
+             * The HTTP Permissions-Policy header provides a mechanism to allow and deny
+             * the use of browser features in a document
+             * or within any <iframe> elements in the document.
+             *
+             * @see https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy
+             */
+            'Permissions-Policy' => 'fullscreen=(self), interest-cohort=()',
+        ];
 
         /* Prevent against ClickJacking by disabling framing */
         if ($this->config->config->AllowThirdPartyFraming === 'sameorigin') {
@@ -340,48 +382,6 @@ class Header
         } elseif ($this->config->config->AllowThirdPartyFraming !== true) {
             $headers['X-Frame-Options'] = 'DENY';
         }
-
-        $headers['Referrer-Policy'] = 'same-origin';
-
-        $headers['Content-Security-Policy'] = $this->getCspHeader();
-
-        /**
-         * Re-enable possible disabled XSS filters.
-         *
-         * @see https://developer.mozilla.org/docs/Web/HTTP/Headers/X-XSS-Protection
-         */
-        $headers['X-XSS-Protection'] = '1; mode=block';
-
-        /**
-         * "nosniff", prevents Internet Explorer and Google Chrome from MIME-sniffing
-         * a response away from the declared content-type.
-         *
-         * @see https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Content-Type-Options
-         */
-        $headers['X-Content-Type-Options'] = 'nosniff';
-
-        /**
-         * Adobe cross-domain-policies.
-         *
-         * @see https://www.sentrium.co.uk/labs/application-security-101-http-headers
-         */
-        $headers['X-Permitted-Cross-Domain-Policies'] = 'none';
-
-        /**
-         * Robots meta tag.
-         *
-         * @see https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag
-         */
-        $headers['X-Robots-Tag'] = 'noindex, nofollow';
-
-        /**
-         * The HTTP Permissions-Policy header provides a mechanism to allow and deny
-         * the use of browser features in a document
-         * or within any <iframe> elements in the document.
-         *
-         * @see https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy
-         */
-        $headers['Permissions-Policy'] = 'fullscreen=(self), interest-cohort=()';
 
         $headers = array_merge($headers, Core::getNoCacheHeaders($clock ?? new Clock()));
 
@@ -427,32 +427,25 @@ class Header
     private function getCspHeader(): string
     {
         $mapTileUrl = ' tile.openstreetmap.org';
-        $captchaUrl = '';
-        $cspAllow = $this->config->config->CSPAllow;
+        $cspAllow = $this->config->config->CSPAllow === '' ? '' : ' ' . $this->config->config->CSPAllow;
+        $captchaUrl =
+            $this->config->config->CaptchaLoginPrivateKey === '' ||
+            $this->config->config->CaptchaLoginPublicKey === '' ||
+            $this->config->config->CaptchaApi === '' ||
+            $this->config->config->CaptchaRequestParam === '' ||
+            $this->config->config->CaptchaResponseParam === ''
+                ? ''
+                : ' ' . $this->config->config->CaptchaCsp;
 
-        if (
-            $this->config->config->CaptchaLoginPrivateKey !== ''
-            && $this->config->config->CaptchaLoginPublicKey !== ''
-            && $this->config->config->CaptchaApi !== ''
-            && $this->config->config->CaptchaRequestParam !== ''
-            && $this->config->config->CaptchaResponseParam !== ''
-        ) {
-            $captchaUrl = ' ' . $this->config->config->CaptchaCsp . ' ';
-        }
+        $csp = [
+            "default-src 'self'" . $captchaUrl . $cspAllow,
+            "img-src 'self' data:" . $captchaUrl . $cspAllow . $mapTileUrl,
+            "object-src 'none'",
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval'" . $captchaUrl . $cspAllow,
+            "style-src 'self' 'unsafe-inline'" . $captchaUrl . $cspAllow,
+        ];
 
-        return sprintf(
-            'default-src \'self\' %s%s;script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' %s%s;'
-                . 'style-src \'self\' \'unsafe-inline\' %s%s;img-src \'self\' data: %s%s%s;object-src \'none\';',
-            $captchaUrl,
-            $cspAllow,
-            $captchaUrl,
-            $cspAllow,
-            $captchaUrl,
-            $cspAllow,
-            $cspAllow,
-            $mapTileUrl,
-            $captchaUrl,
-        );
+        return implode('; ', $csp) . ';';
     }
 
     private function getVariablesForJavaScript(): string

--- a/src/Header.php
+++ b/src/Header.php
@@ -419,7 +419,7 @@ class Header
     /** Get the Content-Security-Policy header */
     private function getCspHeader(): string
     {
-        $mapTileUrl = ' tile.openstreetmap.org';
+        $mapTileUrl = ' https://tile.openstreetmap.org';
         $cspAllow = $this->config->config->CSPAllow === '' ? '' : ' ' . $this->config->config->CSPAllow;
         $captchaUrl =
             $this->config->config->CaptchaLoginPrivateKey === '' ||

--- a/src/Header.php
+++ b/src/Header.php
@@ -343,7 +343,7 @@ class Header
 
         $headers['Referrer-Policy'] = 'same-origin';
 
-        $headers = array_merge($headers, $this->getCspHeaders());
+        $headers['Content-Security-Policy'] = $this->getCspHeader();
 
         /**
          * Re-enable possible disabled XSS filters.
@@ -423,12 +423,8 @@ class Header
         return $this->title;
     }
 
-    /**
-     * Get all the CSP allow policy headers
-     *
-     * @return array<string, string>
-     */
-    private function getCspHeaders(): array
+    /** Get the Content-Security-Policy header */
+    private function getCspHeader(): string
     {
         $mapTileUrl = ' tile.openstreetmap.org';
         $captchaUrl = '';
@@ -444,9 +440,7 @@ class Header
             $captchaUrl = ' ' . $this->config->config->CaptchaCsp . ' ';
         }
 
-        $headers = [];
-
-        $headers['Content-Security-Policy'] = sprintf(
+        return sprintf(
             'default-src \'self\' %s%s;script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' %s%s;'
                 . 'style-src \'self\' \'unsafe-inline\' %s%s;img-src \'self\' data: %s%s%s;object-src \'none\';',
             $captchaUrl,
@@ -459,32 +453,6 @@ class Header
             $mapTileUrl,
             $captchaUrl,
         );
-
-        $headers['X-Content-Security-Policy'] = sprintf(
-            'default-src \'self\' %s%s;options inline-script eval-script;'
-                . 'referrer no-referrer;img-src \'self\' data: %s%s%s;object-src \'none\';',
-            $captchaUrl,
-            $cspAllow,
-            $cspAllow,
-            $mapTileUrl,
-            $captchaUrl,
-        );
-
-        $headers['X-WebKit-CSP'] = sprintf(
-            'default-src \'self\' %s%s;script-src \'self\' %s%s \'unsafe-inline\' \'unsafe-eval\';'
-                . 'referrer no-referrer;style-src \'self\' \'unsafe-inline\' %s;'
-                . 'img-src \'self\' data: %s%s%s;object-src \'none\';',
-            $captchaUrl,
-            $cspAllow,
-            $captchaUrl,
-            $cspAllow,
-            $captchaUrl,
-            $cspAllow,
-            $mapTileUrl,
-            $captchaUrl,
-        );
-
-        return $headers;
     }
 
     private function getVariablesForJavaScript(): string

--- a/src/Header.php
+++ b/src/Header.php
@@ -376,13 +376,6 @@ class Header
             'Permissions-Policy' => 'fullscreen=(self), interest-cohort=()',
         ];
 
-        /* Prevent against ClickJacking by disabling framing */
-        if ($this->config->config->AllowThirdPartyFraming === 'sameorigin') {
-            $headers['X-Frame-Options'] = 'SAMEORIGIN';
-        } elseif ($this->config->config->AllowThirdPartyFraming !== true) {
-            $headers['X-Frame-Options'] = 'DENY';
-        }
-
         $headers = array_merge($headers, Core::getNoCacheHeaders($clock ?? new Clock()));
 
         /**
@@ -444,6 +437,13 @@ class Header
             "script-src 'self' 'unsafe-inline' 'unsafe-eval'" . $captchaUrl . $cspAllow,
             "style-src 'self' 'unsafe-inline'" . $captchaUrl . $cspAllow,
         ];
+
+        // Prevent click-jacking by disabling inline-framing
+        if ($this->config->config->AllowThirdPartyFraming === 'sameorigin') {
+            $csp[] = "frame-ancestors 'self'";
+        } elseif ($this->config->config->AllowThirdPartyFraming !== true) {
+            $csp[] = "frame-ancestors 'none'";
+        }
 
         return implode('; ', $csp) . ';';
     }

--- a/tests/unit/HeaderTest.php
+++ b/tests/unit/HeaderTest.php
@@ -186,7 +186,6 @@ class HeaderTest extends AbstractTestCase
         string $privateKey,
         string $publicKey,
         string $captchaCsp,
-        string|null $expectedFrameOptions,
         string $expectedCsp,
     ): void {
         $header = $this->getNewHeaderInstance();
@@ -206,21 +205,17 @@ class HeaderTest extends AbstractTestCase
             'X-Permitted-Cross-Domain-Policies' => 'none',
             'X-Robots-Tag' => 'noindex, nofollow',
             'Permissions-Policy' => 'fullscreen=(self), interest-cohort=()',
-            'X-Frame-Options' => $expectedFrameOptions ?? '',
             'Expires' => 'Wed, 21 Oct 2015 07:28:00 GMT',
             'Cache-Control' => 'no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0',
             'Pragma' => 'no-cache',
             'Last-Modified' => 'Wed, 21 Oct 2015 07:28:00 GMT',
             'Content-Type' => 'text/html; charset=utf-8',
         ];
-        if ($expectedFrameOptions === null) {
-            unset($expected['X-Frame-Options']);
-        }
 
         self::assertSame($expected, $header->getHttpHeaders(MockClock::from('2015-10-21T05:28:00-02:00')));
     }
 
-    /** @psalm-return list<array{string|bool, string, string, string, string, string|null, string}> */
+    /** @psalm-return list<array{string|bool, string, string, string, string, string}> */
     public static function providerForTestGetHttpHeaders(): array
     {
         return [
@@ -230,12 +225,12 @@ class HeaderTest extends AbstractTestCase
                 '',
                 '',
                 '',
-                'DENY',
                 "default-src 'self';"
                     . " img-src 'self' data: tile.openstreetmap.org;"
                     . " object-src 'none';"
                     . " script-src 'self' 'unsafe-inline' 'unsafe-eval';"
                     . " style-src 'self' 'unsafe-inline';"
+                    . " frame-ancestors 'none';",
             ],
             [
                 'sameorigin',
@@ -243,12 +238,12 @@ class HeaderTest extends AbstractTestCase
                 'PrivateKey',
                 'PublicKey',
                 'captcha.tld csp.tld',
-                'SAMEORIGIN',
                 "default-src 'self' captcha.tld csp.tld example.com example.net;"
                     . " img-src 'self' data: captcha.tld csp.tld example.com example.net tile.openstreetmap.org;"
                     . " object-src 'none';"
                     . " script-src 'self' 'unsafe-inline' 'unsafe-eval' captcha.tld csp.tld example.com example.net;"
                     . " style-src 'self' 'unsafe-inline' captcha.tld csp.tld example.com example.net;"
+                    . " frame-ancestors 'self';",
             ],
             [
                 true,
@@ -256,7 +251,6 @@ class HeaderTest extends AbstractTestCase
                 'PrivateKey',
                 'PublicKey',
                 'captcha.tld csp.tld',
-                null,
                 "default-src 'self' captcha.tld csp.tld;"
                     . " img-src 'self' data: captcha.tld csp.tld tile.openstreetmap.org;"
                     . " object-src 'none';"

--- a/tests/unit/HeaderTest.php
+++ b/tests/unit/HeaderTest.php
@@ -226,7 +226,7 @@ class HeaderTest extends AbstractTestCase
                 '',
                 '',
                 "default-src 'self';"
-                    . " img-src 'self' data: tile.openstreetmap.org;"
+                    . " img-src 'self' data: https://tile.openstreetmap.org;"
                     . " object-src 'none';"
                     . " script-src 'self' 'unsafe-inline' 'unsafe-eval';"
                     . " style-src 'self' 'unsafe-inline';"
@@ -239,7 +239,8 @@ class HeaderTest extends AbstractTestCase
                 'PublicKey',
                 'captcha.tld csp.tld',
                 "default-src 'self' captcha.tld csp.tld example.com example.net;"
-                    . " img-src 'self' data: captcha.tld csp.tld example.com example.net tile.openstreetmap.org;"
+                    . " img-src 'self' data: captcha.tld csp.tld example.com example.net"
+                    . ' https://tile.openstreetmap.org;'
                     . " object-src 'none';"
                     . " script-src 'self' 'unsafe-inline' 'unsafe-eval' captcha.tld csp.tld example.com example.net;"
                     . " style-src 'self' 'unsafe-inline' captcha.tld csp.tld example.com example.net;"
@@ -252,7 +253,7 @@ class HeaderTest extends AbstractTestCase
                 'PublicKey',
                 'captcha.tld csp.tld',
                 "default-src 'self' captcha.tld csp.tld;"
-                    . " img-src 'self' data: captcha.tld csp.tld tile.openstreetmap.org;"
+                    . " img-src 'self' data: captcha.tld csp.tld https://tile.openstreetmap.org;"
                     . " object-src 'none';"
                     . " script-src 'self' 'unsafe-inline' 'unsafe-eval' captcha.tld csp.tld;"
                     . " style-src 'self' 'unsafe-inline' captcha.tld csp.tld;",

--- a/tests/unit/HeaderTest.php
+++ b/tests/unit/HeaderTest.php
@@ -188,8 +188,6 @@ class HeaderTest extends AbstractTestCase
         string $captchaCsp,
         string|null $expectedFrameOptions,
         string $expectedCsp,
-        string $expectedXCsp,
-        string $expectedWebKitCsp,
     ): void {
         $header = $this->getNewHeaderInstance();
 
@@ -204,8 +202,6 @@ class HeaderTest extends AbstractTestCase
             'X-Frame-Options' => $expectedFrameOptions ?? '',
             'Referrer-Policy' => 'same-origin',
             'Content-Security-Policy' => $expectedCsp,
-            'X-Content-Security-Policy' => $expectedXCsp,
-            'X-WebKit-CSP' => $expectedWebKitCsp,
             'X-XSS-Protection' => '1; mode=block',
             'X-Content-Type-Options' => 'nosniff',
             'X-Permitted-Cross-Domain-Policies' => 'none',
@@ -224,7 +220,7 @@ class HeaderTest extends AbstractTestCase
         self::assertSame($expected, $header->getHttpHeaders(MockClock::from('2015-10-21T05:28:00-02:00')));
     }
 
-    /** @return mixed[][] */
+    /** @psalm-return list<array{string|bool, string, string, string, string, string|null, string}> */
     public static function providerForTestGetHttpHeaders(): array
     {
         return [
@@ -238,11 +234,6 @@ class HeaderTest extends AbstractTestCase
                 'default-src \'self\' ;script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' ;'
                     . 'style-src \'self\' \'unsafe-inline\' ;img-src \'self\' data:  tile.openstreetmap.org;'
                     . 'object-src \'none\';',
-                'default-src \'self\' ;options inline-script eval-script;referrer no-referrer;'
-                    . 'img-src \'self\' data:  tile.openstreetmap.org;object-src \'none\';',
-                'default-src \'self\' ;script-src \'self\'  \'unsafe-inline\' \'unsafe-eval\';'
-                    . 'referrer no-referrer;style-src \'self\' \'unsafe-inline\' ;'
-                    . 'img-src \'self\' data:  tile.openstreetmap.org;object-src \'none\';',
             ],
             [
                 'sameorigin',
@@ -257,14 +248,6 @@ class HeaderTest extends AbstractTestCase
                     . 'style-src \'self\' \'unsafe-inline\'  captcha.tld csp.tld example.com example.net;'
                     . 'img-src \'self\' data: example.com example.net tile.openstreetmap.org captcha.tld csp.tld ;'
                     . 'object-src \'none\';',
-                'default-src \'self\'  captcha.tld csp.tld example.com example.net;'
-                    . 'options inline-script eval-script;referrer no-referrer;img-src \'self\' data: example.com '
-                    . 'example.net tile.openstreetmap.org captcha.tld csp.tld ;object-src \'none\';',
-                'default-src \'self\'  captcha.tld csp.tld example.com example.net;script-src \'self\'  '
-                    . 'captcha.tld csp.tld example.com example.net \'unsafe-inline\' \'unsafe-eval\';'
-                    . 'referrer no-referrer;style-src \'self\' \'unsafe-inline\'  captcha.tld csp.tld ;'
-                    . 'img-src \'self\' data: example.com example.net tile.openstreetmap.org captcha.tld csp.tld ;'
-                    . 'object-src \'none\';',
             ],
             [
                 true,
@@ -276,13 +259,6 @@ class HeaderTest extends AbstractTestCase
                 'default-src \'self\'  captcha.tld csp.tld ;'
                     . 'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\'  captcha.tld csp.tld ;'
                     . 'style-src \'self\' \'unsafe-inline\'  captcha.tld csp.tld ;'
-                    . 'img-src \'self\' data:  tile.openstreetmap.org captcha.tld csp.tld ;object-src \'none\';',
-                'default-src \'self\'  captcha.tld csp.tld ;'
-                    . 'options inline-script eval-script;referrer no-referrer;'
-                    . 'img-src \'self\' data:  tile.openstreetmap.org captcha.tld csp.tld ;object-src \'none\';',
-                'default-src \'self\'  captcha.tld csp.tld ;'
-                    . 'script-src \'self\'  captcha.tld csp.tld  \'unsafe-inline\' \'unsafe-eval\';'
-                    . 'referrer no-referrer;style-src \'self\' \'unsafe-inline\'  captcha.tld csp.tld ;'
                     . 'img-src \'self\' data:  tile.openstreetmap.org captcha.tld csp.tld ;object-src \'none\';',
             ],
         ];

--- a/tests/unit/HeaderTest.php
+++ b/tests/unit/HeaderTest.php
@@ -199,7 +199,6 @@ class HeaderTest extends AbstractTestCase
         $config->set('CaptchaCsp', $captchaCsp);
 
         $expected = [
-            'X-Frame-Options' => $expectedFrameOptions ?? '',
             'Referrer-Policy' => 'same-origin',
             'Content-Security-Policy' => $expectedCsp,
             'X-XSS-Protection' => '1; mode=block',
@@ -207,6 +206,7 @@ class HeaderTest extends AbstractTestCase
             'X-Permitted-Cross-Domain-Policies' => 'none',
             'X-Robots-Tag' => 'noindex, nofollow',
             'Permissions-Policy' => 'fullscreen=(self), interest-cohort=()',
+            'X-Frame-Options' => $expectedFrameOptions ?? '',
             'Expires' => 'Wed, 21 Oct 2015 07:28:00 GMT',
             'Cache-Control' => 'no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0',
             'Pragma' => 'no-cache',
@@ -231,9 +231,11 @@ class HeaderTest extends AbstractTestCase
                 '',
                 '',
                 'DENY',
-                'default-src \'self\' ;script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' ;'
-                    . 'style-src \'self\' \'unsafe-inline\' ;img-src \'self\' data:  tile.openstreetmap.org;'
-                    . 'object-src \'none\';',
+                "default-src 'self';"
+                    . " img-src 'self' data: tile.openstreetmap.org;"
+                    . " object-src 'none';"
+                    . " script-src 'self' 'unsafe-inline' 'unsafe-eval';"
+                    . " style-src 'self' 'unsafe-inline';"
             ],
             [
                 'sameorigin',
@@ -242,12 +244,11 @@ class HeaderTest extends AbstractTestCase
                 'PublicKey',
                 'captcha.tld csp.tld',
                 'SAMEORIGIN',
-                'default-src \'self\'  captcha.tld csp.tld example.com example.net;'
-                    . 'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\'  '
-                    . 'captcha.tld csp.tld example.com example.net;'
-                    . 'style-src \'self\' \'unsafe-inline\'  captcha.tld csp.tld example.com example.net;'
-                    . 'img-src \'self\' data: example.com example.net tile.openstreetmap.org captcha.tld csp.tld ;'
-                    . 'object-src \'none\';',
+                "default-src 'self' captcha.tld csp.tld example.com example.net;"
+                    . " img-src 'self' data: captcha.tld csp.tld example.com example.net tile.openstreetmap.org;"
+                    . " object-src 'none';"
+                    . " script-src 'self' 'unsafe-inline' 'unsafe-eval' captcha.tld csp.tld example.com example.net;"
+                    . " style-src 'self' 'unsafe-inline' captcha.tld csp.tld example.com example.net;"
             ],
             [
                 true,
@@ -256,10 +257,11 @@ class HeaderTest extends AbstractTestCase
                 'PublicKey',
                 'captcha.tld csp.tld',
                 null,
-                'default-src \'self\'  captcha.tld csp.tld ;'
-                    . 'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\'  captcha.tld csp.tld ;'
-                    . 'style-src \'self\' \'unsafe-inline\'  captcha.tld csp.tld ;'
-                    . 'img-src \'self\' data:  tile.openstreetmap.org captcha.tld csp.tld ;object-src \'none\';',
+                "default-src 'self' captcha.tld csp.tld;"
+                    . " img-src 'self' data: captcha.tld csp.tld tile.openstreetmap.org;"
+                    . " object-src 'none';"
+                    . " script-src 'self' 'unsafe-inline' 'unsafe-eval' captcha.tld csp.tld;"
+                    . " style-src 'self' 'unsafe-inline' captcha.tld csp.tld;",
             ],
         ];
     }


### PR DESCRIPTION
- Require https for tile.openstreetmaps.org
- Replace `X-Frame-Origin` with `Content-Security-Policy` `frame-ancestors`
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options
- Remove obsolete `X-Content-Security-Policy` and `X-WebKit-CSP` headers, all browsers supported by phpMyAdmin should support `Content-Security-Policy`
https://caniuse.com/contentsecuritypolicy
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#browser_compatibility
https://github.com/phpmyadmin/phpmyadmin/blob/c90affe793b56fb6f5e1c7eed676ec9031fb1480/.browserslistrc#L1-L11