### PR TITLE
Fix #20160 - Skip tables that cannot be read in SQL structure export

### DIFF
--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -812,6 +812,11 @@ class Export
                         }
                     }
 
+                    // Skip tables that cannot be read
+                    if ($tableObject->getColumns() === []) {
+                        continue;
+                    }
+
                     if (
                         ! $exportPlugin->exportStructure(
                             $db,
@@ -1077,6 +1082,11 @@ class Export
                     }
                 }
             } elseif (isset($GLOBALS['sql_create_table'])) {
+                // Skip tables that cannot be read
+                if ($tableObject->getColumns() === []) {
+                    return;
+                }
+
                 if (
                     ! $exportPlugin->exportStructure(
                         $db,


### PR DESCRIPTION
### Description

When a single table cannot be read (for example an InnoDB table on a server started with `skip-innodb`), the whole SQL export failed with an `Error reading structure for table` error instead of exporting the readable tables. The export loop now skips a table whose columns cannot be read and continues, the same way #20224 handles the data export.

Fixes #20160.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
