### PR TITLE
Change column default string value

### DIFF
--- a/libraries/classes/Table/ColumnsDefinition.php
+++ b/libraries/classes/Table/ColumnsDefinition.php
@@ -529,11 +529,11 @@ final class ColumnsDefinition
 
                 break;
             default:
-                $metaDefault['DefaultValue'] = $columnMeta['Default'];
-
                 if (substr((string) $columnMeta['Type'], -4) === 'text') {
                     $textDefault = substr($columnMeta['Default'], 1, -1);
-                    $metaDefault['Default'] = stripcslashes($textDefault);
+                    $metaDefault['DefaultValue'] = stripcslashes($textDefault);
+                } else {
+                    $metaDefault['DefaultValue'] = $columnMeta['Default'];
                 }
 
                 break;

--- a/libraries/classes/Table/ColumnsDefinition.php
+++ b/libraries/classes/Table/ColumnsDefinition.php
@@ -510,10 +510,11 @@ final class ColumnsDefinition
 
         switch ($columnMeta['Default']) {
             case null:
-                if ($columnMeta['Null'] === 'YES') {
-                    $metaDefault['DefaultType'] = 'NULL';
+                // Could be null or empty string here
+                if ($columnMeta['Default'] === null) {
+                    $metaDefault['DefaultType'] = $columnMeta['Null'] === 'YES' ? 'NULL' : 'NONE';
                 } else {
-                    $metaDefault['DefaultType'] = 'NONE';
+                    $columnMeta['DefaultValue'] = $columnMeta['Default'];
                 }
 
                 break;

--- a/libraries/classes/Table/ColumnsDefinition.php
+++ b/libraries/classes/Table/ColumnsDefinition.php
@@ -24,10 +24,13 @@ use function explode;
 use function in_array;
 use function intval;
 use function is_array;
+use function mb_strlen;
 use function mb_strtoupper;
 use function preg_quote;
 use function preg_replace;
 use function rtrim;
+use function str_ends_with;
+use function str_starts_with;
 use function stripcslashes;
 use function substr;
 use function trim;
@@ -514,8 +517,6 @@ final class ColumnsDefinition
                 // Could be null or empty string here
                 if ($columnMeta['Default'] === null) {
                     $metaDefault['DefaultType'] = $columnMeta['Null'] === 'YES' ? 'NULL' : 'NONE';
-                } else {
-                    $columnMeta['DefaultValue'] = $columnMeta['Default'];
                 }
 
                 break;
@@ -531,8 +532,16 @@ final class ColumnsDefinition
                 break;
             default:
                 if (substr((string) $columnMeta['Type'], -4) === 'text') {
-                    $textDefault = substr($columnMeta['Default'], 1, -1);
-                    $metaDefault['DefaultValue'] = stripcslashes($textDefault);
+                    if (
+                        mb_strlen($columnMeta['Default']) >= 2 &&
+                        str_starts_with($columnMeta['Default'], "'") &&
+                        str_ends_with($columnMeta['Default'], "'")
+                    ) {
+                        $textDefault = substr($columnMeta['Default'], 1, -1);
+                        $metaDefault['DefaultValue'] = stripcslashes($textDefault);
+                    } else {
+                        $metaDefault['DefaultValue'] = $columnMeta['Default'];
+                    }
                 } else {
                     $metaDefault['DefaultValue'] = $columnMeta['Default'];
                 }

--- a/libraries/classes/Table/ColumnsDefinition.php
+++ b/libraries/classes/Table/ColumnsDefinition.php
@@ -497,9 +497,10 @@ final class ColumnsDefinition
      * Set default type and default value according to the column metadata
      *
      * @param array $columnMeta Column Metadata
-     * @phpstan-param array<string, string|null> $columnMeta
+     * @phpstan-param array{Default: string|null, Null: 'YES'|'NO', Type: string} $columnMeta
      *
-     * @return non-empty-array<array-key, mixed>
+     * @return non-empty-array<string, string>
+     * @psalm-return array{DefaultType: string, DefaultValue: string}
      */
     public static function decorateColumnMetaDefault(array $columnMeta): array
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -35566,6 +35566,11 @@ parameters:
 			path: libraries/classes/Table/ColumnsDefinition.php
 
 		-
+			message: "#^Casting to string something that's already string\\.$#"
+			count: 1
+			path: libraries/classes/Table/ColumnsDefinition.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
 			path: libraries/classes/Table/ColumnsDefinition.php
@@ -35596,7 +35601,7 @@ parameters:
 			path: libraries/classes/Table/ColumnsDefinition.php
 
 		-
-			message: "#^Parameter \\#1 \\$columnMeta of static method PhpMyAdmin\\\\Table\\\\ColumnsDefinition\\:\\:decorateColumnMetaDefault\\(\\) expects array\\<string, string\\|null\\>, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$columnMeta of static method PhpMyAdmin\\\\Table\\\\ColumnsDefinition\\:\\:decorateColumnMetaDefault\\(\\) expects array\\{Default\\: string\\|null, Null\\: 'NO'\\|'YES', Type\\: string\\}, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Table/ColumnsDefinition.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13459,6 +13459,9 @@
     <PossiblyInvalidCast occurrences="1">
       <code>$_POST['after_field']</code>
     </PossiblyInvalidCast>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string) $columnMeta['Type']</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Table/Indexes.php">
     <PossiblyInvalidArgument occurrences="1">

--- a/test/classes/Table/ColumnsDefinitionTest.php
+++ b/test/classes/Table/ColumnsDefinitionTest.php
@@ -92,9 +92,8 @@ class ColumnsDefinitionTest extends AbstractTestCase
                     'Type' => 'text',
                 ],
                 [
-                    'Default' => 'some/thing',
                     'DefaultType' => 'USER_DEFINED',
-                    'DefaultValue' => '"some\/thing"',
+                    'DefaultValue' => 'some/thing',
                 ],
             ],
             'when Default is anything else and Type is not text' => [
@@ -111,6 +110,16 @@ class ColumnsDefinitionTest extends AbstractTestCase
                 [
                     'Default' => '',
                     'Type' => 'varchar(255)',
+                ],
+                [
+                    'DefaultType' => 'USER_DEFINED',
+                    'DefaultValue' => '',
+                ],
+            ],
+            'when longtext Default is empty string' => [
+                [
+                    'Default' => "''",
+                    'Type' => 'longtext',
                 ],
                 [
                     'DefaultType' => 'USER_DEFINED',

--- a/test/classes/Table/ColumnsDefinitionTest.php
+++ b/test/classes/Table/ColumnsDefinitionTest.php
@@ -111,7 +111,7 @@ class ColumnsDefinitionTest extends AbstractTestCase
                 [
                     'Type' => 'text',
                     'Null' => 'NO',
-                    'Default' => '"some\/thing"',
+                    'Default' => "'some\\/thing'",
                 ],
                 [
                     'DefaultType' => 'USER_DEFINED',
@@ -149,6 +149,17 @@ class ColumnsDefinitionTest extends AbstractTestCase
                 [
                     'DefaultType' => 'USER_DEFINED',
                     'DefaultValue' => '',
+                ],
+            ],
+            'when text type default is an expression' => [
+                [
+                    'Type' => 'tinytext',
+                    'Null' => 'YES',
+                    'Default' => 'unix_timestamp()',
+                ],
+                [
+                    'DefaultType' => 'USER_DEFINED',
+                    'DefaultValue' => 'unix_timestamp()',
                 ],
             ],
         ];

--- a/test/classes/Table/ColumnsDefinitionTest.php
+++ b/test/classes/Table/ColumnsDefinitionTest.php
@@ -17,8 +17,8 @@ class ColumnsDefinitionTest extends AbstractTestCase
      *
      * @param array $columnMeta column metadata
      * @param array $expected   expected result
-     * @phpstan-param array<string, string|null> $columnMeta
-     * @phpstan-param array<string, string> $expected
+     * @phpstan-param array{Default: string|null, Null: 'YES'|'NO', Type: string} $columnMeta
+     * @phpstan-param array{DefaultType: string, DefaultValue: string} $expected
      *
      * @dataProvider providerColumnMetaDefault
      */
@@ -33,15 +33,19 @@ class ColumnsDefinitionTest extends AbstractTestCase
      * Data provider for testDecorateColumnMetaDefault
      *
      * @return array
-     * @psalm-return array<string, array{array<string, string|null>, array<string, string>}>
+     * @psalm-return array<string, array{
+     *   array{Default: string|null, Null: 'YES'|'NO', Type: string},
+     *   array{DefaultType: string, DefaultValue: string},
+     * }>
      */
     public static function providerColumnMetaDefault(): array
     {
         return [
             'when Default is null and Null is YES' => [
                 [
-                    'Default' => null,
+                    'Type' => 'int',
                     'Null' => 'YES',
+                    'Default' => null,
                 ],
                 [
                     'DefaultType' => 'NULL',
@@ -50,8 +54,9 @@ class ColumnsDefinitionTest extends AbstractTestCase
             ],
             'when Default is null and Null is NO' => [
                 [
-                    'Default' => null,
+                    'Type' => 'int',
                     'Null' => 'NO',
+                    'Default' => null,
                 ],
                 [
                     'DefaultType' => 'NONE',
@@ -59,28 +64,44 @@ class ColumnsDefinitionTest extends AbstractTestCase
                 ],
             ],
             'when Default is CURRENT_TIMESTAMP' => [
-                ['Default' => 'CURRENT_TIMESTAMP'],
+                [
+                    'Type' => 'timestamp',
+                    'Null' => 'NO',
+                    'Default' => 'CURRENT_TIMESTAMP',
+                ],
                 [
                     'DefaultType' => 'CURRENT_TIMESTAMP',
                     'DefaultValue' => '',
                 ],
             ],
             'when Default is current_timestamp' => [
-                ['Default' => 'current_timestamp()'],
+                [
+                    'Type' => 'datetime',
+                    'Null' => 'NO',
+                    'Default' => 'current_timestamp()',
+                ],
                 [
                     'DefaultType' => 'CURRENT_TIMESTAMP',
                     'DefaultValue' => '',
                 ],
             ],
             'when Default is UUID' => [
-                ['Default' => 'UUID'],
+                [
+                    'Type' => 'UUID',
+                    'Null' => 'NO',
+                    'Default' => 'UUID',
+                ],
                 [
                     'DefaultType' => 'UUID',
                     'DefaultValue' => '',
                 ],
             ],
             'when Default is uuid()' => [
-                ['Default' => 'uuid()'],
+                [
+                    'Type' => 'UUID',
+                    'Null' => 'YES',
+                    'Default' => 'uuid()',
+                ],
                 [
                     'DefaultType' => 'UUID',
                     'DefaultValue' => '',
@@ -88,8 +109,9 @@ class ColumnsDefinitionTest extends AbstractTestCase
             ],
             'when Default is anything else and Type is text' => [
                 [
-                    'Default' => '"some\/thing"',
                     'Type' => 'text',
+                    'Null' => 'NO',
+                    'Default' => '"some\/thing"',
                 ],
                 [
                     'DefaultType' => 'USER_DEFINED',
@@ -98,8 +120,9 @@ class ColumnsDefinitionTest extends AbstractTestCase
             ],
             'when Default is anything else and Type is not text' => [
                 [
-                    'Default' => '"some\/thing"',
                     'Type' => 'something',
+                    'Null' => 'NO',
+                    'Default' => '"some\/thing"',
                 ],
                 [
                     'DefaultType' => 'USER_DEFINED',
@@ -108,8 +131,9 @@ class ColumnsDefinitionTest extends AbstractTestCase
             ],
             'when varchar Default is empty string' => [
                 [
-                    'Default' => '',
                     'Type' => 'varchar(255)',
+                    'Null' => 'YES',
+                    'Default' => '',
                 ],
                 [
                     'DefaultType' => 'USER_DEFINED',
@@ -118,8 +142,9 @@ class ColumnsDefinitionTest extends AbstractTestCase
             ],
             'when longtext Default is empty string' => [
                 [
-                    'Default' => "''",
                     'Type' => 'longtext',
+                    'Null' => 'YES',
+                    'Default' => "''",
                 ],
                 [
                     'DefaultType' => 'USER_DEFINED',

--- a/test/classes/Table/ColumnsDefinitionTest.php
+++ b/test/classes/Table/ColumnsDefinitionTest.php
@@ -107,6 +107,16 @@ class ColumnsDefinitionTest extends AbstractTestCase
                     'DefaultValue' => '"some\/thing"',
                 ],
             ],
+            'when varchar Default is empty string' => [
+                [
+                    'Default' => '',
+                    'Type' => 'varchar(255)',
+                ],
+                [
+                    'DefaultType' => 'USER_DEFINED',
+                    'DefaultValue' => '',
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fixes the column editing problem from #16801.
The default value for text columns is still displayed in quotes in the table structure page.

Example table, when editing, both column Default values should be `As defined:` with empty string value
```sql
CREATE TABLE `empty_default` (
`c1` TINYTEXT NOT NULL DEFAULT '', 
`c2` VARCHAR(77) NOT NULL DEFAULT '' 
) ENGINE = InnoDB;
```

The problem with the missing default value when it is an empty string was introduces in 8929288efd592047c81df3b9b8b8a8151edaac41

The problem with quotes not being removed when editing a text column is probably even older, the value was assigned to the wrong property.