### PR TITLE
Blur focused element when hiding the GIS editor modal

### DIFF
--- a/resources/js/table/change.ts
+++ b/resources/js/table/change.ts
@@ -624,6 +624,17 @@ AJAX.registerOnload('table/change.js', function () {
         window.openGISEditor(value, field, type, inputName);
     });
 
+    gisEditorModal?.addEventListener('hide.bs.modal', event => {
+        // Move focus out of the modal before Bootstrap marks it aria-hidden.
+        // Otherwise the browser blocks aria-hidden while a descendant (such as
+        // the close button) still holds focus, which hides the focused element
+        // from assistive technology (see issue #19793).
+        const modal = event.currentTarget as HTMLElement;
+        if (modal.contains(document.activeElement)) {
+            (document.activeElement as HTMLElement).blur();
+        }
+    });
+
     /**
      * Forced validation check of fields
      */

--- a/resources/js/table/select.ts
+++ b/resources/js/table/select.ts
@@ -295,6 +295,17 @@ AJAX.registerOnload('table/select.js', function () {
         window.openGISEditor(value, field, type, inputName);
     });
 
+    gisEditorModal?.addEventListener('hide.bs.modal', event => {
+        // Move focus out of the modal before Bootstrap marks it aria-hidden.
+        // Otherwise the browser blocks aria-hidden while a descendant (such as
+        // the close button) still holds focus, which hides the focused element
+        // from assistive technology (see issue #19793).
+        const modal = event.currentTarget as HTMLElement;
+        if (modal.contains(document.activeElement)) {
+            (document.activeElement as HTMLElement).blur();
+        }
+    });
+
     /**
      * Ajax event handler for Range-Search.
      */


### PR DESCRIPTION
## Description

When the GIS editor modal (`#gisEditorModal`) is dismissed, a focused descendant — typically the close button (`.btn-close`, which carries `data-bs-dismiss="modal"`) — keeps focus while Bootstrap sets `aria-hidden="true"` on the modal. Browsers then block the attribute and log:

> Blocked aria-hidden on an element because its descendant retained focus. The focus must not be hidden from assistive technology users.

This moves focus out of the modal on the `hide.bs.modal` event (which fires before the modal becomes `aria-hidden`) by blurring the focused descendant, so focus returns to the document body and the warning no longer occurs.

The handler is added in the two places that wire up `#gisEditorModal` (`resources/js/table/select.ts` and `resources/js/table/change.ts`), mirroring the existing `show.bs.modal` handlers there.

Fixes #19793

## How to test

1. Open a table and start inserting or searching a row that has a geometry (spatial) column.
2. Click the GIS editor button to open the modal, then close it (close button or `Esc`).
3. With the browser DevTools console open, confirm the "Blocked aria-hidden on an element…" warning no longer appears.

The commit is signed off per the DCO.