### PR TITLE
Fix #18941 - Reduce simulate-query memory

### DIFF
--- a/js/src/sql.js
+++ b/js/src/sql.js
@@ -220,6 +220,8 @@ AJAX.registerTeardown('sql.js', function () {
     $(document).off('submit', '.maxRowsForm');
     $(document).off('click', '#view_as');
     $(document).off('click', '#sqlquery');
+
+    $('#simulateDmlModal').modal('hide');
 });
 
 /**

--- a/libraries/classes/Import/SimulateDml.php
+++ b/libraries/classes/Import/SimulateDml.php
@@ -56,11 +56,12 @@ final class SimulateDml
         }
 
         // Execute the query and get the number of matched rows.
-        $matchedRows = $this->executeMatchedRowQuery($matchedRowsQuery);
+        $matchedRows = $this->executeMatchedRowQuery($matchedRowsQuery['count']);
+        $selectQuery = $matchedRowsQuery['select'];
         $matchedRowsUrl = Url::getFromRoute('/sql', [
             'db' => $GLOBALS['db'],
-            'sql_query' => $matchedRowsQuery,
-            'sql_signature' => Core::signSqlQuery($matchedRowsQuery),
+            'sql_query' => $selectQuery,
+            'sql_signature' => Core::signSqlQuery($selectQuery),
         ]);
 
         return [
@@ -78,20 +79,20 @@ final class SimulateDml
     private function executeMatchedRowQuery(string $matchedRowQuery): int
     {
         $this->dbi->selectDb($GLOBALS['db']);
-        $result = $this->dbi->tryQuery($matchedRowQuery);
-        if (! $result) {
+        $count = $this->dbi->fetchValue($matchedRowQuery);
+        if ($count === false) {
             return 0;
         }
 
-        return (int) $result->numRows();
+        return (int) $count;
     }
 
     /**
      * Transforms a DELETE query into SELECT statement.
      *
-     * @return string SQL query
+     * @psalm-return array{select: string, count: string}  SQL queries
      */
-    private function getSimulatedDeleteQuery(Parser $parser, DeleteStatement $statement): string
+    private function getSimulatedDeleteQuery(Parser $parser, DeleteStatement $statement): array
     {
         $tableReferences = Query::getTables($statement);
         Assert::count($tableReferences, 1, 'No joins allowed in simulation query');
@@ -104,15 +105,22 @@ final class SimulateDml
             : ' ORDER BY ' . Query::getClause($statement, $parser->list, 'ORDER BY');
         $limit = $statement->limit === null ? '' : ' LIMIT ' . Query::getClause($statement, $parser->list, 'LIMIT');
 
-        return 'SELECT * FROM ' . $tableReferences[0] . $where . $order . $limit;
+        return [
+            'select' => 'SELECT * FROM (' .
+                'SELECT * FROM ' . $tableReferences[0] . $where . $order . $limit .
+                ') AS pma_tmp',
+            'count' => 'SELECT COUNT(*) FROM (' .
+                'SELECT 1 FROM ' . $tableReferences[0] . $where . $order . $limit .
+                ') AS pma_tmp',
+        ];
     }
 
     /**
      * Transforms a UPDATE query into SELECT statement.
      *
-     * @return string SQL query
+     * @psalm-return array{select: string, count: string} SQL queies
      */
-    private function getSimulatedUpdateQuery(Parser $parser, UpdateStatement $statement): string
+    private function getSimulatedUpdateQuery(Parser $parser, UpdateStatement $statement): array
     {
         $tableReferences = Query::getTables($statement);
         Assert::count($tableReferences, 1, 'No joins allowed in simulation query');
@@ -129,7 +137,7 @@ final class SimulateDml
             }
 
             $oldColumns[] = Util::backquote($column);
-            $values[$column] = $set->value . ' AS ' . ($newColumns[] = Util::backquote($column . ' `new`'));
+            $values[$column] = $set->value . ' AS ' . ($newColumns[] = Util::backquote($column . ' *new*'));
         }
 
         $condition = Query::getClause($statement, $parser->list, 'WHERE');
@@ -139,10 +147,18 @@ final class SimulateDml
             : ' ORDER BY ' . Query::getClause($statement, $parser->list, 'ORDER BY');
         $limit = $statement->limit === null ? '' : ' LIMIT ' . Query::getClause($statement, $parser->list, 'LIMIT');
 
