### PR TITLE
Fix grid edit Enter on datetime fields triggering SQL modal When edit…

### DIFF
--- a/resources/js/makegrid.ts
+++ b/resources/js/makegrid.ts
@@ -1191,7 +1191,10 @@ const makeGrid = function (t, enableResize = undefined, enableReorder = undefine
                         firstDay: window.firstDayOfCalendar,
                     });
 
-                    $inputField.on('keyup', function (e) {
+                    $inputField.off('keydown.gridEditDateTime keyup.gridEditDateTime');
+                    $(g.cEdit).off('keydown.gridEditDateTime');
+
+                    $inputField.on('keydown.gridEditDateTime', function (e) {
                         if (e.which === 13) {
                             // post on pressing "Enter"
                             e.preventDefault();
@@ -1199,6 +1202,15 @@ const makeGrid = function (t, enableResize = undefined, enableReorder = undefine
                             g.saveOrPostEditedCell();
                         } else if (e.which !== 27) {
                             toggleDatepickerIfInvalid($td, $inputField);
+                        }
+                    });
+
+                      // Catch Enter when focus is in the datepicker UI (inside cEdit)
+                    $(g.cEdit).on('keydown.gridEditDateTime', function (e) {
+                        if (e.which === 13 && ! $(e.target).is('.edit_box')) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            g.saveOrPostEditedCell();
                         }
                     });
 


### PR DESCRIPTION
### Description
Fixes #20323
When grid-editing a `datetime` (or other date/time) cell, pressing **Enter** a second time could open the SQL query confirmation/submit flow instead of saving the cell.
The date/time editor only handled Enter on `keyup` on the `.edit_box` input. After the first edit, focus often moves into the jQuery UI datepicker inside `cEdit`, so Enter was not intercepted and bubbled to the page (for example `#sqlqueryform`).
This pull request:
- Handles Enter on `keydown` for the edit input (consistent with other grid cells).
- Handles Enter on `keydown` for the whole `cEdit` when focus is inside the datepicker UI.
- Removes namespaced handlers and destroys the datepicker when closing the editor to avoid stale state.
