### PR TITLE
Fix insert uuid with empty value

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7384,6 +7384,12 @@ parameters:
 			path: src/InsertEdit.php
 
 		-
+			message: '#^Right side of \|\| is always true\.$#'
+			identifier: booleanOr.rightAlwaysTrue
+			count: 1
+			path: src/InsertEdit.php
+
+		-
 			message: '#^Method PhpMyAdmin\\InsertEditColumn\:\:getDisplayType\(\) should return string but returns string\|null\.$#'
 			identifier: return.type
 			count: 1

--- a/src/InsertEdit.php
+++ b/src/InsertEdit.php
@@ -1211,6 +1211,16 @@ class InsertEdit
             return '';
         }
 
+        // For uuid type, generate uuid value
+        // if empty value but not set null or value is uuid() function
+        if (
+            $editField->type === 'uuid'
+                && ! $editField->isNull
+                && in_array($editField->value, ["''", '', "'uuid()'", 'uuid()'], true)
+        ) {
+            return 'uuid()';
+        }
+
         if ($editField->value === '') {
             // When the field is autoIncrement, the best way to avoid problems
             // in strict mode is to set the value to null (works also in non-strict mode)
@@ -1231,16 +1241,6 @@ class InsertEdit
             $currentValue = (string) preg_replace('/[^01]/', '0', $editField->value);
 
             return 'b' . $this->dbi->quoteString($currentValue);
-        }
-
-        // For uuid type, generate uuid value
-        // if empty value but not set null or value is uuid() function
-        if (
-            $editField->type === 'uuid'
-                && ! $editField->isNull
-                && in_array($editField->value, ["''", '', "'uuid()'", 'uuid()'], true)
-        ) {
-            return 'uuid()';
         }
 
         if (

--- a/tests/unit/InsertEditTest.php
+++ b/tests/unit/InsertEditTest.php
@@ -1593,6 +1593,25 @@ class InsertEditTest extends AbstractTestCase
         );
         self::assertSame("''", $result);
 
+        // Datatype: uuid with no value should produce uuid()
+        $result = $this->insertEdit->getQueryValueForInsert(
+            new EditField(
+                '',
+                '',
+                'uuid',
+                false,
+                false,
+                false,
+                '',
+                null,
+                null,
+                false,
+            ),
+            false,
+            '',
+        );
+        self::assertSame('uuid()', $result);
+
         // Datatype: set
         $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(


### PR DESCRIPTION
### Description

I fixed a case where `uuid`  with empty value cannot be inserted. This was possible on `QA_5_2` but not on `master`. I just moved up the code related to `uuid` and added a test.

**QA_5_2**:

https://github.com/user-attachments/assets/6dbb1157-10b8-4ada-b31a-723ca846bf5e

**master (not working):**

https://github.com/user-attachments/assets/3af53c9f-925f-4e90-a4f5-c1673c3441d6

**master (working):**

https://github.com/user-attachments/assets/cce22b49-f713-4bbe-83e1-187ad64522e8

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
