### PR TITLE
Add LIMIT 1 to some queries

### DIFF
--- a/libraries/classes/Controllers/Table/GetFieldController.php
+++ b/libraries/classes/Controllers/Table/GetFieldController.php
@@ -77,7 +77,8 @@ class GetFieldController extends AbstractController
         /* Grab data */
         $sql = 'SELECT ' . Util::backquote($_GET['transform_key'])
             . ' FROM ' . Util::backquote($table)
-            . ' WHERE ' . $_GET['where_clause'] . ';';
+            . ' WHERE ' . $_GET['where_clause']
+            . ' LIMIT 1;';
         $result = $this->dbi->fetchValue($sql);
 
         /* Check return code */

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1428,7 +1428,8 @@ class InsertEdit
                 . ' FROM ' . Util::backquote($foreigner['foreign_db'])
                 . '.' . Util::backquote($foreigner['foreign_table'])
                 . ' WHERE ' . Util::backquote($foreigner['foreign_field'])
-                . $whereComparison;
+                . $whereComparison
+                . ' LIMIT 1';
             $dispresult = $this->dbi->tryQuery($dispsql);
             if ($dispresult && $dispresult->numRows() > 0) {
                 return (string) $dispresult->fetchValue();
@@ -1783,7 +1784,8 @@ class InsertEdit
             ) {
                 $protectedRow = $this->dbi->fetchSingleRow(
                     'SELECT * FROM ' . Util::backquote($table)
-                    . ' WHERE ' . $whereClause . ';'
+                    . ' WHERE ' . $whereClause
+                    . ' LIMIT 1;'
                 );
             }
 
@@ -1883,7 +1885,8 @@ class InsertEdit
             . Util::backquote($columnName)
             . ' FROM ' . Util::backquote($db) . '.'
             . Util::backquote($table)
-            . ' WHERE ' . $_POST['where_clause'][0];
+            . ' WHERE ' . $_POST['where_clause'][0]
+            . ' LIMIT 1';
 
         $result = $this->dbi->tryQuery($sqlForRealValue);
 

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -314,7 +314,7 @@ class Sql
         string $whereClause
     ): string {
         $row = $this->dbi->fetchSingleRow(sprintf(
-            'SELECT `%s` FROM `%s`.`%s` WHERE %s',
+            'SELECT `%s` FROM `%s`.`%s` WHERE %s LIMIT 1',
             $column,
             $db,
             $table,

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -1912,7 +1912,7 @@ class InsertEditTest extends AbstractTestCase
         $dbi->expects($this->once())
             ->method('tryQuery')
             ->with(
-                'SELECT `TABLE_COMMENT` FROM `information_schema`.`TABLES` WHERE `f`=1'
+                'SELECT `TABLE_COMMENT` FROM `information_schema`.`TABLES` WHERE `f`=1 LIMIT 1'
             )
             ->will($this->returnValue($resultStub));
 
@@ -2648,7 +2648,7 @@ class InsertEditTest extends AbstractTestCase
 
         $dbi->expects($this->exactly(3))
             ->method('tryQuery')
-            ->with('SELECT `table`.`a` FROM `db`.`table` WHERE 1')
+            ->with('SELECT `table`.`a` FROM `db`.`table` WHERE 1 LIMIT 1')
             ->willReturn($resultStub);
 
         $meta1 = new FieldMetadata(MYSQLI_TYPE_TINY, 0, (object) []);

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -2570,7 +2570,7 @@ class DbiDummy implements DbiExtension
                 ],
             ],
             [
-                'query' => 'SELECT * FROM `test_table` WHERE `id` = 4;',
+                'query' => 'SELECT * FROM `test_table` WHERE `id` = 4 LIMIT 1;',
                 'columns' => ['id', 'name', 'datetimefield'],
                 'result' => [['4', '101', '2013-01-20 02:00:02']],
             ],


### PR DESCRIPTION
InsertEdit::getDisplayValueForForeignTableColumn is called when a cell is edited and it suffered from the same issue that #20353 fixes with a LIMIT 1 at a different code location.

The rest of the changes are probably only useful for tables that have no unique key. 
In that case all columns are used as an identifier and there may be duplicate rows, but we need only one of the rows.