### PR TITLE
Use utf8mb4 when creating pma tables

### DIFF
--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -18,7 +18,7 @@
 -- Database : `phpmyadmin`
 --
 CREATE DATABASE IF NOT EXISTS `phpmyadmin`
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 USE phpmyadmin;
 
 -- --------------------------------------------------------
@@ -40,12 +40,12 @@ CREATE TABLE IF NOT EXISTS `pma__bookmark` (
   `id` int(10) unsigned NOT NULL auto_increment,
   `dbase` varchar(255) NOT NULL default '',
   `user` varchar(255) NOT NULL default '',
-  `label` varchar(255) COLLATE utf8_general_ci NOT NULL default '',
+  `label` varchar(255) COLLATE utf8mb4_general_ci NOT NULL default '',
   `query` text NOT NULL,
   PRIMARY KEY  (`id`)
 )
   COMMENT='Bookmarks'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -58,8 +58,8 @@ CREATE TABLE IF NOT EXISTS `pma__column_info` (
   `db_name` varchar(64) NOT NULL default '',
   `table_name` varchar(64) NOT NULL default '',
   `column_name` varchar(64) NOT NULL default '',
-  `comment` varchar(255) COLLATE utf8_general_ci NOT NULL default '',
-  `mimetype` varchar(255) COLLATE utf8_general_ci NOT NULL default '',
+  `comment` varchar(255) COLLATE utf8mb4_general_ci NOT NULL default '',
+  `mimetype` varchar(255) COLLATE utf8mb4_general_ci NOT NULL default '',
   `transformation` varchar(255) NOT NULL default '',
   `transformation_options` varchar(255) NOT NULL default '',
   `input_transformation` varchar(255) NOT NULL default '',
@@ -68,7 +68,7 @@ CREATE TABLE IF NOT EXISTS `pma__column_info` (
   UNIQUE KEY `db_name` (`db_name`,`table_name`,`column_name`)
 )
   COMMENT='Column information for phpMyAdmin'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -87,7 +87,7 @@ CREATE TABLE IF NOT EXISTS `pma__history` (
   KEY `username` (`username`,`db`,`table`,`timevalue`)
 )
   COMMENT='SQL history for phpMyAdmin'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -98,12 +98,12 @@ CREATE TABLE IF NOT EXISTS `pma__history` (
 CREATE TABLE IF NOT EXISTS `pma__pdf_pages` (
   `db_name` varchar(64) NOT NULL default '',
   `page_nr` int(10) unsigned NOT NULL auto_increment,
-  `page_descr` varchar(50) COLLATE utf8_general_ci NOT NULL default '',
+  `page_descr` varchar(50) COLLATE utf8mb4_general_ci NOT NULL default '',
   PRIMARY KEY  (`page_nr`),
   KEY `db_name` (`db_name`)
 )
   COMMENT='PDF relation pages for phpMyAdmin'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -117,7 +117,7 @@ CREATE TABLE IF NOT EXISTS `pma__recent` (
   PRIMARY KEY (`username`)
 )
   COMMENT='Recently accessed tables'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -131,7 +131,7 @@ CREATE TABLE IF NOT EXISTS `pma__favorite` (
   PRIMARY KEY (`username`)
 )
   COMMENT='Favorite tables'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -148,7 +148,7 @@ CREATE TABLE IF NOT EXISTS `pma__table_uiprefs` (
   PRIMARY KEY (`username`,`db_name`,`table_name`)
 )
   COMMENT='Tables'' UI preferences'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -167,7 +167,7 @@ CREATE TABLE IF NOT EXISTS `pma__relation` (
   KEY `foreign_field` (`foreign_db`,`foreign_table`)
 )
   COMMENT='Relation table'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -184,7 +184,7 @@ CREATE TABLE IF NOT EXISTS `pma__table_coords` (
   PRIMARY KEY  (`db_name`,`table_name`,`pdf_page_number`)
 )
   COMMENT='Table coordinates for phpMyAdmin PDF output'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -199,7 +199,7 @@ CREATE TABLE IF NOT EXISTS `pma__table_info` (
   PRIMARY KEY  (`db_name`,`table_name`)
 )
   COMMENT='Table information for phpMyAdmin'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -221,7 +221,7 @@ CREATE TABLE IF NOT EXISTS `pma__tracking` (
   PRIMARY KEY  (`db_name`,`table_name`,`version`)
 )
   COMMENT='Database changes tracking for phpMyAdmin'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -236,7 +236,7 @@ CREATE TABLE IF NOT EXISTS `pma__userconfig` (
   PRIMARY KEY  (`username`)
 )
   COMMENT='User preferences storage for phpMyAdmin'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -250,7 +250,7 @@ CREATE TABLE IF NOT EXISTS `pma__users` (
   PRIMARY KEY (`username`,`usergroup`)
 )
   COMMENT='Users and their assignments to user groups'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -265,7 +265,7 @@ CREATE TABLE IF NOT EXISTS `pma__usergroups` (
   PRIMARY KEY (`usergroup`,`tab`,`allowed`)
 )
   COMMENT='User groups with configured menu items'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -282,7 +282,7 @@ CREATE TABLE IF NOT EXISTS `pma__navigationhiding` (
   PRIMARY KEY (`username`,`item_name`,`item_type`,`db_name`,`table_name`)
 )
   COMMENT='Hidden items of navigation tree'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -300,7 +300,7 @@ CREATE TABLE IF NOT EXISTS `pma__savedsearches` (
   UNIQUE KEY `u_savedsearches_username_dbname` (`username`,`db_name`,`search_name`)
 )
   COMMENT='Saved searches'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -320,7 +320,7 @@ CREATE TABLE IF NOT EXISTS `pma__central_columns` (
   PRIMARY KEY (`db_name`,`col_name`)
 )
   COMMENT='Central list of columns'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -334,7 +334,7 @@ CREATE TABLE IF NOT EXISTS `pma__designer_settings` (
   PRIMARY KEY (`username`)
 )
   COMMENT='Settings related to Designer'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -352,4 +352,4 @@ CREATE TABLE IF NOT EXISTS `pma__export_templates` (
   UNIQUE KEY `u_user_type_template` (`username`,`export_type`,`template_name`)
 )
   COMMENT='Saved export templates'
-  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;

--- a/test/classes/ConfigStorage/RelationTest.php
+++ b/test/classes/ConfigStorage/RelationTest.php
@@ -333,9 +333,9 @@ class RelationTest extends AbstractTestCase
                 . '`id` int(10) unsigned NOT NULL auto_increment,'
                 . ' `dbase` varchar(255) NOT NULL default \'\','
                 . ' `user` varchar(255) NOT NULL default \'\','
-                . ' `label` varchar(255) COLLATE utf8_general_ci NOT NULL default \'\','
+                . ' `label` varchar(255) COLLATE utf8mb4_general_ci NOT NULL default \'\','
                 . ' `query` text NOT NULL, PRIMARY KEY (`id`) )'
-                . ' COMMENT=\'Bookmarks\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Bookmarks\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -348,7 +348,7 @@ class RelationTest extends AbstractTestCase
                 . ' `foreign_field` varchar(64) NOT NULL default \'\','
                 . ' PRIMARY KEY (`master_db`,`master_table`,`master_field`),'
                 . ' KEY `foreign_field` (`foreign_db`,`foreign_table`) ) COMMENT=\'Relation table\''
-                . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -357,7 +357,7 @@ class RelationTest extends AbstractTestCase
             . ' -- CREATE TABLE IF NOT EXISTS `pma__table_info` ( '
                 . '`db_name` varchar(64) NOT NULL default \'\', `table_name` varchar(64) NOT NULL default \'\','
                 . ' `display_field` varchar(64) NOT NULL default \'\', PRIMARY KEY (`db_name`,`table_name`) )'
-                . ' COMMENT=\'Table information for phpMyAdmin\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Table information for phpMyAdmin\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
 
@@ -370,7 +370,7 @@ class RelationTest extends AbstractTestCase
                 . ' `y` float unsigned NOT NULL default \'0\','
                 . ' PRIMARY KEY (`db_name`,`table_name`,`pdf_page_number`) )'
                 . ' COMMENT=\'Table coordinates for phpMyAdmin PDF output\''
-                . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -378,9 +378,9 @@ class RelationTest extends AbstractTestCase
             . ' Table structure for table `pma__pdf_pages`'
             . ' -- CREATE TABLE IF NOT EXISTS `pma__pdf_pages` ( '
                 . '`db_name` varchar(64) NOT NULL default \'\', `page_nr` int(10) unsigned NOT NULL auto_increment,'
-                . ' `page_descr` varchar(50) COLLATE utf8_general_ci NOT NULL default \'\', PRIMARY KEY (`page_nr`),'
+                . ' `page_descr` varchar(50) COLLATE utf8mb4_general_ci NOT NULL default \'\', PRIMARY KEY (`page_nr`),'
                 . ' KEY `db_name` (`db_name`) ) COMMENT=\'PDF relation pages for phpMyAdmin\''
-                . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -389,14 +389,14 @@ class RelationTest extends AbstractTestCase
             . ' -- CREATE TABLE IF NOT EXISTS `pma__column_info` ( '
                 . '`id` int(5) unsigned NOT NULL auto_increment, `db_name` varchar(64) NOT NULL default \'\','
                 . ' `table_name` varchar(64) NOT NULL default \'\', `column_name` varchar(64) NOT NULL default \'\','
-                . ' `comment` varchar(255) COLLATE utf8_general_ci NOT NULL default \'\','
-                . ' `mimetype` varchar(255) COLLATE utf8_general_ci NOT NULL default \'\','
+                . ' `comment` varchar(255) COLLATE utf8mb4_general_ci NOT NULL default \'\','
+                . ' `mimetype` varchar(255) COLLATE utf8mb4_general_ci NOT NULL default \'\','
                 . ' `transformation` varchar(255) NOT NULL default \'\','
                 . ' `transformation_options` varchar(255) NOT NULL default \'\','
                 . ' `input_transformation` varchar(255) NOT NULL default \'\','
                 . ' `input_transformation_options` varchar(255) NOT NULL default \'\','
                 . ' PRIMARY KEY (`id`), UNIQUE KEY `db_name` (`db_name`,`table_name`,`column_name`) )'
-                . ' COMMENT=\'Column information for phpMyAdmin\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Column information for phpMyAdmin\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -407,7 +407,7 @@ class RelationTest extends AbstractTestCase
                 . ' `db` varchar(64) NOT NULL default \'\', `table` varchar(64) NOT NULL default \'\','
                 . ' `timevalue` timestamp NOT NULL default CURRENT_TIMESTAMP, `sqlquery` text NOT NULL,'
                 . ' PRIMARY KEY (`id`), KEY `username` (`username`,`db`,`table`,`timevalue`) )'
-                . ' COMMENT=\'SQL history for phpMyAdmin\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'SQL history for phpMyAdmin\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -415,7 +415,7 @@ class RelationTest extends AbstractTestCase
             . ' Table structure for table `pma__recent` '
             . '-- CREATE TABLE IF NOT EXISTS `pma__recent` ( '
                 . '`username` varchar(64) NOT NULL, `tables` text NOT NULL, PRIMARY KEY (`username`) )'
-                . ' COMMENT=\'Recently accessed tables\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Recently accessed tables\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -423,7 +423,7 @@ class RelationTest extends AbstractTestCase
             . ' Table structure for table `pma__favorite` '
             . '-- CREATE TABLE IF NOT EXISTS `pma__favorite` ( '
                 . '`username` varchar(64) NOT NULL, `tables` text NOT NULL, PRIMARY KEY (`username`) )'
-                . ' COMMENT=\'Favorite tables\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Favorite tables\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -434,7 +434,7 @@ class RelationTest extends AbstractTestCase
                 . ' `table_name` varchar(64) NOT NULL, `prefs` text NOT NULL,'
                 . ' `last_update` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,'
                 . ' PRIMARY KEY (`username`,`db_name`,`table_name`) ) COMMENT=\'Tables\'\' UI preferences\''
-                . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -453,7 +453,7 @@ class RelationTest extends AbstractTestCase
                 . ' default NULL, `tracking_active` int(1) unsigned NOT NULL'
                 . ' default \'1\', PRIMARY KEY (`db_name`,`table_name`,`version`) )'
                 . ' COMMENT=\'Database changes tracking for phpMyAdmin\''
-                . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -463,7 +463,7 @@ class RelationTest extends AbstractTestCase
                 . '`username` varchar(64) NOT NULL, `usergroup` varchar(64) NOT NULL,'
                 . ' PRIMARY KEY (`username`,`usergroup`) )'
                 . ' COMMENT=\'Users and their assignments to user groups\''
-                . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -474,7 +474,7 @@ class RelationTest extends AbstractTestCase
                 . ' `allowed` enum(\'Y\',\'N\') NOT NULL DEFAULT \'N\','
                 . ' PRIMARY KEY (`usergroup`,`tab`,`allowed`) )'
                 . ' COMMENT=\'User groups with configured menu items\''
-                . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -485,7 +485,7 @@ class RelationTest extends AbstractTestCase
                 . ' NOT NULL, `item_type` varchar(64) NOT NULL, `db_name` varchar(64) NOT NULL,'
                 . ' `table_name` varchar(64) NOT NULL,'
                 . ' PRIMARY KEY (`username`,`item_name`,`item_type`,`db_name`,`table_name`) )'
-                . ' COMMENT=\'Hidden items of navigation tree\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Hidden items of navigation tree\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -496,7 +496,7 @@ class RelationTest extends AbstractTestCase
                 . ' `db_name` varchar(64) NOT NULL default \'\', `search_name` varchar(64) NOT NULL default \'\','
                 . ' `search_data` text NOT NULL, PRIMARY KEY (`id`),'
                 . ' UNIQUE KEY `u_savedsearches_username_dbname` (`username`,`db_name`,`search_name`) )'
-                . ' COMMENT=\'Saved searches\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Saved searches\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -507,7 +507,7 @@ class RelationTest extends AbstractTestCase
                 . ' `col_length` text, `col_collation` varchar(64) NOT NULL, `col_isNull` boolean NOT NULL,'
                 . ' `col_extra` varchar(255) default \'\', `col_default` text,'
                 . ' PRIMARY KEY (`db_name`,`col_name`) )'
-                . ' COMMENT=\'Central list of columns\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Central list of columns\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -516,7 +516,7 @@ class RelationTest extends AbstractTestCase
             . ' -- CREATE TABLE IF NOT EXISTS `pma__designer_settings` ( '
                 . '`username` varchar(64) NOT NULL, `settings_data` text NOT NULL,'
                 . ' PRIMARY KEY (`username`) )'
-                . ' COMMENT=\'Settings related to Designer\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Settings related to Designer\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -527,7 +527,7 @@ class RelationTest extends AbstractTestCase
                 . ' `export_type` varchar(10) NOT NULL, `template_name` varchar(64) NOT NULL,'
                 . ' `template_data` text NOT NULL, PRIMARY KEY (`id`),'
                 . ' UNIQUE KEY `u_user_type_template` (`username`,`export_type`,`template_name`) )'
-                . ' COMMENT=\'Saved export templates\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Saved export templates\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
 
@@ -618,9 +618,9 @@ class RelationTest extends AbstractTestCase
                 . '`id` int(10) unsigned NOT NULL auto_increment,'
                 . ' `dbase` varchar(255) NOT NULL default \'\','
                 . ' `user` varchar(255) NOT NULL default \'\','
-                . ' `label` varchar(255) COLLATE utf8_general_ci NOT NULL default \'\','
+                . ' `label` varchar(255) COLLATE utf8mb4_general_ci NOT NULL default \'\','
                 . ' `query` text NOT NULL, PRIMARY KEY (`id`) )'
-                . ' COMMENT=\'Bookmarks\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Bookmarks\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -633,7 +633,7 @@ class RelationTest extends AbstractTestCase
                 . ' `foreign_field` varchar(64) NOT NULL default \'\','
                 . ' PRIMARY KEY (`master_db`,`master_table`,`master_field`),'
                 . ' KEY `foreign_field` (`foreign_db`,`foreign_table`) ) COMMENT=\'Relation table\''
-                . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -642,7 +642,7 @@ class RelationTest extends AbstractTestCase
             . ' -- CREATE TABLE IF NOT EXISTS `pma__table_info` ( '
                 . '`db_name` varchar(64) NOT NULL default \'\', `table_name` varchar(64) NOT NULL default \'\','
                 . ' `display_field` varchar(64) NOT NULL default \'\', PRIMARY KEY (`db_name`,`table_name`) )'
-                . ' COMMENT=\'Table information for phpMyAdmin\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Table information for phpMyAdmin\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
 
@@ -655,7 +655,7 @@ class RelationTest extends AbstractTestCase
                 . ' `y` float unsigned NOT NULL default \'0\','
                 . ' PRIMARY KEY (`db_name`,`table_name`,`pdf_page_number`) )'
                 . ' COMMENT=\'Table coordinates for phpMyAdmin PDF output\''
-                . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -663,9 +663,9 @@ class RelationTest extends AbstractTestCase
             . ' Table structure for table `pma__pdf_pages`'
             . ' -- CREATE TABLE IF NOT EXISTS `pma__pdf_pages` ( '
                 . '`db_name` varchar(64) NOT NULL default \'\', `page_nr` int(10) unsigned NOT NULL auto_increment,'
-                . ' `page_descr` varchar(50) COLLATE utf8_general_ci NOT NULL default \'\', PRIMARY KEY (`page_nr`),'
+                . ' `page_descr` varchar(50) COLLATE utf8mb4_general_ci NOT NULL default \'\', PRIMARY KEY (`page_nr`),'
                 . ' KEY `db_name` (`db_name`) ) COMMENT=\'PDF relation pages for phpMyAdmin\''
-                . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -674,14 +674,14 @@ class RelationTest extends AbstractTestCase
             . ' -- CREATE TABLE IF NOT EXISTS `pma__column_info` ( '
                 . '`id` int(5) unsigned NOT NULL auto_increment, `db_name` varchar(64) NOT NULL default \'\','
                 . ' `table_name` varchar(64) NOT NULL default \'\', `column_name` varchar(64) NOT NULL default \'\','
-                . ' `comment` varchar(255) COLLATE utf8_general_ci NOT NULL default \'\','
-                . ' `mimetype` varchar(255) COLLATE utf8_general_ci NOT NULL default \'\','
+                . ' `comment` varchar(255) COLLATE utf8mb4_general_ci NOT NULL default \'\','
+                . ' `mimetype` varchar(255) COLLATE utf8mb4_general_ci NOT NULL default \'\','
                 . ' `transformation` varchar(255) NOT NULL default \'\','
                 . ' `transformation_options` varchar(255) NOT NULL default \'\','
                 . ' `input_transformation` varchar(255) NOT NULL default \'\','
                 . ' `input_transformation_options` varchar(255) NOT NULL default \'\','
                 . ' PRIMARY KEY (`id`), UNIQUE KEY `db_name` (`db_name`,`table_name`,`column_name`) )'
-                . ' COMMENT=\'Column information for phpMyAdmin\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Column information for phpMyAdmin\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -692,7 +692,7 @@ class RelationTest extends AbstractTestCase
                 . ' `db` varchar(64) NOT NULL default \'\', `table` varchar(64) NOT NULL default \'\','
                 . ' `timevalue` timestamp NOT NULL default CURRENT_TIMESTAMP, `sqlquery` text NOT NULL,'
                 . ' PRIMARY KEY (`id`), KEY `username` (`username`,`db`,`table`,`timevalue`) )'
-                . ' COMMENT=\'SQL history for phpMyAdmin\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'SQL history for phpMyAdmin\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -700,7 +700,7 @@ class RelationTest extends AbstractTestCase
             . ' Table structure for table `pma__recent` '
             . '-- CREATE TABLE IF NOT EXISTS `pma__recent` ( '
                 . '`username` varchar(64) NOT NULL, `tables` text NOT NULL, PRIMARY KEY (`username`) )'
-                . ' COMMENT=\'Recently accessed tables\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Recently accessed tables\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -708,7 +708,7 @@ class RelationTest extends AbstractTestCase
             . ' Table structure for table `pma__favorite` '
             . '-- CREATE TABLE IF NOT EXISTS `pma__favorite` ( '
                 . '`username` varchar(64) NOT NULL, `tables` text NOT NULL, PRIMARY KEY (`username`) )'
-                . ' COMMENT=\'Favorite tables\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Favorite tables\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -719,7 +719,7 @@ class RelationTest extends AbstractTestCase
                 . ' `table_name` varchar(64) NOT NULL, `prefs` text NOT NULL,'
                 . ' `last_update` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,'
                 . ' PRIMARY KEY (`username`,`db_name`,`table_name`) ) COMMENT=\'Tables\'\' UI preferences\''
-                . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -738,7 +738,7 @@ class RelationTest extends AbstractTestCase
                 . ' default NULL, `tracking_active` int(1) unsigned NOT NULL'
                 . ' default \'1\', PRIMARY KEY (`db_name`,`table_name`,`version`) )'
                 . ' COMMENT=\'Database changes tracking for phpMyAdmin\''
-                . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -748,7 +748,7 @@ class RelationTest extends AbstractTestCase
                 . '`username` varchar(64) NOT NULL, `usergroup` varchar(64) NOT NULL,'
                 . ' PRIMARY KEY (`username`,`usergroup`) )'
                 . ' COMMENT=\'Users and their assignments to user groups\''
-                . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -759,7 +759,7 @@ class RelationTest extends AbstractTestCase
                 . ' `allowed` enum(\'Y\',\'N\') NOT NULL DEFAULT \'N\','
                 . ' PRIMARY KEY (`usergroup`,`tab`,`allowed`) )'
                 . ' COMMENT=\'User groups with configured menu items\''
-                . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -770,7 +770,7 @@ class RelationTest extends AbstractTestCase
                 . ' NOT NULL, `item_type` varchar(64) NOT NULL, `db_name` varchar(64) NOT NULL,'
                 . ' `table_name` varchar(64) NOT NULL,'
                 . ' PRIMARY KEY (`username`,`item_name`,`item_type`,`db_name`,`table_name`) )'
-                . ' COMMENT=\'Hidden items of navigation tree\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Hidden items of navigation tree\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -781,7 +781,7 @@ class RelationTest extends AbstractTestCase
                 . ' `db_name` varchar(64) NOT NULL default \'\', `search_name` varchar(64) NOT NULL default \'\','
                 . ' `search_data` text NOT NULL, PRIMARY KEY (`id`),'
                 . ' UNIQUE KEY `u_savedsearches_username_dbname` (`username`,`db_name`,`search_name`) )'
-                . ' COMMENT=\'Saved searches\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Saved searches\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -792,7 +792,7 @@ class RelationTest extends AbstractTestCase
                 . ' `col_length` text, `col_collation` varchar(64) NOT NULL, `col_isNull` boolean NOT NULL,'
                 . ' `col_extra` varchar(255) default \'\', `col_default` text,'
                 . ' PRIMARY KEY (`db_name`,`col_name`) )'
-                . ' COMMENT=\'Central list of columns\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Central list of columns\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -801,7 +801,7 @@ class RelationTest extends AbstractTestCase
             . ' -- CREATE TABLE IF NOT EXISTS `pma__designer_settings` ( '
                 . '`username` varchar(64) NOT NULL, `settings_data` text NOT NULL,'
                 . ' PRIMARY KEY (`username`) )'
-                . ' COMMENT=\'Settings related to Designer\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Settings related to Designer\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
         $this->dummyDbi->addResult(
@@ -812,7 +812,7 @@ class RelationTest extends AbstractTestCase
                 . ' `export_type` varchar(10) NOT NULL, `template_name` varchar(64) NOT NULL,'
                 . ' `template_data` text NOT NULL, PRIMARY KEY (`id`),'
                 . ' UNIQUE KEY `u_user_type_template` (`username`,`export_type`,`template_name`) )'
-                . ' COMMENT=\'Saved export templates\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Saved export templates\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             []
         );
 
@@ -888,9 +888,9 @@ class RelationTest extends AbstractTestCase
                 . '`id` int(10) unsigned NOT NULL auto_increment,'
                 . ' `dbase` varchar(255) NOT NULL default \'\','
                 . ' `user` varchar(255) NOT NULL default \'\','
-                . ' `label` varchar(255) COLLATE utf8_general_ci NOT NULL default \'\','
+                . ' `label` varchar(255) COLLATE utf8mb4_general_ci NOT NULL default \'\','
                 . ' `query` text NOT NULL, PRIMARY KEY (`id`) )'
-                . ' COMMENT=\'Bookmarks\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                . ' COMMENT=\'Bookmarks\' DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             false
         );
         $this->dummyDbi->addSelectDb('db_pma');
@@ -1000,12 +1000,12 @@ class RelationTest extends AbstractTestCase
                 '  `id` int(10) unsigned NOT NULL auto_increment,',
                 '  `dbase` varchar(255) NOT NULL default \'\',',
                 '  `user` varchar(255) NOT NULL default \'\',',
-                '  `label` varchar(255) COLLATE utf8_general_ci NOT NULL default \'\',',
+                '  `label` varchar(255) COLLATE utf8mb4_general_ci NOT NULL default \'\',',
                 '  `query` text NOT NULL,',
                 '  PRIMARY KEY  (`id`)',
                 ')',
                 '  COMMENT=\'Bookmarks\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__column_info' => implode("\n", [
                 '',
@@ -1021,8 +1021,8 @@ class RelationTest extends AbstractTestCase
                 '  `db_name` varchar(64) NOT NULL default \'\',',
                 '  `table_name` varchar(64) NOT NULL default \'\',',
                 '  `column_name` varchar(64) NOT NULL default \'\',',
-                '  `comment` varchar(255) COLLATE utf8_general_ci NOT NULL default \'\',',
-                '  `mimetype` varchar(255) COLLATE utf8_general_ci NOT NULL default \'\',',
+                '  `comment` varchar(255) COLLATE utf8mb4_general_ci NOT NULL default \'\',',
+                '  `mimetype` varchar(255) COLLATE utf8mb4_general_ci NOT NULL default \'\',',
                 '  `transformation` varchar(255) NOT NULL default \'\',',
                 '  `transformation_options` varchar(255) NOT NULL default \'\',',
                 '  `input_transformation` varchar(255) NOT NULL default \'\',',
@@ -1031,7 +1031,7 @@ class RelationTest extends AbstractTestCase
                 '  UNIQUE KEY `db_name` (`db_name`,`table_name`,`column_name`)',
                 ')',
                 '  COMMENT=\'Column information for phpMyAdmin\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__history' => implode("\n", [
                 '',
@@ -1053,7 +1053,7 @@ class RelationTest extends AbstractTestCase
                 '  KEY `username` (`username`,`db`,`table`,`timevalue`)',
                 ')',
                 '  COMMENT=\'SQL history for phpMyAdmin\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__pdf_pages' => implode("\n", [
                 '',
@@ -1067,12 +1067,12 @@ class RelationTest extends AbstractTestCase
                 'CREATE TABLE IF NOT EXISTS `pma__pdf_pages` (',
                 '  `db_name` varchar(64) NOT NULL default \'\',',
                 '  `page_nr` int(10) unsigned NOT NULL auto_increment,',
-                '  `page_descr` varchar(50) COLLATE utf8_general_ci NOT NULL default \'\',',
+                '  `page_descr` varchar(50) COLLATE utf8mb4_general_ci NOT NULL default \'\',',
                 '  PRIMARY KEY  (`page_nr`),',
                 '  KEY `db_name` (`db_name`)',
                 ')',
                 '  COMMENT=\'PDF relation pages for phpMyAdmin\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__recent' => implode("\n", [
                 '',
@@ -1089,7 +1089,7 @@ class RelationTest extends AbstractTestCase
                 '  PRIMARY KEY (`username`)',
                 ')',
                 '  COMMENT=\'Recently accessed tables\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__favorite' => implode("\n", [
                 '',
@@ -1106,7 +1106,7 @@ class RelationTest extends AbstractTestCase
                 '  PRIMARY KEY (`username`)',
                 ')',
                 '  COMMENT=\'Favorite tables\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__table_uiprefs' => implode("\n", [
                 '',
@@ -1126,7 +1126,7 @@ class RelationTest extends AbstractTestCase
                 '  PRIMARY KEY (`username`,`db_name`,`table_name`)',
                 ')',
                 '  COMMENT=\'Tables\'\' UI preferences\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__relation' => implode("\n", [
                 '',
@@ -1148,7 +1148,7 @@ class RelationTest extends AbstractTestCase
                 '  KEY `foreign_field` (`foreign_db`,`foreign_table`)',
                 ')',
                 '  COMMENT=\'Relation table\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__table_coords' => implode("\n", [
                 '',
@@ -1168,7 +1168,7 @@ class RelationTest extends AbstractTestCase
                 '  PRIMARY KEY  (`db_name`,`table_name`,`pdf_page_number`)',
                 ')',
                 '  COMMENT=\'Table coordinates for phpMyAdmin PDF output\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__table_info' => implode("\n", [
                 '',
@@ -1186,7 +1186,7 @@ class RelationTest extends AbstractTestCase
                 '  PRIMARY KEY  (`db_name`,`table_name`)',
                 ')',
                 '  COMMENT=\'Table information for phpMyAdmin\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__tracking' => implode("\n", [
                 '',
@@ -1215,7 +1215,7 @@ class RelationTest extends AbstractTestCase
                 '  PRIMARY KEY  (`db_name`,`table_name`,`version`)',
                 ')',
                 '  COMMENT=\'Database changes tracking for phpMyAdmin\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__userconfig' => implode("\n", [
                 '',
@@ -1233,7 +1233,7 @@ class RelationTest extends AbstractTestCase
                 '  PRIMARY KEY  (`username`)',
                 ')',
                 '  COMMENT=\'User preferences storage for phpMyAdmin\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__users' => implode("\n", [
                 '',
@@ -1250,7 +1250,7 @@ class RelationTest extends AbstractTestCase
                 '  PRIMARY KEY (`username`,`usergroup`)',
                 ')',
                 '  COMMENT=\'Users and their assignments to user groups\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__usergroups' => implode("\n", [
                 '',
@@ -1268,7 +1268,7 @@ class RelationTest extends AbstractTestCase
                 '  PRIMARY KEY (`usergroup`,`tab`,`allowed`)',
                 ')',
                 '  COMMENT=\'User groups with configured menu items\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__navigationhiding' => implode("\n", [
                 '',
@@ -1288,7 +1288,7 @@ class RelationTest extends AbstractTestCase
                 '  PRIMARY KEY (`username`,`item_name`,`item_type`,`db_name`,`table_name`)',
                 ')',
                 '  COMMENT=\'Hidden items of navigation tree\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__savedsearches' => implode("\n", [
                 '',
@@ -1309,7 +1309,7 @@ class RelationTest extends AbstractTestCase
                 '  UNIQUE KEY `u_savedsearches_username_dbname` (`username`,`db_name`,`search_name`)',
                 ')',
                 '  COMMENT=\'Saved searches\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__central_columns' => implode("\n", [
                 '',
@@ -1332,7 +1332,7 @@ class RelationTest extends AbstractTestCase
                 '  PRIMARY KEY (`db_name`,`col_name`)',
                 ')',
                 '  COMMENT=\'Central list of columns\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__designer_settings' => implode("\n", [
                 '',
@@ -1349,7 +1349,7 @@ class RelationTest extends AbstractTestCase
                 '  PRIMARY KEY (`username`)',
                 ')',
                 '  COMMENT=\'Settings related to Designer\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
             'pma__export_templates' => implode("\n", [
                 '',
@@ -1370,7 +1370,7 @@ class RelationTest extends AbstractTestCase
                 '  UNIQUE KEY `u_user_type_template` (`username`,`export_type`,`template_name`)',
                 ')',
                 '  COMMENT=\'Saved export templates\'',
-                '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+                '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
             ]),
         ];
 
@@ -1395,7 +1395,7 @@ class RelationTest extends AbstractTestCase
             '  UNIQUE KEY `u_user_type_template` (`username`,`export_type`,`template_name`)',
             ')',
             '  COMMENT=\'Saved export templates\'',
-            '  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
+            '  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;',
         ]);
 
         self::assertSame(


### PR DESCRIPTION
### Description

Create pma database tables with utf8mb4 instead of utf8[mb3].

With only utf8mb3 some data cannot be saved.
For example if you have the history feature enabled, a query like `SELECT '🐛';` causes phpMyAdmin to error because inserting into pma__history fails.