-        return 'SELECT *' .
-            ' FROM (' .
-            'SELECT *, ' . implode(', ', $values) . ' FROM ' . $tableReferences[0] . $where . $order . $limit .
-            ') AS `pma_tmp`' .
-            ' WHERE NOT (' . implode(', ', $oldColumns) . ') <=> (' . implode(', ', $newColumns) . ')';
+        return [
+            'select' => 'SELECT *' .
+                ' FROM (' .
+                'SELECT *, ' . implode(', ', $values) . ' FROM ' . $tableReferences[0] . $where . $order . $limit .
+                ') AS `pma_tmp`' .
+                ' WHERE NOT (' . implode(', ', $oldColumns) . ') <=> (' . implode(', ', $newColumns) . ')',
+            'count' => 'SELECT COUNT(*)' .
+                ' FROM (' .
+                'SELECT ' . implode(', ', $oldColumns) . ', ' . implode(', ', $values) .
+                ' FROM ' . $tableReferences[0] . $where . $order . $limit .
+                ') AS `pma_tmp`' .
+                ' WHERE NOT (' . implode(', ', $oldColumns) . ') <=> (' . implode(', ', $newColumns) . ')',
+        ];
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -20756,11 +20756,6 @@ parameters:
 			path: libraries/classes/Import/Ajax.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
-			count: 1
-			path: libraries/classes/Import/SimulateDml.php
-
-		-
 			message: "#^Parameter \\#1 \\$dbname of method PhpMyAdmin\\\\DatabaseInterface\\:\\:selectDb\\(\\) expects PhpMyAdmin\\\\Dbal\\\\DatabaseName\\|string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Import/SimulateDml.php

--- a/test/classes/Controllers/Import/SimulateDmlControllerTest.php
+++ b/test/classes/Controllers/Import/SimulateDmlControllerTest.php
@@ -27,9 +27,9 @@ class SimulateDmlControllerTest extends AbstractTestCase
      * @param array<array<mixed>> $expectedPerQuery
      * @psalm-param list<
      *   array{
-     *     simulated: string,
-     *     columns: list<string>,
-     *     result: list<list<string|int|null>>,
+     *     count: string,
+     *     select: string,
+     *     affected_rows: int,
      *   }
      * > $expectedPerQuery
      *
@@ -41,7 +41,7 @@ class SimulateDmlControllerTest extends AbstractTestCase
 
         foreach ($expectedPerQuery as $expected) {
             $this->dummyDbi->addSelectDb('PMA');
-            $this->dummyDbi->addResult($expected['simulated'], $expected['result'], $expected['columns']);
+            $this->dummyDbi->addResult($expected['count'], [[$expected['affected_rows']]]);
         }
 
         $controller = new SimulateDmlController(
@@ -68,13 +68,14 @@ class SimulateDmlControllerTest extends AbstractTestCase
         foreach ($expectedPerQuery as $idx => $expectedData) {
             /** @var DeleteStatement|UpdateStatement $statement */
             $statement = $parser->statements[$idx];
+            $selectQuery = $expectedData['select'];
             $expected = [
                 'sql_query' => Generator::formatSql($statement->build()),
-                'matched_rows' => count($expectedData['result']),
+                'matched_rows' => $expectedData['affected_rows'],
                 'matched_rows_url' => Url::getFromRoute('/sql', [
                     'db' => 'PMA',
-                    'sql_query' => $expectedData['simulated'],
-                    'sql_signature' => Core::signSqlQuery($expectedData['simulated']),
+                    'sql_query' => $selectQuery,
+                    'sql_signature' => Core::signSqlQuery($selectQuery),
                 ]),
             ];
 
@@ -88,9 +89,9 @@ class SimulateDmlControllerTest extends AbstractTestCase
      *   array{
      *     string,
      *     list<array{
-     *       simulated: string,
-     *       columns: list<string>,
-     *       result: list<list<string|int|null>>,
+     *       count: string,
+     *       select: string,
+     *       affected_rows: int,
      *     }>
      *   }
      * >
@@ -110,13 +111,17 @@ class SimulateDmlControllerTest extends AbstractTestCase
                 'UPDATE t SET `b` = NULL, a = a ORDER BY id DESC LIMIT 3',
                 [
                     [
-                        'simulated' =>
-                            'SELECT * FROM (' .
-                            'SELECT *, a AS `a ``new```, NULL AS `b ``new``` FROM `t` ORDER BY id DESC LIMIT 3' .
+                        'count' =>
+                            'SELECT COUNT(*) FROM (' .
+                            'SELECT `a`, `b`, a AS `a *new*`, NULL AS `b *new*` FROM `t` ORDER BY id DESC LIMIT 3' .
                             ') AS `pma_tmp`' .
-                            ' WHERE NOT (`a`, `b`) <=> (`a ``new```, `b ``new```)',
-                        'columns' => ['id', 'a', 'b', 'a `new`', 'b `new`'],
-                        'result' => [[5, 2, 'test', 2, null]],
+                            ' WHERE NOT (`a`, `b`) <=> (`a *new*`, `b *new*`)',
+                        'select' =>
+                            'SELECT * FROM (' .
+                            'SELECT *, a AS `a *new*`, NULL AS `b *new*` FROM `t` ORDER BY id DESC LIMIT 3' .
+                            ') AS `pma_tmp`' .
+                            ' WHERE NOT (`a`, `b`) <=> (`a *new*`, `b *new*`)',
+                        'affected_rows' => 1,
                     ],
                 ],
             ],
@@ -124,15 +129,15 @@ class SimulateDmlControllerTest extends AbstractTestCase
                 'UPDATE `t` SET `a` = 20 WHERE `id` > 4',
                 [
                     [
-                        'simulated' =>
+                        'count' =>
+                            'SELECT COUNT(*)' .
+                            ' FROM (SELECT `a`, 20 AS `a *new*` FROM `t` WHERE `id` > 4) AS `pma_tmp`' .
+                            ' WHERE NOT (`a`) <=> (`a *new*`)',
+                        'select' =>
                             'SELECT *' .
-                            ' FROM (SELECT *, 20 AS `a ``new``` FROM `t` WHERE `id` > 4) AS `pma_tmp`' .
-                            ' WHERE NOT (`a`) <=> (`a ``new```)',
-                        'columns' => ['id', 'a', 'b', 'a `new`'],
-                        'result' => [
-                            [5, 2, 'test', 20],
-                            [6, 2, null, 20],
-                        ],
+                            ' FROM (SELECT *, 20 AS `a *new*` FROM `t` WHERE `id` > 4) AS `pma_tmp`' .
+                            ' WHERE NOT (`a`) <=> (`a *new*`)',
+                        'affected_rows' => 2,
                     ],
                 ],
             ],
