### PR TITLE
Fix #19080 - Show correct query in confirmation prompt after inline edit

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -762,7 +762,10 @@ Functions.confirmQuery = function (theForm1, sqlQuery1) {
 Functions.checkSqlQuery = function (theForm) {
     // get the textarea element containing the query
     var sqlQuery;
-    if (codeMirrorEditor) {
+    if (codeMirrorInlineEditor) {
+        codeMirrorInlineEditor.save();
+        sqlQuery = codeMirrorInlineEditor.getValue();
+    } else if (codeMirrorEditor) {
         codeMirrorEditor.save();
         sqlQuery = codeMirrorEditor.getValue();
     } else {


### PR DESCRIPTION
## Summary
  - After editing a query inline and submitting, the confirmation prompt showed the old query instead of the new one
  - Root cause: `checkSqlQuery()` always read from the global `codeMirrorEditor` instead of the active
  `codeMirrorInlineEditor`
  - Fix: check `codeMirrorInlineEditor` first, fall back to `codeMirrorEditor`

  ## How to verify
  1. Create a table with multiple columns (e.g. `email` and `phone`)
  2. Execute `ALTER TABLE t1 DROP COLUMN email` and accept the confirmation
  3. Click "Edit inline"
  4. Change the query to `ALTER TABLE t1 DROP COLUMN phone`
  5. Click Go
  6. The confirmation prompt should now show "DROP COLUMN phone" (before this fix it showed "DROP COLUMN email")

  Fixes #19080