### PR TITLE
Fix #20181 - allow selecting text fragments in cells

### DIFF
--- a/resources/js/makegrid.ts
+++ b/resources/js/makegrid.ts
@@ -2615,8 +2615,9 @@ const makeGrid = function (t, enableResize = undefined, enableReorder = undefine
 
                 selectCell(this);
 
-                // Prevent text selection
-                e.preventDefault();
+                $(g.t).on('mouseleave.cellSelect', 'td.data', function () {
+                    window.getSelection().removeAllRanges();
+                });
 
                 // Dynamic mouseover for drag
                 $(g.t).on('mouseover.cellSelect', 'td.data, thead th:not(.column_action)', function (e) {
@@ -2659,13 +2660,15 @@ const makeGrid = function (t, enableResize = undefined, enableReorder = undefine
                 $(document).on('mouseup.cellSelect', function () {
                     g.isSelectingCells = false;
                     $(g.t).off('mouseover.cellSelect');
+                    $(g.t).off('mouseleave.cellSelect');
                     $(document).off('mouseup.cellSelect');
                 });
             });
 
             // Copy handler
             $(document).on('copy', function (e) {
-                if (!document.body.contains(g.t) || g.isCellEditActive) {
+                const selection = window.getSelection();
+                if (!document.body.contains(g.t) || g.isCellEditActive || (selection.rangeCount > 0 && !selection.isCollapsed)) {
                     return;
                 }
 


### PR DESCRIPTION
### Description

Fix https://github.com/phpmyadmin/phpmyadmin/issues/20181 

Users can now select partial text within a cell as before. At the same time, multi-cell selection for copying is also supported; if the cursor moves to another cell while the mouse is pressed, the text selection is cleared to allow for cell selection.

[2026-03-27 16-14-35.webm](https://github.com/user-attachments/assets/efc4bba2-c656-495e-9155-3df3c4e48f65)