@@ -140,12 +145,15 @@ class SimulateDmlControllerTest extends AbstractTestCase
                 'UPDATE `t` SET `a` = 20 WHERE 0',
                 [
                     [
-                        'simulated' =>
+                        'count' =>
+                            'SELECT COUNT(*)' .
+                            ' FROM (SELECT `a`, 20 AS `a *new*` FROM `t` WHERE 0) AS `pma_tmp`' .
+                            ' WHERE NOT (`a`) <=> (`a *new*`)',
+                        'select' =>
                             'SELECT *' .
-                            ' FROM (SELECT *, 20 AS `a ``new``` FROM `t` WHERE 0) AS `pma_tmp`' .
-                            ' WHERE NOT (`a`) <=> (`a ``new```)',
-                        'columns' => ['id', 'a', 'b', 'a `new`'],
-                        'result' => [],
+                            ' FROM (SELECT *, 20 AS `a *new*` FROM `t` WHERE 0) AS `pma_tmp`' .
+                            ' WHERE NOT (`a`) <=> (`a *new*`)',
+                        'affected_rows' => 0,
                     ],
                 ],
             ],
@@ -153,16 +161,15 @@ class SimulateDmlControllerTest extends AbstractTestCase
                 'UPDATE `t` SET `a` = 2',
                 [
                     [
-                        'simulated' =>
+                        'count' =>
+                            'SELECT COUNT(*)' .
+                            ' FROM (SELECT `a`, 2 AS `a *new*` FROM `t`) AS `pma_tmp`' .
+                            ' WHERE NOT (`a`) <=> (`a *new*`)',
+                        'select' =>
                             'SELECT *' .
-                            ' FROM (SELECT *, 2 AS `a ``new``` FROM `t`) AS `pma_tmp`' .
-                            ' WHERE NOT (`a`) <=> (`a ``new```)',
-                        'columns' => ['id', 'a', 'b', 'a `new`'],
-                        'result' => [
-                            [2, 1, null, 2],
-                            [3, 1, null, 2],
-                            [4, 1, null, 2],
-                        ],
+                            ' FROM (SELECT *, 2 AS `a *new*` FROM `t`) AS `pma_tmp`' .
+                            ' WHERE NOT (`a`) <=> (`a *new*`)',
+                        'affected_rows' => 3,
                     ],
                 ],
             ],
