### PR TITLE
Fix tests issues in PHPUnit 13.1

### DIFF
--- a/tests/unit/Database/SearchTest.php
+++ b/tests/unit/Database/SearchTest.php
@@ -152,7 +152,6 @@ class SearchTest extends AbstractTestCase
                 . " OR HEX(`column1`) LIKE '%search string%'"
                 . " OR CONVERT(`column2` USING utf8) LIKE '%search string%'"
                 . " OR HEX(`column2`) LIKE '%search string%')",
-                'on',
             ],
             [
                 '4',

--- a/tests/unit/Dbal/DatabaseInterfaceTest.php
+++ b/tests/unit/Dbal/DatabaseInterfaceTest.php
@@ -27,7 +27,6 @@ use function array_keys;
 
 #[CoversClass(DatabaseInterface::class)]
 #[CoversClass(Column::class)]
-#[CoversClass(Column::class)]
 final class DatabaseInterfaceTest extends AbstractTestCase
 {
     protected function setUp(): void

--- a/tests/unit/Error/ErrorHandlerTest.php
+++ b/tests/unit/Error/ErrorHandlerTest.php
@@ -26,7 +26,6 @@ use const E_CORE_WARNING;
 use const E_ERROR;
 use const E_NOTICE;
 use const E_RECOVERABLE_ERROR;
-use const E_STRICT;
 use const E_USER_DEPRECATED;
 use const E_USER_ERROR;
 use const E_USER_NOTICE;
@@ -137,7 +136,7 @@ class ErrorHandlerTest extends AbstractTestCase
     /** @return iterable<string, array{int, string}> */
     public static function addErrorProvider(): iterable
     {
-        yield 'E_STRICT' => [@E_STRICT, '[em]Error[/em]'];
+        yield 'E_STRICT' => [2048, '[em]Error[/em]'];
         yield 'E_NOTICE' => [E_NOTICE, '[em]Error[/em]'];
         yield 'E_WARNING' => [E_WARNING, '[em]Error[/em]'];
         yield 'E_CORE_WARNING' => [E_CORE_WARNING, '[em]Error[/em]'];

--- a/tests/unit/Error/ErrorTest.php
+++ b/tests/unit/Error/ErrorTest.php
@@ -18,7 +18,6 @@ use const E_ERROR;
 use const E_NOTICE;
 use const E_PARSE;
 use const E_RECOVERABLE_ERROR;
-use const E_STRICT;
 use const E_USER_DEPRECATED;
 use const E_USER_ERROR;
 use const E_USER_NOTICE;
@@ -165,7 +164,7 @@ class ErrorTest extends AbstractTestCase
         yield 'E_USER_ERROR error' => [E_USER_ERROR, 'danger'];
         yield 'E_USER_WARNING error' => [E_USER_WARNING, 'danger'];
         yield 'E_USER_NOTICE notice' => [E_USER_NOTICE, 'primary'];
-        yield 'E_STRICT notice' => [@E_STRICT, 'primary'];
+        yield 'E_STRICT notice' => [2048, 'primary'];
         yield 'E_DEPRECATED notice' => [E_DEPRECATED, 'primary'];
         yield 'E_USER_DEPRECATED notice' => [E_USER_DEPRECATED, 'primary'];
         yield 'E_RECOVERABLE_ERROR error' => [E_RECOVERABLE_ERROR, 'danger'];
@@ -192,7 +191,7 @@ class ErrorTest extends AbstractTestCase
         yield 'E_USER_ERROR error' => [E_USER_ERROR, 'User Error'];
         yield 'E_USER_WARNING warning' => [E_USER_WARNING, 'User Warning'];
         yield 'E_USER_NOTICE notice' => [E_USER_NOTICE, 'User Notice'];
-        yield 'E_STRICT notice' => [@E_STRICT, 'Runtime Notice'];
+        yield 'E_STRICT notice' => [2048, 'Runtime Notice'];
         yield 'E_DEPRECATED notice' => [E_DEPRECATED, 'Deprecation Notice'];
         yield 'E_USER_DEPRECATED notice' => [E_USER_DEPRECATED, 'Deprecation Notice'];
         yield 'E_RECOVERABLE_ERROR error' => [E_RECOVERABLE_ERROR, 'Catchable Fatal Error'];

--- a/tests/unit/FileTest.php
+++ b/tests/unit/FileTest.php
@@ -45,7 +45,7 @@ class FileTest extends AbstractTestCase
      * @param string $file file string
      */
     #[DataProvider('compressedFiles')]
-    public function testBinaryContent(string $file): void
+    public function testBinaryContent(string $file, string $_mime): void
     {
         $data = '0x' . bin2hex((string) file_get_contents($file));
         $file = new File($file);
@@ -60,7 +60,7 @@ class FileTest extends AbstractTestCase
     #[DataProvider('compressedFiles')]
     #[RequiresPhpExtension('bz2')]
     #[RequiresPhpExtension('zip')]
-    public function testReadCompressed(string $file): void
+    public function testReadCompressed(string $file, string $_mime): void
     {
         $file = new File($file);
         $file->setDecompressContent(true);

--- a/tests/unit/Twig/Node/Expression/TransExpressionTest.php
+++ b/tests/unit/Twig/Node/Expression/TransExpressionTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Twig\Compiler;
 use Twig\Error\SyntaxError;
 use Twig\Node\Expression\ConstantExpression;
-use Twig\Node\Expression\NameExpression;
+use Twig\Node\Expression\Variable\ContextVariable;
 use Twig\Node\Node;
 
 #[CoversClass(TransExpression::class)]
@@ -86,7 +86,7 @@ final class TransExpressionTest extends AbstractTestCase
             [
                 self::getConstantExpression('One apple'),
                 self::getConstantExpression('%d apples'),
-                self::getNameExpression('number_of_apples'),
+                self::getContextVariable('number_of_apples'),
             ],
             '\\_ngettext("One apple", "%d apples", // line 1' . "\n" . '($context["number_of_apples"] ?? null))',
         ];
@@ -95,7 +95,7 @@ final class TransExpressionTest extends AbstractTestCase
             [
                 0 => self::getConstantExpression('One apple'),
                 1 => self::getConstantExpression('%d apples'),
-                'count' => self::getNameExpression('number_of_apples'),
+                'count' => self::getContextVariable('number_of_apples'),
             ],
             '\\_ngettext("One apple", "%d apples", // line 1' . "\n" . '($context["number_of_apples"] ?? null))',
         ];
@@ -104,7 +104,7 @@ final class TransExpressionTest extends AbstractTestCase
             [
                 0 => self::getConstantExpression('One apple'),
                 'plural' => self::getConstantExpression('%d apples'),
-                'count' => self::getNameExpression('number_of_apples'),
+                'count' => self::getContextVariable('number_of_apples'),
             ],
             '\\_ngettext("One apple", "%d apples", // line 1' . "\n" . '($context["number_of_apples"] ?? null))',
         ];
@@ -113,7 +113,7 @@ final class TransExpressionTest extends AbstractTestCase
             [
                 'singular' => self::getConstantExpression('One apple'),
                 'plural' => self::getConstantExpression('%d apples'),
-                'count' => self::getNameExpression('number_of_apples'),
+                'count' => self::getContextVariable('number_of_apples'),
             ],
             '\\_ngettext("One apple", "%d apples", // line 1' . "\n" . '($context["number_of_apples"] ?? null))',
         ];
@@ -170,12 +170,12 @@ final class TransExpressionTest extends AbstractTestCase
         ];
 
         yield 't(variable_name)' => [
-            [self::getNameExpression('variable_name')],
+            [self::getContextVariable('variable_name')],
             'Value for argument "message" must be a non-empty literal string at line 1.',
         ];
 
         yield 't(message = variable_name)' => [
-            ['message' => self::getNameExpression('variable_name')],
+            ['message' => self::getContextVariable('variable_name')],
             'Value for argument "message" must be a non-empty literal string at line 1.',
         ];
 
