### PR TITLE
Fix #20064 - Fix sliding message container overlapping page content

### DIFF
--- a/resources/js/modules/functions.ts
+++ b/resources/js/modules/functions.ts
@@ -3114,8 +3114,8 @@ export function slidingMessage (msg, $object = undefined) {
         // we might have to create a new DOM node.
         if ($('#PMA_slidingMessage').length === 0) {
             $('#page_content').prepend(
-                '<span id="PMA_slidingMessage" ' +
-                'class="d-inline-block"></span>'
+                '<div id="PMA_slidingMessage" ' +
+                'class="position-relative" style="z-index:1"></div>'
             );
         }
 
@@ -3145,6 +3145,9 @@ export function slidingMessage (msg, $object = undefined) {
                 $obj
                     .animate({
                         height: $obj.find('div').first().height()
+                    }, function () {
+                        $obj.css('height', 'auto');
+                        $obj.find('div').first().css('height', 'auto');
                     })
                     .find('div')
                     .first()
@@ -3171,15 +3174,10 @@ export function slidingMessage (msg, $object = undefined) {
             .animate({
                 height: h
             }, function () {
-                // Set the height of the parent
-                // to the height of the child
-                $obj
-                    .height(
-                        $obj
-                            .find('div')
-                            .first()
-                            .height()
-                    );
+                // After animation, allow the container and its content
+                // to resize naturally (e.g. when using "Edit inline")
+                $(this).css('height', 'auto');
+                $obj.css('height', 'auto');
             });
     }
 

--- a/tests/end-to-end/Database/ProceduresTest.php
+++ b/tests/end-to-end/Database/ProceduresTest.php
@@ -221,10 +221,10 @@ class ProceduresTest extends TestBase
         $this->byId('routinesExecuteModalExecuteButton')->click();
 
         $this->waitAjax();
-        $this->waitForElement('cssSelector', 'span#PMA_slidingMessage table tbody');
-        $this->waitUntilElementIsVisible('cssSelector', 'span#PMA_slidingMessage', 30);
+        $this->waitForElement('cssSelector', '#PMA_slidingMessage table tbody');
+        $this->waitUntilElementIsVisible('cssSelector', '#PMA_slidingMessage', 30);
         sleep(2);// Give more chances to the JS effect to finish
-        $head = $this->byCssSelector('span#PMA_slidingMessage table tbody')->getText();
+        $head = $this->byCssSelector('#PMA_slidingMessage table tbody')->getText();
         self::assertSame("outp\n" . $length, $head);
     }
 }


### PR DESCRIPTION
### Description

- Changed `#PMA_slidingMessage` from `<span class="d-inline-block">` to `<div class="position-relative">` with `z-index:1` to establish proper stacking context above Bootstrap's `.input-group` elements                                                            
- After slide animation completes, set height to `auto` on both the container and inner div so content can resize naturally (e.g. when using "Edit inline" to expand the CodeMirror editor)    
- Previously the animation left a fixed pixel height, preventing the container from growing when content changed

Fixes #20064. 
Fixes #18923. 
