### PR TITLE
Fix #20190 - Handle missing parser statement in getForeigners()

### DIFF
--- a/libraries/classes/ConfigStorage/Relation.php
+++ b/libraries/classes/ConfigStorage/Relation.php
@@ -446,7 +446,7 @@ class Relation
             $show_create_table = $tableObj->showCreate();
             if ($show_create_table !== '') {
                 $parser = new Parser($show_create_table);
-                $stmt = $parser->statements[0];
+                $stmt = $parser->statements[0] ?? null;
                 $foreign['foreign_keys_data'] = [];
                 if ($stmt instanceof CreateStatement) {
                     $foreign['foreign_keys_data'] = TableUtils::getForeignKeys($stmt);

--- a/test/classes/ConfigStorage/RelationTest.php
+++ b/test/classes/ConfigStorage/RelationTest.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\RecentFavoriteTable;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
+use PhpMyAdmin\Version;
 use ReflectionClass;
 
 use function implode;
@@ -185,6 +186,43 @@ class RelationTest extends AbstractTestCase
         $expected['on_update'] = 'CASCADE';
 
         self::assertEquals($expected, $foreigner);
+    }
+
+    /**
+     * @see https://github.com/phpmyadmin/phpmyadmin/issues/20190
+     *
+     * @group with-trigger-error
+     */
+    public function testGetForeignersForUnparsableShowCreate(): void
+    {
+        parent::setGlobalDbi();
+
+        $GLOBALS['server'] = 1;
+        $relation = new Relation($this->dbi);
+        $_SESSION['relation'] = [1 => ['version' => Version::VERSION]];
+
+        // Some SHOW CREATE TABLE output leaves the parser with no statement,
+        // such as a binary DEFAULT value on a binary(16) column.
+        $this->dummyDbi->removeDefaultResults();
+        $this->dummyDbi->addResult(
+            'SHOW CREATE TABLE `db`.`table`',
+            [
+                [
+                    'table',
+                    "CREATE TABLE `product` (\n"
+                    . "  `id` binary(16) NOT NULL,\n"
+                    . "  `version_id` binary(16) NOT NULL DEFAULT '\xc7\x84\x1b\x1e\xb9',\n"
+                    . "  PRIMARY KEY (`id`,`version_id`)\n"
+                    . ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+                ],
+            ],
+            ['Table', 'Create Table']
+        );
+
+        $foreigners = $relation->getForeigners('db', 'table', '', 'foreign');
+
+        self::assertSame(['foreign_keys_data' => []], $foreigners);
+        $this->assertAllQueriesConsumed();
     }
 
     public function testFixPmaTablesNothingWorks(): void

--- a/test/classes/ConfigStorage/RelationTest.php
+++ b/test/classes/ConfigStorage/RelationTest.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\RecentFavoriteTable;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
+use PhpMyAdmin\Version;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -181,6 +182,43 @@ class RelationTest extends AbstractTestCase
         $expected['on_update'] = 'CASCADE';
 
         self::assertEquals($expected, $foreigner);
+    }
+
+    /**
+     * @see https://github.com/phpmyadmin/phpmyadmin/issues/20190
+     *
+     * @group with-trigger-error
+     */
+    public function testGetForeignersForUnparsableShowCreate(): void
+    {
+        parent::setGlobalDbi();
+
+        $GLOBALS['server'] = 1;
+        $relation = new Relation($this->dbi);
+        $_SESSION['relation'] = [1 => ['version' => Version::VERSION]];
+
+        // Some SHOW CREATE TABLE output leaves the parser with no statement,
+        // such as a binary DEFAULT value on a binary(16) column.
+        $this->dummyDbi->removeDefaultResults();
+        $this->dummyDbi->addResult(
+            'SHOW CREATE TABLE `db`.`table`',
+            [
+                [
+                    'table',
+                    "CREATE TABLE `product` (\n"
+                    . "  `id` binary(16) NOT NULL,\n"
+                    . "  `version_id` binary(16) NOT NULL DEFAULT '\xc7\x84\x1b\x1e\xb9',\n"
+                    . "  PRIMARY KEY (`id`,`version_id`)\n"
+                    . ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+                ],
+            ],
+            ['Table', 'Create Table']
+        );
+
+        $foreigners = $relation->getForeigners('db', 'table', '', 'foreign');
+
+        self::assertSame(['foreign_keys_data' => []], $foreigners);
+        $this->assertAllQueriesConsumed();
     }
 
     public function testFixPmaTablesNothingWorks(): void


### PR DESCRIPTION
### Description

`getForeigners()` reads `$parser->statements[0]` after parsing the `SHOW CREATE TABLE` output, but the parser returns no statement for some tables, for example a binary column with a binary default value. That raises `Undefined array key 0`. The `instanceof CreateStatement` check right after already handles `null`.

Same pattern on master in `getForeignKeysData()`.

Fixes #20190.
