### PR TITLE
Fix Gis editor form in search view

### DIFF
--- a/resources/js/table/change.ts
+++ b/resources/js/table/change.ts
@@ -608,7 +608,7 @@ AJAX.registerOnload('table/change.js', function () {
     // @ts-ignore
     $.datepicker.initialized = false;
 
-    const gisEditorModal = document.getElementById('gisEditorModal');
+    const gisEditorModal = document.querySelector('#gisEditorModal.editor-for-change');
     gisEditorModal?.addEventListener('show.bs.modal', event => {
         // @ts-ignore
         const button = $(event.relatedTarget as HTMLButtonElement);

--- a/resources/js/table/select.ts
+++ b/resources/js/table/select.ts
@@ -266,7 +266,7 @@ AJAX.registerOnload('table/select.js', function () {
         }
     });
 
-    const gisEditorModal = document.getElementById('gisEditorModal');
+    const gisEditorModal = document.querySelector('#gisEditorModal.editor-for-search');
     gisEditorModal?.addEventListener('show.bs.modal', event => {
         // @ts-ignore
         const button = $(event.relatedTarget as HTMLButtonElement);

--- a/resources/templates/modals/gis_editor.twig
+++ b/resources/templates/modals/gis_editor.twig
@@ -1,4 +1,4 @@
-<div class="modal fade" id="gisEditorModal" data-bs-backdrop="static" tabindex="-1" aria-labelledby="gisEditorModalLabel" aria-hidden="true">
+<div class="modal fade editor-for-{{ location }}" id="gisEditorModal" data-bs-backdrop="static" tabindex="-1" aria-labelledby="gisEditorModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header">

--- a/resources/templates/table/search/index.twig
+++ b/resources/templates/table/search/index.twig
@@ -91,8 +91,6 @@
             </tbody>
           </table>
         </div>
-
-        {% include 'modals/gis_editor.twig' with { 'location': 'search' } only %}
       </div>
 
       {% if default_sliders_state != 'disabled' %}
@@ -172,6 +170,8 @@
     </div>
   </div>
 </form>
+
+{% include 'modals/gis_editor.twig' with { 'location': 'search' } only %}
 
 <div class="modal fade" id="rangeSearchModal" tabindex="-1" aria-labelledby="rangeSearchModalLabel" aria-hidden="false">
   <div class="modal-dialog">

--- a/resources/templates/table/search/index.twig
+++ b/resources/templates/table/search/index.twig
@@ -92,7 +92,7 @@
           </table>
         </div>
 
-        {{ include('modals/gis_editor.twig') }}
+        {% include 'modals/gis_editor.twig' with { 'location': 'search' } only %}
       </div>
 
       {% if default_sliders_state != 'disabled' %}

--- a/resources/templates/table/zoom_search/index.twig
+++ b/resources/templates/table/zoom_search/index.twig
@@ -145,7 +145,7 @@
         </tr>
       </table>
 
-      {{ include('modals/gis_editor.twig') }}
+      {% include 'modals/gis_editor.twig' with { 'location': 'search' } only %}
     </div>
 
     <div class="card-footer">

--- a/resources/templates/table/zoom_search/index.twig
+++ b/resources/templates/table/zoom_search/index.twig
@@ -144,8 +144,6 @@
           </td>
         </tr>
       </table>
-
-      {% include 'modals/gis_editor.twig' with { 'location': 'search' } only %}
     </div>
 
     <div class="card-footer">
@@ -153,4 +151,7 @@
     </div>
   </div>
 </form>
+
+{% include 'modals/gis_editor.twig' with { 'location': 'search' } only %}
+
 <div id="sqlqueryresultsouter"></div>

--- a/src/Controllers/Table/ChangeController.php
+++ b/src/Controllers/Table/ChangeController.php
@@ -276,7 +276,7 @@ class ChangeController implements InvocableController
 
         $htmlOutput .= '</form>';
 
-        $htmlOutput .= $this->template->render('modals/gis_editor');
+        $htmlOutput .= $this->template->render('modals/gis_editor', ['location' => 'change']);
         // end Insert/Edit form
 
         if ($insertMode) {


### PR DESCRIPTION
### Description

Opening the GIS editor form the search view produced an error because both `'show.bs.modal'` listeners were active. (from change.ts and select.ts)

Also copying the value from the editor to the search form did not work because the editor modal which has its own form element was inside the search form element. Nested form elements are stripped away by the browser.