### PR TITLE
Fix create-release.sh script

### DIFF
--- a/bin/internal/create-release.sh
+++ b/bin/internal/create-release.sh
@@ -183,12 +183,8 @@ cleanup_composer_vendors() {
         vendor/williamdes/mariadb-mysql-kbs/dist/merged-ultraslim.php \
         vendor/google/recaptcha/app.yaml \
         vendor/laminas/laminas-httphandlerrunner/.laminas-ci.json \
-        vendor/nikic/fast-route/.travis.yml \
         vendor/nikic/fast-route/.hhconfig \
         vendor/nikic/fast-route/FastRoute.hhi \
-        vendor/nikic/fast-route/phpunit.xml \
-        vendor/nikic/fast-route/psalm.xml \
-        vendor/nikic/fast-route/test/ \
         vendor/twig/twig/README.rst \
         vendor/webmozart/assert/.php-cs-fixer.php \
         vendor/twig/twig/src/Test/ \


### PR DESCRIPTION
https://github.com/phpmyadmin/phpmyadmin/actions/runs/29650553287/job/88096051008#step:9:554

```
* Cleanup of composer packages
rm: cannot remove 'vendor/nikic/fast-route/.travis.yml': No such file or directory
rm: cannot remove 'vendor/nikic/fast-route/phpunit.xml': No such file or directory
rm: cannot remove 'vendor/nikic/fast-route/psalm.xml': No such file or directory
rm: cannot remove 'vendor/nikic/fast-route/test/': No such file or directory
```