### PR TITLE
Allow Node.js 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "GPL-2.0",
   "private": true,
   "engines": {
-    "node": ">=24"
+    "node": ">=22"
   },
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
### Description

Node.js 22 is still [supported until April 2027](https://nodejs.org/en/about/previous-releases) and Ubuntu 26.04 comes with version 22.

Ref: #20345 & https://github.com/phpmyadmin/phpmyadmin/pull/20385