### PR TITLE
Fix .gitignore for *.pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,8 +51,7 @@ web.config
 /docs/html
 /docs/linkcheck/
 /docs/locale
-/docs/*.pyc
-/docs/*.swp
+/docs/**/*.pyc
 
 # Demo server
 revision-info.php


### PR DESCRIPTION
Looks like `/docs/*.pyc` is not the same as `*.pyc` inside the `/docs/` directory. The line `/docs/**/*.pyc` should also be included. But there's no .pyc file inside docs, so only the second is needed. And `/docs/*.swp` is already covered by a previous line.

- Related to https://github.com/phpmyadmin/phpmyadmin/pull/20233

