### PR TITLE
Fix #19084 - Skip CREATE DATABASE when exporting data only

### DIFF
--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -879,6 +879,11 @@ class ExportSql extends ExportPlugin
             return true;
         }
 
+        // Skip CREATE DATABASE when only exporting data
+        if (! $exportStructure) {
+            return $this->exportUseStatement($dbAlias, $compat);
+        }
+
         $createQuery = 'CREATE DATABASE IF NOT EXISTS '
             . Util::backquoteCompat($dbAlias, $compat, isset($GLOBALS['sql_backquotes']));
         $collation = $dbi->getDbCollation($db);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27002,7 +27002,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$compat of method PhpMyAdmin\\\\Plugins\\\\Export\\\\ExportSql\\:\\:exportUseStatement\\(\\) expects string, mixed given\\.$#"
-			count: 2
+			count: 3
 			path: libraries/classes/Plugins/Export/ExportSql.php
 
 		-
@@ -46512,7 +46512,7 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:any\\(\\)\\.$#"
-			count: 25
+			count: 26
 			path: test/classes/Plugins/Export/ExportSqlTest.php
 
 		-
@@ -46532,7 +46532,7 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:returnArgument\\(\\)\\.$#"
-			count: 15
+			count: 16
 			path: test/classes/Plugins/Export/ExportSqlTest.php
 
 		-

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -471,6 +471,31 @@ class ExportSqlTest extends AbstractTestCase
         self::assertStringContainsString('USE db;', $result);
     }
 
+    public function testExportDBCreateDataOnly(): void
+    {
+        $GLOBALS['sql_compatibility'] = 'NONE';
+        $GLOBALS['sql_backquotes'] = true;
+        $GLOBALS['sql_create_database'] = true;
+        $GLOBALS['sql_structure_or_data'] = 'data';
+        $GLOBALS['crlf'] = "\n";
+
+        $dbi = $this->getMockBuilder(DatabaseInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $dbi->expects($this->any())->method('escapeString')
+            ->will($this->returnArgument(0));
+
+        $GLOBALS['dbi'] = $dbi;
+
+        ob_start();
+        self::assertTrue($this->object->exportDBCreate('db', 'server'));
+        $result = ob_get_clean();
+
+        self::assertIsString($result);
+        self::assertStringNotContainsString('CREATE DATABASE', $result);
+        self::assertStringContainsString('USE `db`;', $result);
+    }
+
     public function testExportDBHeader(): void
     {
         $GLOBALS['sql_compatibility'] = 'MSSQL';


### PR DESCRIPTION
## Summary
  - When doing a server export with "data" only, `CREATE DATABASE IF NOT EXISTS` was still included in the SQL output 
  - The `$exportStructure` check was only guarding the `DROP DATABASE` statement, not the `CREATE DATABASE` statement 
  - Added an early return to skip `CREATE DATABASE` when only data is being exported, while keeping the `USE`         
  statement                                                                                                           
                                                                                                                      
  **Note:** This bug also exists on master (6.0.0-dev) with the same root cause.                                      
                                                            
  ## Test plan                                                                                                        
  - [ ] Server export → Custom → SQL → select database → "data" only → no `CREATE DATABASE` in output
  - [ ] Server export → "structure and data" → `CREATE DATABASE` still present                                        
  - [ ] Database export → data only → still works correctly                                                           
  - [ ] Added unit test `testExportDBCreateDataOnly`                                                                  
                                                                                                                      
  Fixes #19084