### PR TITLE
Fix #20063 - Fix routine, event and trigger duplication when editing 

### DIFF
--- a/resources/js/database/events.ts
+++ b/resources/js/database/events.ts
@@ -116,11 +116,11 @@ const DatabaseEvents = {
                 eventsExportModal.querySelector('.modal-body').innerHTML = eventsExportTextarea;
                 document.getElementById('eventsExportTextarea').textContent = data.message;
                 getSqlEditor($('#eventsExportTextarea'));
-            });
+            }, { once: true });
 
             eventsExportModal.addEventListener('hidden.bs.modal', function () {
                 eventsExportModal.querySelector('.modal-body').innerHTML = eventsExportTextarea;
-            });
+            }, { once: true });
 
             bootstrap.Modal.getOrCreateInstance(eventsExportModal).show();
         }
@@ -325,14 +325,14 @@ const DatabaseEvents = {
                 };
                 that.syntaxHiglighter = getSqlEditor($elm, {}, 'vertical', linterOptions);
                 window.codeMirrorEditor = that.syntaxHiglighter;
-            });
+            }, { once: true });
 
             eventsEditorModal.addEventListener('hidden.bs.modal', function () {
                 const eventsEditorModalSaveButton = document.getElementById('eventsEditorModalSaveButton');
                 eventsEditorModalSaveButton?.removeEventListener('click', eventsEditorModalSaveEventHandler);
                 document.getElementById('eventsEditorModal').querySelector('.modal-body').innerHTML = '<div class="spinner-border" role="status">' +
                     '<span class="visually-hidden">' + window.Messages.strLoading + '</span></div>';
-            });
+            }, { once: true });
 
             bootstrap.Modal.getOrCreateInstance(eventsEditorModal).show();
         });

--- a/resources/js/database/routines.ts
+++ b/resources/js/database/routines.ts
@@ -132,11 +132,11 @@ const DatabaseRoutines = {
                 routinesExportModal.querySelector('.modal-body').innerHTML = routinesExportTextarea;
                 document.getElementById('routinesExportTextarea').textContent = data.message;
                 getSqlEditor($('#routinesExportTextarea'));
-            });
+            }, { once: true });
 
             routinesExportModal.addEventListener('hidden.bs.modal', function () {
                 routinesExportModal.querySelector('.modal-body').innerHTML = routinesExportTextarea;
-            });
+            }, { once: true });
 
             bootstrap.Modal.getOrCreateInstance(routinesExportModal).show();
         }
@@ -348,14 +348,14 @@ const DatabaseRoutines = {
 
                 // Execute item-specific code
                 that.postDialogShow(data);
-            });
+            }, { once: true });
 
             routinesEditorModal.addEventListener('hidden.bs.modal', function () {
                 const routinesEditorModalSaveButton = document.getElementById('routinesEditorModalSaveButton');
                 routinesEditorModalSaveButton?.removeEventListener('click', routinesEditorModalSaveEventHandler);
                 document.getElementById('routinesEditorModal').querySelector('.modal-body').innerHTML = '<div class="spinner-border" role="status">' +
                     '<span class="visually-hidden">' + window.Messages.strLoading + '</span></div>';
-            });
+            }, { once: true });
 
             bootstrap.Modal.getOrCreateInstance(routinesEditorModal).show();
         });
@@ -840,7 +840,7 @@ const DatabaseRoutines = {
 
                 const routinesExecuteModalExecuteButton = document.getElementById('routinesExecuteModalExecuteButton');
                 routinesExecuteModalExecuteButton?.removeEventListener('click', routinesExecuteButtonEventHandler);
-            });
+            }, { once: true });
 
             routinesExecuteModal.addEventListener('shown.bs.modal', function () {
                 routinesExecuteModal.querySelector('.modal-title').textContent = data.title;
@@ -890,7 +890,7 @@ const DatabaseRoutines = {
                         modal.hide();
                     });
                 });
-            });
+            }, { once: true });
 
             modal.show();
         });

--- a/resources/js/triggers.ts
+++ b/resources/js/triggers.ts
@@ -123,11 +123,11 @@ const DatabaseTriggers = {
                 triggersExportModal.querySelector('.modal-body').innerHTML = triggersExportTextarea;
                 document.getElementById('triggersExportTextarea').textContent = data.message;
                 getSqlEditor($('#triggersExportTextarea'));
-            });
+            }, { once: true });
 
             triggersExportModal.addEventListener('hidden.bs.modal', function () {
                 triggersExportModal.querySelector('.modal-body').innerHTML = triggersExportTextarea;
-            });
+            }, { once: true });
 
             bootstrap.Modal.getOrCreateInstance(triggersExportModal).show();
         }
@@ -334,14 +334,14 @@ const DatabaseTriggers = {
                 };
                 that.syntaxHiglighter = getSqlEditor($elm, {}, 'vertical', linterOptions);
                 window.codeMirrorEditor = that.syntaxHiglighter;
-            });
+            }, { once: true });
 
             triggersEditorModal.addEventListener('hidden.bs.modal', function () {
                 const triggersEditorModalSaveButton = document.getElementById('triggersEditorModalSaveButton');
                 triggersEditorModalSaveButton?.removeEventListener('click', triggersEditorModalSaveEventHandler);
                 document.getElementById('triggersEditorModal').querySelector('.modal-body').innerHTML = '<div class="spinner-border" role="status">' +
                     '<span class="visually-hidden">' + window.Messages.strLoading + '</span></div>';
-            });
+            }, { once: true });
 
             bootstrap.Modal.getOrCreateInstance(triggersEditorModal).show();
         });


### PR DESCRIPTION
## Summary                                                                                      
- Modal event listeners (`shown.bs.modal`, `hidden.bs.modal`) accumulated on each `editorDialog()` call, causing duplicate rows after repeated edits                              
- Added `{ once: true }` to all affected listeners in routines, events, and triggers
- Same fix applied to editor, export, and execute modals                                                                                                                                   
                                                                                                  
Fixes #20063 