### PR TITLE
Fix PSR-7 host header parsing

### DIFF
--- a/libraries/classes/Http/Factory/ServerRequestFactory.php
+++ b/libraries/classes/Http/Factory/ServerRequestFactory.php
@@ -20,17 +20,20 @@ use function class_exists;
 use function count;
 use function current;
 use function explode;
-use function function_exists;
-use function getallheaders;
+use function filter_var;
 use function in_array;
+use function is_callable;
 use function is_numeric;
 use function is_string;
 use function parse_url;
 use function preg_match;
-use function strpos;
-use function strstr;
+use function str_contains;
+use function str_starts_with;
+use function strlen;
 use function substr;
 
+use const FILTER_FLAG_IPV6;
+use const FILTER_VALIDATE_IP;
 use const PHP_URL_QUERY;
 
 class ServerRequestFactory
@@ -40,6 +43,9 @@ class ServerRequestFactory
 
     /** @var UriFactoryInterface */
     private $uriFactory;
+
+    /** @var mixed */
+    private static $getAllHeaders = 'getallheaders';
 
     public function __construct(
         ?ServerRequestFactoryInterface $serverRequestFactory = null,
@@ -107,7 +113,7 @@ class ServerRequestFactory
     protected function getallheaders(): array
     {
         /** @var array<string, string> $headers */
-        $headers = function_exists('getallheaders') ? getallheaders() : [];
+        $headers = is_callable(self::$getAllHeaders) ? (self::$getAllHeaders)() : [];
 
         return $headers;
     }
@@ -162,30 +168,10 @@ class ServerRequestFactory
             );
         }
 
-        if (isset($server['HTTP_HOST']) && is_string($server['HTTP_HOST'])) {
-            $uri = $uri->withHost($server['HTTP_HOST']);
-        } elseif (isset($server['SERVER_NAME']) && is_string($server['SERVER_NAME'])) {
-            $uri = $uri->withHost($server['SERVER_NAME']);
-        }
-
-        if (isset($server['SERVER_PORT']) && is_numeric($server['SERVER_PORT']) && $server['SERVER_PORT'] >= 1) {
-            $uri = $uri->withPort((int) $server['SERVER_PORT']);
-        } else {
-            $uri = $uri->withPort($uri->getScheme() === 'https' ? 443 : 80);
-        }
-
-        if (preg_match('/^(\[[a-fA-F0-9:.]+])(:\d+)?\z/', $uri->getHost(), $matches)) {
-            $uri = $uri->withHost($matches[1]);
-            if (isset($matches[2])) {
-                $uri = $uri->withPort((int) substr($matches[2], 1));
-            }
-        } else {
-            $pos = strpos($uri->getHost(), ':');
-            if ($pos !== false) {
-                $port = (int) substr($uri->getHost(), $pos + 1);
-                $host = (string) strstr($uri->getHost(), ':', true);
-                $uri = $uri->withHost($host)->withPort($port);
-            }
+        [$host, $port] = $this->getHostAndPort($server);
+        $uri = $uri->withHost($host !== '' ? $host : 'localhost');
+        if ($port !== null) {
+            $uri = $uri->withPort($port);
         }
 
         if (isset($server['QUERY_STRING']) && is_string($server['QUERY_STRING'])) {
@@ -203,6 +189,60 @@ class ServerRequestFactory
             }
         }
 
+        $path = $uri->getPath();
+        if (! str_starts_with($path, '/')) {
+            $uri = $uri->withPath('/' . $path);
+        }
+
         return $uri;
