### PR TITLE
Use vanilla locutus for sprintf

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jquery-uitablefilter": "^1.0.0",
     "jquery-validation": "^1.22.1",
     "js-cookie": "3.0.5",
-    "locutus.sprintf": "^2.0.32-code-lts.1",
+    "locutus": "^3.0.36",
     "mini-css-extract-plugin": "^2.5.3",
     "ol": "^10.7.0",
     "postcss": "^8.5.6",

--- a/resources/js/database/operations.ts
+++ b/resources/js/database/operations.ts
@@ -7,6 +7,7 @@ import { ajaxShowMessage } from '../modules/ajax-message.ts';
 import getJsConfirmCommonParam from '../modules/functions/getJsConfirmCommonParam.ts';
 import { escapeHtml } from '../modules/functions/escape.ts';
 import refreshMainContent from '../modules/functions/refreshMainContent.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * @fileoverview    function used in server privilege pages
@@ -160,7 +161,7 @@ AJAX.registerOnload('database/operations.js', function () {
          * @var {string} question String containing the question to be asked for confirmation
          */
         let question = window.Messages.strDropDatabaseStrongWarning + ' ';
-        question += window.sprintf(
+        question += sprintf(
             window.Messages.strDoYouReally,
             'DROP DATABASE `' + escapeHtml(CommonParams.get('db') + '`')
         );

--- a/resources/js/database/query_generator.ts
+++ b/resources/js/database/query_generator.ts
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import { escapeBacktick, escapeSingleQuote } from '../modules/functions/escape.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * @fileoverview    function used in QBE for DB
@@ -108,16 +109,16 @@ function generateCondition (criteriaDiv, table) {
 
             criteriaText = joinWrappingElementsWith(critertiaTextArray, '\'');
 
-            query += window.sprintf(formatsText[criteriaOp], criteriaText);
+            query += sprintf(formatsText[criteriaOp], criteriaText);
         } else if (acceptsTwoValues(criteriaOp)) {
             const formatsText = getFormatsText();
             const valuesInputs = criteriaDiv.find('input.val');
 
-            query += window.sprintf(formatsText[criteriaOp], valuesInputs[0].value, valuesInputs[1].value);
+            query += sprintf(formatsText[criteriaOp], valuesInputs[0].value, valuesInputs[1].value);
         } else {
             const formatsText = getFormatsText();
 
-            query += window.sprintf(formatsText[criteriaOp], criteriaText);
+            query += sprintf(formatsText[criteriaOp], criteriaText);
         }
     } else {
         query += ' ' + criteriaOp;

--- a/resources/js/database/search.ts
+++ b/resources/js/database/search.ts
@@ -5,6 +5,7 @@ import { CommonParams } from '../modules/common.ts';
 import highlightSql from '../modules/sql-highlight.ts';
 import { ajaxRemoveMessage, ajaxShowMessage } from '../modules/ajax-message.ts';
 import getImageTag from '../modules/functions/getImageTag.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * JavaScript functions used on Database Search page
@@ -171,10 +172,10 @@ AJAX.registerOnload('database/search.js', function () {
         $('#sqlqueryform').hide();
         $('#togglequerybox').hide();
         /** Conformation message for deletion */
-        const msg = window.sprintf(
+        const msg = sprintf(
             window.Messages.strConfirmDeleteResults,
             $(this).data('table-name'),
-        );
+        ) as string;
         if (confirm(msg)) {
             const $msg = ajaxShowMessage(window.Messages.strDeleting, false);
             /** Load the deleted option to the page*/

--- a/resources/js/database/structure.ts
+++ b/resources/js/database/structure.ts
@@ -8,6 +8,7 @@ import { ajaxRemoveMessage, ajaxShowMessage } from '../modules/ajax-message.ts';
 import getJsConfirmCommonParam from '../modules/functions/getJsConfirmCommonParam.ts';
 import { escapeHtml, escapeJsString } from '../modules/functions/escape.ts';
 import adjustTotals from '../modules/functions/adjustTotals.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * @fileoverview    functions used on the database structure page
@@ -233,7 +234,7 @@ AJAX.registerOnload('database/structure.js', function () {
          * @var question    String containing the question to be asked for confirmation
          */
         const question = window.Messages.strTruncateTableStrongWarning + ' ' +
-            window.sprintf(window.Messages.strDoYouReally, 'TRUNCATE `' + escapeHtml(currTableName) + '`') +
+            sprintf(window.Messages.strDoYouReally, 'TRUNCATE `' + escapeHtml(currTableName) + '`') +
             getForeignKeyCheckboxLoader();
 
         $thisAnchor.confirm(question, $thisAnchor.attr('href'), function (url) {
@@ -283,10 +284,10 @@ AJAX.registerOnload('database/structure.js', function () {
         let question;
         if (! isView) {
             question = window.Messages.strDropTableStrongWarning + ' ' +
-                window.sprintf(window.Messages.strDoYouReally, 'DROP TABLE `' + escapeHtml(currTableName) + '`');
+                sprintf(window.Messages.strDoYouReally, 'DROP TABLE `' + escapeHtml(currTableName) + '`');
         } else {
             question =
-                window.sprintf(window.Messages.strDoYouReally, 'DROP VIEW `' + escapeHtml(currTableName) + '`');
+                sprintf(window.Messages.strDoYouReally, 'DROP VIEW `' + escapeHtml(currTableName) + '`');
         }
 
         question += getForeignKeyCheckboxLoader();

--- a/resources/js/designer/move.ts
+++ b/resources/js/designer/move.ts
@@ -8,6 +8,7 @@ import { DesignerObjects } from './objects.ts';
 import { DesignerHistory } from './history.ts';
 import { DesignerPage } from './page.ts';
 import { DesignerConfig } from './config.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 let change = 0; // variable to track any change in designer layout.
 let showRelationLines = true;
@@ -675,7 +676,7 @@ const addOtherDbTables = function () {
         const $table = $('[id="' + encodeURIComponent(db) + '.' + encodeURIComponent(table) + '"]');
         if ($table.length !== 0) {
             ajaxShowMessage(
-                window.sprintf(window.Messages.strTableAlreadyExists, db + '.' + table),
+                sprintf(window.Messages.strTableAlreadyExists, db + '.' + table),
                 undefined,
                 'error'
             );
@@ -1948,7 +1949,7 @@ const addObject = function (dbName, tableName, colName, dbTableNameUrl) {
     const init = DesignerHistory.historyArray.length;
     if (rel.value !== '--') {
         if ((document.getElementById('Query') as HTMLTextAreaElement).value === '') {
-            ajaxShowMessage(window.sprintf(window.Messages.strQueryEmpty));
+            ajaxShowMessage(sprintf(window.Messages.strQueryEmpty));
 
             return;
         }
@@ -2001,7 +2002,7 @@ const addObject = function (dbName, tableName, colName, dbTableNameUrl) {
         // make orderby
     }
 
-    ajaxShowMessage(window.sprintf(window.Messages.strObjectsCreated, sum));
+    ajaxShowMessage(sprintf(window.Messages.strObjectsCreated, sum));
     // output sum new objects created
     const existingDiv = document.getElementById('ab');
     existingDiv.innerHTML = DesignerHistory.display(init, DesignerHistory.historyArray.length);

--- a/resources/js/global.d.ts
+++ b/resources/js/global.d.ts
@@ -9,8 +9,6 @@ interface Window {
     msCrypto: any;
     u2f: any;
     variableNames: string[];
-
-    sprintf(format: string, ...values: (string|number)[]): string;
 }
 
 interface JQuery {

--- a/resources/js/import.ts
+++ b/resources/js/import.ts
@@ -4,6 +4,7 @@ import { formatBytes } from './modules/functions.ts';
 import { Navigation } from './modules/navigation.ts';
 import { CommonParams } from './modules/common.ts';
 import { ajaxShowMessage } from './modules/ajax-message.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * Functions used in the import tab
@@ -215,7 +216,7 @@ AJAX.registerOnload('import.js', function () {
                                 nowDate.getSeconds(),
                             ) + nowDate.getMilliseconds() - 1000;
 
-                            let statusText = window.sprintf(
+                            let statusText = sprintf(
                                 window.Messages.uploadProgressStatusText,
                                 formatBytes(
                                     complete, 1, window.Messages.strDecimalSeparator,
@@ -223,7 +224,7 @@ AJAX.registerOnload('import.js', function () {
                                 formatBytes(
                                     total, 1, window.Messages.strDecimalSeparator,
                                 ),
-                            );
+                            ) as string;
 
                             if ($('#importmain').is(':visible')) {
                                 // Show progress UI
@@ -241,7 +242,7 @@ AJAX.registerOnload('import.js', function () {
                                 // Calculate estimated time
                                 const usedTime = now - importStart;
                                 let seconds = parseInt((((total - complete) / complete) * usedTime / 1000).toString());
-                                const speed = window.sprintf(
+                                const speed = sprintf(
                                     window.Messages.uploadProgressPerSecond,
                                     formatBytes(complete / usedTime * 1000, 1, window.Messages.strDecimalSeparator),
                                 );

--- a/resources/js/modules/ajax.ts
+++ b/resources/js/modules/ajax.ts
@@ -9,6 +9,7 @@ import { ignorePhpErrors } from './functions/ignorePhpErrors.ts';
 import handleRedirectAndReload from './functions/handleRedirectAndReload.ts';
 import checkNumberOfFields from './functions/checkNumberOfFields.ts';
 import mainMenuResizerCallback from './functions/mainMenuResizerCallback.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * This object handles ajax requests for pages. It also
@@ -966,10 +967,10 @@ const AJAX = {
                 }
 
                 if (request.status !== 0) {
-                    details += '<div>' + escapeHtml(window.sprintf(window.Messages.strErrorCode, request.status)) + '</div>';
+                    details += '<div>' + escapeHtml(sprintf(window.Messages.strErrorCode, request.status) as string) + '</div>';
                 }
 
-                details += '<div>' + escapeHtml(window.sprintf(window.Messages.strErrorText, request.statusText + ' (' + state + ')')) + '</div>';
+                details += '<div>' + escapeHtml(sprintf(window.Messages.strErrorText, request.statusText + ' (' + state + ')') as string) + '</div>';
                 if (state === 'rejected' || state === 'timeout') {
                     details += '<div>' + escapeHtml(window.Messages.strErrorConnection) + '</div>';
                 }

--- a/resources/js/modules/common.ts
+++ b/resources/js/modules/common.ts
@@ -1,3 +1,5 @@
+import { sprintf } from "locutus/php/strings/sprintf";
+
 /**
  * Holds common parameters such as server, db, table, etc
  *
@@ -85,7 +87,7 @@ const CommonParams = (function () {
                 common = common.endsWith(argsep) ? common : common + argsep;
             }
 
-            return window.sprintf(
+            return sprintf(
                 '%s%sserver=%s' + argsep + 'db=%s' + argsep + 'table=%s',
                 sep,
                 common,

--- a/resources/js/modules/config.ts
+++ b/resources/js/modules/config.ts
@@ -3,6 +3,7 @@ import { CommonParams } from './common.ts';
 import { ajaxShowMessage } from './ajax-message.ts';
 import isStorageSupported from './functions/isStorageSupported.ts';
 import formatDateTime from './functions/formatDateTime.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 let configInlineParams: any[] | undefined;
 let configScriptLoaded: boolean = false;
@@ -304,7 +305,7 @@ const validators = {
             return true;
         }
 
-        return val <= maxValue ? true : window.sprintf(window.Messages.configErrorInvalidUpperBound, maxValue);
+        return val <= maxValue ? true : sprintf(window.Messages.configErrorInvalidUpperBound, maxValue);
     },
     // field validators
     field: {},

--- a/resources/js/modules/console.ts
+++ b/resources/js/modules/console.ts
@@ -6,6 +6,7 @@ import { CommonParams } from './common.ts';
 import { Navigation } from './navigation.ts';
 import Config from './console/config.ts';
 import { escapeHtml } from './functions/escape.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 let config: Config;
 
@@ -1275,7 +1276,7 @@ const ConsoleDebug = {
                 .append(
                     $('<div class="message welcome">')
                         .text(
-                            window.sprintf(
+                            sprintf(
                                 window.Messages.strConsoleDebugArgsSummary,
                                 dbgStep.args.length
                             )
@@ -1507,7 +1508,7 @@ const ConsoleDebug = {
         // Show summary
         $('#debug_console').find('.debug>.welcome').append(
             $('<span class="debug_summary">').text(
-                window.sprintf(
+                sprintf(
                     window.Messages.strConsoleDebugSummary,
                     totalUnique,
                     totalExec,

--- a/resources/js/modules/functions.ts
+++ b/resources/js/modules/functions.ts
@@ -14,6 +14,7 @@ import checkIndexName from './indexes/checkIndexName.ts';
 import mainMenuResizerCallback from './functions/mainMenuResizerCallback.ts';
 import isStorageSupported from './functions/isStorageSupported.ts';
 import adjustTotals from './functions/adjustTotals.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * Object containing CodeMirror editor of the query editor in SQL tab.
@@ -521,7 +522,7 @@ export function confirmLink (theLink, theSqlQuery) {
         return true;
     }
 
-    const isConfirmed = window.confirm(window.sprintf(window.Messages.strDoYouReally, theSqlQuery));
+    const isConfirmed = window.confirm(sprintf(window.Messages.strDoYouReally, theSqlQuery) as string);
     if (isConfirmed) {
         if (typeof (theLink.href) !== 'undefined') {
             theLink.href += CommonParams.get('arg_separator') + 'is_js_confirmed=1';
@@ -574,7 +575,7 @@ export function confirmQuery (theForm1, sqlQuery1) {
             message = sqlQuery1;
         }
 
-        const isConfirmed = window.confirm(window.sprintf(window.Messages.strDoYouReally, message));
+        const isConfirmed = window.confirm(sprintf(window.Messages.strDoYouReally, message) as string);
         // statement is confirmed -> update the
         // "is_js_confirmed" form field so the confirm test won't be
         // run on the server side and allows to submit the form
@@ -694,7 +695,7 @@ export function checkFormElementInRange (theForm, theFieldName, message, minimum
         return false;
     } else if (val < min || val > max) {
         theField.select();
-        alert(window.sprintf(message, val));
+        alert(sprintf(message, val));
         theField.focus();
 
         return false;
@@ -2424,7 +2425,7 @@ export function onloadEnumSetEditor (): void {
             '<div class="slider"></div>' +
             '</td><td>' +
             '<form><div><input type="submit" class="add_value btn btn-primary" value="' +
-            window.sprintf(window.Messages.enum_addValue, 1) +
+            sprintf(window.Messages.enum_addValue, 1) +
             '"></div></form>' +
             '</td></tr></table>' +
             '<input type="hidden" value="' + // So we know which column's data is being edited
@@ -2474,7 +2475,7 @@ export function onloadEnumSetEditor (): void {
             max: 9,
             slide: function (event, ui) {
                 $(this).closest('table').find('input[type=submit]').val(
-                    window.sprintf(window.Messages.enum_addValue, ui.value)
+                    sprintf(window.Messages.enum_addValue, ui.value) as string
                 );
             }
         });
@@ -2547,7 +2548,7 @@ export function onloadEnumSetEditor (): void {
         let resultPointer = i;
         let searchIn = '<input type="text" class="filter_rows" placeholder="' + window.Messages.searchList + '">';
         if (fields === '') {
-            fields = window.sprintf(window.Messages.strEmptyCentralList, '\'' + escapeHtml(db) + '\'');
+            fields = sprintf(window.Messages.strEmptyCentralList, '\'' + escapeHtml(db) + '\'') as string;
             searchIn = '';
         }
 
@@ -2877,7 +2878,7 @@ export function showIndexEditDialog ($outer) {
         max: 16,
         slide: function (event, ui) {
             $(this).closest('.card-body').find('input[type=submit]').val(
-                window.sprintf(window.Messages.strAddToIndex, ui.value)
+                sprintf(window.Messages.strAddToIndex, ui.value) as string
             );
         }
     });

--- a/resources/js/modules/functions/adjustTotals.ts
+++ b/resources/js/modules/functions/adjustTotals.ts
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * Adjust number of rows and total size in the summary
@@ -104,7 +105,7 @@ export default function adjustTotals () {
 
     // Update summary with new data
     const $summary = $('#tbl_summary_row');
-    $summary.find('.tbl_num').text(window.sprintf(window.Messages.strNTables, tableSum));
+    $summary.find('.tbl_num').text(sprintf(window.Messages.strNTables, tableSum));
     if (rowSumApproximated) {
         $summary.find('.row_count_sum').text(strRowSum);
     } else {

--- a/resources/js/modules/functions/chartByteFormatter.ts
+++ b/resources/js/modules/functions/chartByteFormatter.ts
@@ -1,3 +1,5 @@
+import { sprintf } from 'locutus/php/strings/sprintf';
+
 function formatByte (value, index) {
     let val = value;
     let i = index;
@@ -20,9 +22,7 @@ function formatByte (value, index) {
         format = '%.0f';
     }
 
-    return window.sprintf(
-        format + ' ' + units[i], val
-    );
+    return sprintf(format + ' ' + units[i], val);
 }
 
 /**

--- a/resources/js/modules/functions/checkNumberOfFields.ts
+++ b/resources/js/modules/functions/checkNumberOfFields.ts
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import { ajaxShowMessage } from '../ajax-message.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * Check than forms have less fields than max allowed by PHP.
@@ -18,7 +19,7 @@ export default function checkNumberOfFields () {
     $('form').each(function () {
         const nbInputs = $(this).find(':input').length;
         if (nbInputs > window.maxInputVars) {
-            const warning = window.sprintf(window.Messages.strTooManyInputs, window.maxInputVars);
+            const warning = sprintf(window.Messages.strTooManyInputs, window.maxInputVars);
             ajaxShowMessage(warning);
 
             return false;

--- a/resources/js/modules/git-info.ts
+++ b/resources/js/modules/git-info.ts
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import { CommonParams } from './common.ts';
 import { escapeHtml } from './functions/escape.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 const GitInfo = {
     /**
@@ -66,11 +67,11 @@ const GitInfo = {
             versionInformationMessage.appendChild(prefixMessage);
             versionInformationMessage.appendChild(versionInformationMessageLink);
             if (latest > current) {
-                const message = window.sprintf(
+                const message = sprintf(
                     window.Messages.strNewerVersion,
                     escapeHtml(data.version),
                     escapeHtml(data.date)
-                );
+                ) as string;
                 let htmlClass = 'alert alert-primary';
                 if (Math.floor(latest / 10000) === Math.floor(current / 10000)) {
                     /* Security update */

--- a/resources/js/modules/sql-highlight.ts
+++ b/resources/js/modules/sql-highlight.ts
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * Definition of links to MySQL documentation.
@@ -377,7 +378,7 @@ function documentationAdd ($elm, params) {
         return;
     }
 
-    let url = window.sprintf(
+    let url = sprintf(
         decodeURIComponent(window.mysqlDocTemplate),
         params[0],
     );

--- a/resources/js/normalization.ts
+++ b/resources/js/normalization.ts
@@ -4,6 +4,7 @@ import { indexEditorDialog } from './modules/functions.ts';
 import { CommonParams } from './modules/common.ts';
 import { ajaxShowMessage } from './modules/ajax-message.ts';
 import { escapeHtml, escapeJsString } from './modules/functions/escape.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * @fileoverview   events handling from normalization page
@@ -128,7 +129,7 @@ function goToFinish1NF () {
 
     $('#mainContent .card-header').html(window.Messages.strEndStep);
     $('#mainContent h4').html(
-        '<h3>' + window.sprintf(window.Messages.strFinishMsg, escapeHtml(CommonParams.get('table'))) + '</h3>'
+        '<h3>' + sprintf(window.Messages.strFinishMsg, escapeHtml(CommonParams.get('table'))) + '</h3>'
     );
 
     $('#mainContent p').html('');
@@ -743,7 +744,7 @@ AJAX.registerOnload('normalization.js', function () {
         if (repeatingCols !== '') {
             const newColName = ($('#extra input[type=checkbox]:checked').first().val() as string);
             repeatingCols = repeatingCols.slice(0, -2);
-            let confirmStr = window.sprintf(window.Messages.strMoveRepeatingGroup, escapeHtml(repeatingCols), escapeHtml(CommonParams.get('table')));
+            let confirmStr = sprintf(window.Messages.strMoveRepeatingGroup, escapeHtml(repeatingCols), escapeHtml(CommonParams.get('table'))) as string;
             confirmStr += '<input type="text" name="repeatGroupTable" placeholder="' + window.Messages.strNewTablePlaceholder + '">' +
                 '( ' + escapeHtml(primaryKey.toString()) + ', <input type="text" name="repeatGroupColumn" placeholder="' + window.Messages.strNewColumnPlaceholder + '" value="' + escapeHtml(newColName) + '">)' +
                 '</ol>';

--- a/resources/js/server/databases.ts
+++ b/resources/js/server/databases.ts
@@ -7,6 +7,7 @@ import { ajaxShowMessage } from '../modules/ajax-message.ts';
 import getJsConfirmCommonParam from '../modules/functions/getJsConfirmCommonParam.ts';
 import { escapeHtml } from '../modules/functions/escape.ts';
 import refreshMainContent from '../modules/functions/refreshMainContent.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
@@ -45,7 +46,7 @@ const DropDatabases = {
          * @var question    String containing the question to be asked for confirmation
          */
         const question = window.Messages.strDropDatabaseStrongWarning + ' ' +
-            window.sprintf(window.Messages.strDoYouReally, selectedDbs.join('<br>'));
+            sprintf(window.Messages.strDoYouReally, selectedDbs.join('<br>'));
 
         const modal = $('#dropDatabaseModal');
         modal.find('.modal-body').html(question);

--- a/resources/js/server/privileges.ts
+++ b/resources/js/server/privileges.ts
@@ -13,6 +13,7 @@ import { CommonParams } from '../modules/common.ts';
 import { Navigation } from '../modules/navigation.ts';
 import { ajaxRemoveMessage, ajaxShowMessage } from '../modules/ajax-message.ts';
 import getImageTag from '../modules/functions/getImageTag.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * Export privileges modal handler
@@ -243,7 +244,7 @@ const RevokeUser = {
         $thisButton.confirm(window.Messages.strDropUserWarning, $form.attr('action'), function (url) {
             const $dropUsersDbCheckbox = $('#dropUsersDbCheckbox');
             if ($dropUsersDbCheckbox.is(':checked')) {
-                const isConfirmed = confirm(window.Messages.strDropDatabaseStrongWarning + '\n' + window.sprintf(window.Messages.strDoYouReally, 'DROP DATABASE'));
+                const isConfirmed = confirm(window.Messages.strDropDatabaseStrongWarning + '\n' + sprintf(window.Messages.strDoYouReally, 'DROP DATABASE'));
                 if (! isConfirmed) {
                     // Uncheck the drop users database checkbox
                     $dropUsersDbCheckbox.prop('checked', false);

--- a/resources/js/server/status/monitor.ts
+++ b/resources/js/server/status/monitor.ts
@@ -8,6 +8,7 @@ import { escapeHtml } from '../../modules/functions/escape.ts';
 import getImageTag from '../../modules/functions/getImageTag.ts';
 import isStorageSupported from '../../modules/functions/isStorageSupported.ts';
 import chartByteFormatter from '../../modules/functions/chartByteFormatter.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * @fileoverview    Javascript functions used in server status monitor page
@@ -805,13 +806,13 @@ AJAX.registerOnload('server/status/monitor.js', function () {
                 if (logVars.slow_query_log === 'ON') {
                     if (logVars.long_query_time > 2) {
                         str += getImageTag('s_attention') + ' ';
-                        str += window.sprintf(window.Messages.strSmallerLongQueryTimeAdvice, logVars.long_query_time);
+                        str += sprintf(window.Messages.strSmallerLongQueryTimeAdvice, logVars.long_query_time);
                         str += '<br>';
                     }
 
                     if (logVars.long_query_time < 2) {
                         str += getImageTag('s_success') + ' ';
-                        str += window.sprintf(window.Messages.strLongQueryTimeSet, logVars.long_query_time);
+                        str += sprintf(window.Messages.strLongQueryTimeSet, logVars.long_query_time);
                         str += '<br>';
                     }
                 }
@@ -829,26 +830,26 @@ AJAX.registerOnload('server/status/monitor.js', function () {
                     }
 
                     str += '- <a class="set" href="#log_output-' + varValue + '">';
-                    str += window.sprintf(window.Messages.strSetLogOutput, varValue);
+                    str += sprintf(window.Messages.strSetLogOutput, varValue);
                     str += ' </a><br>';
 
                     if (logVars.general_log !== 'ON') {
                         str += '- <a class="set" href="#general_log-ON">';
-                        str += window.sprintf(window.Messages.strEnableVar, 'general_log');
+                        str += sprintf(window.Messages.strEnableVar, 'general_log');
                         str += ' </a><br>';
                     } else {
                         str += '- <a class="set" href="#general_log-OFF">';
-                        str += window.sprintf(window.Messages.strDisableVar, 'general_log');
+                        str += sprintf(window.Messages.strDisableVar, 'general_log');
                         str += ' </a><br>';
                     }
 
                     if (logVars.slow_query_log !== 'ON') {
                         str += '- <a class="set" href="#slow_query_log-ON">';
-                        str += window.sprintf(window.Messages.strEnableVar, 'slow_query_log');
+                        str += sprintf(window.Messages.strEnableVar, 'slow_query_log');
                         str += ' </a><br>';
                     } else {
                         str += '- <a class="set" href="#slow_query_log-OFF">';
-                        str += window.sprintf(window.Messages.strDisableVar, 'slow_query_log');
+                        str += sprintf(window.Messages.strDisableVar, 'slow_query_log');
                         str += ' </a><br>';
                     }
 
@@ -858,7 +859,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
                     }
 
                     str += '- <a class="set" href="#long_query_time-' + varValue + '">';
-                    str += window.sprintf(window.Messages.setSetLongQueryTime, varValue);
+                    str += sprintf(window.Messages.setSetLongQueryTime, varValue);
                     str += ' </a><br>';
                 } else {
                     str += window.Messages.strNoSuperUser + '<br>';
@@ -974,7 +975,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
         }
 
         let str = serie.display === 'differential' ? ', ' + window.Messages.strDifferential : '';
-        str += serie.valueDivisor ? (', ' + window.sprintf(window.Messages.strDividedBy, serie.valueDivisor)) : '';
+        str += serie.valueDivisor ? (', ' + sprintf(window.Messages.strDividedBy, serie.valueDivisor)) : '';
         str += serie.unit ? (', ' + window.Messages.strUnit + ': ' + serie.unit) : '';
 
         const newSeries = {
@@ -1209,11 +1210,11 @@ AJAX.registerOnload('server/status/monitor.js', function () {
             settings.axes.yaxis.tickOptions = {
                 formatter: function (format, val) {
                     if (Math.abs(val) >= 1000000) {
-                        return window.sprintf('%.3g M', val / 1000000);
+                        return sprintf('%.3g M', val / 1000000);
                     } else if (Math.abs(val) >= 1000) {
-                        return window.sprintf('%.3g k', val / 1000);
+                        return sprintf('%.3g k', val / 1000);
                     } else {
-                        return window.sprintf('%d', val);
+                        return sprintf('%d', val);
                     }
                 }
             };
@@ -1275,7 +1276,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
                 } else if (plot.series[0]._yaxis.tickOptions.formatString) { // eslint-disable-line no-underscore-dangle
                     // using format string
                     // eslint-disable-next-line no-underscore-dangle
-                    seriesValue = window.sprintf(plot.series[0]._yaxis.tickOptions.formatString, seriesValue);
+                    seriesValue = sprintf(plot.series[0]._yaxis.tickOptions.formatString, seriesValue);
                 }
 
                 tooltipHtml += '<br><span style="color:' + seriesColor + '">' +
@@ -1333,7 +1334,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
                                 stepSize: settings.axes.yaxis.tickInterval,
                                 callback: function (value, index, ticks) {
                                     if (settings.axes.yaxis?.tickOptions?.formatString) {
-                                        return window.sprintf(settings.axes.yaxis.tickOptions.formatString, value);
+                                        return sprintf(settings.axes.yaxis.tickOptions.formatString, value);
                                     }
 
                                     if (settings.axes.yaxis?.tickOptions?.formatter) {

--- a/resources/js/server/user_groups.ts
+++ b/resources/js/server/user_groups.ts
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import { AJAX } from '../modules/ajax.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * @fileoverview    Javascript functions used in server user groups page
@@ -23,10 +24,10 @@ AJAX.registerOnload('server/user_groups.js', function () {
     deleteUserGroupModal.on('show.bs.modal', function (event) {
         // @ts-ignore
         const userGroupName = $(event.relatedTarget).data('user-group');
-        (this.querySelector('.modal-body') as HTMLDivElement).innerText = window.sprintf(
+        (this.querySelector('.modal-body') as HTMLDivElement).innerText = sprintf(
             window.Messages.strDropUserGroupWarning,
             userGroupName
-        );
+        ) as string;
     });
 
     deleteUserGroupModal.on('shown.bs.modal', function (event) {

--- a/resources/js/sql.ts
+++ b/resources/js/sql.ts
@@ -11,6 +11,7 @@ import { ajaxRemoveMessage, ajaxShowMessage } from './modules/ajax-message.ts';
 import { escapeBacktick, escapeHtml } from './modules/functions/escape.ts';
 import refreshMainContent from './modules/functions/refreshMainContent.ts';
 import isStorageSupported from './modules/functions/isStorageSupported.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * @fileoverview    functions used wherever an sql query form is used
@@ -527,7 +528,7 @@ AJAX.registerOnload('sql.js', function () {
     // Delete row from SQL results
     $(document).on('click', 'a.delete_row.ajax', function (e) {
         e.preventDefault();
-        const question = window.sprintf(window.Messages.strDoYouReally, escapeHtml($(this).closest('td').find('div').text()));
+        const question = sprintf(window.Messages.strDoYouReally, escapeHtml($(this).closest('td').find('div').text()));
         const $link = $(this);
         $link.confirm(question, $link.attr('href'), function (url) {
             ajaxShowMessage();
@@ -766,7 +767,7 @@ AJAX.registerOnload('sql.js', function () {
         $varDiv.empty();
         for (let i = 1; i <= varCount; i++) {
             $varDiv.append($('<div class="mb-3">'));
-            $varDiv.append($('<label for="bookmarkVariable' + i + '">' + window.sprintf(window.Messages.strBookmarkVariable, i) + '</label>'));
+            $varDiv.append($('<label for="bookmarkVariable' + i + '">' + sprintf(window.Messages.strBookmarkVariable, i) + '</label>'));
             $varDiv.append($('<input class="form-control" type="text" size="10" name="bookmark_variable[' + i + ']" id="bookmarkVariable' + i + '">'));
             $varDiv.append($('</div>'));
         }

--- a/resources/js/table/operations.ts
+++ b/resources/js/table/operations.ts
@@ -8,6 +8,7 @@ import { ajaxRemoveMessage, ajaxShowMessage } from '../modules/ajax-message.ts';
 import getJsConfirmCommonParam from '../modules/functions/getJsConfirmCommonParam.ts';
 import { escapeHtml } from '../modules/functions/escape.ts';
 import refreshMainContent from '../modules/functions/refreshMainContent.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * Unbind all event handlers before tearing down a page
@@ -41,7 +42,7 @@ const confirmAndPost = function (linkObject, action): void {
         question += window.Messages.strDeleteTableStrongWarning + ' ';
     }
 
-    question += window.sprintf(window.Messages.strDoYouReally, linkObject.data('query'));
+    question += sprintf(window.Messages.strDoYouReally, linkObject.data('query'));
     question += getForeignKeyCheckboxLoader();
     linkObject.confirm(question, linkObject.attr('href'), function (url) {
         ajaxShowMessage(window.Messages.strProcessingRequest);
@@ -288,7 +289,7 @@ AJAX.registerOnload('table/operations.js', function () {
          * @var {string} question String containing the question to be asked for confirmation
          */
         let question = window.Messages.strDropTableStrongWarning + ' ';
-        question += window.sprintf(window.Messages.strDoYouReally, $link[0].getAttribute('data-query'));
+        question += sprintf(window.Messages.strDoYouReally, $link[0].getAttribute('data-query'));
         question += getForeignKeyCheckboxLoader();
 
         $(this).confirm(question, $(this).attr('href'), function (url) {
@@ -320,7 +321,7 @@ AJAX.registerOnload('table/operations.js', function () {
          * @var {string} question String containing the question to be asked for confirmation
          */
         let question = window.Messages.strDropTableStrongWarning + ' ';
-        question += window.sprintf(
+        question += sprintf(
             window.Messages.strDoYouReally,
             'DROP VIEW `' + escapeHtml(CommonParams.get('table') + '`')
         );

--- a/resources/js/table/relation.ts
+++ b/resources/js/table/relation.ts
@@ -5,6 +5,7 @@ import { ajaxRemoveMessage, ajaxShowMessage } from '../modules/ajax-message.ts';
 import getJsConfirmCommonParam from '../modules/functions/getJsConfirmCommonParam.ts';
 import { escapeHtml } from '../modules/functions/escape.ts';
 import refreshMainContent from '../modules/functions/refreshMainContent.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * for table relation
@@ -252,7 +253,7 @@ AJAX.registerOnload('table/relation.js', function () {
                 .val() as string),
         );
 
-        const question = window.sprintf(window.Messages.strDoYouReally, dropQuery);
+        const question = sprintf(window.Messages.strDoYouReally, dropQuery);
 
         $anchor.confirm(question, $anchor.attr('href'), function (url) {
             const $msg = ajaxShowMessage(window.Messages.strDroppingForeignKey, false);

--- a/resources/js/table/structure.ts
+++ b/resources/js/table/structure.ts
@@ -9,6 +9,7 @@ import { Indexes } from '../modules/indexes.ts';
 import getJsConfirmCommonParam from '../modules/functions/getJsConfirmCommonParam.ts';
 import { escapeHtml, escapeJsString } from '../modules/functions/escape.ts';
 import refreshMainContent from '../modules/functions/refreshMainContent.ts';
+import { sprintf } from 'locutus/php/strings/sprintf';
 
 /**
  * @fileoverview    functions used on the table structure page
@@ -161,7 +162,7 @@ AJAX.registerOnload('table/structure.js', function () {
 
                 // If Collation is changed, Warn and Confirm
                 if (checkIfConfirmRequired($form)) {
-                    const question = window.sprintf(
+                    const question = sprintf(
                         window.Messages.strChangeColumnCollation, 'https://wiki.phpmyadmin.net/pma/Garbled_data',
                     );
                     $form.confirm(question, $form.attr('action'), function () {
@@ -200,7 +201,7 @@ AJAX.registerOnload('table/structure.js', function () {
         /**
          * @var question String containing the question to be asked for confirmation
          */
-        const question = window.sprintf(window.Messages.strDoYouReally, 'ALTER TABLE `' + currTableName + '` DROP `' + currColumnName + '`;');
+        const question = sprintf(window.Messages.strDoYouReally, 'ALTER TABLE `' + currTableName + '` DROP `' + currColumnName + '`;');
         const $thisAnchor = $(this);
         $thisAnchor.confirm(question, $thisAnchor.attr('href'), function (url) {
             const $msg = ajaxShowMessage(window.Messages.strDroppingColumn, false);
@@ -277,7 +278,7 @@ AJAX.registerOnload('table/structure.js', function () {
             addClause = 'ADD FULLTEXT';
         }
 
-        const question = window.sprintf(window.Messages.strDoYouReally, 'ALTER TABLE `' +
+        const question = sprintf(window.Messages.strDoYouReally, 'ALTER TABLE `' +
             escapeHtml(currTableName) + '` ' + addClause + '(`' + escapeHtml(currColumnName) + '`);');
 
         const $thisAnchor = $(this);

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -159,7 +159,6 @@ module.exports = [
                     { from: rootPath + '/node_modules/tablesorter/dist/js/jquery.tablesorter.js', to: publicPath + '/js/vendor/jquery/jquery.tablesorter.js' },
                     { from: rootPath + '/node_modules/jquery-ui-timepicker-addon/dist/jquery-ui-timepicker-addon.min.js', to: publicPath + '/js/vendor/jquery/jquery-ui-timepicker-addon.min.js' },
                     { from: rootPath + '/node_modules/ol/ol.css', to: publicPath + '/js/vendor/openlayers/openlayers.css' },
-                    { from: rootPath + '/node_modules/locutus.sprintf/src/php/strings/sprintf.browser.js', to: publicPath + '/js/vendor/sprintf.js' },
                     { from: rootPath + '/node_modules/chart.js/dist/chart.umd.js', to: publicPath + '/js/vendor/chart.umd.js' },
                     { from: rootPath + '/node_modules/chart.js/dist/chart.umd.js.map', to: publicPath + '/js/vendor/chart.umd.js.map' },
                     { from: rootPath + '/node_modules/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.js', to: publicPath + '/js/vendor/chartjs-adapter-date-fns.bundle.js' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4049,10 +4049,10 @@ locate-path@^7.1.0:
   dependencies:
     p-locate "^6.0.0"
 
-locutus.sprintf@^2.0.32-code-lts.1:
-  version "2.0.32-code-lts.1"
-  resolved "https://registry.yarnpkg.com/locutus.sprintf/-/locutus.sprintf-2.0.32-code-lts.1.tgz#ec6dc980046480de12fa650682576d621f052f72"
-  integrity sha512-+e/iW8ngWB7s3QxXALY3GyLktLFx9ZPNabdPxJwkxVgFNF9KuBtY62rbb/j6nEcBAcSVL5cTj+CSIT9C+WFq+g==
+locutus@^3.0.36:
+  version "3.0.36"
+  resolved "https://registry.yarnpkg.com/locutus/-/locutus-3.0.36.tgz#a1a427becf5c69f06c0703dbdd644224abbeefbf"
+  integrity sha512-ilsz33lqEd+KerV9JnSHM9EApVYOZ86/JTGKyafmWvhTFtjYauzT1WmZgdJ4JBGR3dY0N0PTfIq2uLvazw5QsQ==
 
 lodash.debounce@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
### Description

Use the upstream locutus version instead of a fork.
The fork was created to be able to import sprintf with a script tag, but that's no longer necessary.

The original function signature returns false on error, instead of the old declaration that only returned string, but that should never happen. So I added type casts to string where it was required.