### PR TITLE
Remove app/cache/* folder from PHPStan

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,6 +15,7 @@ parameters:
         - config.inc.php (?)
         - config.sample.inc.php
         - examples/config.manyhosts.inc.php
+        - app/*
         - node_modules/*
         - libraries/cache/*
         - test/doctum-config.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,7 @@ parameters:
         - config.inc.php (?)
         - config.sample.inc.php
         - examples/config.manyhosts.inc.php
-        - app/*
+        - app/cache/*
         - node_modules/*
         - libraries/cache/*
         - test/doctum-config.php


### PR DESCRIPTION
### Description

This is only for `QA_5_2`. I did not know why my baselines always looked strange until a few months ago. And it was because of this folder.

When I use PHPUnit on `master` and switch branch to `QA_5_2` in Github Desktop (Windows), `app` folder remains. It contains Twig cache files and the folder is not ignored by PHPStan. Besides, it consumes a lot of memory, usually won't finish and gives timed out.

**Before**

```
E:\GitHub\phpmyadmin>php ./vendor/bin/phpstan analyse --debug
Note: Using configuration file E:\GitHub\phpmyadmin\phpstan.neon.dist.
E:\GitHub\phpmyadmin\app\cache\routes.cache.php
E:\GitHub\phpmyadmin\app\cache\twig\00\00039a4e0f635c8c0370028ec806865e.php
E:\GitHub\phpmyadmin\app\cache\twig\00\006423abf7cb2ae812b3499f93c4454d.php
E:\GitHub\phpmyadmin\app\cache\twig\00\009c0f9a98957af14e2a09b6cc82c151.php
E:\GitHub\phpmyadmin\app\cache\twig\00\00eae49a7c024214d7f1d28894ff0adb.php
^C
```

**After**

```
E:\GitHub\phpmyadmin>php ./vendor/bin/phpstan analyse --debug
Note: Using configuration file E:\GitHub\phpmyadmin\phpstan.neon.dist.
E:\GitHub\phpmyadmin\examples\openid.php
E:\GitHub\phpmyadmin\examples\signon-script.php
E:\GitHub\phpmyadmin\examples\signon.php
E:\GitHub\phpmyadmin\index.php
E:\GitHub\phpmyadmin\js\messages.php
^C
```