@@ -170,16 +177,15 @@ class SimulateDmlControllerTest extends AbstractTestCase
                 'UPDATE `t` SET `id` = 20 ORDER BY `id` ASC LIMIT 3',
                 [
                     [
-                        'simulated' =>
+                        'count' =>
+                            'SELECT COUNT(*)' .
+                            ' FROM (SELECT `id`, 20 AS `id *new*` FROM `t` ORDER BY `id` ASC LIMIT 3) AS `pma_tmp`' .
+                            ' WHERE NOT (`id`) <=> (`id *new*`)',
+                        'select' =>
                             'SELECT *' .
-                            ' FROM (SELECT *, 20 AS `id ``new``` FROM `t` ORDER BY `id` ASC LIMIT 3) AS `pma_tmp`' .
-                            ' WHERE NOT (`id`) <=> (`id ``new```)',
-                        'columns' => ['id', 'a', 'b', 'id `new`'],
-                        'result' => [
-                            [1, 2, 'test', 20],
-                            [2, 1, null, 20],
-                            [3, 1, null, 20],
-                        ],
+                            ' FROM (SELECT *, 20 AS `id *new*` FROM `t` ORDER BY `id` ASC LIMIT 3) AS `pma_tmp`' .
+                            ' WHERE NOT (`id`) <=> (`id *new*`)',
+                        'affected_rows' => 3,
                     ],
                 ],
             ],
@@ -187,12 +193,15 @@ class SimulateDmlControllerTest extends AbstractTestCase
                 'UPDATE `t` SET `id` = 2, `id` = 1 WHERE `id` = 1',
                 [
                     [
-                        'simulated' =>
+                        'count' =>
+                            'SELECT COUNT(*)' .
+                            ' FROM (SELECT `id`, 1 AS `id *new*` FROM `t` WHERE `id` = 1) AS `pma_tmp`' .
+                            ' WHERE NOT (`id`) <=> (`id *new*`)',
+                        'select' =>
                             'SELECT *' .
-                            ' FROM (SELECT *, 1 AS `id ``new``` FROM `t` WHERE `id` = 1) AS `pma_tmp`' .
-                            ' WHERE NOT (`id`) <=> (`id ``new```)',
-                        'columns' => ['id', 'a', 'b', 'id `new`'],
-                        'result' => [],
+                            ' FROM (SELECT *, 1 AS `id *new*` FROM `t` WHERE `id` = 1) AS `pma_tmp`' .
+                            ' WHERE NOT (`id`) <=> (`id *new*`)',
+                        'affected_rows' => 0,
                     ],
                 ],
             ],
@@ -200,12 +209,9 @@ class SimulateDmlControllerTest extends AbstractTestCase
                 'DELETE FROM `t` WHERE `id` > 4',
                 [
                     [
-                        'simulated' => 'SELECT * FROM `t` WHERE `id` > 4',
-                        'columns' => ['id', 'a', 'b'],
-                        'result' => [
-                            [5, 2, 'test'],
-                            [6, 2, null],
-                        ],
+                        'count' => 'SELECT COUNT(*) FROM (SELECT 1 FROM `t` WHERE `id` > 4) AS pma_tmp',
+                        'select' => 'SELECT * FROM (SELECT * FROM `t` WHERE `id` > 4) AS pma_tmp',
+                        'affected_rows' => 2,
                     ],
                 ],
             ],
@@ -213,9 +219,9 @@ class SimulateDmlControllerTest extends AbstractTestCase
                 'DELETE FROM `t` WHERE 0',
                 [
                     [
-                        'simulated' => 'SELECT * FROM `t` WHERE 0',
-                        'columns' => ['id', 'a', 'b'],
-                        'result' => [],
+                        'count' => 'SELECT COUNT(*) FROM (SELECT 1 FROM `t` WHERE 0) AS pma_tmp',
+                        'select' => 'SELECT * FROM (SELECT * FROM `t` WHERE 0) AS pma_tmp',
+                        'affected_rows' => 0,
                     ],
                 ],
             ],
