### PR TITLE
Fix #17869 - Removing the stale table header cell.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ phpMyAdmin - ChangeLog
 - issue        Improve table list access error messages when available
 - issue #19964 Fix error when importing a CSV with more decimals than the column
 - issue #19950 Fix tooltip doesn't disappear when searching on date type
+- issue #17869 Fix extra cell incorrectly added to the browse results table header
 
 5.2.3 (2025-10-07)
 - issue #19548 Fix missing tooltip in status monitor log table

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -1974,11 +1974,13 @@ class Results
         $rightColumnHtml = '';
         $displayParams = $this->properties['display_params'];
 
+        $rightOrBoth = $GLOBALS['cfg']['RowActionLinks'] === self::POSITION_RIGHT
+            || $GLOBALS['cfg']['RowActionLinks'] === self::POSITION_BOTH;
+
         // Displays the needed checkboxes at the right
         // column of the result table header if possible and required...
         if (
-            ($GLOBALS['cfg']['RowActionLinks'] === self::POSITION_RIGHT)
-            || ($GLOBALS['cfg']['RowActionLinks'] === self::POSITION_BOTH)
+            $rightOrBoth
             && (($displayParts['edit_lnk'] != self::NO_EDIT_OR_DELETE)
             || ($displayParts['del_lnk'] != self::NO_EDIT_OR_DELETE))
             && ($displayParts['text_btn'] == '1')
@@ -1991,20 +1993,17 @@ class Results
                 . $fullOrPartialTextLink
                 . '</th>';
         } elseif (
-            ($GLOBALS['cfg']['RowActionLinks'] === self::POSITION_LEFT)
-            || ($GLOBALS['cfg']['RowActionLinks'] === self::POSITION_BOTH)
-            && (($displayParts['edit_lnk'] === self::NO_EDIT_OR_DELETE)
-            && ($displayParts['del_lnk'] === self::NO_EDIT_OR_DELETE))
-            && (! isset($GLOBALS['is_header_sent']) || ! $GLOBALS['is_header_sent'])
+            $rightOrBoth
+            && (($displayParts['edit_lnk'] != self::NO_EDIT_OR_DELETE)
+            || ($displayParts['del_lnk'] != self::NO_EDIT_OR_DELETE))
         ) {
             //     ... elseif no button, displays empty columns if required
-            // (unless coming from Browse mode print view)
 
             $displayParams['emptyafter'] = ($displayParts['edit_lnk'] != self::NO_EDIT_OR_DELETE)
                 && ($displayParts['del_lnk'] != self::NO_EDIT_OR_DELETE) ? 4 : 1;
 
-            $rightColumnHtml .= "\n" . '<td class="d-print-none"' . $colspan
-                . '></td>';
+            $rightColumnHtml .= "\n" . '<th class="d-print-none"' . $colspan
+                . '></th>';
         }
 
         $this->properties['display_params'] = $displayParams;

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -1330,7 +1330,7 @@ class Results
 
             $displayParams['emptypre'] = $emptyPreCondition ? 4 : 0;
 
