### PR TITLE
Fix #20253 - Missing parameter: db when clicking on index in tree

### DIFF
--- a/resources/templates/navigation/tree/node.twig
+++ b/resources/templates/navigation/tree/node.twig
@@ -36,7 +36,11 @@
       {% if node_is_container %}
         &nbsp;<a class="hover_show_full disableAjax" href="{{ url(text_link.route, text_link.params) }}">{{ node.name }}</a>
       {% elseif 'index' in node.classes %}
-        <a class="hover_show_full disableAjax" href="{{ url(text_link.route) }}" data-post="{{ get_common(text_link.params|merge({'is_from_nav': true})) }}" title="{{ text_link.title }}">
+        {# No `disableAjax`: this link relies on `data-post` for its params, which #}
+        {# is consumed by the AJAX request handler (Generator::linkOrButton). With #}
+        {# `disableAjax` the browser navigates natively to the href, which carries #}
+        {# only the route, and the controller fails with "Missing parameter: db". #}
+        <a class="hover_show_full" href="{{ url(text_link.route) }}" data-post="{{ get_common(text_link.params|merge({'is_from_nav': true})) }}" title="{{ text_link.title }}">
           {{- displayName -}}
         </a>
       {% else %}

--- a/tests/unit/Navigation/NavigationTreeTest.php
+++ b/tests/unit/Navigation/NavigationTreeTest.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Current;
 use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Navigation\NavigationTree;
+use PhpMyAdmin\Navigation\Nodes\NodeIndex;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
@@ -95,5 +96,48 @@ class NavigationTreeTest extends AbstractTestCase
         self::assertStringContainsString('<div class="list_container" style="display: none;">', $result);
         self::assertStringContainsString('functions__a', $result);
         self::assertStringContainsString('functions__b', $result);
+    }
+
+    /**
+     * Regression test for https://github.com/phpmyadmin/phpmyadmin/issues/20253:
+     * The link to a specific index in the navigation tree must NOT have the
+     * `disableAjax` class. The link relies on `data-post` for `db`/`table`/
+     * `index`, which is consumed by the AJAX request handler — with
+     * `disableAjax` the browser navigates natively to the bare href and the
+     * controller fails with "Missing parameter: db".
+     */
+    public function testIndexNodeLinkUsesAjaxFlow(): void
+    {
+        $config = new Config();
+        $template = new Template($config);
+        $node = new NodeIndex($this->createDatabaseInterface(), $config, 'idx_mail');
+
+        $output = $template->render('navigation/tree/node', [
+            'node' => $node,
+            'displayName' => 'idx_mail',
+            'class' => '',
+            'show_node' => true,
+            'has_siblings' => false,
+            'li_classes' => '',
+            'control_buttons' => '',
+            'node_is_container' => false,
+            'has_second_icon' => false,
+            'recursive' => ['html' => '', 'has_wrapper' => false, 'is_hidden' => false],
+            'icon_links' => [],
+            'text_link' => [
+                'route' => '/table/indexes',
+                'params' => ['db' => 'testdb', 'table' => 'users', 'index' => 'idx_mail'],
+                'title' => 'Edit',
+                'is_ajax' => false,
+            ],
+            'pagination_params' => [],
+            'node_is_group' => false,
+            'link_classes' => '',
+            'paths' => ['a_path' => '', 'v_path' => '', 'pos' => 0],
+            'node_icon' => '',
+        ]);
+
+        self::assertStringContainsString('data-post=', $output);
+        self::assertStringNotContainsString('class="hover_show_full disableAjax"', $output);
     }
 }


### PR DESCRIPTION
Closes #20253.

Clicking an index in the navigation tree (or the "New" entry under the
Indexes group) produced "Missing parameter: db". The link relies on
`data-post` to carry `db`/`table`/`index`/`is_from_nav`, which the AJAX
request handler reads via `getPostData()`. Commit 38b796fc78 ("Disable
AJAX for navigation sidebar links") added the `disableAjax` class to all
nav-tree links, including this branch — that bypasses the AJAX handler
and lets the browser navigate natively to the bare href, dropping the
data-post and breaking the controller.

Fix: drop `disableAjax` from the index branch only. The other branches
keep their params in the href and are unaffected. Adds a regression test
asserting the rendered link contains `data-post=` and does not have the
`hover_show_full disableAjax` class combination.

Signed-off-by: Nicolai Ehrhardt <245527909+predictor2718@users.noreply.github.com>