### PR TITLE
Do not persist Git credentials in actions workflows

### DIFF
--- a/.github/workflows/daily-snapshots.yml
+++ b/.github/workflows/daily-snapshots.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ matrix.branch }}
+          persist-credentials: false
 
       - name: Install Gettext
         run: sudo apt-get install -y gettext

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -43,6 +45,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -62,6 +66,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
@@ -68,6 +70,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Lint phpdoc blocks
         uses: sudo-bot/action-doctum@v5

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -37,12 +37,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Checkout base ref code
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v6
         with:
           ref: ${{ github.base_ref }}
+          persist-credentials: false
 
       - name: Install Gettext
         run: sudo apt-get install -y gettext

--- a/.github/workflows/other-tools.yml
+++ b/.github/workflows/other-tools.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Sphinx for the documentation build
         run: |
@@ -34,6 +36,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install gettext
         run: sudo apt-get install -y gettext

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Run ShellCheck
         uses: reviewdog/action-shellcheck@v1

--- a/.github/workflows/test-selenium.yml
+++ b/.github/workflows/test-selenium.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - id: tests-list
         name: Send test names to outputs
         run: |
@@ -79,6 +81,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install gettext
         run: sudo apt-get update && sudo apt-get install -y gettext

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Write script
         # tcpdf allowed memory exhausted needs the memory_limit workaround
@@ -82,6 +84,7 @@ jobs:
         with:
           # Fetch some commits for Scrutinizer coverage upload
           fetch-depth: 15
+          persist-credentials: false
 
       - name: Install gettext
         run: sudo apt-get install -y gettext
@@ -143,6 +146,7 @@ jobs:
         with:
           # Fetch some commits for Scrutinizer coverage upload
           fetch-depth: 15
+          persist-credentials: false
 
       - name: Install gettext
         run: sudo apt-get install -y gettext

--- a/.github/workflows/update-po.yml
+++ b/.github/workflows/update-po.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: true
 
       - name: Install Gettext
         run: |


### PR DESCRIPTION
Only persist for `update-po.yml`.

Detected by the static analyser [zizmor](https://zizmor.sh/).

- https://docs.zizmor.sh/audits/#artipacked
- https://phpunit.expert/articles/hardening-github-actions-workflows.html
