### PR TITLE
Fix #17713 - Show clear error when SQL setup files are missing

### DIFF
--- a/src/ConfigStorage/Relation.php
+++ b/src/ConfigStorage/Relation.php
@@ -1244,7 +1244,10 @@ class Relation
     public function getCreateTableSqlQueries(array $tableNameReplacements): array
     {
         $pmaTables = [];
-        $createTablesFile = (string) file_get_contents(SQL_DIR . 'create_tables.sql');
+        // The resources/sql/ directory may have been removed by the user (per
+        // FAQ 1.44), so don't emit a warning when the file is missing. The
+        // empty result signals to fixPmaTables() that no tables can be created.
+        $createTablesFile = (string) @file_get_contents(SQL_DIR . 'create_tables.sql');
 
         $queries = explode(';', $createTablesFile);
 
@@ -1344,6 +1347,25 @@ class Relation
         $createQueries = [];
         if ($create) {
             $createQueries = $this->getCreateTableSqlQueries($tableNameReplacements);
+            if ($createQueries === []) {
+                // The SQL setup files (resources/sql/create_tables.sql) are
+                // missing — most likely the user removed the resources/sql/
+                // directory per FAQ 1.44 to save disk space. We can't create
+                // the configuration storage without them, so give the user a
+                // clear error rather than a TypeError further down.
+                $sqlDir = SQL_DIR . '';
+                Current::$message = Message::error(sprintf(
+                    __(
+                        'Cannot create the phpMyAdmin configuration storage:'
+                        . ' the SQL setup files in %s are missing. Please restore'
+                        . ' the directory from the phpMyAdmin distribution.',
+                    ),
+                    $sqlDir,
+                ));
+
+                return;
+            }
+
             if (! $this->dbi->selectDb($db, ConnectionType::ControlUser)) {
                 Current::$message = Message::error($this->dbi->getError(ConnectionType::ControlUser));
 


### PR DESCRIPTION
Closes #17713 (parallel of #20293 for master/6.0-dev — same fix at the new file paths).

When the user removes the `resources/sql/` directory (per FAQ 1.44 to reduce
installed size on disk) and then clicks "Create" on the configuration-storage
prompt, `Relation::getCreateTableSqlQueries()` returns an empty array
(`file_get_contents` fails). `Relation::fixPmaTables()` then accessed
`$createQueries[$table]` which was undefined, ending up with
`tryQuery(null, ...)` — `TypeError`, HTTP 500.

This patch:
- Suppresses the `file_get_contents` warning when the SQL file is missing (the
  `resources/sql/` directory is intentionally removable per FAQ).
- Detects the empty-result case in `fixPmaTables()` and sets a clear message
  pointing the user at the missing directory, instead of crashing.

Verified end-to-end against MySQL 8 — clicking "Create" with the
`resources/sql/` directory removed now shows
"Cannot create the phpMyAdmin configuration storage: the SQL setup files in
/…/resources/sql/ are missing. Please restore the directory from the
phpMyAdmin distribution." instead of an "Internal error: TypeError".


Error message after the fix:

<img width="1854" height="909" alt="issue17713-master-after" src="https://github.com/user-attachments/assets/6629d079-6ecb-413e-8f05-213c19acb79a" />
