### PR TITLE
Fix #18510 - Use database and table aliases in export filename template

### DIFF
--- a/libraries/classes/Controllers/Export/ExportController.php
+++ b/libraries/classes/Controllers/Export/ExportController.php
@@ -400,7 +400,8 @@ final class ExportController extends AbstractController
                 $remember_template,
                 $export_plugin,
                 $compression,
-                $filename_template
+                $filename_template,
+                $aliases
             );
         } else {
             $mime_type = '';

--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -335,7 +335,7 @@ class Export
      * @param ExportPlugin $exportPlugin     the export plugin
      * @param string       $compression      compression asked
      * @param string       $filenameTemplate the filename template
-     * @param array        $aliases          alias information for db/table/column
+     * @param mixed[]      $aliases          alias information for db/table/column
      *
      * @return string[] the filename template and mime type
      */

--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -335,6 +335,7 @@ class Export
      * @param ExportPlugin $exportPlugin     the export plugin
      * @param string       $compression      compression asked
      * @param string       $filenameTemplate the filename template
+     * @param array        $aliases          alias information for db/table/column
      *
      * @return string[] the filename template and mime type
      */
@@ -343,7 +344,8 @@ class Export
         string $rememberTemplate,
         ExportPlugin $exportPlugin,
         string $compression,
-        string $filenameTemplate
+        string $filenameTemplate,
+        array $aliases = []
     ): array {
         if ($exportType === 'server') {
             if (! empty($rememberTemplate)) {
@@ -379,7 +381,20 @@ class Export
             }
         }
 
-        $filename = Util::expandUserString($filenameTemplate);
+        // Substitute the database and table aliases in the filename template
+        // so that @DATABASE@ and @TABLE@ reflect the renamed values.
+        $db = $GLOBALS['db'] ?? '';
+        $table = $GLOBALS['table'] ?? '';
+        $updates = [];
+        if (! empty($aliases[$db]['alias'])) {
+            $updates['database'] = (string) $aliases[$db]['alias'];
+        }
+
+        if (! empty($aliases[$db]['tables'][$table]['alias'])) {
+            $updates['table'] = (string) $aliases[$db]['tables'][$table]['alias'];
+        }
+
+        $filename = Util::expandUserString($filenameTemplate, null, $updates);
         // remove dots in filename (coming from either the template or already
         // part of the filename) to avoid a remote code execution vulnerability
         $filename = Sanitize::sanitizeFilename($filename, true);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17122,7 +17122,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'alias' on mixed\\.$#"
-			count: 6
+			count: 8
 			path: libraries/classes/Export.php
 
 		-
@@ -17132,12 +17132,12 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'tables' on mixed\\.$#"
-			count: 3
+			count: 4
 			path: libraries/classes/Export.php
 
 		-
 			message: "#^Cannot access offset mixed on mixed\\.$#"
-			count: 3
+			count: 4
 			path: libraries/classes/Export.php
 
 		-
@@ -17157,7 +17157,7 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
-			count: 4
+			count: 6
 			path: libraries/classes/Export.php
 
 		-
@@ -17167,7 +17167,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 16
+			count: 18
 			path: libraries/classes/Export.php
 
 		-
@@ -44109,6 +44109,11 @@ parameters:
 			message: "#^Parameter \\#1 \\$dir of static method PhpMyAdmin\\\\Util\\:\\:userDir\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: test/classes/Export/OptionsTest.php
+
+		-
+			message: "#^Cannot access offset 'Server' on mixed\\.$#"
+			count: 1
+			path: test/classes/ExportTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$dbi of class PhpMyAdmin\\\\Export constructor expects PhpMyAdmin\\\\DatabaseInterface, mixed given\\.$#"

--- a/test/classes/ExportTest.php
+++ b/test/classes/ExportTest.php
@@ -118,4 +118,37 @@ class ExportTest extends AbstractTestCase
             'application/x-gzip',
         ], $finalFileName);
     }
+
+    /**
+     * Test that getFilenameAndMimetype uses database/table aliases in the
+     * filename template (see issue #18510).
+     */
+    public function testGetFilenameAndMimetypeUsesAliases(): void
+    {
+        parent::setGlobalConfig();
+        $GLOBALS['cfg']['Server']['host'] = 'localhost';
+        $GLOBALS['cfg']['Server']['verbose'] = '';
+        $GLOBALS['db'] = 'test_db';
+        $GLOBALS['table'] = 'test_table';
+
+        $aliases = [
+            'test_db' => [
+                'alias' => 'aliasdb',
+                'tables' => [
+                    'test_table' => ['alias' => 'aliastbl'],
+                ],
+            ],
+        ];
+
+        [$filename] = $this->export->getFilenameAndMimetype(
+            'table',
+            '',
+            new ExportPhparray(),
+            'none',
+            '@DATABASE@-@TABLE@',
+            $aliases
+        );
+
+        self::assertSame('aliasdb-aliastbl.php', $filename);
+    }
 }

--- a/test/classes/ExportTest.php
+++ b/test/classes/ExportTest.php
@@ -125,9 +125,9 @@ class ExportTest extends AbstractTestCase
      */
     public function testGetFilenameAndMimetypeUsesAliases(): void
     {
-        parent::setGlobalConfig();
-        $GLOBALS['cfg']['Server']['host'] = 'localhost';
-        $GLOBALS['cfg']['Server']['verbose'] = '';
+        // Util::expandUserString() reads the current server host/verbose when
+        // building the filename, so provide a minimal server configuration.
+        $GLOBALS['cfg']['Server'] = ['host' => 'localhost', 'verbose' => ''];
         $GLOBALS['db'] = 'test_db';
         $GLOBALS['table'] = 'test_table';
 


### PR DESCRIPTION
### Description

When exporting with the *rename exported db/table/columns* option and a filename template that uses `@DATABASE@` / `@TABLE@`, the generated filename used the **original** database and table names instead of the aliases the user entered.

`Export::getFilenameAndMimetype()` built the filename via `Util::expandUserString($filenameTemplate)` with no variable overrides, so `@DATABASE@` and `@TABLE@` always resolved to `$GLOBALS['db']` / `$GLOBALS['table']`. The export aliases were already assembled in `ExportController` but were never passed to the filename generator.

This passes the aliases down and, when an alias is defined for the current database or table, uses it as the replacement for `@DATABASE@` / `@TABLE@`. Database/server exports (empty `$table`) are unaffected.

Adds a regression test that fails on current `QA_5_2` (`test_db-test_table.php`) and passes with the fix (`aliasdb-aliastbl.php`); phpcs clean.

Fixes #18510

This change was prepared with the assistance of AI (Claude); it has been reviewed and tested, and I take responsibility for it.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch (QA_5_2 — the bug affects released 5.2 and forward-merges to master).
- [x] Every commit has proper `Signed-off-by` line as described in our DCO.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own.
- [x] Any new functionality is covered by tests.
