### PR TITLE
Fix #20198 - Show bookmarks with blank database in any database

### DIFF
--- a/libraries/classes/Bookmark.php
+++ b/libraries/classes/Bookmark.php
@@ -250,7 +250,8 @@ class Bookmark
             . " WHERE ( `user` = ''"
             . " OR `user` = '" . $dbi->escapeString($user) . "' )";
         if ($db !== false) {
-            $query .= " AND dbase = '" . $dbi->escapeString($db) . "'";
+            $query .= " AND ( dbase = ''"
+                . " OR dbase = '" . $dbi->escapeString($db) . "' )";
         }
 
         $query .= ' ORDER BY label ASC';
@@ -308,7 +309,8 @@ class Bookmark
             . ' WHERE ' . Util::backquote($id_field)
             . " = '" . $dbi->escapeString((string) $id) . "'";
         if ($db !== '') {
-            $query .= " AND dbase = '" . $dbi->escapeString($db) . "'";
+            $query .= " AND ( dbase = ''"
+                . " OR dbase = '" . $dbi->escapeString($db) . "' )";
         }
 
         if (! $action_bookmark_all) {

--- a/test/classes/BookmarkTest.php
+++ b/test/classes/BookmarkTest.php
@@ -36,8 +36,11 @@ class BookmarkTest extends AbstractTestCase
     {
         $this->dummyDbi->addResult(
             'SELECT * FROM `phpmyadmin`.`pma_bookmark` WHERE ( `user` = \'\' OR `user` = \'root\' )'
-                . ' AND dbase = \'sakila\' ORDER BY label ASC',
-            [['1', 'sakila', 'root', 'label', 'SELECT * FROM `actor` WHERE `actor_id` < 10;']],
+                . ' AND ( dbase = \'\' OR dbase = \'sakila\' ) ORDER BY label ASC',
+            [
+                ['1', 'sakila', 'root', 'sakila-only', 'SELECT * FROM `actor` WHERE `actor_id` < 10;'],
+                ['2', '', 'root', 'shared', 'SELECT 1;'],
+            ],
             ['id', 'dbase', 'user', 'label', 'query']
         );
         $actual = Bookmark::getList(
@@ -47,6 +50,7 @@ class BookmarkTest extends AbstractTestCase
             'sakila'
         );
         self::assertContainsOnlyInstancesOf(Bookmark::class, $actual);
+        self::assertCount(2, $actual);
         $this->assertAllSelectsConsumed();
     }
 

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -2492,7 +2492,8 @@ class DbiDummy implements DbiExtension
             ],
             [
                 'query' => 'SELECT * FROM `information_schema`.`bookmark` WHERE `label` = \'test_tbl\''
-                . ' AND dbase = \'my_db\' AND (user = \'user\') LIMIT 1',
+                . ' AND ( dbase = \'\' OR dbase = \'my_db\' )'
+                . ' AND (user = \'user\') LIMIT 1',
                 'result' => [],
             ],
             [


### PR DESCRIPTION
### Description

`Bookmark::getList()` and `Bookmark::get()` filter by `AND dbase = '<db>'`, so a bookmark stored with `dbase = ''` is hidden once a current database is selected. The user clause already has a matching blank fallback (`( user = '' OR user = '<user>' )`). The dbase clause now mirrors it: `( dbase = '' OR dbase = '<db>' )`.

Note: in `Sql::storeTheQueryAsBookmark`, the "replace existing bookmark" path now also matches a same-labeled shared (blank-database) bookmark when saving from a current database. Happy to scope that down if it's unwanted.

Fixes #20198.
