### PR TITLE
Fix quoting of INET search values

### DIFF
--- a/libraries/classes/Table/Search.php
+++ b/libraries/classes/Table/Search.php
@@ -167,7 +167,7 @@ final class Search
             // strings to numbers and numbers to strings as necessary
             // during the comparison
             if (
-                preg_match('@char|binary|blob|text|set|date|time|year|uuid@i', $types)
+                preg_match('@char|binary|blob|text|set|date|time|year|uuid|inet[46]@i', $types)
                 || mb_strpos(' ' . $func_type, 'LIKE')
             ) {
                 $quot = '\'';

--- a/test/classes/Table/SearchTest.php
+++ b/test/classes/Table/SearchTest.php
@@ -203,6 +203,21 @@ class SearchTest extends AbstractTestCase
         );
     }
 
+    public function testBuildSqlQueryWithWhereClauseInet(): void
+    {
+        $_POST['zoom_submit'] = true;
+        $_POST['table'] = 'hosts';
+        $_POST['criteriaColumnNames'] = ['ipv4', 'ipv6'];
+        $_POST['criteriaColumnOperators'] = ['=', '='];
+        $_POST['criteriaValues'] = ['1.2.3.4', '2001:db8::1'];
+        $_POST['criteriaColumnTypes'] = ['inet4', 'inet6'];
+
+        self::assertSame(
+            "SELECT * FROM `hosts` WHERE `ipv4` = '1.2.3.4' AND `ipv6` = '2001:db8::1'",
+            $this->search->buildSqlQuery()
+        );
+    }
+
     public function testBuildSqlQueryWithoutConditions(): void
     {
         $_POST['db'] = 'opengis';


### PR DESCRIPTION
### Description

Fixes #20395.

The table search query builder treats MariaDB `INET4` and `INET6` columns as unquoted numeric types when using operators such as `=`. This generates invalid SQL such as:

```sql
SELECT * FROM `test` WHERE `ip` = 1.2.3.4
```

This adds `INET4` and `INET6` to the existing set of string-like column types that require quoted and escaped search values. Numeric columns keep their current unquoted behavior.

A regression test covers both address families:

```sql
SELECT * FROM `hosts` WHERE `ipv4` = '1.2.3.4' AND `ipv6` = '2001:db8::1'
```

Before the fix, the test failed with both values unquoted. After the fix:

- `SearchTest`: 7 tests, 17 assertions pass.
- PHPCS passes for both changed files.
- PHPStan passes for both changed files with no errors.
- `git diff --check` passes.

Target branch: `QA_5_2`, because the report affects phpMyAdmin 5.2.3.

Before submitting pull request, please review the following checklist:

- [x] I have read `CONTRIBUTING.md`.
- [x] This bug fix targets the corresponding `QA_5_2` branch.
- [x] Every commit contains the required Signed-off-by line.
- [x] The commit message is descriptive and the commit is independently needed.
- [x] The changed behavior is covered by a regression test.
