### PR TITLE
Fix #20256 - Restore active preferences tab after page refresh

### DIFF
--- a/js/src/config.js
+++ b/js/src/config.js
@@ -44,6 +44,7 @@ AJAX.registerTeardown('config.js', function () {
     $('form.prefs-form').off('change').off('submit');
     $(document).off('click', 'div.click-hide-message');
     $('#prefs_autoload').find('a').off('click');
+    $('form.config-form').off('shown.bs.tab');
 });
 
 AJAX.registerOnload('config.js', function () {
@@ -51,6 +52,43 @@ AJAX.registerOnload('config.js', function () {
     $topmenuUpt.find('a.active').attr('rel', 'samepage');
     $topmenuUpt.find('a:not(.active)').attr('rel', 'newpage');
 });
+
+// ------------------------------------------------------------------
+// Tabbed forms - tab state persistence via location.hash
+//
+
+function setupConfigTabsPersistence () {
+    var $form = $('form.config-form');
+    if (!$form.length) {
+        return;
+    }
+
+    // Activate the tab indicated by the URL hash on page load
+    var hash = window.location.hash;
+    if (hash && /^#[a-zA-Z0-9_]+$/.test(hash)) {
+        var $tabLink = $form.find('a[data-bs-toggle="tab"][href="' + hash + '"]');
+        if ($tabLink.length) {
+            bootstrap.Tab.getOrCreateInstance($tabLink[0]).show();
+        }
+    }
+
+    // Keep the URL hash and the tab_hash hidden input in sync when the user switches tabs
+    $form.on('shown.bs.tab', '[data-bs-toggle="tab"]', function () {
+        var href = $(this).attr('href');
+        if (href) {
+            window.location.hash = href;
+            $form.find('input[name="tab_hash"]').val(href.replace(/^#/, ''));
+        }
+    });
+}
+
+AJAX.registerOnload('config.js', function () {
+    setupConfigTabsPersistence();
+});
+
+//
+// END: Tabbed forms
+// ------------------------------------------------------------------
 
 // default values for fields
 var defaultValues = {};

--- a/test/selenium/ServerSettingsTest.php
+++ b/test/selenium/ServerSettingsTest.php
@@ -102,6 +102,32 @@ class ServerSettingsTest extends TestBase
     }
 
     /**
+     * Tests that the active preferences tab is restored after a page refresh
+     *
+     * @group large
+     */
+    public function testActiveTabRestoredAfterRefresh(): void
+    {
+        $this->byPartialLinkText('Main panel')->click();
+        $this->waitAjax();
+
+        $this->waitForElement('className', 'nav-tabs');
+
+        // Switch to a non-default tab
+        $this->byCssSelector("a[href='#Tabs']")->click();
+        self::assertTrue($this->byId('Tabs')->isDisplayed());
+        self::assertFalse($this->byId('Startup')->isDisplayed());
+
+        // Reload the page – the hash is preserved in the URL
+        $this->reloadPage();
+        $this->waitAjax();
+
+        // The previously active tab must still be shown
+        self::assertTrue($this->byId('Tabs')->isDisplayed());
+        self::assertFalse($this->byId('Startup')->isDisplayed());
+    }
+
+    /**
      * Tests if hiding the logo works or not
      *
      * @group large


### PR DESCRIPTION
Fixes #20256

## What this fixes

On all preferences pages (`/preferences/features`, `/preferences/sql`, `/preferences/navigation`, `/preferences/main-panel`, etc.) the active sub-tab was not remembered after a page refresh or after clicking Apply — the page always reset to the first tab.

## Root cause

This is a **regression** that affects both **5.2 and 6.0**.

Commit **53f5247811** ("Merge FormDisplay::getDisplay templates") replaced the old custom `ul.tabs` jQuery tab system with Bootstrap `data-bs-toggle="tab"`. The old implementation in `js/config.js` had:

- `setTab()` — set `location.hash = 'tab_' + tabId` and wrote the value into `input[name=tab_hash]`
- `setupConfigTabs()` — wired up tab click handlers
- `window.onhashchange` — read `location.hash` on page load and activated the matching tab

When Bootstrap tabs were introduced, all three were deleted without a replacement, even though the **PHP side was never broken**: `MainPanelController` (and all other preferences controllers) still read `tab_hash` from the POST body and redirect to the same URL with the tab ID as a URL fragment via `UserPreferences::getUrlToRedirect()`.

## Fix

Restore the behaviour using Bootstrap's own API in `js/src/config.js`:

1. **On page load** — read `window.location.hash` and activate the matching tab via `bootstrap.Tab.getOrCreateInstance()`.
2. **On `shown.bs.tab`** — write the tab id back to `window.location.hash` and to `input[name=tab_hash]`, so the PHP redirect after Apply also lands on the correct tab.
3. **On teardown** — remove the `shown.bs.tab` listener to avoid leaks across AJAX navigation.

## Test

Added a Selenium E2E test `testActiveTabRestoredAfterRefresh` in `ServerSettingsTest` that:
1. Navigates to Main panel preferences
2. Switches to the "Tabs" sub-tab
3. Reloads the page
4. Asserts that "Tabs" is still active and "Startup" is not visible