### PR TITLE
Partially fixes #20332 - Fix compressed columns not detected in MariaDB

### DIFF
--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -1402,7 +1402,7 @@ class Util
             $zerofill = ($zerofillCount > 0);
             $printType = (string) preg_replace('@unsigned@', '', $printType, -1, $unsignedCount);
             $unsigned = ($unsignedCount > 0);
-            $printType = (string) preg_replace('@\/\*!100301 compressed\*\/@', '', $printType, -1, $compressedCount);
+            $printType = (string) preg_replace('@\/\*m?!100301 compressed\*\/@', '', $printType, -1, $compressedCount);
             $compressed = ($compressedCount > 0);
             $printType = trim($printType);
         }

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -851,6 +851,21 @@ class UtilTest extends AbstractTestCase
                     'displayed_type' => 'varchar(11)',
                 ],
             ],
+            [
+                'varchar(11) /*M!100301 COMPRESSED*/',
+                [
+                    'type' => 'varchar',
+                    'print_type' => 'varchar(11)',
+                    'binary' => false,
+                    'unsigned' => false,
+                    'zerofill' => false,
+                    'spec_in_brackets' => '11',
+                    'enum_set_values' => [],
+                    'attribute' => 'COMPRESSED=zlib',
+                    'can_contain_collation' => true,
+                    'displayed_type' => 'varchar(11)',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
### Description

MariaDB-only executable comments have a `M` char.

https://mariadb.com/docs/server/reference/sql-statements/comment-syntax

Before:

https://github.com/user-attachments/assets/282f83d2-45de-400b-8023-a5648002fddc

After:

https://github.com/user-attachments/assets/009555be-1fa3-48ac-9030-908e5b5e1013

Fixes first issue in #20332

The second issue - export, should be fixed in sql-parser. Same issue, doesn't recognize MariaDB-only comments. I'll also link https://github.com/phpmyadmin/sql-parser/issues/256 which is somehow related.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
