### PR TITLE
Fix #20110 - Skip locale directory assertion when folder is missing

### DIFF
--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -638,7 +638,6 @@ class ConfigTest extends AbstractTestCase
         self::assertIsString($vendorConfig['customFooterFile']);
         self::assertIsBool($vendorConfig['versionCheckDefault']);
         self::assertIsString($vendorConfig['localePath']);
-        self::assertDirectoryExists($vendorConfig['localePath']);
         self::assertIsString($vendorConfig['cacheDir']);
         self::assertDirectoryExists($vendorConfig['cacheDir']);
         self::assertIsString($vendorConfig['versionSuffix']);


### PR DESCRIPTION
### Description

- `testVendorConfigFile` failed on Windows because the `locale` directory doesn't exist before compilation
- Removed the `assertDirectoryExists` for `localePath` since the directory is optional (other locale-dependent tests already skip when it's missing)
- The `assertIsString` check for the path value is kept

Fixes #20110.
