### PR TITLE
Better types for ajaxShowMessage

### DIFF
--- a/resources/js/database/central_columns.ts
+++ b/resources/js/database/central_columns.ts
@@ -176,12 +176,7 @@ AJAX.registerOnload('database/central_columns.js', function () {
             dataType: 'json',
             success: function (data) {
                 if (data.message !== '1') {
-                    ajaxShowMessage(
-                        '<div class="alert alert-danger" role="alert">' +
-                        data.message +
-                        '</div>',
-                        false
-                    );
+                    ajaxShowMessage(data.message, false, 'error');
                 } else {
                     $('#f_' + rownum + ' td input[id=checkbox_row_' + rownum + ']').val($('#f_' + rownum + ' input[name=col_name]').val()).html();
                     $('#f_' + rownum + ' td[name=col_name] span').text(($('#f_' + rownum + ' input[name=col_name]').val() as string)).html();
@@ -201,12 +196,7 @@ AJAX.registerOnload('database/central_columns.js', function () {
                 $('#tableslistcontainer').find('.checkall').show();
             },
             error: function () {
-                ajaxShowMessage(
-                    '<div class="alert alert-danger" role="alert">' +
-                    window.Messages.strErrorProcessingRequest +
-                    '</div>',
-                    false
-                );
+                ajaxShowMessage(window.Messages.strErrorProcessingRequest, false, 'error');
             }
         });
     });

--- a/resources/js/designer/move.ts
+++ b/resources/js/designer/move.ts
@@ -676,7 +676,7 @@ const addOtherDbTables = function () {
         const $table = $('[id="' + encodeURIComponent(db) + '.' + encodeURIComponent(table) + '"]');
         if ($table.length !== 0) {
             ajaxShowMessage(
-                sprintf(window.Messages.strTableAlreadyExists, db + '.' + table),
+                sprintf(window.Messages.strTableAlreadyExists, db + '.' + table) as string,
                 undefined,
                 'error'
             );
@@ -1949,7 +1949,7 @@ const addObject = function (dbName, tableName, colName, dbTableNameUrl) {
     const init = DesignerHistory.historyArray.length;
     if (rel.value !== '--') {
         if ((document.getElementById('Query') as HTMLTextAreaElement).value === '') {
-            ajaxShowMessage(sprintf(window.Messages.strQueryEmpty));
+            ajaxShowMessage(sprintf(window.Messages.strQueryEmpty) as string);
 
             return;
         }
@@ -2002,7 +2002,7 @@ const addObject = function (dbName, tableName, colName, dbTableNameUrl) {
         // make orderby
     }
 
-    ajaxShowMessage(sprintf(window.Messages.strObjectsCreated, sum));
+    ajaxShowMessage(sprintf(window.Messages.strObjectsCreated, sum) as string);
     // output sum new objects created
     const existingDiv = document.getElementById('ab');
     existingDiv.innerHTML = DesignerHistory.display(init, DesignerHistory.historyArray.length);

--- a/resources/js/export.ts
+++ b/resources/js/export.ts
@@ -790,10 +790,9 @@ function checkTimeOut (timeLimit) {
             function (data) {
                 if (data.message === 'timeout') {
                     ajaxShowMessage(
-                        '<div class="alert alert-danger" role="alert">' +
-                        window.Messages.strTimeOutError +
-                        '</div>',
-                        false
+                        window.Messages.strTimeOutError,
+                        false,
+                        'error'
                     );
                 }
             }

--- a/resources/js/import.ts
+++ b/resources/js/import.ts
@@ -74,30 +74,34 @@ AJAX.registerOnload('import.js', function () {
     $(document).on('submit', '#import_file_form', function () {
         const radioLocalImport = $('#localFileTab');
         const radioImport = $('#uploadFileTab');
-        const fileMsg = '<div class="alert alert-danger" role="alert"><img src="themes/dot.gif" title="" alt="" class="icon ic_s_error"> ' + window.Messages.strImportDialogMessage + '</div>';
-        const wrongTblNameMsg = '<div class="alert alert-danger" role="alert"><img src="themes/dot.gif" title="" alt="" class="icon ic_s_error">' + window.Messages.strTableNameDialogMessage + '</div>';
-        const wrongDBNameMsg = '<div class="alert alert-danger" role="alert"><img src="themes/dot.gif" title="" alt="" class="icon ic_s_error">' + window.Messages.strDBNameDialogMessage + '</div>';
+        const fileMsg = '<img src="themes/dot.gif" title="" alt="" class="icon ic_s_error"> ' + window.Messages.strImportDialogMessage;
+        const wrongTblNameMsg = '<img src="themes/dot.gif" title="" alt="" class="icon ic_s_error">' + window.Messages.strTableNameDialogMessage;
+        const wrongDBNameMsg = '<img src="themes/dot.gif" title="" alt="" class="icon ic_s_error">' + window.Messages.strDBNameDialogMessage;
 
         if (radioLocalImport.length !== 0) {
             // remote upload.
 
             if (radioImport.hasClass('active') && $('#input_import_file').val() === '') {
                 $('#input_import_file').trigger('focus');
-                ajaxShowMessage(fileMsg, false);
+                ajaxShowMessage(fileMsg, false, 'error');
 
                 return false;
             }
 
             if (radioLocalImport.hasClass('active')) {
                 if ($('#select_local_import_file').length === 0) {
-                    ajaxShowMessage('<div class="alert alert-danger" role="alert"><img src="themes/dot.gif" title="" alt="" class="icon ic_s_error"> ' + window.Messages.strNoImportFile + ' </div>', false);
+                    ajaxShowMessage(
+                        '<img src="themes/dot.gif" title="" alt="" class="icon ic_s_error"> ' + window.Messages.strNoImportFile,
+                        false,
+                        'error',
+                    );
 
                     return false;
                 }
 
                 if ($('#select_local_import_file').val() === '') {
                     $('#select_local_import_file').trigger('focus');
-                    ajaxShowMessage(fileMsg, false);
+                    ajaxShowMessage(fileMsg, false, 'error');
 
                     return false;
                 }
@@ -106,7 +110,7 @@ AJAX.registerOnload('import.js', function () {
             // local upload.
             if ($('#input_import_file').val() === '') {
                 $('#input_import_file').trigger('focus');
-                ajaxShowMessage(fileMsg, false);
+                ajaxShowMessage(fileMsg, false, 'error');
 
                 return false;
             }
@@ -114,7 +118,7 @@ AJAX.registerOnload('import.js', function () {
             if ($('#text_csv_new_tbl_name').length > 0) {
                 const newTblName = ($('#text_csv_new_tbl_name').val() as string);
                 if (newTblName.length > 0 && newTblName.trim().length === 0) {
-                    ajaxShowMessage(wrongTblNameMsg, false);
+                    ajaxShowMessage(wrongTblNameMsg, false, 'error');
 
                     return false;
                 }
@@ -123,7 +127,7 @@ AJAX.registerOnload('import.js', function () {
             if ($('#text_csv_new_db_name').length > 0) {
                 const newDBName = ($('#text_csv_new_db_name').val() as string);
                 if (newDBName.length > 0 && newDBName.trim().length === 0) {
-                    ajaxShowMessage(wrongDBNameMsg, false);
+                    ajaxShowMessage(wrongDBNameMsg, false, 'error');
 
                     return false;
                 }

--- a/resources/js/makegrid.ts
+++ b/resources/js/makegrid.ts
@@ -447,10 +447,7 @@ const makeGrid = function (t, enableResize = undefined, enableReorder = undefine
 
                 $.post('index.php?route=/sql/set-column-preferences', postParams, function (data) {
                     if (data.success !== true) {
-                        const $tempDiv = $(document.createElement('div'));
-                        $tempDiv.html(data.error);
-                        $tempDiv.addClass('alert alert-danger');
-                        ajaxShowMessage($tempDiv, false);
+                        ajaxShowMessage(data.error, false, 'error');
                     }
                 });
             }
@@ -1607,8 +1604,7 @@ const makeGrid = function (t, enableResize = undefined, enableReorder = undefine
                     if (($(g.cEdit).find('.edit_box').val() as string).match(/^(0x)?[a-f0-9]*$/i) !== null) {
                         thisFieldParams[fieldName] = $(g.cEdit).find('.edit_box').val();
                     } else {
-                        const hexError = '<div class="alert alert-danger" role="alert">' + window.Messages.strEnterValidHex + '</div>';
-                        ajaxShowMessage(hexError, false);
+                        ajaxShowMessage(window.Messages.strEnterValidHex, false, 'error');
                         thisFieldParams[fieldName] = getCellValue(g.currentEditCell);
                     }
                 } else {

--- a/resources/js/modules/ajax-message.ts
+++ b/resources/js/modules/ajax-message.ts
@@ -31,90 +31,65 @@ let ajaxMessageCount = 0;
  * This will show a message that will not disappear automatically, but it
  * can be dismissed by the user after they have finished reading it.
  *
- * @param {string|null} message string containing the message to be shown.
- *                              optional, defaults to 'Loading...'
- * @param {any} timeout         number of milliseconds for the message to be visible
- *                              optional, defaults to 5000. If set to 'false', the
- *                              notification will never disappear
- * @param {string|null} type    string to dictate the type of message shown.
- *                              optional, defaults to normal notification.
- *                              If set to 'error', the notification will show message
- *                              with red background.
- *                              If set to 'success', the notification will show with
- *                              a green background.
- * @return {JQuery<Element>}   jQuery Element that holds the message div
- *                              this object can be passed to ajaxRemoveMessage()
- *                              to remove the notification
+ * @param message string containing the message to be shown.
+ *                optional, defaults to 'Loading...'
+ * @param timeout number of milliseconds for the message to be visible
+ *                optional, defaults to 5000. If set to 'false', the notification will never disappear
+ * @param type    string to dictate the type of message shown. optional, defaults to normal notification.
+ *                If set to 'error', the notification will show message with red background.
+ *                If set to 'warning', the notification will show with a yellow background.
+ *                If set to 'success', the notification will show with a green background.
+ * @return        jQuery Element that holds the message div this object can be passed
+ *                to ajaxRemoveMessage() to remove the notification
  */
-const ajaxShowMessage = function (message = null, timeout = null, type = null) {
-    let msg = message;
-    let newTimeOut = timeout;
-    /**
-     * @var self_closing Whether the notification will automatically disappear
-     */
-    let selfClosing = true;
-    /**
-     * @var dismissable Whether the user will be able to remove
-     *                  the notification by clicking on it
-     */
-    let dismissable = true;
+const ajaxShowMessage = function (
+    message: string|null = null,
+    timeout: number|false|null = null,
+    type: 'error'|'warning'|'success'|null = null,
+): JQuery<HTMLElement>|true {
     // Handle the case when a empty data.message is passed.
     // We don't want the empty message
-    if (msg === '') {
+    if (message === '') {
         return true;
-    } else if (! msg) {
-        // If the message is undefined, show the default
-        msg = window.Messages.strLoading;
-        dismissable = false;
-        selfClosing = false;
-    } else if (msg === window.Messages.strProcessingRequest) {
-        // This is another case where the message should not disappear
-        dismissable = false;
-        selfClosing = false;
-    }
-
-    // Figure out whether (or after how long) to remove the notification
-    if (newTimeOut === undefined || newTimeOut === null) {
-        newTimeOut = 5000;
-    } else if (newTimeOut === false) {
-        selfClosing = false;
-    }
-
-    // Determine type of message, add styling as required
-    if (type === 'error') {
-        msg = '<div class="alert alert-danger" role="alert">' + msg + '</div>';
-    } else if (type === 'success') {
-        msg = '<div class="alert alert-success" role="alert">' + msg + '</div>';
     }
 
     // Create a parent element for the AJAX messages, if necessary
     if ($('#loading_parent').length === 0) {
-        $('<div id="loading_parent"></div>')
-            .prependTo('#page_content');
+        $('<div id="loading_parent"></div>').prependTo('#page_content');
     }
 
-    // Update message count to create distinct message elements every time
-    ajaxMessageCount++;
     // Remove all old messages, if any
     $('[role="tooltip"]').remove();
     $('span.ajax_notification[id^=ajax_message_num]').remove();
-    /**
-     * @var $retval    a jQuery object containing the reference
-     *                 to the created AJAX message
-     */
+
+    const msg = message ?? window.Messages.strLoading;
+    // Determine type of message, add styling as required
+    let html = msg;
+    if (type === 'error') {
+        html = `<div class="alert alert-danger" role="alert">${msg}</div>`;
+    } else if (type === 'warning') {
+        html = `<div class="alert alert-warning" role="alert">${msg}</div>`;
+    } else if (type === 'success') {
+        html = `<div class="alert alert-success" role="alert">${msg}</div>`;
+    }
+
+    /** A jQuery object containing the reference to the created AJAX message with unique id */
     const $retval = $(
-        '<span class="ajax_notification" id="ajax_message_num_' +
-        ajaxMessageCount +
-        '"></span>',
+        `<span class="ajax_notification" id="ajax_message_num_${++ajaxMessageCount}"></span>`,
     )
         .hide()
         .appendTo('#loading_parent')
-        .html(msg)
+        .html(html)
         .show();
     // If the notification is self-closing we should create a callback to remove it
+    /** Whether the notification will automatically disappear */
+    const selfClosing =
+        msg !== window.Messages.strLoading &&
+        msg !== window.Messages.strProcessingRequest &&
+        timeout !== false;
     if (selfClosing) {
         $retval
-            .delay(newTimeOut)
+            .delay(timeout ?? 5000)
             .fadeOut('medium', function () {
                 bootstrap.Tooltip.getInstance(this)?.dispose();
 
@@ -125,6 +100,9 @@ const ajaxShowMessage = function (message = null, timeout = null, type = null) {
 
     // If the notification is dismissable we need to add the relevant class to it
     // and add a tooltip so that the users know that it can be removed
+    const dismissable =
+        msg !== window.Messages.strLoading &&
+        msg !== window.Messages.strProcessingRequest;
     if (dismissable) {
         $retval.addClass('dismissable').css('cursor', 'pointer');
         /**

--- a/resources/js/modules/ajax.ts
+++ b/resources/js/modules/ajax.ts
@@ -953,13 +953,7 @@ const AJAX = {
                     'isErrorResponse' in request.responseJSON &&
                     request.responseJSON.isErrorResponse
                 ) {
-                    ajaxShowMessage(
-                        '<div class="alert alert-danger" role="alert">' +
-                        escapeHtml(request.responseJSON.error) +
-                        '</div>',
-                        false
-                    );
-
+                    ajaxShowMessage(escapeHtml(request.responseJSON.error), false, 'error');
                     AJAX.active = false;
                     AJAX.xhr = null;
 
@@ -976,11 +970,9 @@ const AJAX = {
                 }
 
                 ajaxShowMessage(
-                    '<div class="alert alert-danger" role="alert">' +
-                    window.Messages.strErrorProcessingRequest +
-                    details +
-                    '</div>',
-                    false
+                    window.Messages.strErrorProcessingRequest + details,
+                    false,
+                    'error',
                 );
 
                 AJAX.active = false;

--- a/resources/js/modules/console/config.ts
+++ b/resources/js/modules/console/config.ts
@@ -134,8 +134,8 @@ function setConfigValue (key: string, value: boolean|number|string): void {
         },
     ).fail(function (data) {
         if (typeof data !== 'undefined' && data.responseJSON) {
-            const message = '<div class="alert alert-danger" role="alert">' + escapeHtml(data.responseJSON.error) + '</div>';
-            ajaxShowMessage(message, false);
+            const message = escapeHtml(data.responseJSON.error);
+            ajaxShowMessage(message, false, 'error');
         }
     });
 }

--- a/resources/js/modules/functions.ts
+++ b/resources/js/modules/functions.ts
@@ -1834,10 +1834,7 @@ export function onloadCreateTableEvents (): void {
             // User wants to submit the form
             $.post($form.attr('action'), $form.serialize() + CommonParams.get('arg_separator') + 'do_save_data=1', function (data) {
                 if (typeof data === 'undefined' || data.success !== true) {
-                    ajaxShowMessage(
-                        '<div class="alert alert-danger" role="alert">' + data.error + '</div>',
-                        false
-                    );
+                    ajaxShowMessage(data.error, false, 'error');
 
                     return;
                 }

--- a/resources/js/modules/functions/checkNumberOfFields.ts
+++ b/resources/js/modules/functions/checkNumberOfFields.ts
@@ -19,7 +19,7 @@ export default function checkNumberOfFields () {
     $('form').each(function () {
         const nbInputs = $(this).find(':input').length;
         if (nbInputs > window.maxInputVars) {
-            const warning = sprintf(window.Messages.strTooManyInputs, window.maxInputVars);
+            const warning = sprintf(window.Messages.strTooManyInputs, window.maxInputVars) as string;
             ajaxShowMessage(warning);
 
             return false;

--- a/resources/js/modules/indexes.ts
+++ b/resources/js/modules/indexes.ts
@@ -286,9 +286,9 @@ const addIndexGo = function (sourceArray, arrayIndex, index, colIndex) {
         );
     } else {
         ajaxShowMessage(
-            '<div class="alert alert-danger" role="alert"><img src="themes/dot.gif" title="" alt=""' +
-            ' class="icon ic_s_error"> ' + window.Messages.strMissingColumn +
-            ' </div>', false,
+            '<img src="themes/dot.gif" title="" alt="" class="icon ic_s_error"> ' + window.Messages.strMissingColumn,
+            false,
+            'error',
         );
 
         return false;
@@ -417,9 +417,10 @@ function showAddIndexDialog (sourceArray, arrayIndex, targetColumns, colIndex, i
                     );
                 } else {
                     ajaxShowMessage(
-                        '<div class="alert alert-danger" role="alert"><img src="themes/dot.gif" title="" alt=""' +
-                        ' class="icon ic_s_error"> ' + window.Messages.strMissingColumn +
-                        ' </div>', false
+                        '<img src="themes/dot.gif" title="" alt="" class="icon ic_s_error"> ' +
+                            window.Messages.strMissingColumn,
+                        false,
+                        'error'
                     );
 
                     return false;
@@ -474,11 +475,10 @@ function indexTypeSelectionDialog (sourceArray, indexChoice, colIndex): void {
             if ($('input[name="composite_with"]').length !== 0 && $('input[name="composite_with"]:checked').length === 0
             ) {
                 ajaxShowMessage(
-                    '<div class="alert alert-danger" role="alert"><img src="themes/dot.gif" title=""' +
-                    ' alt="" class="icon ic_s_error"> ' +
-                    window.Messages.strFormEmpty +
-                    ' </div>',
-                    false
+                    '<img src="themes/dot.gif" title="" alt="" class="icon ic_s_error"> ' +
+                        window.Messages.strFormEmpty,
+                    false,
+                    'error',
                 );
 
                 return false;

--- a/resources/js/server/databases.ts
+++ b/resources/js/server/databases.ts
@@ -33,10 +33,9 @@ const DropDatabases = {
 
         if (! selectedDbs.length) {
             ajaxShowMessage(
-                $('<div class="alert alert-warning" role="alert"></div>').text(
-                    window.Messages.strNoDatabasesSelected
-                ),
-                2000
+                window.Messages.strNoDatabasesSelected,
+                2000,
+                'warning',
             );
 
             return;

--- a/src/Controllers/ErrorReportController.php
+++ b/src/Controllers/ErrorReportController.php
@@ -25,6 +25,7 @@ use function __;
 use function in_array;
 use function is_string;
 use function json_decode;
+use function json_encode;
 use function time;
 
 /**
@@ -119,9 +120,7 @@ final readonly class ErrorReportController implements InvocableController
                         $this->response->addJSON('errSubmitMsg', $msg);
                     }
                 } elseif ($exceptionType === 'php') {
-                    $jsCode = 'window.ajaxShowMessage(\'<div class="alert alert-danger" role="alert">'
-                        . $msg
-                        . '</div>\', false);';
+                    $jsCode = 'window.ajaxShowMessage(' . json_encode((string) $msg) . ', false, \'error\');';
                     $this->response->getFooterScripts()->addCode($jsCode);
                 }
 


### PR DESCRIPTION
### Description

This adds typescript types to `ajaxShowMessage`, and removes the code duplication of `<div class="alert alert-danger" role="alert">` etc. in favor of `'error'`, `'warning'`, `'success'` type instead.