@@ -223,13 +229,9 @@ class SimulateDmlControllerTest extends AbstractTestCase
                 'DELETE FROM `t` ORDER BY `id` ASC LIMIT 3',
                 [
                     [
-                        'simulated' => 'SELECT * FROM `t` ORDER BY `id` ASC LIMIT 3',
-                        'columns' => ['id', 'a', 'b'],
-                        'result' => [
-                            [1, 2, 'test'],
-                            [2, 1, null],
-                            [3, 1, null],
-                        ],
+                        'count' => 'SELECT COUNT(*) FROM (SELECT 1 FROM `t` ORDER BY `id` ASC LIMIT 3) AS pma_tmp',
+                        'select' => 'SELECT * FROM (SELECT * FROM `t` ORDER BY `id` ASC LIMIT 3) AS pma_tmp',
+                        'affected_rows' => 3,
                     ],
                 ],
             ],
@@ -237,31 +239,20 @@ class SimulateDmlControllerTest extends AbstractTestCase
                 'UPDATE `t` SET `b` = `a`; DELETE FROM `t` WHERE 1',
                 [
                     [
-                        'simulated' =>
+                        'count' =>
+                            'SELECT COUNT(*)' .
+                            ' FROM (SELECT `b`, `a` AS `b *new*` FROM `t`) AS `pma_tmp`' .
+                            ' WHERE NOT (`b`) <=> (`b *new*`)',
+                        'select' =>
                             'SELECT *' .
-                            ' FROM (SELECT *, `a` AS `b ``new``` FROM `t`) AS `pma_tmp`' .
-                            ' WHERE NOT (`b`) <=> (`b ``new```)',
-                        'columns' => ['id', 'a', 'b', 'b `new`'],
-                        'result' => [
-                            [1, 2, 2, 'test'],
-                            [2, 1, 1, null],
-                            [3, 1, 1, null],
-                            [4, 1, 1, null],
-                            [5, 2, 2, 'test'],
-                            [6, 2, 2, null],
-                        ],
+                            ' FROM (SELECT *, `a` AS `b *new*` FROM `t`) AS `pma_tmp`' .
+                            ' WHERE NOT (`b`) <=> (`b *new*`)',
+                        'affected_rows' => 6,
                     ],
                     [
-                        'simulated' => 'SELECT * FROM `t` WHERE 1',
-                        'columns' => ['id', 'a', 'b'],
-                        'result' => [
-                            [1, 2, 'test'],
-                            [2, 1, null],
-                            [3, 1, null],
-                            [4, 1, null],
-                            [5, 2, 'test'],
-                            [6, 2, null],
-                        ],
+                        'count' => 'SELECT COUNT(*) FROM (SELECT 1 FROM `t` WHERE 1) AS pma_tmp',
+                        'select' => 'SELECT * FROM (SELECT * FROM `t` WHERE 1) AS pma_tmp',
+                        'affected_rows' => 6,
                     ],
                 ],
             ],
@@ -269,12 +260,15 @@ class SimulateDmlControllerTest extends AbstractTestCase
                 "UPDATE `t` SET `a` = 20 -- oops\nWHERE 0",
                 [
                     [
-                        'simulated' =>
+                        'count' =>
+                            'SELECT COUNT(*)' .
+                            ' FROM (SELECT `a`, 20 AS `a *new*` FROM `t` WHERE 0) AS `pma_tmp`' .
+                            ' WHERE NOT (`a`) <=> (`a *new*`)',
+                        'select' =>
                             'SELECT *' .
-                            ' FROM (SELECT *, 20 AS `a ``new``` FROM `t` WHERE 0) AS `pma_tmp`' .
-                            ' WHERE NOT (`a`) <=> (`a ``new```)',
-                        'columns' => ['id', 'a', 'b', 'a `new`'],
-                        'result' => [],
+                            ' FROM (SELECT *, 20 AS `a *new*` FROM `t` WHERE 0) AS `pma_tmp`' .
+                            ' WHERE NOT (`a`) <=> (`a *new*`)',
+                        'affected_rows' => 0,
                     ],
                 ],
             ],


### PR DESCRIPTION
### Description

Fixes #18941

When the modal is opened it adds `overflow: hidden` style to body.
After clicking the `Affected rows` link, scrolling was disabled because the modal was not properly closed. Intrduced in #17065
<img width="485" height="245" alt="image" src="https://github.com/user-attachments/assets/5fc1b935-e9da-4dc0-b539-21550669aa34" />

- Adds a separate query to count the affected rows to no longer load all rows from the db.
- Allows paging for the changed-rows preview, this is done by wrapping the query with limit in another SELECT query.
<img width="506" height="271" alt="image" src="https://github.com/user-attachments/assets/b699e249-857c-4f48-a3bd-4acff08dd4a9" />

- Changes the name of the new-value column from `` x `new` `` to `x *new*` to circumvent a sql-parser error

