### PR TITLE
Cache foreign key display values and add limit 1 to query

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -35,6 +35,7 @@ use PhpMyAdmin\Utils\Gis;
 use function __;
 use function _pgettext;
 use function array_filter;
+use function array_key_exists;
 use function array_keys;
 use function array_merge;
 use function array_shift;
@@ -248,6 +249,9 @@ class Results
 
     /** @var Template */
     public $template;
+
+    /** @var array<string, string|null> */
+    private $foreignKeyDisplayCache = [];
 
     /**
      * @param string $db       the database name
@@ -4367,18 +4371,19 @@ class Results
             . ' FROM ' . Util::backquote($fieldInfo[3]) . '.' . Util::backquote($fieldInfo[0])
             . ' WHERE ' . Util::backquote($fieldInfo[1]) . $whereComparison
             . ' LIMIT 1';
+        if (array_key_exists($dispsql, $this->foreignKeyDisplayCache)) {
+            return $this->foreignKeyDisplayCache[$dispsql];
+        }
 
         $dispval = $this->dbi->fetchValue($dispsql);
         if ($dispval === false) {
-            return __('Link not found!');
+            $dispval = __('Link not found!');
+        } elseif ($dispval !== null) {
+            // Truncate values that are too long, see: #17902
+            [, $dispval] = $this->getPartialText($dispval);
         }
 
-        if ($dispval === null) {
-            return null;
-        }
-
-        // Truncate values that are too long, see: #17902
-        [, $dispval] = $this->getPartialText($dispval);
+        $this->foreignKeyDisplayCache[$dispsql] = $dispval;
 
         return $dispval;
     }

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -4363,15 +4363,10 @@ class Results
      */
     private function getFromForeign(array $fieldInfo, string $whereComparison): ?string
     {
-        $dispsql = 'SELECT '
-            . Util::backquote($fieldInfo[2])
-            . ' FROM '
-            . Util::backquote($fieldInfo[3])
-            . '.'
-            . Util::backquote($fieldInfo[0])
-            . ' WHERE '
-            . Util::backquote($fieldInfo[1])
-            . $whereComparison;
+        $dispsql = 'SELECT ' . Util::backquote($fieldInfo[2])
+            . ' FROM ' . Util::backquote($fieldInfo[3]) . '.' . Util::backquote($fieldInfo[0])
+            . ' WHERE ' . Util::backquote($fieldInfo[1]) . $whereComparison
+            . ' LIMIT 1';
 
         $dispval = $this->dbi->fetchValue($dispsql);
         if ($dispval === false) {


### PR DESCRIPTION
### Description

Add LIMIT 1 to query getting foreign key display values and cache these values to avoid identical queries.

See also #18728, #19045

Performance test, Tested on MariaDB 11.8:
```sql
DROP TABLE IF EXISTS child;
DROP TABLE IF EXISTS parent;

CREATE TABLE `parent` (
  `id` INT(11) NOT NULL AUTO_INCREMENT,
  `k1` int(11) NOT NULL,
  `k2` int(11) NOT NULL,
  `name` CHAR(36) NOT NULL DEFAULT (UUID()) NULL,
  PRIMARY KEY (`id`),
  KEY (`k1`, `k2`)
) ENGINE=InnoDB;

CREATE TABLE `child` (
  `id` INT(11) NOT NULL AUTO_INCREMENT, 
  `parent_k1` int(11) NOT NULL,
  `parent_k2` int(11) NOT NULL,
  PRIMARY KEY (`id`),
  KEY `child_ibfk_1` (`parent_k1`,`parent_k2`),
  CONSTRAINT `child_ibfk_1` FOREIGN KEY (`parent_k1`, `parent_k2`) REFERENCES `parent` (`k1`, `k2`) ON DELETE CASCADE ON UPDATE CASCADE
) ENGINE=InnoDB;

INSERT INTO parent (k1, k2) VALUES (1, 1);
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 0) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 1) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 2) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 3) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 4) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 5) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 6) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 7) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 8) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 9) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 10) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 11) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 12) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 13) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 14) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1, k2 + POW(2, 15) FROM parent;
INSERT INTO parent (k1, k2) SELECT k1 + POW(2, 0), k2 FROM parent;
INSERT INTO parent (k1, k2) SELECT k1 + POW(2, 1), k2 FROM parent;
INSERT INTO parent (k1, k2) SELECT k1 + POW(2, 2), k2 FROM parent;
INSERT INTO parent (k1, k2) SELECT k1 + POW(2, 3), k2 FROM parent;

INSERT INTO child (parent_k1, parent_k2)
 SELECT k1, k2 FROM parent WHERE k2 BETWEEN 65001 AND 65040;
```
Then run `SELECT * FROM child LIMIT 500;` Check browser developer tools for request time.

| |no Limit|Limit 1|
|----|----|---------|
|no cache|44 seconds|2.4 seconds|
|cache|6.4 seconds|0.6 seconds|