### PR TITLE
[Security] Add allowed_classes => false to Core::safeUnserialize() as defence-in-depth

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -640,7 +640,11 @@ class Core
             return null;
         }
 
-        return unserialize($data);
+        // The manual parser above only permits scalars and plain arrays (s/b/i/d/N/a);
+        // any object token ('O:'/'C:') causes an early return null. Explicitly passing
+        // allowed_classes => false here adds defence-in-depth in case of parser edge
+        // cases and makes the intent clear to static analysis tools.
+        return unserialize($data, ['allowed_classes' => false]);
     }
 
     /**


### PR DESCRIPTION
## Summary

`Core::safeUnserialize()` validates the serialized string with a custom manual parser before calling `unserialize()`. The parser correctly rejects object tokens (`O:`/`C:`), but the final `unserialize()` call does **not** pass `allowed_classes` — leaving object instantiation unrestricted if the parser is ever bypassed.

## Why this matters

The manual validator is a best-effort approach written in PHP. If a future PHP serialization format change, a subtle tokenizer edge-case, or a crafted input sequence ever bypasses the manual check, `unserialize()` would instantiate arbitrary PHP objects — enabling **PHP Object Injection → RCE** via gadget chains.

Adding `'allowed_classes' => false` as a second guard is a one-line hardening with zero functional impact: the manual parser already ensures only scalars and arrays reach `unserialize()`, so rejecting objects at the `unserialize()` level as well costs nothing.

## Files changed

- `src/Core.php` — add `['allowed_classes' => false]` to the `unserialize()` call in `safeUnserialize()`