### PR TITLE
Fix #18304 - Avoid TypeError when adding a column without index data

### DIFF
--- a/libraries/classes/CreateAddField.php
+++ b/libraries/classes/CreateAddField.php
@@ -42,11 +42,11 @@ class CreateAddField
     private function getIndexedColumns(): array
     {
         $fieldCount = count($_POST['field_name']);
-        $fieldPrimary = json_decode($_POST['primary_indexes'], true);
-        $fieldIndex = json_decode($_POST['indexes'], true);
-        $fieldUnique = json_decode($_POST['unique_indexes'], true);
-        $fieldFullText = json_decode($_POST['fulltext_indexes'], true);
-        $fieldSpatial = json_decode($_POST['spatial_indexes'], true);
+        $fieldPrimary = json_decode($_POST['primary_indexes'] ?? '[]', true);
+        $fieldIndex = json_decode($_POST['indexes'] ?? '[]', true);
+        $fieldUnique = json_decode($_POST['unique_indexes'] ?? '[]', true);
+        $fieldFullText = json_decode($_POST['fulltext_indexes'] ?? '[]', true);
+        $fieldSpatial = json_decode($_POST['spatial_indexes'] ?? '[]', true);
 
         return [
             $fieldCount,

--- a/test/classes/CreateAddFieldTest.php
+++ b/test/classes/CreateAddFieldTest.php
@@ -527,4 +527,48 @@ class CreateAddFieldTest extends AbstractTestCase
         $sqlQuery = $this->createAddField->getColumnCreationQuery('my_table');
         self::assertSame($expected, $sqlQuery);
     }
+
+    /**
+     * Adding a column must not fail when the request does not contain the index
+     * arrays (primary_indexes, indexes, unique_indexes, fulltext_indexes and
+     * spatial_indexes). This happens for instance when a primary key column is
+     * added from the normalization page, which does not submit those fields.
+     *
+     * Regression test for https://github.com/phpmyadmin/phpmyadmin/issues/18304
+     */
+    public function testGetColumnCreationQueryWithoutIndexPostVariables(): void
+    {
+        $_POST = [
+            'db' => '2fa',
+            'field_where' => 'after',
+            'after_field' => 'd',
+            'table' => 'aes',
+            'orig_num_fields' => '1',
+            'orig_field_where' => 'after',
+            'orig_after_field' => 'd',
+            'field_name' => ['dd'],
+            'field_type' => ['INT'],
+            'field_length' => [''],
+            'field_default_type' => ['NONE'],
+            'field_default_value' => [''],
+            'field_collation' => [''],
+            'field_attribute' => [''],
+            'field_key' => ['none_0'],
+            'field_comments' => [''],
+            'field_virtuality' => [''],
+            'field_expression' => [''],
+            'field_move_to' => [''],
+            'field_mimetype' => [''],
+            'field_transformation' => [''],
+            'field_transformation_options' => [''],
+            'field_input_transformation' => [''],
+            'field_input_transformation_options' => [''],
+            'do_save_data' => '1',
+            'preview_sql' => '1',
+            'ajax_request' => '1',
+        ];
+
+        $sqlQuery = $this->createAddField->getColumnCreationQuery('my_table');
+        self::assertSame('ALTER TABLE `my_table` ADD `dd` INT NOT NULL AFTER `d`;', $sqlQuery);
+    }
 }


### PR DESCRIPTION
### Description

`CreateAddField::getIndexedColumns()` passed the raw `$_POST` index values straight to `json_decode()`. When a column is added through a request that does not submit the `primary_indexes`, `indexes`, `unique_indexes`, `fulltext_indexes` and `spatial_indexes` fields — for example when adding a primary key column from the normalization page — those keys are undefined. Under `strict_types` this raised `TypeError: json_decode(): Argument #1 ($json) must be of type string, null given` together with `Undefined array key` warnings, and the column was not added.

This defaults each of those request values to an empty JSON array, so adding a column keeps working when no index information is provided (no indexes are created, which is the intended behaviour for that flow). Adds a regression test that errors on the current QA_5_2 code and passes with the fix (`OK, 13 tests, 13 assertions`); phpcs clean.

Fixes #18304

This change was prepared with the assistance of AI (Claude); it has been reviewed and tested, and I take responsibility for it.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch (QA_5_2 — the bug affects the released 5.2 version and forward-merges to master).
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO).
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own.
- [x] Any new functionality is covered by tests.
