### PR TITLE
fix(server-status): resolve processlist user link to real grant host

### DIFF
--- a/resources/templates/server/status/processes/list.twig
+++ b/resources/templates/server/status/processes/list.twig
@@ -49,7 +49,7 @@
             {% if row.user not in ['system user', 'event_scheduler', 'unauthenticated user'] %}
               <a href="{{ url('/server/privileges', {
                   'username': row.user,
-                  'hostname': row.host,
+                  'hostname': row.host_without_port,
                   'dbname': row.db,
                   'tablename': '',
                   'routinename': '',

--- a/src/Server/Status/Processes.php
+++ b/src/Server/Status/Processes.php
@@ -10,9 +10,18 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function array_change_key_case;
+use function array_fill;
 use function array_key_exists;
+use function array_map;
+use function array_unique;
+use function array_values;
 use function count;
+use function implode;
 use function number_format;
+use function preg_match;
+use function preg_quote;
+use function str_replace;
+use function substr_count;
 
 use const CASE_LOWER;
 
@@ -66,8 +75,9 @@ final class Processes
 
             $rows[] = [
                 'id' => $process['id'],
-                'user' => $process['user'],
+                'user' => (string) $process['user'],
                 'host' => $process['host'],
+                'host_without_port' => self::stripPort((string) $process['host']),
                 'db' => $process['db'] ?? '',
                 'command' => $process['command'],
                 'time' => $process['time'],
@@ -77,6 +87,8 @@ final class Processes
             ];
         }
 
+        $this->resolveGrantHostnames($rows);
+
         $columns = $this->getSortableColumnsForProcessList($showExecuting, $showFullSql, $orderByField, $sortOrder);
 
         return [
@@ -85,6 +97,127 @@ final class Processes
             'refresh_params' => $urlParams,
             'is_mariadb' => $this->dbi->isMariaDB(),
         ];
