### PR TITLE
Don't do an unnecessary query per table when exporting sql

### DIFF
--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -1461,15 +1461,15 @@ class ExportSql extends ExportPlugin
             $compat = 'NONE';
         }
 
-        $result = $dbi->tryQuery(
-            'SHOW TABLE STATUS FROM ' . Util::backquote($db)
-            . ' WHERE Name = \'' . $dbi->escapeString((string) $table) . '\''
-        );
-        if ($result != false) {
-            if ($result->numRows() > 0) {
+        if ($showDates) {
+            $result = $dbi->tryQuery(
+                'SHOW TABLE STATUS FROM ' . Util::backquote($db)
+                . ' WHERE Name = \'' . $dbi->escapeString((string) $table) . '\''
+            );
+            if ($result != false && $result->numRows() > 0) {
                 $tmpres = $result->fetchAssoc();
 
-                if ($showDates && isset($tmpres['Create_time']) && ! empty($tmpres['Create_time'])) {
+                if (isset($tmpres['Create_time']) && ! empty($tmpres['Create_time'])) {
                     $schemaCreate .= $this->exportComment(
                         __('Creation:') . ' '
                         . Util::localisedDate(
@@ -1479,7 +1479,7 @@ class ExportSql extends ExportPlugin
                     $newCrlf = $this->exportComment() . $crlf;
                 }
 
-                if ($showDates && isset($tmpres['Update_time']) && ! empty($tmpres['Update_time'])) {
+                if (isset($tmpres['Update_time']) && ! empty($tmpres['Update_time'])) {
                     $schemaCreate .= $this->exportComment(
                         __('Last update:') . ' '
                         . Util::localisedDate(
@@ -1489,7 +1489,7 @@ class ExportSql extends ExportPlugin
                     $newCrlf = $this->exportComment() . $crlf;
                 }
 
-                if ($showDates && isset($tmpres['Check_time']) && ! empty($tmpres['Check_time'])) {
+                if (isset($tmpres['Check_time']) && ! empty($tmpres['Check_time'])) {
                     $schemaCreate .= $this->exportComment(
                         __('Last check:') . ' '
                         . Util::localisedDate(

--- a/test/classes/TrackerTest.php
+++ b/test/classes/TrackerTest.php
@@ -210,11 +210,9 @@ class TrackerTest extends AbstractTestCase
             ->with('pma_test', 'pma_tbl')
             ->willReturn($getIndexesResult);
 
-        $showTableStatusQuery = "SHOW TABLE STATUS FROM `pma_test` WHERE Name = 'pma_tbl'";
         $useStatement = 'USE `pma_test`';
         $showCreateTableQuery = 'SHOW CREATE TABLE `pma_test`.`pma_tbl`';
-        $dbi->expects(self::exactly(3))->method('tryQuery')->willReturnMap([
-            [$showTableStatusQuery, DatabaseInterface::CONNECT_USER, 0, true, $resultStub],
+        $dbi->expects(self::exactly(2))->method('tryQuery')->willReturnMap([
             [$useStatement, DatabaseInterface::CONNECT_USER, 0, true, $resultStub],
             [$showCreateTableQuery, DatabaseInterface::CONNECT_USER, 0, true, $resultStub],
         ]);


### PR DESCRIPTION
All usage of the `SHOW TABLE STATUS` query result is guarded by `$showDates`, so executing the query is also only necessary when `$showDates` is `true`.