### PR TITLE
Fix #17713 - Show clear error when SQL setup files are missing

### DIFF
--- a/libraries/classes/ConfigStorage/Relation.php
+++ b/libraries/classes/ConfigStorage/Relation.php
@@ -1515,7 +1515,10 @@ class Relation
     public function getDefaultPmaTableNames(array $tableNameReplacements): array
     {
         $pma_tables = [];
-        $create_tables_file = (string) file_get_contents(SQL_DIR . 'create_tables.sql');
+        // The sql/ directory may have been removed by the user (per FAQ 1.44),
+        // so don't emit a warning when the file is missing. The empty result
+        // signals to fixPmaTables() that no tables can be created.
+        $create_tables_file = (string) @file_get_contents(SQL_DIR . 'create_tables.sql');
 
         $queries = explode(';', $create_tables_file);
 
@@ -1645,6 +1648,26 @@ class Relation
                 if ($create) {
                     if ($createQueries == null) { // first create
                         $createQueries = $this->getDefaultPmaTableNames($tableNameReplacements);
+                        if ($createQueries === []) {
+                            // The SQL setup files (sql/create_tables.sql) are
+                            // missing — most likely the user removed the sql/
+                            // directory per FAQ 1.44 to save disk space. We
+                            // can't create the configuration storage without
+                            // them, so give the user a clear error rather than
+                            // a TypeError further down.
+                            $sqlDir = SQL_DIR . '';
+                            $GLOBALS['message'] = sprintf(
+                                __(
+                                    'Cannot create the phpMyAdmin configuration storage:'
+                                    . ' the SQL setup files in %s are missing. Please restore'
+                                    . ' the directory from the phpMyAdmin distribution.'
+                                ),
+                                $sqlDir
+                            );
+
+                            return;
+                        }
+
                         if (! $this->dbi->selectDb($db, DatabaseInterface::CONNECT_CONTROL)) {
                             $GLOBALS['message'] = $this->dbi->getError(DatabaseInterface::CONNECT_CONTROL);
 


### PR DESCRIPTION
Closes #17713.

When the user removes the `sql/` directory (per FAQ 1.44 to reduce installed
size on disk) and then clicks "Create" on the configuration-storage prompt,
`Relation::getDefaultPmaTableNames()` returns an empty array (`file_get_contents`
fails). `Relation::fixPmaTables()` then accessed `$createQueries[$table]` which
was undefined, ending up with `tryQuery(null, ...)` — `TypeError`, HTTP 500.

This patch:
- Suppresses the `file_get_contents` warning when the SQL file is missing (the
  `sql/` directory is intentionally removable per FAQ).
- Detects the empty-result case in `fixPmaTables()` and sets a clear message
  pointing the user at the missing directory, instead of crashing.

Before / after with the `sql/` directory removed:

<img width="1854" height="909" alt="issue17713-before" src="https://github.com/user-attachments/assets/79989f23-1b84-44be-961d-cf3528ea7d85" />
<img width="1854" height="909" alt="issue17713-after" src="https://github.com/user-attachments/assets/ecdca887-41b7-48c9-9ba6-89549ac774f9" />


A parallel PR for master/6.0-dev will follow (same fix, different file paths).