### PR TITLE
remove auto escape from page title to avoid & bug

### DIFF
--- a/resources/templates/base.twig
+++ b/resources/templates/base.twig
@@ -22,7 +22,7 @@
     {% endif %}
   {% endif %}
   <link rel="stylesheet" type="text/css" href="{{ header.theme_path }}/css/theme{{ pma.text_dir == 'rtl' ? '.rtl' }}.css?v={{ pma.version|url_encode }}">
-  <title>{{ header.title }}</title>
+  <title>{{ header.title|raw }}</title>
   {{ header.scripts|raw }}
   <noscript><style>html{display:block}</style></noscript>
 </head>


### PR DESCRIPTION
### Description

This pull request is to disable twig auto escaping on header.title. When & is used in the title with this enabled it is rendered as ```&amp;``` in the title.


Fixes #
This fixes the incorrect title rendered when a & is passed to the title.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
