### PR TITLE
Fix #19728 - Match available charsets case-insensitively

### DIFF
--- a/libraries/classes/Encoding.php
+++ b/libraries/classes/Encoding.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin;
 
 use function array_filter;
-use function array_intersect;
 use function array_map;
 use function explode;
 use function fclose;
@@ -15,6 +14,7 @@ use function fopen;
 use function function_exists;
 use function fwrite;
 use function iconv;
+use function in_array;
 use function is_string;
 use function mb_convert_encoding;
 use function mb_convert_kana;
@@ -24,6 +24,7 @@ use function preg_replace;
 use function recode_string;
 use function str_contains;
 use function str_starts_with;
+use function strtolower;
 use function strtoupper;
 use function tempnam;
 use function unlink;
@@ -368,9 +369,14 @@ class Encoding
             });
         }
 
-        return array_intersect(
-            array_map('strtolower', mb_list_encodings()),
-            $GLOBALS['cfg']['AvailableCharsets']
+        /* mb_list_encodings() and AvailableCharsets may differ in case (SJIS) */
+        $supportedEncodings = array_map('strtolower', mb_list_encodings());
+
+        return array_filter(
+            $GLOBALS['cfg']['AvailableCharsets'],
+            static function (string $charset) use ($supportedEncodings): bool {
+                return in_array(strtolower($charset), $supportedEncodings, true);
+            }
         );
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16707,7 +16707,7 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Encoding\\:\\:listEncodings\\(\\) should return array but returns \\(array\\|null\\)\\.$#"
-			count: 1
+			count: 2
 			path: libraries/classes/Encoding.php
 
 		-
@@ -16727,17 +16727,12 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$input of function array_filter expects array, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Encoding.php
-
-		-
-			message: "#^Parameter \\#2 \\$arr2 of function array_intersect expects array, mixed given\\.$#"
-			count: 1
+			count: 2
 			path: libraries/classes/Encoding.php
 
 		-
 			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(mixed\\)\\: bool\\)\\|null, Closure\\(string\\)\\: bool given\\.$#"
-			count: 1
+			count: 2
 			path: libraries/classes/Encoding.php
 
 		-
@@ -43872,7 +43867,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'AvailableCharsets' on mixed\\.$#"
-			count: 2
+			count: 3
 			path: test/classes/EncodingTest.php
 
 		-

--- a/test/classes/EncodingTest.php
+++ b/test/classes/EncodingTest.php
@@ -204,4 +204,15 @@ class EncodingTest extends AbstractTestCase
 
         self::assertSame(['utf-8', 'ISO-2022-CN', 'ISO2022CN'], Encoding::listEncodings());
     }
+
+    public function testListEncodingsKeepsUppercaseMbCharsets(): void
+    {
+        Encoding::setEngine(Encoding::ENGINE_MB);
+        $GLOBALS['cfg']['AvailableCharsets'] = ['utf-8', 'SJIS', 'SJIS-win'];
+
+        $result = Encoding::listEncodings();
+        self::assertContains('SJIS', $result);
+        self::assertContains('SJIS-win', $result);
+        self::assertContains('utf-8', $result);
+    }
 }


### PR DESCRIPTION
### Description

`Encoding::listEncodings()` applied `strtolower` to `mb_list_encodings()` and matched the result against `AvailableCharsets` with a case-sensitive `array_intersect`, so uppercase entries like `SJIS` were dropped from the supported list. Selecting `SJIS` for a CSV export then had no effect and the file stayed UTF-8. The mbstring branch now matches the two ignoring case.

Fixes #19728.
