### PR TITLE
fix(bookmarks): count variables by highest number, not occurrences

### DIFF
--- a/src/Bookmarks/Bookmark.php
+++ b/src/Bookmarks/Bookmark.php
@@ -12,12 +12,11 @@ use PhpMyAdmin\Dbal\ConnectionType;
 use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Util;
 
-use function count;
+use function array_map;
+use function max;
 use function preg_match_all;
 use function preg_replace;
 use function str_replace;
-
-use const PREG_SET_ORDER;
 
 /**
  * Handles bookmarking SQL queries
@@ -111,16 +110,27 @@ class Bookmark
     }
 
     /**
-     * Returns the number of variables in a bookmark
+     * Returns the highest variable number referenced in the bookmark.
      *
-     * @return int number of variables
+     * This is not the number of `[VARIABLEn]` occurrences — a query can
+     * reference the same number more than once, or skip a number, and the
+     * count of placeholders would then diverge from the count of distinct
+     * variables actually needed. applyVariables() relies on this to know how
+     * many substitution slots to fill; the bare `[VARIABLE]` form (no
+     * number) counts as variable 1, same as applyVariables() treats it.
+     *
+     * @return int highest variable number referenced, or 0 if none
      */
     public function getVariableCount(): int
     {
-        $matches = [];
-        preg_match_all('/\[VARIABLE[0-9]*\]/', $this->query, $matches, PREG_SET_ORDER);
+        preg_match_all('/\[VARIABLE([0-9]*)\]/', $this->query, $matches);
 
-        return count($matches);
+        $numbers = array_map(
+            static fn (string $number): int => $number === '' ? 1 : (int) $number,
+            $matches[1],
+        );
+
+        return $numbers === [] ? 0 : max($numbers);
     }
 
     /**

--- a/tests/unit/Bookmarks/BookmarkTest.php
+++ b/tests/unit/Bookmarks/BookmarkTest.php
@@ -7,8 +7,11 @@ namespace PhpMyAdmin\Tests\Bookmarks;
 use PhpMyAdmin\Bookmarks\Bookmark;
 use PhpMyAdmin\Bookmarks\BookmarkRepository;
 use PhpMyAdmin\Config;
+use PhpMyAdmin\ConfigStorage\Features\BookmarkFeature;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
+use PhpMyAdmin\Identifiers\DatabaseName;
+use PhpMyAdmin\Identifiers\TableName;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionProperty;
@@ -87,5 +90,153 @@ class BookmarkTest extends AbstractTestCase
         $bookmark = $bookmarkRepository->createBookmark('SELECT "phpmyadmin"', 'bookmark1', 'root', 'phpmyadmin');
         self::assertNotFalse($bookmark);
         self::assertTrue($bookmark->save());
+    }
+
+    public function testGetVariableCountWithSequentialVariables(): void
+    {
+        $bookmark = $this->createBookmarkWithQuery(
+            'SELECT * FROM t WHERE a = /* [VARIABLE1] */ 1 AND b = /* [VARIABLE2] */ 2',
+        );
+
+        self::assertSame(2, $bookmark->getVariableCount());
+    }
+
+    /**
+     * A query referencing [VARIABLE1] and [VARIABLE3] (skipping [VARIABLE2])
+     * needs 3 substitution slots, not 2 — getVariableCount() must return the
+     * highest number referenced, not the number of placeholder occurrences.
+     */
+    public function testGetVariableCountWithGapInNumbering(): void
+    {
+        $bookmark = $this->createBookmarkWithQuery(
+            'SELECT * FROM t WHERE a = /* [VARIABLE1] */ 1 AND b = /* [VARIABLE3] */ 2',
+        );
+
+        self::assertSame(3, $bookmark->getVariableCount());
+    }
+
+    public function testGetVariableCountWithNoVariables(): void
+    {
+        $bookmark = $this->createBookmarkWithQuery('SELECT 1');
+
+        self::assertSame(0, $bookmark->getVariableCount());
+    }
+
+    public function testGetVariableCountWithBareVariablePlaceholder(): void
+    {
+        $bookmark = $this->createBookmarkWithQuery('SELECT * FROM t WHERE a = /* [VARIABLE] */ 1');
+
+        self::assertSame(1, $bookmark->getVariableCount());
+    }
+
+    /**
+     * The same number referenced twice must not inflate the count — it is
+     * still a single substitution slot, filled in both occurrences.
+     */
+    public function testGetVariableCountWithDuplicateVariable(): void
+    {
+        $bookmark = $this->createBookmarkWithQuery(
+            'SELECT * FROM t WHERE a = /* [VARIABLE1] */ 1 OR a = /* [VARIABLE1] */ 2',
+        );
+
+        self::assertSame(1, $bookmark->getVariableCount());
+    }
+
+    /**
+     * A query can reference a high variable number without using any of the
+     * lower ones at all — getVariableCount() must still report that high
+     * number, not be thrown off by the absence of [VARIABLE1]..[VARIABLE4].
+     */
+    public function testGetVariableCountWithOnlyAHighNumberReferenced(): void
+    {
+        $bookmark = $this->createBookmarkWithQuery('SELECT * FROM t WHERE a = /* [VARIABLE5] */ 1');
+
+        self::assertSame(5, $bookmark->getVariableCount());
+    }
+
+    /**
+     * End-to-end regression test for the gap-in-numbering bug: before the
+     * fix, [VARIABLE3] was never substituted because the loop in
+     * applyVariables() only ran up to getVariableCount() (2 occurrences),
+     * leaving the literal placeholder text in the query that gets executed.
+     */
+    public function testApplyVariablesSubstitutesAllReferencedNumbersEvenWithGap(): void
+    {
+        $bookmark = $this->createBookmarkWithQuery(
+            'SELECT * FROM t WHERE a = /* [VARIABLE1] */ 1 AND b = /* [VARIABLE3] */ 2',
+        );
+
+        $query = $bookmark->applyVariables([1 => 'x', 3 => 'z']);
+
+        self::assertSame('SELECT * FROM t WHERE a =  x  1 AND b =  z  2', $query);
+    }
+
+    public function testApplyVariablesSupportsBareVariablePlaceholder(): void
+    {
+        $bookmark = $this->createBookmarkWithQuery('SELECT * FROM t WHERE a = /* [VARIABLE] */ 1');
+
+        $query = $bookmark->applyVariables([1 => 'x']);
+
+        self::assertSame('SELECT * FROM t WHERE a =  x  1', $query);
+    }
+
+    public function testApplyVariablesReplacesEveryOccurrenceOfADuplicateNumber(): void
+    {
+        $bookmark = $this->createBookmarkWithQuery(
+            'SELECT * FROM t WHERE a = /* [VARIABLE1] */ 1 OR a = /* [VARIABLE1] */ 2',
+        );
+
+        $query = $bookmark->applyVariables([1 => 'x']);
+
+        self::assertSame('SELECT * FROM t WHERE a =  x  1 OR a =  x  2', $query);
+    }
+
+    /**
+     * With only [VARIABLE5] referenced (no lower numbers in the query), the
+     * loop from 1 to 5 has to reach i = 5 without erroring on the absent
+     * intermediate placeholders, and substitute using key 5 of $variables.
+     */
+    public function testApplyVariablesWithOnlyAHighNumberReferenced(): void
+    {
+        $bookmark = $this->createBookmarkWithQuery('SELECT * FROM t WHERE a = /* [VARIABLE5] */ 1');
+
+        $query = $bookmark->applyVariables([5 => 'z']);
+
+        self::assertSame('SELECT * FROM t WHERE a =  z  1', $query);
+    }
+
+    public function testApplyVariablesDefaultsMissingValueToEmptyString(): void
+    {
+        $bookmark = $this->createBookmarkWithQuery('SELECT * FROM t WHERE a = /* [VARIABLE5] */ 1');
+
+        $query = $bookmark->applyVariables([]);
+
+        self::assertSame('SELECT * FROM t WHERE a =    1', $query);
+    }
+
+    /**
+     * The bare [VARIABLE] form and a numbered placeholder can coexist in the
+     * same query — the "backward compatibility" branch in applyVariables()
+     * must fill both independently.
+     */
+    public function testApplyVariablesWithBareAndNumberedPlaceholdersTogether(): void
+    {
+        $bookmark = $this->createBookmarkWithQuery('a /* [VARIABLE] */ b /* [VARIABLE2] */ c');
+
+        $query = $bookmark->applyVariables([1 => 'x', 2 => 'y']);
+
+        self::assertSame('a  x  b  y  c', $query);
+    }
+
+    private function createBookmarkWithQuery(string $query): Bookmark
+    {
+        return new Bookmark(
+            $this->createDatabaseInterface(),
+            new BookmarkFeature(DatabaseName::from('phpmyadmin'), TableName::from('pma_bookmark')),
+            'db',
+            'user',
+            'label',
+            $query,
+        );
     }
 }


