### PR TITLE
Fix ImportXML existence check

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9441,7 +9441,7 @@ parameters:
 		-
 			message: '#^Argument of an invalid type SimpleXMLElement\|null supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
-			count: 1
+			count: 2
 			path: src/Plugins/Import/ImportXml.php
 
 		-
@@ -9477,7 +9477,7 @@ parameters:
 		-
 			message: '#^Offset ''name'' might not exist on SimpleXMLElement\|null\.$#'
 			identifier: offsetAccess.notFound
-			count: 4
+			count: 3
 			path: src/Plugins/Import/ImportXml.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6287,11 +6287,8 @@
       <code><![CDATA[string[]]]></code>
     </PossiblyUnusedReturnValue>
     <RedundantCondition>
-      <code><![CDATA[$databaseXml->table]]></code>
+      <code><![CDATA[isset($xml->database)]]></code>
     </RedundantCondition>
-    <TypeDoesNotContainType>
-      <code><![CDATA[[]]]></code>
-    </TypeDoesNotContainType>
     <UnnecessaryVarAnnotation>
       <code><![CDATA[SimpleXMLElement]]></code>
       <code><![CDATA[SimpleXMLElement]]></code>

--- a/src/Plugins/Import/ImportXml.php
+++ b/src/Plugins/Import/ImportXml.php
@@ -157,35 +157,42 @@ class ImportXml extends ImportPlugin
         /**
          * Move down the XML tree to the actual data
          */
-        $databaseXml = $xml->database;
 
         $analyses = null;
         /** @var ImportTable[] $tables */
         $tables = [];
 
-        $databaseName = (string) $databaseXml['name'];
+        $databaseName = '';
+        // SimpleXMLElement does not obey typical PHP rules.
+        // Children can be fetched through the magical __get() method,but if the child does not exist,
+        // it will return an empty SimpleXMLElement instead of null.
+        // This means that we need to check for the existence of the child before trying to access it.
+        if (isset($xml->database)) {
+            $databaseXml = $xml->database;
+            $databaseName = (string) $databaseXml['name'];
 
-        /** @var SimpleXMLElement $tableRowXml */
-        foreach ($databaseXml->table ?? [] as $tableRowXml) {
-            $tableName = (string) $tableRowXml['name'];
+            /** @var SimpleXMLElement $tableRowXml */
+            foreach ($databaseXml->table as $tableRowXml) {
+                $tableName = (string) $tableRowXml['name'];
 
-            $table = $tables[$tableName] ?? new ImportTable($tableName);
+                $table = $tables[$tableName] ?? new ImportTable($tableName);
 
-            $tableRow = [];
-            /** @var SimpleXMLElement $tableCellXml */
-            foreach ($tableRowXml->column as $tableCellXml) {
-                /** @psalm-suppress PossiblyNullArrayAccess */
-                $columnName = (string) $tableCellXml['name'];
-                if (! in_array($columnName, $table->columns, true)) {
-                    $table->columns[] = $columnName;
+                $tableRow = [];
+                /** @var SimpleXMLElement $tableCellXml */
+                foreach ($tableRowXml->column as $tableCellXml) {
+                    /** @psalm-suppress PossiblyNullArrayAccess */
+                    $columnName = (string) $tableCellXml['name'];
+                    if (! in_array($columnName, $table->columns, true)) {
+                        $table->columns[] = $columnName;
+                    }
+
+                    $tableRow[] = (string) $tableCellXml;
                 }
 
-                $tableRow[] = (string) $tableCellXml;
+                $table->rows[] = $tableRow;
+
+                $tables[$tableName] = $table;
             }
-
-            $table->rows[] = $tableRow;
-
-            $tables[$tableName] = $table;
         }
 
         unset($xml);


### PR DESCRIPTION
Fixes #20153

Alternative to #20170. Adds an explanatory comment and avoids the Psalm issue. 

`SimpleXMLElement` is a bit magical because they are both acting as an array and as a string. Fetching children can be done via the magic `__get` method. If the child does not exist, an empty `SimpleXMLElement` is returned. It is considered empty both in string and in array context, and therefore also if used in a boolean context, e.g. `if($element)` will convert to `''` which is falseish. Static analysers are not very good at identifying this, so the easiest way is to check if the child exists before fetching it. 

I think I have introduced this error in one of my refactorings because I believed incorrectly that an empty `SimpleXMLElement` would still return an empty `SimpleXMLElement` when asked for a child, but it returns `null` instead. 