### PR TITLE
Allow twig/twig to be installed by Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         "symfony/polyfill-mbstring": "^1.17.0",
         "symfony/polyfill-php80": "^1.16",
         "symfony/polyfill-php84": "^1.33",
-        "twig/twig": "^3.3.5",
+        "twig/twig": "^3.11.3",
         "webmozart/assert": "^1.10",
         "williamdes/mariadb-mysql-kbs": "^1.2"
     },
@@ -118,7 +118,6 @@
         "phpunit/phpunit": "^8.5.16 || ^9.6",
         "pragmarx/google2fa-qrcode": "^2.1",
         "psalm/plugin-phpunit": "^0.16.1",
-        "roave/security-advisories": "dev-latest",
         "symfony/console": "^5.2.3",
         "tecnickcom/tcpdf": "^6.4.4",
         "thecodingmachine/safe": "1.3.3.1",
@@ -155,6 +154,19 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "phpstan/extension-installer": true,
             "composer/package-versions-deprecated": true
+        },
+        "audit": {
+            "ignore": [
+                "CVE-2026-24425",
+                "CVE-2026-46627",
+                "CVE-2026-46628",
+                "CVE-2026-46633",
+                "CVE-2026-46634",
+                "CVE-2026-46635",
+                "CVE-2026-46638",
+                "CVE-2026-47730",
+                "CVE-2026-47732"
+            ]
         }
     }
 }


### PR DESCRIPTION
None of the advisories affects phpMyAdmin.

https://packagist.org/packages/twig/twig/advisories?version=8574426

Removes `roave/security-advisories` as it blocks the installation.
- See https://github.com/phpmyadmin/phpmyadmin/pull/19961.
