### PR TITLE
fix(bookmarks): honor shared-bookmark rules in getList and getByLabel

### DIFF
--- a/src/Bookmarks/BookmarkRepository.php
+++ b/src/Bookmarks/BookmarkRepository.php
@@ -63,10 +63,16 @@ final class BookmarkRepository
     }
 
     /**
-     * Gets the list of bookmarks defined for the current database
+     * Retrieve the bookmarks visible to the given user, optionally scoped to a database.
+     *
+     * Bookmarks shared across users (empty `user`, subject to
+     * AllowSharedBookmarks) and bookmarks shared across databases (empty
+     * `dbase`, created without a database context) are always included
+     * alongside the exact matches.
      *
      * @param string       $user Current user
-     * @param string|false $db   the current database name or false
+     * @param string|false $db   the database to scope the results to, or false to return
+     *                           bookmarks for every database
      *
      * @return Bookmark[] the bookmarks list
      *
@@ -81,19 +87,12 @@ final class BookmarkRepository
             return [];
         }
 
-        $exactUserMatch = ! $this->config->config->AllowSharedBookmarks;
-
         $query = 'SELECT * FROM ' . Util::backquote($bookmarkFeature->database)
             . '.' . Util::backquote($bookmarkFeature->bookmark)
-            . ' WHERE (`user` = ' . $this->dbi->quoteString($user);
-        if (! $exactUserMatch) {
-            $query .= " OR `user` = ''";
-        }
-
-        $query .= ')';
+            . ' WHERE (' . $this->userMatchCondition('`user`', $user) . ')';
 
         if ($db !== false) {
-            $query .= ' AND dbase = ' . $this->dbi->quoteString($db);
+            $query .= ' AND (dbase = ' . $this->dbi->quoteString($db) . " OR dbase = '')";
         }
 
         $query .= ' ORDER BY label ASC';
@@ -109,7 +108,14 @@ final class BookmarkRepository
     }
 
     /**
-     * Retrieve a specific bookmark
+     * Retrieve a specific bookmark by id.
+     *
+     * When $user is not null, only bookmarks owned by that user (or shared,
+     * subject to AllowSharedBookmarks) are matched. Passing null skips the
+     * user filter entirely, returning the bookmark regardless of its owner
+     * — callers are responsible for their own authorization check in that case.
+     *
+     * @return Bookmark|null the matching bookmark, or null if none exists
      */
     public function get(
         string|null $user,
@@ -125,14 +131,7 @@ final class BookmarkRepository
             . ' WHERE `id` = ' . $id;
 
         if ($user !== null) {
-            $query .= ' AND (user = ' . $this->dbi->quoteString($user);
-
-            $exactUserMatch = ! $this->config->config->AllowSharedBookmarks;
-            if (! $exactUserMatch) {
-                $query .= " OR user = ''";
-            }
-
-            $query .= ')';
+            $query .= ' AND (' . $this->userMatchCondition('user', $user) . ')';
         }
 
         $query .= ' LIMIT 1';
@@ -146,7 +145,16 @@ final class BookmarkRepository
     }
 
     /**
-     * Retrieve a specific bookmark by its label
+     * Retrieve a specific bookmark by its label.
+     *
+     * Matches bookmarks shared across users (empty `user`, subject to
+     * AllowSharedBookmarks) as well as bookmarks owned by the given user —
+     * same fallback behavior as getList(). Used by
+     * {@see \PhpMyAdmin\Sql::getDefaultSqlQueryForBrowse()} to look up a
+     * per-table default browse query, which is why a bookmark labeled after
+     * a table can be shared to apply to every user browsing it.
+     *
+     * @return Bookmark|null the matching bookmark, or null if none exists
      */
     public function getByLabel(
         string $user,
@@ -163,7 +171,7 @@ final class BookmarkRepository
             . ' WHERE `label`'
             . ' = ' . $this->dbi->quoteString($label)
             . ' AND dbase = ' . $this->dbi->quoteString($db->getName())
-            . ' AND user = ' . $this->dbi->quoteString($user)
+            . ' AND (' . $this->userMatchCondition('user', $user) . ')'
             . ' LIMIT 1';
 
         $result = $this->dbi->fetchSingleRow($query, DatabaseInterface::FETCH_ASSOC, ConnectionType::ControlUser);
@@ -186,6 +194,19 @@ final class BookmarkRepository
             $row['query'],
             (int) $row['id'],
         );
