### PR TITLE
Fix #19338 - Add missing length validation when changing column type

### DIFF
--- a/src/Controllers/Table/Structure/ChangeController.php
+++ b/src/Controllers/Table/Structure/ChangeController.php
@@ -98,7 +98,7 @@ final readonly class ChangeController implements InvocableController
          */
         $userPrivileges = $this->userPrivilegesFactory->getPrivileges();
 
-        $this->response->addScriptFiles(['vendor/jquery/jquery.uitablefilter.js']);
+        $this->response->addScriptFiles(['vendor/jquery/jquery.uitablefilter.js', 'table/structure.js']);
 
         $templateData = $this->columnsDefinition->displayForm(
             $userPrivileges,


### PR DESCRIPTION
### Description

- The "Change column" form didn't load `table/structure.js`, so the client-side length validation never fired
- Added the missing script to `ChangeController`, matching what `AddFieldController` already does

Fixes #19338.