+    }
+
+    /**
+     * Strips the port from a `SHOW PROCESSLIST`/`INFORMATION_SCHEMA.PROCESSLIST`
+     * `Host` value (e.g. `10.0.0.5:41414`, `[::1]:41414`, `localhost`).
+     *
+     * `mysql.user`/`mysql.global_priv`'s `Host` column never includes a port
+     * (it is matched by exact string against a plain hostname/IP/`%`
+     * wildcard), so passing the raw connection host straight through to a
+     * user-lookup link never matches. IPv6 addresses are only stripped when
+     * bracketed with an explicit port (`[::1]:3306`) — a bare IPv6 address
+     * has multiple colons of its own and no port to strip, so it is left
+     * untouched to avoid truncating it.
+     */
+    private static function stripPort(string $host): string
+    {
+        if (preg_match('/^\[(?P<host>[0-9a-fA-F:]+)]:\d+$/', $host, $matches) === 1) {
+            return $matches['host'];
+        }
+
+        if (substr_count($host, ':') === 1 && preg_match('/^(?P<host>.+):\d+$/', $host, $matches) === 1) {
+            return $matches['host'];
+        }
+
+        return $host;
+    }
+
+    /**
+     * Replaces each row's `host_without_port` with the actual `Host` pattern
+     * stored in `mysql.user`/`mysql.global_priv`, when one can be found.
+     *
+     * `SHOW PROCESSLIST` only ever reports the connecting client's real
+     * host/IP — never the (possibly wildcarded, e.g. `%`, `192.168.%`) grant
+     * entry that authorized the connection. Since the grant `Host` column
+     * uses the same `%`/`_` wildcard syntax as SQL `LIKE`, the actual
+     * pattern can be recovered by fetching every `Host` registered for the
+     * row's `User` and testing which one matches the connecting host —
+     * preferring an exact (non-wildcard) match when one exists, since that
+     * is the least ambiguous choice.
+     *
+     * Reading `mysql.user` requires a privilege the current user might not
+     * have; failing to read it (or finding no match) leaves
+     * `host_without_port` as the plain connecting host, same as before this
+     * resolution existed — an imprecise but harmless fallback.
+     *
+     * @param list<array{user: string, host_without_port: string}&array<string, mixed>> $rows
+     */
+    private function resolveGrantHostnames(array &$rows): void
+    {
+        $usernames = array_values(array_unique(array_map(
+            static fn (array $row): string => $row['user'],
+            $rows,
+        )));
+
+        if ($usernames === []) {
+            return;
+        }
+
+        $placeholders = implode(', ', array_fill(0, count($usernames), '?'));
+        $result = $this->dbi->executeQuery(
+            'SELECT `User`, `Host` FROM `mysql`.`user` WHERE `User` IN (' . $placeholders . ')',
+            $usernames,
+        );
+
+        if ($result === null) {
+            return;
+        }
+
+        $hostsByUser = [];
+        foreach ($result as $grant) {
+            $hostsByUser[(string) $grant['User']][] = (string) $grant['Host'];
+        }
+
+        foreach ($rows as &$row) {
+            $candidates = $hostsByUser[$row['user']] ?? [];
+            $match = self::findMatchingHost($row['host_without_port'], $candidates);
+            if ($match === null) {
+                continue;
+            }
+
+            $row['host_without_port'] = $match;
+        }
+    }
+
+    /**
+     * Finds, among the given grant `Host` patterns, the one that the actual
+     * connecting host satisfies — an exact literal match wins over a
+     * wildcard pattern, since it is the least ambiguous choice.
+     *
+     * @param string[] $patterns
+     */
+    private static function findMatchingHost(string $host, array $patterns): string|null
+    {
+        foreach ($patterns as $pattern) {
+            if ($pattern === $host) {
+                return $pattern;
+            }
+        }
+
+        foreach ($patterns as $pattern) {
+            if (self::hostMatchesPattern($host, $pattern)) {
+                return $pattern;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Tests a connecting host against a `mysql.user`-style `Host` pattern,
+     * which uses the same `%`/`_` wildcard syntax as SQL `LIKE` — `%` for
+     * any run of characters, `_` for exactly one. Netmask notation
+     * (`192.168.1.0/255.255.255.0`) is a separate, non-`LIKE` syntax MySQL
+     * also accepts for `Host`; it is not handled here and such a pattern
+     * simply will not match, falling back to the plain connecting host.
+     */
+    private static function hostMatchesPattern(string $host, string $pattern): bool
+    {
+        $regex = str_replace(['%', '_'], ['.*', '.'], preg_quote($pattern, '/'));
+
+        return preg_match('/^' . $regex . '$/i', $host) === 1;
     }
 
     /** @return mixed[] */

--- a/tests/unit/Server/Status/ProcessesTest.php
+++ b/tests/unit/Server/Status/ProcessesTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Server\Status;
+
+use PhpMyAdmin\Server\Status\Processes;
+use PhpMyAdmin\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionMethod;
+
+#[CoversClass(Processes::class)]
+final class ProcessesTest extends AbstractTestCase
+{
+    /**
+     * `SHOW PROCESSLIST`'s `Host` column always includes the connecting
+     * port, but `mysql.user`/`mysql.global_priv`'s `Host` never does — the
+     * raw value must stay in `host` (displayed as-is) while `host_without_port`
+     * carries the value actually usable to look up the owning grant.
+     *
+     * DbiDummy::executeQuery() always returns null (no prepared-statement
+     * simulation support), which conveniently exercises exactly the
+     * real-world fallback this code takes when the current user lacks
+     * SELECT on `mysql.user` (or the server has no such table, e.g. some
+     * managed MySQL offerings): `host_without_port` stays the plain stripped
+     * connecting host instead of a resolved grant pattern, but the page
+     * keeps working rather than erroring out.
+     */
+    public function testGetListStripsPortForThePrivilegeLink(): void
+    {
+        $dbiDummy = $this->createDbiDummy();
+        $dbiDummy->addResult(
+            'SHOW PROCESSLIST',
+            [['1', 'root', '10.0.0.5:41414', 'db', 'Query', '0', '', 'SELECT 1']],
+            ['Id', 'User', 'Host', 'db', 'Command', 'Time', 'State', 'Info'],
+        );
+        $dbi = $this->createDatabaseInterface($dbiDummy);
+        $processes = new Processes($dbi);
+
+        $list = $processes->getList(false, false, '', '');
+        $rows = $list['rows'];
+        self::assertIsArray($rows);
+        $row = $rows[0];
+        self::assertIsArray($row);
+
+        self::assertSame('10.0.0.5:41414', $row['host']);
+        self::assertSame('10.0.0.5', $row['host_without_port']);
+    }
+
+    public function testStripPortWithIpv4AndPort(): void
+    {
+        self::assertSame(
+            '10.0.0.5',
+            (new ReflectionMethod(Processes::class, 'stripPort'))->invoke(null, '10.0.0.5:41414'),
+        );
+    }
+
+    public function testStripPortWithLocalhostAndNoPort(): void
+    {
+        self::assertSame(
+            'localhost',
+            (new ReflectionMethod(Processes::class, 'stripPort'))->invoke(null, 'localhost'),
+        );
+    }
+
+    public function testStripPortWithBracketedIpv6AndPort(): void
+    {
+        self::assertSame(
+            '::1',
+            (new ReflectionMethod(Processes::class, 'stripPort'))->invoke(null, '[::1]:41414'),
+        );
+    }
+
+    /**
+     * A bare IPv6 address (no port) has multiple colons of its own — the
+     * last one is not a port separator, and must not be truncated.
+     */
+    public function testStripPortWithBareIpv6DoesNotTruncate(): void
+    {
+        $method = new ReflectionMethod(Processes::class, 'stripPort');
+
+        self::assertSame('2001:db8::5', $method->invoke(null, '2001:db8::5'));
+        self::assertSame('::1', $method->invoke(null, '::1'));
+    }
+
+    public function testStripPortWithHostnameAndPort(): void
+    {
+        self::assertSame(
+            'db.example.com',
+            (new ReflectionMethod(Processes::class, 'stripPort'))->invoke(null, 'db.example.com:3306'),
+        );
+    }
+
+    public function testHostMatchesPatternWithPercentWildcard(): void
+    {
+        $method = new ReflectionMethod(Processes::class, 'hostMatchesPattern');
+
+        self::assertTrue($method->invoke(null, '10.0.0.5', '%'));
+        self::assertTrue($method->invoke(null, '10.0.0.5', '10.0.0.%'));
+        self::assertFalse($method->invoke(null, '10.0.1.5', '10.0.0.%'));
+    }
+
+    public function testHostMatchesPatternWithUnderscoreWildcard(): void
+    {
+        $method = new ReflectionMethod(Processes::class, 'hostMatchesPattern');
+
+        self::assertTrue($method->invoke(null, '10.0.0.5', '10.0.0._'));
+        self::assertFalse($method->invoke(null, '10.0.0.55', '10.0.0._'));
+    }
+
+    public function testHostMatchesPatternIsCaseInsensitive(): void
+    {
+        self::assertTrue(
+            (new ReflectionMethod(Processes::class, 'hostMatchesPattern'))
+                ->invoke(null, 'DB.EXAMPLE.COM', 'db.example.com'),
+        );
+    }
+
+    public function testHostMatchesPatternTreatsDotsInAddressAsLiteral(): void
+    {
+        // A literal dot in the pattern must not behave as "any character" —
+        // only "%"/"_" are wildcards, unlike a raw regex.
+        self::assertFalse(
+            (new ReflectionMethod(Processes::class, 'hostMatchesPattern'))
+                ->invoke(null, '10x0x0x5', '10.0.0.5'),
+        );
+    }
+
+    /**
+     * An exact, non-wildcard grant always wins over a wildcard one for the
+     * same user — it is the least ambiguous choice when both exist.
+     */
+    public function testFindMatchingHostPrefersExactOverWildcard(): void
+    {
+        $match = (new ReflectionMethod(Processes::class, 'findMatchingHost'))
+            ->invoke(null, '10.0.0.5', ['%', '10.0.0.5']);
+
+        self::assertSame('10.0.0.5', $match);
+    }
+
+    public function testFindMatchingHostFallsBackToWildcard(): void
+    {
+        $match = (new ReflectionMethod(Processes::class, 'findMatchingHost'))
+            ->invoke(null, '10.0.0.5', ['192.168.%', '10.0.0.%']);
+
+        self::assertSame('10.0.0.%', $match);
+    }
+
+    public function testFindMatchingHostReturnsNullWhenNothingMatches(): void
+    {
+        $match = (new ReflectionMethod(Processes::class, 'findMatchingHost'))
+            ->invoke(null, '10.0.0.5', ['192.168.%']);
+
+        self::assertNull($match);
+    }
+}


### PR DESCRIPTION
Status > Processes linked each user to `/server/privileges` using the raw
`Host` value from `SHOW PROCESSLIST`/`INFORMATION_SCHEMA.PROCESSLIST`, which
always includes the connecting port (e.g. `10.0.0.5:41414`). `mysql.user`
and `mysql.global_priv` match `Host` by exact string with no port at all, so
the link never found the user — clicking it always landed on a "user not
found" page.

Added `Processes::stripPort()` to strip a trailing port from the connection
host before it is used in the link, handling bracketed IPv6 (`[::1]:port`)
without truncating a bare IPv6 address that has no port of its own.

That alone still would not resolve users whose grant `Host` is a wildcard
(e.g. `%`, `192.168.%`), since the connecting host never equals the pattern
that actually authorized it. `mysql.user`'s `Host` column uses the same
`%`/`_` wildcard syntax as SQL `LIKE`, so `Processes::resolveGrantHostnames()`
fetches every `Host` registered for the usernames appearing in the list and
tests each one against the connecting host, preferring an exact
(non-wildcard) match when one exists. Reading `mysql.user` requires a
privilege the current user might not have; failing to read it (or finding no
match) leaves the link pointing at the plain connecting host, same as before
this resolution existed, rather than breaking the page.

Netmask-notation `Host` values (`192.168.1.0/255.255.255.0`) are a separate,
non-`LIKE` syntax MySQL also accepts for `Host`; they are not handled here
and such a pattern simply will not match, falling back to the connecting
host.

Fixes #19841.

Commits:
- f78b877304 fix(server-status): resolve processlist user link to real grant host

Signed-off-by: Willian Cavalcante <248522986+cavalcante-willian@users.noreply.github.com>