### PR TITLE
Fix #19842 - skip user link for non-real users in processes list

### DIFF
--- a/templates/server/status/processes/list.twig
+++ b/templates/server/status/processes/list.twig
@@ -46,7 +46,7 @@
           </td>
           <td class="font-monospace text-end">{{ row.id }}</td>
           <td>
-            {% if row.user != 'system user' %}
+            {% if row.user not in ['system user', 'event_scheduler', 'unauthenticated user'] %}
               <a href="{{ url('/server/privileges', {
                   'username': row.user,
                   'hostname': row.host,


### PR DESCRIPTION
The processes list currently links every user name to the privileges page.
Pseudo-users like `event_scheduler` and `unauthenticated user` have no
corresponding entry in the user accounts table, so the link leads to an
empty or broken page.

This extends the existing `system user` check to also cover
`event_scheduler` and `unauthenticated user` by switching the condition
to a Twig `not in` list.

Fixes #19842