### PR TITLE
Fix #19841 - Strip port from host when linking to user privileges in processes list

### DIFF
--- a/libraries/classes/Server/Status/Processes.php
+++ b/libraries/classes/Server/Status/Processes.php
@@ -14,6 +14,7 @@ use function array_keys;
 use function count;
 use function mb_strtolower;
 use function number_format;
+use function preg_replace;
 use function strlen;
 use function ucfirst;
 
@@ -93,6 +94,7 @@ final class Processes
                 'id' => $process['Id'],
                 'user' => $process['User'],
                 'host' => $process['Host'],
+                'user_host' => preg_replace('/:\d+$/', '', $process['Host'] ?? ''),
                 'db' => ! isset($process['Db']) || strlen($process['Db']) === 0 ? '' : $process['Db'],
                 'command' => $process['Command'],
                 'time' => $process['Time'],

--- a/templates/server/status/processes/list.twig
+++ b/templates/server/status/processes/list.twig
@@ -49,7 +49,7 @@
             {% if row.user not in ['system user', 'event_scheduler', 'unauthenticated user'] %}
               <a href="{{ url('/server/privileges', {
                   'username': row.user,
-                  'hostname': row.host,
+                  'hostname': row.user_host,
                   'dbname': row.db,
                   'tablename': '',
                   'routinename': '',

--- a/test/classes/Controllers/Server/Status/Processes/RefreshControllerTest.php
+++ b/test/classes/Controllers/Server/Status/Processes/RefreshControllerTest.php
@@ -44,7 +44,7 @@ class RefreshControllerTest extends AbstractTestCase
     {
         $process = [
             'User' => 'User1',
-            'Host' => 'Host1',
+            'Host' => 'Host1:12345',
             'Id' => 'Id1',
             'Db' => 'db1',
             'Command' => 'Command1',
@@ -98,5 +98,24 @@ class RefreshControllerTest extends AbstractTestCase
 
         //validate 8: $process['info']
         self::assertStringContainsString($process['Info'], $html);
+
+        // The Host column shows the full value including port
+        self::assertStringContainsString('Host1:12345', $html);
+
+        // The privileges link must use the bare hostname (port stripped) so the
+        // link target matches mysql.user.Host which never contains port numbers.
+        self::assertStringContainsString(
+            Url::getFromRoute('/server/privileges', [
+                'username' => $process['User'],
+                'hostname' => 'Host1',
+                'dbname' => $process['Db'],
+                'tablename' => '',
+                'routinename' => '',
+            ]),
+            $html
+        );
+
+        // The privileges link must NOT contain the raw host:port value as hostname
+        self::assertStringNotContainsString('hostname=Host1%3A12345', $html);
     }
 }

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -2174,7 +2174,7 @@ class DbiDummy implements DbiExtension
             [
                 'query' => 'SELECT * FROM `INFORMATION_SCHEMA`.`PROCESSLIST` ORDER BY `process` DESC',
                 'columns' => ['Id', 'User', 'Host', 'db', 'Command', 'Time', 'State', 'Info'],
-                'result' => [['Id1', 'User1', 'Host1', 'db1', 'Command1', 'Time1', 'State1', 'Info1']],
+                'result' => [['Id1', 'User1', 'Host1:12345', 'db1', 'Command1', 'Time1', 'State1', 'Info1']],
             ],
             [
                 'query' => 'SELECT UNIX_TIMESTAMP() - 36000',


### PR DESCRIPTION
### Description

The Host field in `SHOW PROCESSLIST` includes the client's TCP port
(e.g., `localhost:64776`). This value was passed directly as the
`hostname` parameter when building the link to a user's privileges page.
The privileges page queries `mysql.user WHERE Host = 'localhost:64776'`,
which never matches — the user table stores bare hostnames without ports.

This change adds a `user_host` key to the process row array in
`Processes::getList()`. The value is the host with any trailing `:port`
suffix stripped via `preg_replace('/:\d+$/', '', $host)`. The template
uses `row.user_host` for the privileges link URL, while `row.host`
(unchanged) continues to populate the Host column display.

Fixes #19841.

---

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