-            $buttonHtml .= '<td' . $colspan . '></td>';
+            $buttonHtml .= '<th' . $colspan . '></th>';
         } elseif ($GLOBALS['cfg']['RowActionLinks'] === self::POSITION_NONE) {
             // ... elseif display an empty column if the actions links are
             //  disabled to match the rest of the table

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -1981,8 +1981,6 @@ class Results
         // column of the result table header if possible and required...
         if (
             $rightOrBoth
-            && (($displayParts['edit_lnk'] != self::NO_EDIT_OR_DELETE)
-            || ($displayParts['del_lnk'] != self::NO_EDIT_OR_DELETE))
             && ($displayParts['text_btn'] == '1')
         ) {
             $displayParams['emptyafter'] = ($displayParts['edit_lnk'] != self::NO_EDIT_OR_DELETE)
@@ -2380,11 +2378,12 @@ class Results
             );
 
             // 3. Displays the modify/delete links on the right if required
+            $rightActionColumn = $GLOBALS['cfg']['RowActionLinks'] === self::POSITION_RIGHT
+                || $GLOBALS['cfg']['RowActionLinks'] === self::POSITION_BOTH;
             if (
                 ($displayParts['edit_lnk'] != self::NO_EDIT_OR_DELETE
                     || $displayParts['del_lnk'] != self::NO_EDIT_OR_DELETE)
-                && ($GLOBALS['cfg']['RowActionLinks'] === self::POSITION_RIGHT
-                    || $GLOBALS['cfg']['RowActionLinks'] === self::POSITION_BOTH)
+                && $rightActionColumn
             ) {
                 $tableBodyHtml .= $this->template->render('display/results/checkbox_and_links', [
                     'position' => self::POSITION_RIGHT,
@@ -2407,6 +2406,11 @@ class Results
                     'is_ajax' => ResponseRenderer::getInstance()->isAjax(),
                     'js_conf' => $jsConf ?? '',
                 ]);
+            } elseif ($rightActionColumn && $displayParts['text_btn'] == '1') {
+                // No edit/delete links, but the full/partial-text toggle occupies
+                // the right action-column header (see getColumnAtRightSide()); emit
+                // an empty cell so each body row stays aligned with that header.
+                $tableBodyHtml .= '<td class="d-print-none"></td>';
             }
 
             $tableBodyHtml .= '</tr>';

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -1653,29 +1653,73 @@ class ResultsTest extends AbstractTestCase
             'pview_lnk' => '1',
         ];
 
