### PR TITLE
Fix #19627 - Reset UNSIGNED attribute when changing to non-numeric co…

### DIFF
--- a/resources/js/modules/functions.ts
+++ b/resources/js/modules/functions.ts
@@ -737,7 +737,7 @@ export function checkTableEditForm (theForm, fieldsCnt) {
         const typeVal = String($typeField.val() || '').toUpperCase();
         const attrVal = String($attrField.val() || '').toUpperCase();
         if (attrVal === 'UNSIGNED' || attrVal === 'UNSIGNED ZEROFILL' || attrVal === 'ZEROFILL') {
-            var numTypes = [
+            const numTypes = [
                 'TINYINT',
                 'SMALLINT',
                 'MEDIUMINT',

--- a/resources/js/modules/functions.ts
+++ b/resources/js/modules/functions.ts
@@ -738,8 +738,14 @@ export function checkTableEditForm (theForm, fieldsCnt) {
         var attrVal = String($attrField.val() || '').toUpperCase();
         if (attrVal === 'UNSIGNED' || attrVal === 'UNSIGNED ZEROFILL' || attrVal === 'ZEROFILL') {
             var numTypes = [
-                'TINYINT', 'SMALLINT', 'MEDIUMINT', 'INT', 'BIGINT',
-                'FLOAT', 'DOUBLE', 'DECIMAL',
+                'TINYINT',
+                'SMALLINT',
+                'MEDIUMINT',
+                'INT',
+                'BIGINT',
+                'FLOAT',
+                'DOUBLE',
+                'DECIMAL',
             ];
             elm3 = $('#field_' + i + '_1');
             if (numTypes.indexOf(typeVal) === -1 && elm3.val() !== '') {
@@ -1598,8 +1604,14 @@ function showNoticeForEnum (selectElement) {
 function resetAttributeForNonNumericType ($typeSelector) {
     var type = String($typeSelector.val() || '').toUpperCase();
     var numericTypes = [
-        'TINYINT', 'SMALLINT', 'MEDIUMINT', 'INT', 'BIGINT',
-        'FLOAT', 'DOUBLE', 'DECIMAL',
+        'TINYINT',
+        'SMALLINT',
+        'MEDIUMINT',
+        'INT',
+        'BIGINT',
+        'FLOAT',
+        'DOUBLE',
+        'DECIMAL',
     ];
 
     if (numericTypes.indexOf(type) === -1) {

--- a/resources/js/modules/functions.ts
+++ b/resources/js/modules/functions.ts
@@ -749,9 +749,9 @@ export function checkTableEditForm (theForm, fieldsCnt) {
             ];
             elm3 = $('#field_' + i + '_1');
             if (numTypes.indexOf(typeVal) === -1 && elm3.val() !== '') {
-                $attrField.select();
-                alert(typeVal + ' ' + window.Messages.strInvalidAttribute);
-                $attrField.focus();
+                $attrField.trigger('select');
+                ajaxShowMessage(typeVal + ' ' + window.Messages.strInvalidAttribute, null, 'error');
+                $attrField.trigger('focus');
 
                 return false;
             }

--- a/resources/js/modules/functions.ts
+++ b/resources/js/modules/functions.ts
@@ -1616,9 +1616,9 @@ function resetAttributeForNonNumericType ($typeSelector) {
 
     if (numericTypes.indexOf(type) === -1) {
         // Find the attribute select in the same row
-        var $row = $typeSelector.closest('tr');
-        var $attrSelect = $row.find('select[name^="field_attribute"]');
-        var currentAttr = String($attrSelect.val() || '').toUpperCase();
+        const $row = $typeSelector.closest('tr');
+        const $attrSelect = $row.find('select[name^="field_attribute"]');
+        const currentAttr = String($attrSelect.val() || '').toUpperCase();
         if (currentAttr === 'UNSIGNED' || currentAttr === 'UNSIGNED ZEROFILL'
             || currentAttr === 'ZEROFILL'
         ) {

--- a/resources/js/modules/functions.ts
+++ b/resources/js/modules/functions.ts
@@ -732,10 +732,10 @@ export function checkTableEditForm (theForm, fieldsCnt) {
         }
 
         // Check for UNSIGNED/ZEROFILL on non-numeric types
-        var $typeField = $('#field_' + i + '_2');
-        var $attrField = $typeField.closest('tr').find('select[name^="field_attribute"]');
-        var typeVal = String($typeField.val() || '').toUpperCase();
-        var attrVal = String($attrField.val() || '').toUpperCase();
+        const $typeField = $('#field_' + i + '_2');
+        const $attrField = $typeField.closest('tr').find('select[name^="field_attribute"]');
+        const typeVal = String($typeField.val() || '').toUpperCase();
+        const attrVal = String($attrField.val() || '').toUpperCase();
         if (attrVal === 'UNSIGNED' || attrVal === 'UNSIGNED ZEROFILL' || attrVal === 'ZEROFILL') {
             var numTypes = [
                 'TINYINT',

--- a/resources/js/modules/functions.ts
+++ b/resources/js/modules/functions.ts
@@ -1602,8 +1602,8 @@ function showNoticeForEnum (selectElement) {
  * are only valid for numeric types.
  */
 function resetAttributeForNonNumericType ($typeSelector) {
-    var type = String($typeSelector.val() || '').toUpperCase();
-    var numericTypes = [
+    const type = String($typeSelector.val() || '').toUpperCase();
+    const numericTypes = [
         'TINYINT',
         'SMALLINT',
         'MEDIUMINT',

--- a/resources/js/modules/functions.ts
+++ b/resources/js/modules/functions.ts
@@ -731,6 +731,26 @@ export function checkTableEditForm (theForm, fieldsCnt) {
             }
         }
 
+        // Check for UNSIGNED/ZEROFILL on non-numeric types
+        var $typeField = $('#field_' + i + '_2');
+        var $attrField = $typeField.closest('tr').find('select[name^="field_attribute"]');
+        var typeVal = String($typeField.val() || '').toUpperCase();
+        var attrVal = String($attrField.val() || '').toUpperCase();
+        if (attrVal === 'UNSIGNED' || attrVal === 'UNSIGNED ZEROFILL' || attrVal === 'ZEROFILL') {
+            var numTypes = [
+                'TINYINT', 'SMALLINT', 'MEDIUMINT', 'INT', 'BIGINT',
+                'FLOAT', 'DOUBLE', 'DECIMAL',
+            ];
+            elm3 = $('#field_' + i + '_1');
+            if (numTypes.indexOf(typeVal) === -1 && elm3.val() !== '') {
+                $attrField.select();
+                alert(typeVal + ' ' + window.Messages.strInvalidAttribute);
+                $attrField.focus();
+
+                return false;
+            }
+        }
+
         if (atLeastOneField === 0) {
             id = 'field_' + i + '_1';
             if (! emptyCheckTheField(theForm, id)) {
@@ -1570,6 +1590,31 @@ function showNoticeForEnum (selectElement) {
 /**
  * Hides/shows a warning message when LENGTH is used with inappropriate integer type
  */
+/**
+ * Reset the attribute dropdown when the column type is changed
+ * to a non-numeric type. Attributes like UNSIGNED and ZEROFILL
+ * are only valid for numeric types.
+ */
+function resetAttributeForNonNumericType ($typeSelector) {
+    var type = String($typeSelector.val() || '').toUpperCase();
+    var numericTypes = [
+        'TINYINT', 'SMALLINT', 'MEDIUMINT', 'INT', 'BIGINT',
+        'FLOAT', 'DOUBLE', 'DECIMAL',
+    ];
+
+    if (numericTypes.indexOf(type) === -1) {
+        // Find the attribute select in the same row
+        var $row = $typeSelector.closest('tr');
+        var $attrSelect = $row.find('select[name^="field_attribute"]');
+        var currentAttr = String($attrSelect.val() || '').toUpperCase();
+        if (currentAttr === 'UNSIGNED' || currentAttr === 'UNSIGNED ZEROFILL'
+            || currentAttr === 'ZEROFILL'
+        ) {
+            $attrSelect.val('');
+        }
+    }
+}
+
 function showWarningForIntTypes () {
     if (! $('div#length_not_allowed').length) {
         return;
@@ -2144,6 +2189,7 @@ export function onloadEnumSetEditorMessage (): void {
     $(document).on('change', 'select.column_type', function () {
         showNoticeForEnum($(this));
         showWarningForIntTypes();
+        resetAttributeForNonNumericType($(this));
     });
 
     $(document).on('change', 'select.default_type', function () {

--- a/src/Controllers/JavaScriptMessagesController.php
+++ b/src/Controllers/JavaScriptMessagesController.php
@@ -116,6 +116,7 @@ final readonly class JavaScriptMessagesController implements InvocableController
             'strRadioUnchecked' => __('Select at least one of the options!'),
             'strEnterValidNumber' => __('Please enter a valid number!'),
             'strEnterValidLength' => __('Please enter a valid length!'),
+            'strInvalidAttribute' => __('does not support the UNSIGNED attribute.'),
             'strAddIndex' => __('Add index'),
             'strEditIndex' => __('Edit index'),
             /* l10n: Rename a table Index */


### PR DESCRIPTION
## Summary                                                                                                          
  - When changing a column from INT UNSIGNED to VARCHAR, the UNSIGNED attribute stayed selected, producing invalid SQL
  - Added two fixes:                                                                                                  
    1. Automatically reset the attribute dropdown when the type changes to a non-numeric type                         
    2. Validate on submit that UNSIGNED/ZEROFILL is not used with non-numeric types, showing an error message         
                                                                                                                      
  ## How to verify                                                                                                    
  1. Create table with `INTEGER UNSIGNED` column                                                                      
  2. Change → switch type to VARCHAR(32) → attribute dropdown resets automatically                                    
  3. Manually re-select UNSIGNED → click Save → validation error appears                                              
                                                                                                                      
  Fixes #19627