### PR TITLE
Fix #19225 - Fix wrong row count when column alias shadows existing column name

### DIFF
--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -781,8 +781,17 @@ class Sql
                 // Removes LIMIT clause that might have been added
                 $statement->limit = null;
 
-                if ($changeExpression) {
-                    $statement->expr[0] = new Expression();
+                // Replace SELECT expressions with 1 to avoid
+                // "Duplicate column name" errors when aliases shadow
+                // existing column names (e.g. SELECT id, name AS id).
+                // Only safe when there's no GROUP BY, DISTINCT, or UNION
+                // since those depend on the actual expressions.
+                if (
+                    $analyzedSqlResults['is_group'] === false
+                    && $analyzedSqlResults['distinct'] === false
+                    && $analyzedSqlResults['union'] === false
+                ) {
+                    $statement->expr = [new Expression()];
                     $statement->expr[0]->expr = '1';
                 }
 

--- a/test/classes/SqlTest.php
+++ b/test/classes/SqlTest.php
@@ -513,7 +513,8 @@ class SqlTest extends AbstractTestCase
                 ],
                 20,
                 42,
-
+                false,
+                'SELECT COUNT(*) FROM (SELECT 1 FROM company_users WHERE subquery_case = 0 ) as cnt',
             ],
             [
                 'SELECT ( as c2 FROM company_users WHERE working_count = 0',// Invalid query
@@ -545,6 +546,14 @@ class SqlTest extends AbstractTestCase
                 100,
                 false,
                 'SELECT COUNT(*) FROM (SELECT 1 FROM t1 WHERE id <> 0 ) as cnt',
+            ],
+            'duplicate column alias should not break count' => [
+                'SELECT id, name AS id FROM company_users WHERE working_count = 0',
+                ['max_rows' => 10, 'pos' => 0],
+                25,
+                384,
+                false,
+                'SELECT COUNT(*) FROM (SELECT 1 FROM company_users WHERE working_count = 0 ) as cnt',
             ],
         ];
     }


### PR DESCRIPTION
## Summary                                                                                      
  - When a SELECT aliases a column with the same name as another column (e.g.h`SELECT id, name AS
  id`), the row count display was incorrect (showed total table rows instead of filtered rows)    
  - Root cause: the COUNT subquery `SELECT COUNT(*) FROM (SELECT id, name AS id ...) as cnt` fails
   with MySQL error "Duplicate column name", causing a fallback to `countRecords()` which counts  
  all rows without the WHERE clause                         
  - Fix: replace all SELECT expressions with `SELECT 1` in the count subquery (when no GROUP BY,  
  DISTINCT, or UNION), since only the row count matters, not the column values                    
  - This also improves performance for queries with expensive subqueries in the SELECT list, as   
  they are no longer executed during counting                                                     
                                                                                                                              
                                                            
  Fixes #19225