### PR TITLE
Remove usergroup from primary key of pma__users

### DIFF
--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -247,7 +247,7 @@ CREATE TABLE IF NOT EXISTS `pma__userconfig` (
 CREATE TABLE IF NOT EXISTS `pma__users` (
   `username` varchar(64) NOT NULL,
   `usergroup` varchar(64) NOT NULL,
-  PRIMARY KEY (`username`,`usergroup`)
+  PRIMARY KEY (`username`)
 )
   COMMENT='Users and their assignments to user groups'
   DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;

--- a/test/classes/ConfigStorage/RelationTest.php
+++ b/test/classes/ConfigStorage/RelationTest.php
@@ -457,7 +457,7 @@ class RelationTest extends AbstractTestCase
             . ' Table structure for table `pma__users` '
             . '-- CREATE TABLE IF NOT EXISTS `pma__users` ( '
                 . '`username` varchar(64) NOT NULL, `usergroup` varchar(64) NOT NULL,'
-                . ' PRIMARY KEY (`username`,`usergroup`) )'
+                . ' PRIMARY KEY (`username`) )'
                 . ' COMMENT=\'Users and their assignments to user groups\''
                 . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
@@ -742,7 +742,7 @@ class RelationTest extends AbstractTestCase
             . ' Table structure for table `pma__users` '
             . '-- CREATE TABLE IF NOT EXISTS `pma__users` ( '
                 . '`username` varchar(64) NOT NULL, `usergroup` varchar(64) NOT NULL,'
-                . ' PRIMARY KEY (`username`,`usergroup`) )'
+                . ' PRIMARY KEY (`username`) )'
                 . ' COMMENT=\'Users and their assignments to user groups\''
                 . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
@@ -1243,7 +1243,7 @@ class RelationTest extends AbstractTestCase
                 'CREATE TABLE IF NOT EXISTS `pma__users` (',
                 '  `username` varchar(64) NOT NULL,',
                 '  `usergroup` varchar(64) NOT NULL,',
-                '  PRIMARY KEY (`username`,`usergroup`)',
+                '  PRIMARY KEY (`username`)',
                 ')',
                 '  COMMENT=\'Users and their assignments to user groups\'',
                 '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',


### PR DESCRIPTION
### Description
Each user can only belong to a single pma usergroup, so the primary key should only be on username.

See the code that assigns users to groups. If a username already exists in the table it updates this row instead of inserting a new one.
https://github.com/phpmyadmin/phpmyadmin/blob/ebac48183bf71c2f85491e71b9e9e8f382eb45cb/libraries/classes/Server/Privileges.php#L568-L591

Is there a mechanism in place to update existing pma tables?