### PR TITLE
fix: restore monospace font size to 14px in bootstrap theme Fix #19489

### DIFF
--- a/public/themes/bootstrap/scss/_codemirror.scss
+++ b/public/themes/bootstrap/scss/_codemirror.scss
@@ -1,6 +1,25 @@
 $textarea-cols: 40;
 $textarea-rows: 15;
 
+// Restore monospace font size to match 5.2 default (~14px)
+// See: https://github.com/phpmyadmin/phpmyadmin/issues/19489
+:root {
+  --font-size-monospace: 14px;
+}
+
+.cm-editor,
+.CodeMirror,
+.cm-scroller,
+code,
+pre,
+textarea.monospace,
+.sql,
+pre.sql,
+.result_query .sql,
+.result_query pre {
+  font-size: var(--font-size-monospace, 14px) !important;
+}
+
 .CodeMirror {
   height: 20rem;
   border: $card-border-width solid $card-border-color;
@@ -12,7 +31,7 @@ $textarea-rows: 15;
 
 .CodeMirror-gutters {
   border-right-color: var(--#{$prefix}border-color);
-  background-color: rgba(var(--#{$prefix}body-color-rgb), .03);
+  background-color: rgba(var(--#{$prefix}body-color-rgb), 0.03);
 }
 
 // Code mirror default style (do not affect the console style)


### PR DESCRIPTION
Fixes #19489

## Problem
After migrating to phpMyAdmin 6.0, the monospace/code font size was reduced from the 5.2 default (~14px) to a smaller value (~12px).

## Fix
Added CSS custom property `--font-size-monospace: 14px` in `_codemirror.scss` and applied it to CodeMirror and code elements.

## Testing
Verified in phpMyAdmin 6.0 with bootstrap theme - font size is now 14px matching 5.2 behavior.
<img width="585" height="594" alt="Zrzut ekranu 2026-05-27 214208" src="https://github.com/user-attachments/assets/6bac7fe2-b5d3-43f0-936c-4d447cad43f3" />
<img width="304" height="139" alt="Zrzut ekranu 2026-05-27 214311" src="https://github.com/user-attachments/assets/c089d84a-f53c-4376-b700-a9b3aaaa9290" />
