### PR TITLE
Fix #18204 - Remove getInnodbPluginVersion() and refactor getInnodbFileFormat() for MariaDB compatibility

### DIFF
--- a/libraries/classes/Engines/Innodb.php
+++ b/libraries/classes/Engines/Innodb.php
@@ -294,7 +294,8 @@ class Innodb extends StorageEngine
 
         return
           ($dbi->isMariaDB() && $dbi->getVersion() >= 100600)
-          || ($dbi->isMySql() && $dbi->getVersion() >= 80000) ? '' : $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_format';", 1);
+          || ($dbi->isMySql() && $dbi->getVersion() >= 80000) ? ''
+            : $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_format';", 1);
     }
 
     /**

--- a/libraries/classes/Engines/Innodb.php
+++ b/libraries/classes/Engines/Innodb.php
@@ -288,7 +288,7 @@ class Innodb extends StorageEngine
      *
      * @return string|null the InnoDB file format
      */
-    public function getInnodbFileFormat(): string|null
+    public function getInnodbFileFormat()
     {
         global $dbi;
 

--- a/libraries/classes/Engines/Innodb.php
+++ b/libraries/classes/Engines/Innodb.php
@@ -292,10 +292,10 @@ class Innodb extends StorageEngine
     {
         global $dbi;
 
-        return (
+        return
           ($dbi->isMariaDB() && $dbi->getVersion() >= 100600)
-          || ($dbi->isMySql() && $dbi->getVersion() >= 80000) 
-        ) ? '' : $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_format';", 1);
+          || ($dbi->isMySql() && $dbi->getVersion() >= 80000)
+        ? '' : $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_format';", 1);
     }
 
     /**

--- a/libraries/classes/Engines/Innodb.php
+++ b/libraries/classes/Engines/Innodb.php
@@ -282,37 +282,20 @@ class Innodb extends StorageEngine
     }
 
     /**
-     * Gets the InnoDB plugin version number
-     *
-     * @return string the version number, or empty if not running as a plugin
-     */
-    public function getInnodbPluginVersion()
-    {
-        global $dbi;
-
-        return $dbi->fetchValue('SELECT @@innodb_version;') ?: '';
-    }
-
-    /**
      * Gets the InnoDB file format
      *
      * (do not confuse this with phpMyAdmin's storage engine plugins!)
      *
      * @return string|null the InnoDB file format
      */
-    public function getInnodbFileFormat(): ?string
+    public function getInnodbFileFormat(): string|null
     {
         global $dbi;
 
-        $value = $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_format';", 1);
-
-        if ($value === false) {
-            // This variable does not exist anymore on MariaDB >= 10.6.0
-            // This variable does not exist anymore on MySQL >= 8.0.0
-            return null;
-        }
-
-        return (string) $value;
+        return (
+          ($dbi->isMariaDB() && $dbi->getVersion() >= 100600)
+          || ($dbi->isMySql() && $dbi->getVersion() >= 80000) 
+        ) ? '' : $dbi->fetchValue("SELECT @@innodb_file_format;");
     }
 
     /**

--- a/libraries/classes/Engines/Innodb.php
+++ b/libraries/classes/Engines/Innodb.php
@@ -294,7 +294,8 @@ class Innodb extends StorageEngine
 
         return
           ($dbi->isMariaDB() && $dbi->getVersion() >= 100600)
-          || ($dbi->isMySql() && $dbi->getVersion() >= 80000) ? ''
+          || ($dbi->isMySql() && $dbi->getVersion() >= 80000)
+            ? ''
             : $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_format';", 1);
     }
 

--- a/libraries/classes/Engines/Innodb.php
+++ b/libraries/classes/Engines/Innodb.php
@@ -294,8 +294,7 @@ class Innodb extends StorageEngine
 
         return
           ($dbi->isMariaDB() && $dbi->getVersion() >= 100600)
-          || ($dbi->isMySql() && $dbi->getVersion() >= 80000)
-        ? '' : $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_format';", 1);
+          || ($dbi->isMySql() && $dbi->getVersion() >= 80000) ? '' : $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_format';", 1);
     }
 
     /**

--- a/libraries/classes/Engines/Innodb.php
+++ b/libraries/classes/Engines/Innodb.php
@@ -295,7 +295,7 @@ class Innodb extends StorageEngine
         return (
           ($dbi->isMariaDB() && $dbi->getVersion() >= 100600)
           || ($dbi->isMySql() && $dbi->getVersion() >= 80000) 
-        ) ? '' : $dbi->fetchValue("SELECT @@innodb_file_format;");
+        ) ? '' : $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_format';");
     }
 
     /**

--- a/libraries/classes/Engines/Innodb.php
+++ b/libraries/classes/Engines/Innodb.php
@@ -295,7 +295,7 @@ class Innodb extends StorageEngine
         return (
           ($dbi->isMariaDB() && $dbi->getVersion() >= 100600)
           || ($dbi->isMySql() && $dbi->getVersion() >= 80000) 
-        ) ? '' : $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_format';");
+        ) ? '' : $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_format';", 1);
     }
 
     /**

--- a/libraries/classes/Operations.php
+++ b/libraries/classes/Operations.php
@@ -519,11 +519,7 @@ class Operations
 
         /** @var Innodb $innodbEnginePlugin */
         $innodbEnginePlugin = StorageEngine::getEngine('Innodb');
-        $innodbPluginVersion = $innodbEnginePlugin->getInnodbPluginVersion();
-        $innodb_file_format = '';
-        if (! empty($innodbPluginVersion)) {
-            $innodb_file_format = $innodbEnginePlugin->getInnodbFileFormat() ?? '';
-        }
+        $innodb_file_format = $innodbEnginePlugin->getInnodbFileFormat();
 
         /**
          * Newer MySQL/MariaDB always return empty a.k.a '' on $innodb_file_format otherwise

--- a/test/classes/Engines/InnodbTest.php
+++ b/test/classes/Engines/InnodbTest.php
@@ -226,14 +226,6 @@ class InnodbTest extends AbstractTestCase
     }
 
     /**
-     * Test for getInnodbPluginVersion
-     */
-    public function testGetInnodbPluginVersion(): void
-    {
-        self::assertSame('1.1.8', $this->object->getInnodbPluginVersion());
-    }
-
-    /**
      * Test for supportsFilePerTable
      */
     public function testSupportsFilePerTable(): void


### PR DESCRIPTION
### Description

Starting from version 10.10 MariaDB removed the system variable 'innodb_version' (https://jira.mariadb.org/browse/MDEV-28554), so clicking on the 'Operations' link produces an error in the SQL errors log (if enabled):

ERROR 1193: Unknown system variable 'innodb_version' : SELECT @@innodb_version

Fixes https://github.com/phpmyadmin/phpmyadmin/issues/18204

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
