### PR TITLE
Fix #20409: editing column structure for varchar with empty string as default

### DIFF
--- a/libraries/classes/Table/ColumnsDefinition.php
+++ b/libraries/classes/Table/ColumnsDefinition.php
@@ -496,58 +496,38 @@ final class ColumnsDefinition
     /**
      * Set default type and default value according to the column metadata
      *
-     * @param array $columnMeta Column Metadata
-     * @phpstan-param array<string, string|null> $columnMeta
+     * @param array<string, string|null> $columnMeta Column Metadata
      *
-     * @return non-empty-array<array-key, mixed>
+     * @return non-empty-array<string, string>
      */
     public static function decorateColumnMetaDefault(array $columnMeta): array
     {
-        $metaDefault = [
-            'DefaultType' => 'USER_DEFINED',
-            'DefaultValue' => '',
-        ];
+        $meta = [];
+        $default = $columnMeta['Default'];
+        if ($default === null) {
+            $meta['DefaultType'] = $columnMeta['Null'] === 'YES' ? 'NULL' : 'NONE';
+            $meta['DefaultValue'] = '';
+        } elseif ($default === 'CURRENT_TIMESTAMP' || $default === 'current_timestamp()') {
+            $meta['DefaultType'] = 'CURRENT_TIMESTAMP';
+            $meta['DefaultValue'] = '';
+        } elseif ($default === 'UUID' || $default === 'uuid()') {
+            $meta['DefaultType'] = 'UUID';
+            $meta['DefaultValue'] = '';
+        } elseif ($default === 'UUID_v4' || $default === 'uuid_v4()') {
+            $meta['DefaultType'] = 'UUID_v4';
+            $meta['DefaultValue'] = '';
+        } elseif ($default === 'UUID_v7' || $default === 'uuid_v7()') {
+            $meta['DefaultType'] = 'UUID_v7';
+            $meta['DefaultValue'] = '';
+        } else {
+            $meta['DefaultType'] = 'USER_DEFINED';
+            $meta['DefaultValue'] = $default;
 
-        switch ($columnMeta['Default']) {
-            case null:
-                if ($columnMeta['Null'] === 'YES') {
-                    $metaDefault['DefaultType'] = 'NULL';
-                } else {
-                    $metaDefault['DefaultType'] = 'NONE';
-                }
-
-                break;
-            case 'CURRENT_TIMESTAMP':
-            case 'current_timestamp()':
-                $metaDefault['DefaultType'] = 'CURRENT_TIMESTAMP';
-
-                break;
-            case 'UUID':
-            case 'uuid()':
-                $metaDefault['DefaultType'] = 'UUID';
-
-                break;
-            case 'UUID_v4':
-            case 'uuid_v4()':
-                $metaDefault['DefaultType'] = 'UUID_v4';
-
-                break;
-            case 'UUID_v7':
-            case 'uuid_v7()':
-                $metaDefault['DefaultType'] = 'UUID_v7';
-
-                break;
-            default:
-                $metaDefault['DefaultValue'] = $columnMeta['Default'];
-
-                if (substr((string) $columnMeta['Type'], -4) === 'text') {
-                    $textDefault = substr($columnMeta['Default'], 1, -1);
-                    $metaDefault['Default'] = stripcslashes($textDefault);
-                }
-
-                break;
+            if (substr((string) $columnMeta['Type'], -4) === 'text') {
+                $meta['Default'] = stripcslashes(substr($default, 1, -1));
+            }
         }
 
-        return $metaDefault;
+        return $meta;
     }
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13451,6 +13451,10 @@
       <code>$submit_attribute</code>
       <code>$type</code>
     </MixedAssignment>
+    <PossiblyFalseArgument occurrences="2">
+      <code>$columnMeta['Default']</code>
+      <code>$columnMeta['Type']</code>
+    </PossiblyFalseArgument>
     <PossiblyInvalidCast occurrences="1">
       <code>$_POST['after_field']</code>
     </PossiblyInvalidCast>

--- a/test/classes/Table/ColumnsDefinitionTest.php
+++ b/test/classes/Table/ColumnsDefinitionTest.php
@@ -62,6 +62,17 @@ class ColumnsDefinitionTest extends AbstractTestCase
                     'DefaultValue' => '',
                 ],
             ],
+            'when Default is empty string' => [
+                [
+                    'Type' => 'varchar(20)',
+                    'Null' => 'NO',
+                    'Default' => '',
+                ],
+                [
+                    'DefaultType' => 'USER_DEFINED',
+                    'DefaultValue' => '',
+                ],
+            ],
             'when Default is CURRENT_TIMESTAMP' => [
                 ['Default' => 'CURRENT_TIMESTAMP'],
                 [


### PR DESCRIPTION
### Description

Don't lose empty string default value when editing a varchar column.
This was introduced in 8929288efd592047c81df3b9b8b8a8151edaac41

Fixes #20409