### PR TITLE
Apply order_by to multi-table query builder criteria

### DIFF
--- a/js/src/database/multi_table_query.js
+++ b/js/src/database/multi_table_query.js
@@ -9,7 +9,7 @@
  *
  */
 
-/* global generateFromBlock, generateWhereBlock */ // js/database/query_generator.js
+/* global generateFromBlock, generateWhereBlock, generateOrderBlock  */ // js/database/query_generator.js
 
 /**
  * js file for handling AJAX and other events in /database/multi-table-query
@@ -123,6 +123,11 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
         if ($criteriaColCount > 0) {
             query += '\nWHERE ';
             query += generateWhereBlock();
+        }
+
+        var $orderParts = generateOrderBlock();
+        if ($orderParts !== '') {
+            query += '\nORDER BY ' + $orderParts;
         }
 
         query += ';';

--- a/js/src/database/query_generator.js
+++ b/js/src/database/query_generator.js
@@ -97,6 +97,22 @@ function generateWhereBlock () {
     return query;
 }
 
+function generateOrderBlock() {
+  var parts = [];
+  $('.tableNameSelect').each(function () {
+    var criteriaDiv = $(this).siblings('.jsCriteriaOptions').first();
+    var useCriteria = criteriaDiv.find('input.sort_or:checked');
+    if (useCriteria.length > 0 && $(this).val() !== '' && $(this).siblings('.criteria_col').first().prop('checked')) {
+      var tableName = $(this).val();
+      var tableShort = $(this).siblings('.table_alias').val();
+      var ref = '`' + Functions.escapeBacktick(tableShort !== '' ? tableShort : tableName) + '`';
+      ref += '.`' + Functions.escapeBacktick($(this).parent().find('.opColumn').first().val()) + '`';
+      parts.push(ref + ' ' + useCriteria.val());
+    }
+  });
+  return parts.join(', ');
+}
+
 function generateJoin (newTable, tableAliases, fk) {
     var query = '';
     query += ' \n\tLEFT JOIN ' + '`' + Functions.escapeBacktick(newTable) + '`';

--- a/templates/database/multi_table_query/form.twig
+++ b/templates/database/multi_table_query/form.twig
@@ -65,8 +65,8 @@
 
                         <tr class="sort_order query-form__tr--bg-none">
                             <td>{% trans 'Sort' %}</td>
-                            <td><input type="radio" name="sort[{{ id }}]">{% trans 'Ascending' %}</td>
-                            <td><input type="radio" name="sort[{{ id }}]">{% trans 'Descending' %}</td>
+                            <td><input type="radio" name="sort[{{ id }}]" value="ASC" class="sort_or">{% trans 'Ascending' %}</td>
+                            <td><input type="radio" name="sort[{{ id }}]" value="DESC" class="sort_or">{% trans 'Descending' %}</td>
                         </tr>
 
                         <tr class="logical_operator query-form__tr--bg-none query-form__tr--hide">


### PR DESCRIPTION
### Description

Please describe your pull request.
In the multi-table query builder there is a criteria checkbox that shows new fields to make the query more precise. The sort radio inputs in the fields seem to be empty of values. Basing myself with the logic of generateWhereBlock I added what was necessary for the "ORDER BY" to be inserted on the query.

Fixes #17841 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
