### PR TITLE
Fix create new user with single quote in password

### DIFF
--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -3554,7 +3554,7 @@ class Privileges
                     $hashedPassword = $_POST['pma_pw'];
                 }
 
-                $createUserReal = sprintf($createUserStmt, $hashedPassword);
+                $createUserReal = sprintf($createUserStmt, $this->dbi->escapeString($hashedPassword));
                 $createUserShow = sprintf($createUserStmt, '***');
             }
         } else {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -32772,7 +32772,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:escapeString\\(\\) expects string, mixed given\\.$#"
-			count: 15
+			count: 16
 			path: libraries/classes/Server/Privileges.php
 
 		-
@@ -32823,11 +32823,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$userGroup of method PhpMyAdmin\\\\Server\\\\Privileges\\:\\:setUserGroup\\(\\) expects string, mixed given\\.$#"
 			count: 2
-			path: libraries/classes/Server/Privileges.php
-
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
-			count: 1
 			path: libraries/classes/Server/Privileges.php
 
 		-
@@ -47237,7 +47232,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method expects\\(\\) on mixed\\.$#"
-			count: 5
+			count: 6
 			path: test/classes/Server/PrivilegesTest.php
 
 		-
@@ -47247,12 +47242,12 @@ parameters:
 
 		-
 			message: "#^Cannot call method method\\(\\) on mixed\\.$#"
-			count: 5
+			count: 6
 			path: test/classes/Server/PrivilegesTest.php
 
 		-
 			message: "#^Cannot call method will\\(\\) on mixed\\.$#"
-			count: 5
+			count: 6
 			path: test/classes/Server/PrivilegesTest.php
 
 		-
@@ -47262,7 +47257,7 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:any\\(\\)\\.$#"
-			count: 30
+			count: 31
 			path: test/classes/Server/PrivilegesTest.php
 
 		-
@@ -47287,12 +47282,17 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:returnArgument\\(\\)\\.$#"
-			count: 8
+			count: 7
+			path: test/classes/Server/PrivilegesTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:returnCallback\\(\\)\\.$#"
+			count: 1
 			path: test/classes/Server/PrivilegesTest.php
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:returnValue\\(\\)\\.$#"
-			count: 21
+			count: 22
 			path: test/classes/Server/PrivilegesTest.php
 
 		-
@@ -47337,7 +47337,7 @@ parameters:
 
 		-
 			message: "#^Property PhpMyAdmin\\\\Server\\\\Privileges\\:\\:\\$dbi \\(PhpMyAdmin\\\\DatabaseInterface\\) does not accept mixed\\.$#"
-			count: 9
+			count: 10
 			path: test/classes/Server/PrivilegesTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -12394,7 +12394,7 @@
       <code>$oldUserGroup</code>
       <code>$user</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="28">
+    <PossiblyInvalidCast occurrences="29">
       <code>$_GET['username']</code>
       <code>$_POST['authentication_plugin']</code>
       <code>$_POST['authentication_plugin']</code>
@@ -12422,6 +12422,7 @@
       <code>$dbname</code>
       <code>$dbname[0]</code>
       <code>$eachUser</code>
+      <code>$hashedPassword</code>
       <code>$oldUserGroup</code>
     </PossiblyInvalidCast>
     <PossiblyInvalidOperand occurrences="8">
@@ -15930,7 +15931,7 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$this-&gt;serverPrivileges-&gt;extractPrivInfo(null, true)</code>
     </MixedArgumentTypeCoercion>
-    <MixedMethodCall occurrences="19">
+    <MixedMethodCall occurrences="21">
       <code>getMessage</code>
       <code>getMessage</code>
       <code>getMessage</code>
@@ -15945,6 +15946,8 @@
       <code>method</code>
       <code>method</code>
       <code>method</code>
+      <code>method</code>
+      <code>will</code>
       <code>will</code>
       <code>will</code>
       <code>will</code>
@@ -15954,7 +15957,8 @@
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>assertNull</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedMethod occurrences="5">
+    <UndefinedMethod occurrences="6">
+      <code>expects</code>
       <code>expects</code>
       <code>expects</code>
       <code>expects</code>

--- a/test/classes/Server/PrivilegesTest.php
+++ b/test/classes/Server/PrivilegesTest.php
@@ -29,6 +29,7 @@ use function _pgettext;
 use function htmlspecialchars;
 use function implode;
 use function preg_quote;
+use function str_replace;
 
 use const PHP_VERSION_ID;
 
@@ -118,7 +119,9 @@ class PrivilegesTest extends AbstractTestCase
             ->will($this->returnValue($resultStub));
 
         $dbi->expects($this->any())->method('escapeString')
-            ->will($this->returnArgument(0));
+            ->will($this->returnCallback(static function (string $arg0): string {
+                return str_replace(['\\', "'"], ['\\\\', "\\'"], $arg0);
+            }));
 
         $dbi->expects($this->any())->method('isCreateUser')
             ->will($this->returnValue(true));
@@ -245,7 +248,7 @@ class PrivilegesTest extends AbstractTestCase
         self::assertSame(" WHERE `User` LIKE 'INIT%' OR `User` LIKE 'init%'", $ret);
 
         $ret = $this->serverPrivileges->rangeOfUsers('%');
-        self::assertSame(' WHERE `User` LIKE \'\\%%\' OR `User` LIKE \'\\%%\'', $ret);
+        self::assertSame(" WHERE `User` LIKE '\\\\%%' OR `User` LIKE '\\\\%%'", $ret);
 
         $ret = $this->serverPrivileges->rangeOfUsers('');
         self::assertSame(" WHERE `User` = ''", $ret);
@@ -336,7 +339,7 @@ class PrivilegesTest extends AbstractTestCase
         $ret = $this->serverPrivileges->getSqlQueryForDisplayPrivTable($db, $table, $username, $hostname);
         self::assertSame('SELECT `Table_priv` FROM `mysql`.`tables_priv` '
         . "WHERE `User` = 'pma_username' AND "
-        . "`Host` = 'pma_hostname' AND `Db` = 'db' AND' AND "
+        . "`Host` = 'pma_hostname' AND `Db` = 'db\\' AND' AND "
         . "`Table_name` = 'pma_table';", $ret);
     }
 
