### PR TITLE
Monitor autocomplete

### DIFF
--- a/js/src/server/status/monitor.js
+++ b/js/src/server/status/monitor.js
@@ -1025,6 +1025,21 @@ AJAX.registerOnload('server/status/monitor.js', function () {
         return false;
     });
 
+    if (!$.ui.autocomplete.resizeReplaced) {
+        $.ui.autocomplete.resizeReplaced = true;
+        // eslint-disable-next-line no-underscore-dangle
+        const originalResizeMenu = $.ui.autocomplete.prototype._resizeMenu;
+        // Make sure the autocomplete menu does not overflow the browser window
+        // eslint-disable-next-line no-underscore-dangle
+        $.ui.autocomplete.prototype._resizeMenu = function () {
+            const containerRect = this.menu.element[0].parentNode.getBoundingClientRect();
+            const inputRect = this.element[0].getBoundingClientRect();
+            const maxMenuSize = Math.max(100, containerRect.height - inputRect.bottom - 5);
+            this.menu.element[0].style.maxHeight = maxMenuSize + 'px';
+
+            return originalResizeMenu.apply(this, arguments);
+        };
+    }
     $('#variableInput').autocomplete({
         source: variableNames,
         appendTo: '#addChartModal',

--- a/js/src/server/status/monitor.js
+++ b/js/src/server/status/monitor.js
@@ -1026,7 +1026,8 @@ AJAX.registerOnload('server/status/monitor.js', function () {
     });
 
     $('#variableInput').autocomplete({
-        source: variableNames
+        source: variableNames,
+        appendTo: '#addChartModal',
     });
 
     /* Initializes the monitor, called only once */

--- a/libraries/classes/Controllers/Server/Status/MonitorController.php
+++ b/libraries/classes/Controllers/Server/Status/MonitorController.php
@@ -13,6 +13,7 @@ use PhpMyAdmin\Url;
 
 use function is_numeric;
 use function microtime;
+use function sort;
 
 class MonitorController extends AbstractController
 {
@@ -67,6 +68,8 @@ class MonitorController extends AbstractController
 
             $javascriptVariableNames[] = $name;
         }
+
+        sort($javascriptVariableNames);
 
         $this->render('server/status/monitor/index', [
             'javascript_variable_names' => $javascriptVariableNames,

--- a/themes/bootstrap/scss/_common.scss
+++ b/themes/bootstrap/scss/_common.scss
@@ -1750,6 +1750,13 @@ input#auto_increment_opt {
   }
 }
 
+.ui-autocomplete {
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
+
 // css for timepicker
 .ui-timepicker-div {
   .ui-widget-header {

--- a/themes/metro/scss/_common.scss
+++ b/themes/metro/scss/_common.scss
@@ -1999,8 +1999,14 @@ form.append_fields_form .tblFooters {
   margin-right: 5px;
 }
 
-/* css for timepicker */
+.ui-autocomplete {
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
 
+// css for timepicker
 .ui-timepicker-div {
   .ui-widget-header {
     margin-bottom: 8px;

--- a/themes/original/scss/_common.scss
+++ b/themes/original/scss/_common.scss
@@ -1732,8 +1732,14 @@ input#auto_increment_opt {
   padding-left: 20px;
 }
 
-/* css for timepicker */
+.ui-autocomplete {
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
 
+// css for timepicker
 .ui-timepicker-div {
   .ui-widget-header {
     margin-bottom: 8px;

--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -1937,6 +1937,13 @@ input#auto_increment_opt {
   }
 }
 
+.ui-autocomplete {
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
+
 // css for timepicker
 .ui-timepicker-div {
   .ui-widget-header {


### PR DESCRIPTION
### Description

In Status -> Monitor -> Settings -> Add chart the autocomplete menu for variable names is behind the modal.
<img width="520" height="285" alt="image" src="https://github.com/user-attachments/assets/e4d2441d-400f-4a7e-a6a5-d88d986ef106" />
<img width="547" height="777" alt="image" src="https://github.com/user-attachments/assets/7c8a449e-8e4c-4d99-bd86-e375ca857551" />

This sets the appendTo property for the autocomplete list to the modal background instead of the default body.
It also limits the height of the list to not overflow the webpage.
And sorts the list alphabetically, the items were in the order in which the db outputs them, `SHOW GLOBAL STATUS` is mostly sorted, but not completely.
