### PR TITLE
Fix #19939 - Use TEXT instead of VARCHAR when CSV column exceeds max …

### DIFF
--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -1098,9 +1098,19 @@ class Import
                         $size = 10;
                     }
 
+                    $colType = $typeArray[$analyses[$i][self::TYPES][$j]];
+
+                    // Use TEXT instead of VARCHAR when the length exceeds
+                    // the maximum allowed for VARCHAR. The limit depends on
+                    // the charset (e.g. 16383 for utf8mb4, 65535 for latin1).
+                    // We use the most restrictive limit (utf8mb4) to be safe.
+                    if ($colType === 'varchar' && (int) $size > 16383) {
+                        $colType = 'text';
+                    }
+
                     $tempSQLStr .= Util::backquote($tables[$i][self::COL_NAMES][$j]) . ' '
-                    . $typeArray[$analyses[$i][self::TYPES][$j]];
-                    if ($analyses[$i][self::TYPES][$j] != self::GEOMETRY) {
+                    . $colType;
+                    if ($colType !== 'text' && $analyses[$i][self::TYPES][$j] != self::GEOMETRY) {
                         $tempSQLStr .= '(' . $size . ')';
                     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -20242,7 +20242,7 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to int\\.$#"
-			count: 3
+			count: 4
 			path: libraries/classes/Import.php
 
 		-


### PR DESCRIPTION
## Summary                                                                                                          
  - When importing a CSV file with values longer than 16383 characters, phpMyAdmin generated `VARCHAR(17256)` which   
  exceeds MySQL's maximum VARCHAR length for utf8mb4                                                                  
  - Now uses `TEXT` instead of `VARCHAR` when the detected column size exceeds 16383 (the most restrictive limit,     
  based on utf8mb4's 4 bytes per character)                                                                           
                                                                                                                    
  ## How to verify                                                                                                    
  1. Create a CSV file with a value longer than 16383 characters                                                    
  2. Import it via Database → Import                                                                                  
  3. Table should be created with `TEXT` column instead of failing with an error
                                                                                                                      
  Fixes #19939