+    }
+
+    /**
+     * Builds the `WHERE` fragment that matches the owner of a bookmark,
+     * accounting for shared (publicly owned, empty `user`) bookmarks.
+     */
+    private function userMatchCondition(string $column, string $user): string
+    {
+        $condition = $column . ' = ' . $this->dbi->quoteString($user);
+
+        return $this->config->config->AllowSharedBookmarks
+            ? $condition . ' OR ' . $column . " = ''"
+            : $condition;
     }
 
     private function getBookmarkFeature(): BookmarkFeature|null

--- a/tests/unit/Bookmarks/BookmarkRepositoryTest.php
+++ b/tests/unit/Bookmarks/BookmarkRepositoryTest.php
@@ -4,25 +4,36 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Bookmarks;
 
+use PhpMyAdmin\Bookmarks\Bookmark;
 use PhpMyAdmin\Bookmarks\BookmarkRepository;
 use PhpMyAdmin\Config;
+use PhpMyAdmin\Config\Settings;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
+use PhpMyAdmin\Identifiers\DatabaseName;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionProperty;
 
+use function array_map;
+
 #[CoversClass(BookmarkRepository::class)]
 final class BookmarkRepositoryTest extends AbstractTestCase
 {
-    public function testCreateBookmark(): void
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $relationParameters = RelationParameters::fromArray([
             RelationParameters::BOOKMARK_WORK => true,
             RelationParameters::DATABASE => 'phpmyadmin',
             RelationParameters::BOOKMARK => 'pma_bookmark',
         ]);
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
+    }
+
+    public function testCreateBookmark(): void
+    {
         $config = new Config();
         $dbi = $this->createDatabaseInterface();
         $bookmarkRepository = new BookmarkRepository($dbi, new Relation($dbi, $config), $config);
@@ -34,5 +45,185 @@ final class BookmarkRepositoryTest extends AbstractTestCase
         self::assertSame('bookmark1', $bookmark->getLabel());
         self::assertSame('SELECT "phpmyadmin"', $bookmark->getQuery());
         self::assertSame(0, $bookmark->getVariableCount());
+    }
+
+    /**
+     * A bookmark created without a database context (dbase = '', e.g. via the
+     * Console, which does not require a database to be selected) must still
+     * show up when browsing bookmarks for a specific database — the query
+     * filter has to match the requested database OR an empty dbase.
+     */
+    public function testGetListIncludesBookmarksWithoutDatabase(): void
+    {
+        $dbiDummy = $this->createDbiDummy();
+        $dbiDummy->addResult(
+            'SELECT * FROM `phpmyadmin`.`pma_bookmark` WHERE (`user` = \'root\' OR `user` = \'\')'
+                . ' AND (dbase = \'sakila\' OR dbase = \'\') ORDER BY label ASC',
+            [
+                ['1', 'sakila', 'root', 'per-db', 'SELECT 1;'],
+                ['2', '', 'root', 'global', 'SELECT 2;'],
+            ],
+            ['id', 'dbase', 'user', 'label', 'query'],
+        );
+        $config = new Config();
+        $dbi = $this->createDatabaseInterface($dbiDummy, $config);
+        $bookmarkRepository = new BookmarkRepository($dbi, new Relation($dbi, $config), $config);
+
+        $actual = $bookmarkRepository->getList('root', 'sakila');
+
+        self::assertSame(['per-db', 'global'], array_map(
+            static fn (Bookmark $bookmark): string => $bookmark->getLabel(),
+            $actual,
+        ));
+        $dbiDummy->assertAllSelectsConsumed();
+    }
+
+    public function testGetListWithoutDatabaseFilter(): void
+    {
+        $dbiDummy = $this->createDbiDummy();
+        $dbiDummy->addResult(
+            'SELECT * FROM `phpmyadmin`.`pma_bookmark` WHERE (`user` = \'root\' OR `user` = \'\') ORDER BY label ASC',
+            [['1', 'sakila', 'root', 'label', 'SELECT 1;']],
+            ['id', 'dbase', 'user', 'label', 'query'],
+        );
+        $config = new Config();
+        $dbi = $this->createDatabaseInterface($dbiDummy, $config);
+        $bookmarkRepository = new BookmarkRepository($dbi, new Relation($dbi, $config), $config);
+
+        $actual = $bookmarkRepository->getList('root');
+
+        self::assertCount(1, $actual);
+        $dbiDummy->assertAllSelectsConsumed();
+    }
+
+    public function testGetListWithSharedBookmarksDisallowedUsesExactUserMatch(): void
+    {
+        $dbiDummy = $this->createDbiDummy();
+        $dbiDummy->addResult(
+            'SELECT * FROM `phpmyadmin`.`pma_bookmark` WHERE (`user` = \'root\')'
+                . ' AND (dbase = \'sakila\' OR dbase = \'\') ORDER BY label ASC',
+            [],
+            ['id', 'dbase', 'user', 'label', 'query'],
+        );
+        $config = new Config();
+        $config->config = new Settings(['AllowSharedBookmarks' => false]);
+        $dbi = $this->createDatabaseInterface($dbiDummy, $config);
+        $bookmarkRepository = new BookmarkRepository($dbi, new Relation($dbi, $config), $config);
+
+        $actual = $bookmarkRepository->getList('root', 'sakila');
+
+        self::assertSame([], $actual);
+        $dbiDummy->assertAllSelectsConsumed();
+    }
+
+    /**
+     * get() must also match bookmarks shared by another user (user = ''),
+     * the same fallback behavior as getList()/getByLabel() — this is the
+     * positive-match case that BookmarkTest::testGet() (empty result) does
+     * not exercise.
+     */
+    public function testGetMatchesSharedBookmark(): void
+    {
+        $dbiDummy = $this->createDbiDummy();
+        $dbiDummy->addResult(
+            "SELECT * FROM `phpmyadmin`.`pma_bookmark` WHERE `id` = 1 AND (user = 'root' OR user = '') LIMIT 1",
+            [['1', 'sakila', '', 'shared', 'SELECT * FROM `actor` LIMIT 10;']],
+            ['id', 'dbase', 'user', 'label', 'query'],
+        );
+        $config = new Config();
+        $dbi = $this->createDatabaseInterface($dbiDummy, $config);
+        $bookmarkRepository = new BookmarkRepository($dbi, new Relation($dbi, $config), $config);
+
+        $bookmark = $bookmarkRepository->get('root', 1);
+
+        self::assertNotNull($bookmark);
+        self::assertSame('', $bookmark->getUser());
+        self::assertSame('SELECT * FROM `actor` LIMIT 10;', $bookmark->getQuery());
+        $dbiDummy->assertAllSelectsConsumed();
+    }
+
+    public function testGetWithSharedBookmarksDisallowedUsesExactUserMatch(): void
+    {
+        $dbiDummy = $this->createDbiDummy();
+        $dbiDummy->addResult(
+            "SELECT * FROM `phpmyadmin`.`pma_bookmark` WHERE `id` = 1 AND (user = 'root') LIMIT 1",
+            [],
+            ['id', 'dbase', 'user', 'label', 'query'],
+        );
+        $config = new Config();
+        $config->config = new Settings(['AllowSharedBookmarks' => false]);
+        $dbi = $this->createDatabaseInterface($dbiDummy, $config);
+        $bookmarkRepository = new BookmarkRepository($dbi, new Relation($dbi, $config), $config);
+
+        $bookmark = $bookmarkRepository->get('root', 1);
+
+        self::assertNull($bookmark);
+        $dbiDummy->assertAllSelectsConsumed();
+    }
+
+    /**
+     * getByLabel() backs the "default browse query" feature (bookmark named
+     * after a table). It must honor AllowSharedBookmarks the same way
+     * get()/getList() do — a bookmark shared by another user (user = '')
+     * has to match, not just the exact current user.
+     */
+    public function testGetByLabelMatchesSharedBookmark(): void
+    {
+        $dbiDummy = $this->createDbiDummy();
+        $dbiDummy->addResult(
+            'SELECT * FROM `phpmyadmin`.`pma_bookmark` WHERE `label` = \'actor\''
+                . ' AND dbase = \'sakila\' AND (user = \'root\' OR user = \'\') LIMIT 1',
+            [['1', 'sakila', '', 'actor', 'SELECT * FROM `actor` LIMIT 10;']],
+            ['id', 'dbase', 'user', 'label', 'query'],
+        );
+        $config = new Config();
+        $dbi = $this->createDatabaseInterface($dbiDummy, $config);
+        $bookmarkRepository = new BookmarkRepository($dbi, new Relation($dbi, $config), $config);
+
+        $bookmark = $bookmarkRepository->getByLabel('root', DatabaseName::from('sakila'), 'actor');
+
+        self::assertNotNull($bookmark);
+        self::assertSame('', $bookmark->getUser());
+        self::assertSame('SELECT * FROM `actor` LIMIT 10;', $bookmark->getQuery());
+        $dbiDummy->assertAllSelectsConsumed();
+    }
+
+    public function testGetByLabelWithSharedBookmarksDisallowedUsesExactUserMatch(): void
+    {
+        $dbiDummy = $this->createDbiDummy();
+        $dbiDummy->addResult(
+            'SELECT * FROM `phpmyadmin`.`pma_bookmark` WHERE `label` = \'actor\''
+                . ' AND dbase = \'sakila\' AND (user = \'root\') LIMIT 1',
+            [],
+            ['id', 'dbase', 'user', 'label', 'query'],
+        );
+        $config = new Config();
+        $config->config = new Settings(['AllowSharedBookmarks' => false]);
+        $dbi = $this->createDatabaseInterface($dbiDummy, $config);
+        $bookmarkRepository = new BookmarkRepository($dbi, new Relation($dbi, $config), $config);
+
+        $bookmark = $bookmarkRepository->getByLabel('root', DatabaseName::from('sakila'), 'actor');
+
+        self::assertNull($bookmark);
+        $dbiDummy->assertAllSelectsConsumed();
+    }
+
+    public function testGetByLabelReturnsNullWhenNotFound(): void
+    {
+        $dbiDummy = $this->createDbiDummy();
+        $dbiDummy->addResult(
+            'SELECT * FROM `phpmyadmin`.`pma_bookmark` WHERE `label` = \'missing\''
+                . ' AND dbase = \'sakila\' AND (user = \'root\' OR user = \'\') LIMIT 1',
+            [],
+            ['id', 'dbase', 'user', 'label', 'query'],
+        );
+        $config = new Config();
+        $dbi = $this->createDatabaseInterface($dbiDummy, $config);
+        $bookmarkRepository = new BookmarkRepository($dbi, new Relation($dbi, $config), $config);
+
+        $bookmark = $bookmarkRepository->getByLabel('root', DatabaseName::from('sakila'), 'missing');
+
+        self::assertNull($bookmark);
+        $dbiDummy->assertAllSelectsConsumed();
     }
 }

