### PR TITLE
Fix MySQL documentation links

### DIFF
--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -213,23 +213,19 @@ class Util
             $link = 'index';
         }
 
-        $mysql = '5.5';
+        $mysql = '5.7';
         $lang = 'en';
         if (isset($dbi)) {
             $serverVersion = $dbi->getVersion();
-            if ($serverVersion >= 80000) {
+            if ($serverVersion >= 90000) {
+                $mysql = '9.0';
+            } elseif ($serverVersion >= 80000) {
                 $mysql = '8.0';
-            } elseif ($serverVersion >= 50700) {
-                $mysql = '5.7';
-            } elseif ($serverVersion >= 50600) {
-                $mysql = '5.6';
-            } elseif ($serverVersion >= 50500) {
-                $mysql = '5.5';
             }
         }
 
-        $url = 'https://dev.mysql.com/doc/refman/'
-            . $mysql . '/' . $lang . '/' . $link . '.html';
+        $section = $link === 'server-error-reference' ? 'mysql-errors' : 'refman';
+        $url = 'https://dev.mysql.com/doc/' . $section . '/' . $mysql . '/' . $lang . '/' . $link . '.html';
         if (! empty($anchor)) {
             $url .= '#' . $anchor;
         }

--- a/test/classes/Plugins/Auth/AuthenticationConfigTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationConfigTest.php
@@ -83,17 +83,17 @@ class AuthenticationConfigTest extends AbstractTestCase
         self::assertIsString($html);
 
         self::assertStringContainsString('You probably did not create a configuration file. You might want ' .
-        'to use the <a href="setup/">setup script</a> to create one.', $html);
+            'to use the <a href="setup/">setup script</a> to create one.', $html);
 
         self::assertStringContainsString('<strong>MySQL said: </strong><a href="./url.php?url=https%3A%2F%2F' .
-        'dev.mysql.com%2Fdoc%2Frefman%2F5.5%2Fen%2Fserver-error-reference.html"' .
-        ' target="mysql_doc">' .
-        '<img src="themes/dot.gif" title="Documentation" alt="Documentation" ' .
-        'class="icon ic_b_help"></a>', $html);
+            'dev.mysql.com%2Fdoc%2Fmysql-errors%2F5.7%2Fen%2Fserver-error-reference.html"' .
+            ' target="mysql_doc">' .
+            '<img src="themes/dot.gif" title="Documentation" alt="Documentation" ' .
+            'class="icon ic_b_help"></a>', $html);
 
         self::assertStringContainsString('Cannot connect: invalid settings.', $html);
 
         self::assertStringContainsString('<a href="index.php?route=/&server=0&lang=en" '
-        . 'class="btn btn-primary mt-1 mb-1 disableAjax">Retry to connect</a>', $html);
+            . 'class="btn btn-primary mt-1 mb-1 disableAjax">Retry to connect</a>', $html);
     }
 }


### PR DESCRIPTION
### Description

Remove versions below 5.7 as they redirect to the latest version (currently 9.7).
Add a special condition for server-error-reference as it lives at a different section of the docs.
Support links to MySQL version 9.

Fixes #20375