+    }
+
+    /**
+     * @param array<mixed> $server
+     *
+     * @return array{string, int|null}
+     */
+    private function getHostAndPort(array $server): array
+    {
+        $host = '';
+        if (isset($server['HTTP_HOST']) && is_string($server['HTTP_HOST'])) {
+            $host = $server['HTTP_HOST'];
+        } elseif (isset($server['SERVER_NAME']) && is_string($server['SERVER_NAME'])) {
+            $host = $server['SERVER_NAME'];
+        } elseif (isset($server['SERVER_ADDR']) && is_string($server['SERVER_ADDR'])) {
+            $host = $server['SERVER_ADDR'];
+        }
+
+        $serverPort = $this->getPort($server['SERVER_PORT'] ?? null);
+        if (preg_match('/[\x00-\x20\x7F\/\?#@\\\\,]/', $host) !== 0) {
+            return ['', $serverPort];
+        }
+
+        if (
+            preg_match('/^(\[[a-fA-F0-9:.]+])(:\d+)?\z/', $host, $matches) === 1
+            && filter_var(substr($matches[1], 1, -1), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false
+        ) {
+            $port = isset($matches[2]) ? $this->getPort(substr($matches[2], 1)) : null;
+
+            return [$matches[1], $port ?? $serverPort];
+        }
+
+        $port = null;
+        if (preg_match('/:(\d+)$/', $host, $matches) === 1) {
+            $port = $this->getPort($matches[1]);
+            $host = (string) substr($host, 0, (strlen($matches[1]) + 1) * -1);
+        }
+
+        if ($host === '' || str_contains($host, ':') || str_contains($host, '[') || str_contains($host, ']')) {
+            return ['', $serverPort];
+        }
+
+        return [$host, $port ?? $serverPort];
+    }
+
+    /** @param mixed $port */
+    private function getPort($port): ?int
+    {
+        return is_numeric($port) && $port >= 1 && $port <= 65535 ? (int) $port : null;
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -20056,11 +20056,6 @@ parameters:
 			path: libraries/classes/Html/MySQLDocumentation.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 1
-			path: libraries/classes/Http/Factory/ServerRequestFactory.php
-
-		-
 			message: "#^Parameter \\#1 \\$method of method Psr\\\\Http\\\\Message\\\\ServerRequestFactoryInterface\\:\\:createServerRequest\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Http/Factory/ServerRequestFactory.php

--- a/test/classes/Http/Factory/ServerRequestFactoryTest.php
+++ b/test/classes/Http/Factory/ServerRequestFactoryTest.php
@@ -11,9 +11,15 @@ use PhpMyAdmin\Http\Factory\ServerRequestFactory;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\UriInterface;
+use ReflectionMethod;
+use ReflectionProperty;
 use Slim\Psr7\Factory\ServerRequestFactory as SlimServerRequestFactory;
 
+use function array_merge;
 use function class_exists;
+
+use const PHP_VERSION_ID;
 
 /**
  * @covers \PhpMyAdmin\Http\Factory\ServerRequestFactory
@@ -97,9 +103,6 @@ class ServerRequestFactoryTest extends AbstractTestCase
         ], $request->getQueryParams());
     }
 
-    /**
-     * @requires PHPUnit < 10
-     */
     public function testCreateServerRequestFromGlobals(): void
     {
         $_GET['foo'] = 'bar';
@@ -112,20 +115,21 @@ class ServerRequestFactoryTest extends AbstractTestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_SERVER['HTTP_HOST'] = 'phpmyadmin.local';
 
-        $creator = $this->getMockBuilder(ServerRequestFactory::class)
-            ->onlyMethods(['getallheaders'])
-            ->getMock();
+        $property = new ReflectionProperty(ServerRequestFactory::class, 'getAllHeaders');
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
-        $creator
-            ->method('getallheaders')
-            ->willReturn(['Content-Type' => 'application/x-www-form-urlencoded']);
+        $property->setValue(null, static function (): array {
+            return ['Content-Type' => 'application/x-www-form-urlencoded'];
+        });
 
-        $serverRequest = $this->callFunction(
-            $creator,
-            ServerRequestFactory::class,
-            'createServerRequestFromGlobals',
-            [$creator]
-        );
+        $method = (new ReflectionMethod(ServerRequestFactory::class, 'createServerRequestFromGlobals'));
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        $serverRequest = $method->invokeArgs(null, [new ServerRequestFactory()]);
 
         $request = new ServerRequest($serverRequest);
 
@@ -165,9 +169,197 @@ class ServerRequestFactoryTest extends AbstractTestCase
         $serverRequestFactory = new $className();
         self::assertInstanceOf(ServerRequestFactoryInterface::class, $serverRequestFactory);
 
-        $factory = new ServerRequestFactory(
-            $serverRequestFactory
-        );
+        $factory = new ServerRequestFactory($serverRequestFactory);
         self::assertInstanceOf(ServerRequestFactory::class, $factory);
+    }
+
+    /**
+     * @param array<string, mixed> $server
+     *
+     * @dataProvider providerCreateUriFromGlobals
+     */
+    public function testCreateUriFromGlobals(string $expected, array $server): void
+    {
+        $createUriFromGlobals = (new ReflectionMethod(ServerRequestFactory::class, 'createUriFromGlobals'));
+        if (PHP_VERSION_ID < 80100) {
+            $createUriFromGlobals->setAccessible(true);
+        }
+
+        $uri = $createUriFromGlobals->invoke(new ServerRequestFactory(), $server);
+        self::assertInstanceOf(UriInterface::class, $uri);
+        self::assertSame($expected, (string) $uri);
+    }
+
+    /**
+     * @see https://github.com/guzzle/psr7/blob/7ec62dc3f44aa218487dbed81a9bf9bc647be55d/tests/ServerRequestTest.php#L296
+     *
+     * @return iterable<string, array{string, array<string, mixed>}>
+     */
+    public static function providerCreateUriFromGlobals(): iterable
+    {
+        $server = [
+            'REQUEST_URI' => '/blog/article.php?id=10&user=foo',
+            'SERVER_PORT' => '443',
+            'SERVER_ADDR' => '217.112.82.20',
+            'SERVER_NAME' => 'www.example.org',
+            'SERVER_PROTOCOL' => 'HTTP/1.1',
+            'REQUEST_METHOD' => 'POST',
+            'QUERY_STRING' => 'id=10&user=foo',
+            'DOCUMENT_ROOT' => '/path/to/your/server/root/',
+            'HTTP_HOST' => 'www.example.org',
+            'HTTPS' => 'on',
+            'REMOTE_ADDR' => '193.60.168.69',
+            'REMOTE_PORT' => '5390',
+            'SCRIPT_NAME' => '/blog/article.php',
+            'SCRIPT_FILENAME' => '/path/to/your/server/root/blog/article.php',
+            'PHP_SELF' => '/blog/article.php',
+        ];
+
+        yield 'HTTPS request' => ['https://www.example.org/blog/article.php?id=10&user=foo', $server];
+
+        yield 'HTTPS request with different on value' => [
+            'https://www.example.org/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTPS' => '1']),
+        ];
+
+        yield 'HTTP request' => [
+            'http://www.example.org/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTPS' => 'off', 'SERVER_PORT' => '80']),
+        ];
+
+        yield 'HTTP_HOST missing -> fallback to SERVER_NAME' => [
+            'https://www.example.org/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => null]),
+        ];
+
+        yield 'HTTP_HOST and SERVER_NAME missing -> fallback to SERVER_ADDR' => [
+            'https://217.112.82.20/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => null, 'SERVER_NAME' => null]),
+        ];
+
+        yield 'Query string with ?' => [
+            'https://www.example.org/path?continue=https://example.com/path?param=1',
+            array_merge(
+                $server,
+                ['REQUEST_URI' => '/path?continue=https://example.com/path?param=1', 'QUERY_STRING' => '']
+            ),
+        ];
+
+        yield 'No query String' => [
+            'https://www.example.org/blog/article.php',
+            array_merge($server, ['REQUEST_URI' => '/blog/article.php', 'QUERY_STRING' => '']),
+        ];
+
+        yield 'Host header with port' => [
+            'https://www.example.org:8324/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => 'www.example.org:8324']),
+        ];
+
+        yield 'IPv6 local loopback address' => [
+            'https://[::1]:8000/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => '[::1]:8000']),
+        ];
+
+        yield 'Invalid host' => [
+            'https://localhost/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => 'a:b']),
+        ];
+
+        yield 'Host header with userinfo delimiter' => [
+            'https://localhost/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => 'trusted.example@evil.example']),
+        ];
+
+        yield 'Host header with path delimiter' => [
+            'https://localhost/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => 'example.com/path']),
+        ];
+
+        yield 'Host header with query delimiter' => [
+            'https://localhost/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => 'example.com?x=1']),
+        ];
+
+        yield 'Host header with fragment delimiter' => [
+            'https://localhost/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => 'example.com#frag']),
+        ];
+
+        yield 'Host header with backslash delimiter' => [
+            'https://localhost/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => 'example.com\\evil']),
+        ];
+
+        yield 'Host header with space' => [
+            'https://localhost/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => 'bad host']),
+        ];
+
+        yield 'Host header with multiple ports' => [
+            'https://localhost/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => 'example.com:80:90']),
+        ];
+
+        yield 'Host header with invalid ip literal' => [
+            'https://localhost/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => '[bad]']),
+        ];
+
+        yield 'Host header with invalid ip literal 2' => [
+            'https://localhost/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => '[b:ad]']),
+        ];
+
+        yield 'Host header with unexpected opening bracket' => [
+            'https://localhost/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => 'foo[bar']),
+        ];
+
+        yield 'Host header with unexpected closing bracket' => [
+            'https://localhost/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => 'foo]bar']),
+        ];
+
+        yield 'Different port with SERVER_PORT' => [
+            'https://www.example.org:8324/blog/article.php?id=10&user=foo',
+            array_merge($server, ['SERVER_PORT' => '8324']),
+        ];
+
+        yield 'Invalid SERVER_PORT is ignored instead of coerced to zero' => [
+            'https://www.example.org/blog/article.php?id=10&user=foo',
+            array_merge($server, ['SERVER_PORT' => 'not-a-port']),
+        ];
+
+        yield 'Non-string SERVER_PORT is ignored' => [
+            'https://www.example.org/blog/article.php?id=10&user=foo',
+            array_merge($server, ['SERVER_PORT' => ['443']]),
+        ];
+
+        yield 'Non-string HTTP_HOST falls back to SERVER_NAME' => [
+            'https://www.example.org/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => ['www.example.org']]),
+        ];
+
+        yield 'Non-string SERVER_NAME falls back to SERVER_ADDR' => [
+            'https://217.112.82.20/blog/article.php?id=10&user=foo',
+            array_merge($server, ['HTTP_HOST' => null, 'SERVER_NAME' => ['www.example.org']]),
+        ];
+
+        yield 'REQUEST_URI missing query string' => [
+            'https://www.example.org/blog/article.php?id=10&user=foo',
+            array_merge($server, ['REQUEST_URI' => '/blog/article.php']),
+        ];
+
+        yield 'Non-string REQUEST_URI is treated as missing' => [
+            'https://www.example.org/?id=10&user=foo',
+            array_merge($server, ['REQUEST_URI' => ['bad']]),
+        ];
+
+        yield 'Non-string QUERY_STRING is treated as missing' => [
+            'https://www.example.org/blog/article.php',
+            array_merge($server, ['REQUEST_URI' => '/blog/article.php', 'QUERY_STRING' => ['bad']]),
+        ];
+
+        yield 'Empty server variable' => ['http://localhost/', []];
     }
 }


### PR DESCRIPTION
Although QA_5_2 doesn't have a failing test, it's not working when using guzzlehttp/psr7 as the PSR-7 implementation.

- Fixes https://github.com/phpmyadmin/phpmyadmin/issues/20338