@@ -185,7 +185,7 @@ final class TransExpressionTest extends AbstractTestCase
         ];
 
         yield 't("Message", notes = variable_name)' => [
-            [self::getConstantExpression('Message'), 'notes' => self::getNameExpression('variable_name')],
+            [self::getConstantExpression('Message'), 'notes' => self::getContextVariable('variable_name')],
             'Value for argument "notes" must be a non-empty literal string at line 1.',
         ];
 
@@ -200,7 +200,7 @@ final class TransExpressionTest extends AbstractTestCase
         ];
 
         yield 't("Message", context = variable_name)' => [
-            [self::getConstantExpression('Message'), 'context' => self::getNameExpression('variable_name')],
+            [self::getConstantExpression('Message'), 'context' => self::getContextVariable('variable_name')],
             'Value for argument "context" must be a non-empty literal string at line 1.',
         ];
 
@@ -234,7 +234,7 @@ final class TransExpressionTest extends AbstractTestCase
 
         yield 't(variable_name, "%d apples", 3)' => [
             [
-                self::getNameExpression('variable_name'),
+                self::getContextVariable('variable_name'),
                 self::getConstantExpression('%d apples'),
                 self::getConstantExpression(3),
             ],
@@ -253,7 +253,7 @@ final class TransExpressionTest extends AbstractTestCase
         yield 't("One apple", variable_name, 3)' => [
             [
                 self::getConstantExpression('One apple'),
-                self::getNameExpression('variable_name'),
+                self::getContextVariable('variable_name'),
                 self::getConstantExpression(3),
             ],
             'Value for argument "plural" must be a non-empty literal string at line 1.',
@@ -303,9 +303,9 @@ final class TransExpressionTest extends AbstractTestCase
         return new ConstantExpression($value, 1);
     }
 
-    private static function getNameExpression(string $name): NameExpression
+    private static function getContextVariable(string $name): ContextVariable
     {
-        return new NameExpression($name, 1);
+        return new ContextVariable($name, 1);
     }
 
     private function getCompiler(): Compiler


### PR DESCRIPTION
### Description

I ran PHPUnit 13.1.14 and I found some issues in tests. There are few more which require more work. I opened an issue about it.

```
OK, but there were issues!
Tests: 5584, Assertions: 17822, PHPUnit Warnings: 115, Deprecations: 4, PHPUnit Deprecations: 163, PHPUnit Notices: 172, Skipped: 51.

115 tests triggered 117 PHPUnit warnings:

1) PhpMyAdmin\Tests\Database\SearchTest::testGetWhereClause
Data set #7 provided by PhpMyAdmin\Tests\Database\SearchTest::searchTypesAndOptions has more arguments (4) than the test method accepts (3)

E:\GitHub\phpmyadmin\tests\unit\Database\SearchTest.php:65

2) PhpMyAdmin\Tests\FileTest::testBinaryContent
* Data set #0 provided by PhpMyAdmin\Tests\FileTest::compressedFiles has more arguments (2) than the test method accepts (1)

* Data set #1 provided by PhpMyAdmin\Tests\FileTest::compressedFiles has more arguments (2) than the test method accepts (1)

* Data set #2 provided by PhpMyAdmin\Tests\FileTest::compressedFiles has more arguments (2) than the test method accepts (1)

E:\GitHub\phpmyadmin\tests\unit\FileTest.php:48

3) PhpMyAdmin\Tests\Dbal\DatabaseInterfaceTest::testGetServerCollation
Class PhpMyAdmin\Column is targeted multiple times by the same "Covers" attribute

E:\GitHub\phpmyadmin\tests\unit\Dbal\DatabaseInterfaceTest.php:295

4) PhpMyAdmin\Tests\Dbal\DatabaseInterfaceTest::testGetTables@tables without NaturalOrder sort with data (['Table3', 'table1', 'table10', 'table2', 'table20', 'table200'], [['Table3'], ['table1']], ...11 more elements)
Class PhpMyAdmin\Column is targeted multiple times by the same "Covers" attribute

...

115) PhpMyAdmin\Tests\Dbal\DatabaseInterfaceTest::testGetTablesWithEmptyDatabaseName
Class PhpMyAdmin\Column is targeted multiple times by the same "Covers" attribute

E:\GitHub\phpmyadmin\tests\unit\Dbal\DatabaseInterfaceTest.php:991

...

1) E:\GitHub\phpmyadmin\vendor\symfony\deprecation-contracts\function.php:25
Since twig/twig 3.15: The "Twig\Node\Expression\NameExpression" class is deprecated, use "Twig\Node\Expression\Variable\ContextVariable" instead.

Triggered by:

* PhpMyAdmin\Tests\Twig\Node\Expression\TransExpressionTest::testTransExpressions#t("Message") (4 times)
  E:\GitHub\phpmyadmin\tests\unit\Twig\Node\Expression\TransExpressionTest.php:23

...

42 tests triggered 3 PHP deprecations:

1) E:\GitHub\phpmyadmin\tests\unit\Error\ErrorHandlerTest.php:140
Constant E_STRICT is deprecated since 8.4, the error level was removed

Triggered by:

* PhpMyAdmin\Tests\Error\ErrorHandlerTest::testAddError#E_COMPILE_WARNING
  E:\GitHub\phpmyadmin\tests\unit\Error\ErrorHandlerTest.php:126
```