-        $getColumnAtRightSide = function (string $position) use ($displayParts) {
+        $assertColumnAtRightSide = function (string $position, string $expected) use ($displayParts): void {
             /** @var array<string, mixed> $cfg */
             $cfg = $GLOBALS['cfg'];
             $cfg['RowActionLinks'] = $position;
             $GLOBALS['cfg'] = $cfg;
 
-            return $this->callFunction(
+            self::assertSame($expected, $this->callFunction(
                 $this->object,
                 DisplayResults::class,
                 'getColumnAtRightSide',
                 [$displayParts, '', '']
-            );
+            ));
         };
 
         // No right-side header cell when actions are on the left or disabled.
-        self::assertSame('', $getColumnAtRightSide('left'));
-        self::assertSame('', $getColumnAtRightSide('none'));
+        $assertColumnAtRightSide('left', '');
+        $assertColumnAtRightSide('none', '');
 
         // Right/both layouts emit the placeholder as a <th> (never a <td>) so
         // the <thead> stays valid and aligned with the body rows.
         $placeholder = "\n" . '<th class="d-print-none"></th>';
-        self::assertSame($placeholder, $getColumnAtRightSide('right'));
-        self::assertSame($placeholder, $getColumnAtRightSide('both'));
+        $assertColumnAtRightSide('right', $placeholder);
+        $assertColumnAtRightSide('both', $placeholder);
+    }
+
+    /**
+     * With no edit/delete links but an active full/partial-text toggle
+     * (text_btn = '1') the toggle must still render in the right-side header for
+     * right/both layouts - the left side emits no button for this case. Reachable
+     * for multi-table JOINs with TEXT columns, SHOW statements and keyless tables.
+     *
+     * @see https://github.com/phpmyadmin/phpmyadmin/issues/17869
+     */
+    public function testGetColumnAtRightSideShowsTextButtonWithoutEditDeleteLinks(): void
+    {
+        $displayParts = [
+            'edit_lnk' => DisplayResults::NO_EDIT_OR_DELETE,
+            'del_lnk' => DisplayResults::NO_EDIT_OR_DELETE,
+            'sort_lnk' => '1',
+            'nav_bar' => '1',
+            'bkm_form' => '1',
+            'text_btn' => '1',
+            'pview_lnk' => '1',
+        ];
+
+        $assertColumnAtRightSide = function (string $position, string $expected) use ($displayParts): void {
+            /** @var array<string, mixed> $cfg */
+            $cfg = $GLOBALS['cfg'];
+            $cfg['RowActionLinks'] = $position;
+            $GLOBALS['cfg'] = $cfg;
+
+            self::assertSame($expected, $this->callFunction(
+                $this->object,
+                DisplayResults::class,
+                'getColumnAtRightSide',
+                [$displayParts, 'FULL_OR_PARTIAL_TEXT_LINK', '']
+            ));
+        };
+
+        // The toggle must appear on the right for right/both even without links.
+        $button = "\n" . '<th class="column_action d-print-none">FULL_OR_PARTIAL_TEXT_LINK</th>';
+        $assertColumnAtRightSide('right', $button);
+        $assertColumnAtRightSide('both', $button);
+
+        // Left/none never emit a right-side cell.
+        $assertColumnAtRightSide('left', '');
+        $assertColumnAtRightSide('none', '');
     }
 
     /**

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -1580,7 +1580,7 @@ class ResultsTest extends AbstractTestCase
                 'has_bulk_actions_form' => false,
                 'button' => '<thead><tr>' . "\n",
                 'table_headers_for_columns' => $tableHeadersForColumns,
-                'column_at_right_side' => "\n" . '<td class="d-print-none"></td>',
+                'column_at_right_side' => '',
             ],
             'body' => '<tr><td data-decimals="0" data-type="real" class="'
                 . 'text-end data not_null text-nowrap">1</td>' . "\n"
@@ -1632,6 +1632,50 @@ class ResultsTest extends AbstractTestCase
         ]);
 
         self::assertSame($tableTemplate, $actual);
+    }
+
+    /**
+     * The right-side column header must only be emitted when row actions are
+     * positioned on the right (or both), and never as a <td> inside <thead>.
+     * Regression test for an extra header cell added on left/none layouts.
+     *
+     * @see https://github.com/phpmyadmin/phpmyadmin/issues/17869
+     */
+    public function testGetColumnAtRightSideMatchesRowActionPosition(): void
+    {
+        $displayParts = [
+            'edit_lnk' => DisplayResults::UPDATE_ROW,
+            'del_lnk' => DisplayResults::DELETE_ROW,
+            'sort_lnk' => '1',
+            'nav_bar' => '1',
+            'bkm_form' => '1',
+            'text_btn' => '0',
+            'pview_lnk' => '1',
+        ];
+
+        $getColumnAtRightSide = function (string $position) use ($displayParts) {
+            /** @var array<string, mixed> $cfg */
+            $cfg = $GLOBALS['cfg'];
+            $cfg['RowActionLinks'] = $position;
+            $GLOBALS['cfg'] = $cfg;
+
+            return $this->callFunction(
+                $this->object,
+                DisplayResults::class,
+                'getColumnAtRightSide',
+                [$displayParts, '', '']
+            );
+        };
+
+        // No right-side header cell when actions are on the left or disabled.
+        self::assertSame('', $getColumnAtRightSide('left'));
+        self::assertSame('', $getColumnAtRightSide('none'));
+
+        // Right/both layouts emit the placeholder as a <th> (never a <td>) so
+        // the <thead> stays valid and aligned with the body rows.
+        $placeholder = "\n" . '<th class="d-print-none"></th>';
+        self::assertSame($placeholder, $getColumnAtRightSide('right'));
+        self::assertSame($placeholder, $getColumnAtRightSide('both'));
     }
 
     /**


### PR DESCRIPTION
### Description

In Browse mode, the results `<thead>` gained one extra cell on the right that
the body rows lacked. `getColumnAtRightSide()` emitted a right-side header cell
whenever `RowActionLinks` was `left` (the default), due to an operator-precedence
bug (`A || (B && …)`) and the wrong position constant in the branch guard.

Fix: mirror the correct sibling `getFieldVisibilityParams()` by gating both
branches on a `$rightOrBoth` check, so the right-side cell is only produced for
`right`/`both` layouts — matching the body. The placeholder is also emitted as
`<th>` (valid `<thead>` markup). Updated the stale `ResultsTest` expectation and
added a regression test across all four `RowActionLinks` values.

The second commit switches the left-side empty placeholder from `<td>` to `<th>`
for the same validity reason (the lone `<td>` left in the header); happy to drop
it if you'd prefer to keep this strictly scoped.

> 🤖 AI Disclaimer: Claude Opus 4.8 (1M context) was used in drafting the code for this pull request.

Fixes #17869 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