--- a/tests/unit/Bookmarks/BookmarkTest.php
+++ b/tests/unit/Bookmarks/BookmarkTest.php
@@ -40,7 +40,7 @@ class BookmarkTest extends AbstractTestCase
         $dbiDummy = $this->createDbiDummy();
         $dbiDummy->addResult(
             'SELECT * FROM `phpmyadmin`.`pma_bookmark` WHERE (`user` = \'root\' OR `user` = \'\')'
-                . ' AND dbase = \'sakila\' ORDER BY label ASC',
+                . ' AND (dbase = \'sakila\' OR dbase = \'\') ORDER BY label ASC',
             [['1', 'sakila', 'root', 'label', 'SELECT * FROM `actor` WHERE `actor_id` < 10;']],
             ['id', 'dbase', 'user', 'label', 'query'],
         );

--- a/tests/unit/Stubs/DbiDummy.php
+++ b/tests/unit/Stubs/DbiDummy.php
@@ -1813,7 +1813,7 @@ class DbiDummy implements DbiExtension
             ['query' => 'SHOW WARNINGS', 'result' => []],
             [
                 'query' => 'SELECT * FROM `information_schema`.`bookmark` WHERE `label` = \'test_tbl\''
-                . ' AND dbase = \'my_db\' AND user = \'user\' LIMIT 1',
+                . ' AND dbase = \'my_db\' AND (user = \'user\' OR user = \'\') LIMIT 1',
                 'result' => [],
             ],
             [


### PR DESCRIPTION
`BookmarkRepository::getList()` filtered strictly by the requested database,
so bookmarks created without a database context (`dbase = ''`, e.g. saved from
the Console, which does not require a database to be selected) never appeared
when browsing a specific database's bookmark list, even though the equivalent
shared-user fallback (`user = ''`) already existed for the user filter.

`BookmarkRepository::getByLabel()` ignored the `AllowSharedBookmarks` setting
entirely, requiring an exact user match. This method backs
`Sql::getDefaultSqlQueryForBrowse()`, the per-table default browse query
feature described in FAQ 6.22, so a bookmark shared by another user never
applied to anyone browsing that table, unlike `get()`/`getList()` which
already honored the setting consistently.

Both methods now fall back to the shared value the same way `get()` already
did. The repeated "exact match, falling back to shared" SQL fragment was
extracted into a single `userMatchCondition()` helper reused by all three
methods, instead of a third copy of the same conditional.

Commits:
- e39d997e09 fix(bookmarks): honor shared-bookmark rules in getList and getByLabel

Signed-off-by: Willian Cavalcante <248522986+cavalcante-willian@users.noreply.github.com>