### PR DESCRIPTION
`Bookmark::getVariableCount()` counted how many `[VARIABLEn]` placeholders
occur in the bookmarked query, but `applyVariables()` used that count as the
highest variable number to substitute. Those differ whenever the numbering
has a gap or a repeat: a query using `[VARIABLE1]` and `[VARIABLE3]` (skipping
`[VARIABLE2]`) has 2 occurrences, so the old count was 2, and the
substitution loop never reached `[VARIABLE3]` at all. The literal placeholder
text stayed in the query that actually got executed, which is invalid SQL and
fails. The UI (`resources/js/sql.ts`) generates exactly one input box per unit
of this count, so it also never offered a third box to fill in. Nothing in
`docs/bookmarks.rst` requires variable numbers to be sequential, so this is
reachable through normal use of the feature.

`getVariableCount()` now returns the highest variable number actually
referenced instead of the number of matches, treating the bare `[VARIABLE]`
form (no number) as variable 1 to match the existing backward-compatibility
handling already in `applyVariables()`. In the common case (sequential
numbering, no gaps) the result is identical to before, so this only changes
behavior for the previously-broken case.

The exact same logic is duplicated unchanged in `libraries/classes/Bookmark.php`
on `QA_5_2`, so the currently released 5.2.x line has the same bug — a
separate PR against that branch will follow, referencing the same issue.

Fixes #20348.

Commits:
- 0eed4d2876 fix(bookmarks): count variables by highest number, not occurrences

Signed-off-by: Willian Cavalcante <248522986+cavalcante-willian@users.noreply.github.com>