@@ -759,6 +762,35 @@ class PrivilegesTest extends AbstractTestCase
 
         //validate 2: $create_user_show
         self::assertSame('CREATE USER \'PMA_username\'@\'PMA_hostname\' IDENTIFIED BY \'***\';', $create_user_show);
+    }
+
+    /**
+     * Test case for getSqlQueriesForDisplayAndAddUser
+     */
+    public function testGetSqlQueriesForDisplayAndAddUserMySql8044EscapePw(): void
+    {
+        $GLOBALS['dbi']->expects($this->any())->method('getVersion')
+            ->will($this->returnValue(80044));
+        $this->serverPrivileges->dbi = $GLOBALS['dbi'];
+
+        $username = 'PMA_username';
+        $hostname = 'PMA_hostname';
+        $_POST['pred_password'] = 'userdefined';
+        $_POST['pma_pw'] = 'pma_password\'';
+
+        [
+            $create_user_real,
+            $create_user_show,
+        ] = $this->serverPrivileges->getSqlQueriesForDisplayAndAddUser($username, $hostname, '');
+
+        //validate 1: $create_user_real
+        self::assertSame(
+            "CREATE USER 'PMA_username'@'PMA_hostname' IDENTIFIED BY 'pma_password\\'';",
+            $create_user_real
+        );
+
+        //validate 2: $create_user_show
+        self::assertSame("CREATE USER 'PMA_username'@'PMA_hostname' IDENTIFIED BY '***';", $create_user_show);
     }
 
     /**


### PR DESCRIPTION
When creating a user, the new password was not escaped when it is used as clear text in the SQL query.