### PR TITLE
Fix #20041 - Fix export for raw queries without table reference

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15054,7 +15054,7 @@ parameters:
 				Use dependency injection instead\.$#
 			'''
 			identifier: staticMethod.deprecated
-			count: 1
+			count: 2
 			path: tests/unit/Controllers/Table/ExportControllerTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2128,24 +2128,12 @@
     </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Controllers/Table/ExportController.php">
-    <MixedArgument>
-      <code><![CDATA[Current::$database]]></code>
-      <code><![CDATA[Current::$table]]></code>
-    </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[Current::$whereClause]]></code>
     </MixedArgumentTypeCoercion>
-    <MixedPropertyTypeCoercion>
-      <code><![CDATA[UrlParams::$params]]></code>
-      <code><![CDATA[UrlParams::$params]]></code>
-      <code><![CDATA[['db' => Current::$database, 'table' => Current::$table]]]></code>
-    </MixedPropertyTypeCoercion>
     <PossiblyNullArgument>
       <code><![CDATA[$parser->list]]></code>
     </PossiblyNullArgument>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[Response]]></code>
-    </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Controllers/Table/ExportRowsController.php">
     <InvalidPropertyAssignmentValue>
@@ -9430,6 +9418,7 @@
   </file>
   <file src="tests/unit/Controllers/Table/ExportControllerTest.php">
     <DeprecatedMethod>
+      <code><![CDATA[Config::getInstance()]]></code>
       <code><![CDATA[Config::getInstance()]]></code>
     </DeprecatedMethod>
   </file>

--- a/src/Controllers/Table/ExportController.php
+++ b/src/Controllers/Table/ExportController.php
@@ -45,11 +45,13 @@ readonly class ExportController implements InvocableController
 
         $this->response->addScriptFiles(['export.js']);
 
-        if (Current::$database === '') {
+        $isRawQuery = $request->has('raw_query');
+
+        if (Current::$database === '' && ! $isRawQuery) {
             return $this->response->missingParameterError('db');
         }
 
-        if (Current::$table === '') {
+        if (Current::$table === '' && ! $isRawQuery) {
             return $this->response->missingParameterError('table');
         }
 

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -3457,7 +3457,7 @@ class Results
              * first table of this database, so that /table/export and
              * the script it calls do not fail
              */
-            if ($urlParams['table'] === '' && $urlParams['db'] !== '') {
+            if (! isset($urlParams['raw_query']) && $urlParams['table'] === '' && $urlParams['db'] !== '') {
                 $urlParams['table'] = (string) $this->dbi->fetchValue('SHOW TABLES');
             }
 

--- a/tests/unit/Controllers/Table/ExportControllerTest.php
+++ b/tests/unit/Controllers/Table/ExportControllerTest.php
@@ -124,4 +124,39 @@ class ExportControllerTest extends AbstractTestCase
         (new ExportController($response, $options, $pageSettings))(self::createStub(ServerRequest::class));
         self::assertSame($expected, $response->getHTMLResult());
     }
+
+    public function testExportControllerWithRawQuery(): void
+    {
+        Current::$database = '';
+        Current::$table = '';
+        Current::$sqlQuery = 'SELECT 1 as foo';
+        $config = Config::getInstance();
+        $config->selectedServer = $config->getSettings()->Servers[1]->asArray();
+
+        $dbi = $this->createDatabaseInterface();
+        DatabaseInterface::$instance = $dbi;
+
+        $response = new ResponseRenderer();
+        $relation = new Relation($dbi, $config);
+        $template = new Template($config);
+        $userPreferences = new UserPreferences($dbi, $relation, $template, $config, new Clock());
+        $pageSettings = new PageSettings($userPreferences, $response);
+
+        $userPreferencesHandler = new UserPreferencesHandler(
+            $config,
+            $dbi,
+            $userPreferences,
+            new LanguageManager($config),
+            new ThemeManager(),
+        );
+        $options = new Options($relation, new TemplateModel($dbi), $userPreferencesHandler);
+
+        $request = self::createStub(ServerRequest::class);
+        $request->method('has')->willReturnMap([['raw_query', true], ['single_table', false]]);
+
+        $result = (new ExportController($response, $options, $pageSettings))($request);
+
+        // Should return 200 instead of 400 for missing db/table params
+        self::assertSame(200, $result->getStatusCode());
+    }
 }


### PR DESCRIPTION
### Description

- Raw queries like `SELECT 1 as foo` failed to export because `/table/export` required `db` and `table` parameters
- Skip `db`/`table` validation in `ExportController` when `raw_query` is set                    
- Skip `SHOW TABLES` workaround in `Results.php` for raw queries to avoid injecting a fake table name
- Added unit test for the raw query export case

Fixes #20041