### PR TITLE
Fix #20254 - Tree collapses when clicking on a column in nav tree

### DIFF
--- a/resources/js/modules/navigation/event-loader.ts
+++ b/resources/js/modules/navigation/event-loader.ts
@@ -313,10 +313,14 @@ export default function onloadNavigation () {
                 typeof storage.navTreePaths === 'undefined'
             ) {
                 Navigation.reload();
-            } else if (CommonParams.get('server') === storage.server &&
+            } else if (String(CommonParams.get('server')) === storage.server &&
                 CommonParams.get('token') === storage.token
             ) {
-                // Reload the tree to the state before page refresh
+                // Reload the tree to the state before page refresh.
+                // `server` is a number in CommonParams but a string in sessionStorage
+                // (sessionStorage stringifies values), so coerce to string before
+                // comparing — otherwise the strict equality always fails and the
+                // saved expansion paths get discarded.
                 Navigation.reload(Navigation.filterStateRestore, JSON.parse(storage.navTreePaths));
             } else {
                 // If the user is different


### PR DESCRIPTION
Closes #20254.

`CommonParams.get('server')` returns a **number** (`1`); `sessionStorage`
stringifies values, so `storage.server` is `"1"`. Strict equality on
`number` vs `string` always fails, so the page-load logic in
`event-loader.ts` falls into the `else` branch on every reload — it wipes
the saved tree paths via `treeStateUpdate()` and calls `Navigation.reload()`
without them, collapsing the tree.

The bug was latent until 38b796fc78 added `disableAjax` to all nav-tree
links and made every click trigger a full page reload.

Fix: coerce to string before comparing.

Verified end-to-end with Playwright against MySQL 8.