### PR TITLE
Keep the Execute action available to users holding only the EXECUTE privilege

### DIFF
--- a/libraries/classes/Database/Routines.php
+++ b/libraries/classes/Database/Routines.php
@@ -545,13 +545,16 @@ class Routines
      * This function will generate the values that are required to complete
      * the "Edit routine" form given the name of a routine.
      *
-     * @param string $name The name of the routine.
-     * @param string $type Type of routine (ROUTINE|PROCEDURE)
-     * @param bool   $all  Whether to return all data or just the info about parameters.
+     * @param string $name           The name of the routine.
+     * @param string $type           Type of routine (ROUTINE|PROCEDURE)
+     * @param bool   $all            Whether to return all data or just the info about parameters.
+     * @param bool   $paramsOnlyData Describe a routine we are not allowed to read from its
+     *                               parameters alone, leaving the body empty. Only safe when
+     *                               executing it: the editor would save that empty body back.
      *
      * @return array|null    Data necessary to create the routine editor.
      */
-    public function getDataFromName($name, $type, $all = true): ?array
+    public function getDataFromName($name, $type, $all = true, $paramsOnlyData = false): ?array
     {
         global $db;
 
@@ -578,6 +581,13 @@ class Routines
         $retval['item_type'] = $routine['ROUTINE_TYPE'];
 
         $definition = $this->dbi->getDefinition($db, $routine['ROUTINE_TYPE'], $routine['SPECIFIC_NAME']);
+
+        if ($definition === null && $paramsOnlyData) {
+            // The routine's source is hidden from this user, but its parameters
+            // are listed separately in INFORMATION_SCHEMA.PARAMETERS, so we can
+            // still build a (bodyless) definition good enough to execute it.
+            $definition = $this->getDefinitionFromParameters($type, $name, (string) $routine['DTD_IDENTIFIER']);
+        }
 
         if ($definition === null) {
             return null;
@@ -669,6 +679,51 @@ class Routines
         $retval['item_comment'] = $routine['ROUTINE_COMMENT'];
 
         return $retval;
+    }
+
+    /**
+     * Rebuilds a bare-bones routine definition (parameters only, empty body) from
+     * INFORMATION_SCHEMA.PARAMETERS, for when SHOW CREATE is hiding the real one.
+     *
+     * @param string $type       Type of routine (PROCEDURE|FUNCTION)
+     * @param string $name       The name of the routine
+     * @param string $returnType The return type, for a function
+     *
+     * @return string|null The definition, or null if it cannot be built
+     */
+    private function getDefinitionFromParameters(string $type, string $name, string $returnType): ?string
+    {
+        global $db;
+
+        if ($type === 'FUNCTION' && $returnType === '') {
+            return null;
+        }
+
+        $query = 'SELECT PARAMETER_MODE, PARAMETER_NAME, DTD_IDENTIFIER'
+            . ' FROM INFORMATION_SCHEMA.PARAMETERS'
+            . ' WHERE SPECIFIC_SCHEMA ' . Util::getCollateForIS() . '='
+            . "'" . $this->dbi->escapeString($db) . "'"
+            . " AND SPECIFIC_NAME='" . $this->dbi->escapeString($name) . "'"
+            . " AND ROUTINE_TYPE='" . $this->dbi->escapeString($type) . "'"
+            // Position 0 holds the return type of a function, not a parameter.
+            . ' AND ORDINAL_POSITION > 0'
+            . ' ORDER BY ORDINAL_POSITION;';
+
+        /** @var array<int, array<string, string>> $rows */
+        $rows = $this->dbi->fetchResult($query);
+
+        $parameters = [];
+        foreach ($rows as $parameter) {
+            $paramName = Util::backquote($parameter['PARAMETER_NAME']);
+            $parameters[] = $parameter['PARAMETER_MODE'] . ' ' . $paramName . ' ' . $parameter['DTD_IDENTIFIER'];
+        }
+
+        $definition = 'CREATE ' . $type . ' ' . Util::backquote($name) . ' (' . implode(', ', $parameters) . ')';
+        if ($type === 'FUNCTION') {
+            $definition .= ' RETURNS ' . $returnType;
+        }
+
+        return $definition . ' BEGIN END';
     }
 
     /**
@@ -1151,7 +1206,7 @@ class Routines
         global $db;
 
         // Build the queries
-        $routine = $this->getDataFromName($_POST['item_name'], $_POST['item_type'], false);
+        $routine = $this->getDataFromName($_POST['item_name'], $_POST['item_type'], false, true);
         if ($routine === null) {
             $message = __('Error in processing request:') . ' ';
             $message .= sprintf(
@@ -1303,7 +1358,7 @@ class Routines
             /**
              * Display the execute form for a routine.
              */
-            $routine = $this->getDataFromName($_GET['item_name'], $_GET['item_type'], true);
+            $routine = $this->getDataFromName($_GET['item_name'], $_GET['item_type'], true, true);
             if ($routine !== null) {
                 $form = $this->getExecuteForm($routine);
                 if ($this->response->isAjax()) {
@@ -1488,27 +1543,29 @@ class Routines
         // it does not detect all kinds of privileges, for example
         // a direct privilege on a specific routine. So, at this point,
         // we show the Execute link, hoping that the user has the correct rights.
-        // Also, information_schema might be hiding the ROUTINE_DEFINITION
-        // but a routine with no input parameters can be nonetheless executed.
 
         // Check if the routine has any input parameters. If it does,
         // we will show a dialog to get values for these parameters,
         // otherwise we can execute it directly.
 
-        $definition = $this->dbi->getDefinition($db, $routine['type'], $routine['name']);
         $executeAction = '';
 
-        if ($definition !== null) {
-            $parser = new Parser('DELIMITER $$' . "\n" . $definition);
+        if ($hasExecutePrivilege) {
+            // Default to the dialog: a user with only the EXECUTE privilege can't
+            // read the routine below, so we won't know if it takes any parameters.
+            $executeAction = 'execute_dialog';
 
-            /**
-             * @var CreateStatement $stmt
-             */
-            $stmt = $parser->statements[0];
+            $definition = $this->dbi->getDefinition($db, $routine['type'], $routine['name']);
+            if ($definition !== null) {
+                $parser = new Parser('DELIMITER $$' . "\n" . $definition);
 
-            $params = Routine::getParameters($stmt);
+                /**
+                 * @var CreateStatement $stmt
+                 */
+                $stmt = $parser->statements[0];
 
-            if ($hasExecutePrivilege) {
+                $params = Routine::getParameters($stmt);
+
                 $executeAction = 'execute_routine';
                 for ($i = 0; $i < $params['num']; $i++) {
                     if ($routine['type'] === 'PROCEDURE' && $params['dir'][$i] === 'OUT') {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13922,7 +13922,7 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
-			count: 1
+			count: 2
 			path: libraries/classes/Database/Routines.php
 
 		-
@@ -14142,7 +14142,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:escapeString\\(\\) expects string, mixed given\\.$#"
-			count: 6
+			count: 7
 			path: libraries/classes/Database/Routines.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5281,7 +5281,8 @@
     <InvalidArrayOffset occurrences="1">
       <code>$retval['item_param_dir'][$key]</code>
     </InvalidArrayOffset>
-    <MixedArgument occurrences="47">
+    <MixedArgument occurrences="48">
+      <code>$db</code>
       <code>$db</code>
       <code>$db</code>
       <code>$db</code>

--- a/test/classes/Database/RoutinesTest.php
+++ b/test/classes/Database/RoutinesTest.php
@@ -1416,4 +1416,128 @@ class RoutinesTest extends AbstractTestCase
             ],
         ];
     }
+
+    /**
+     * A user who was only granted the EXECUTE privilege cannot read the source of a
+     * routine, but is still allowed to call it, so the Execute link must stay usable.
+     *
+     * @see https://github.com/phpmyadmin/phpmyadmin/issues/19543
+     */
+    public function testGetRowWithOnlyExecutePrivilege(): void
+    {
+        $this->dummyDbi->removeDefaultResults();
+        $this->dummyDbi->addResult('SELECT @@lower_case_table_names', []);
+        // phpcs:disable Generic.Files.LineLength.TooLong
+        $this->dummyDbi->addResult(
+            "SELECT `DEFINER` FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_SCHEMA ='db' AND SPECIFIC_NAME='test_proc'AND ROUTINE_TYPE='PROCEDURE';",
+            [['root@localhost']],
+            ['DEFINER']
+        );
+        $this->dummyDbi->addResult('SELECT CURRENT_USER();', [['john@%']], ['CURRENT_USER()']);
+        // No CREATE ROUTINE privilege, globally or on the database.
+        $this->dummyDbi->addResult(
+            "SELECT `PRIVILEGE_TYPE` FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES` WHERE GRANTEE='''john''@''%''' AND PRIVILEGE_TYPE='CREATE ROUTINE'",
+            []
+        );
+        $this->dummyDbi->addResult(
+            "SELECT `PRIVILEGE_TYPE` FROM `INFORMATION_SCHEMA`.`SCHEMA_PRIVILEGES` WHERE GRANTEE='''john''@''%''' AND PRIVILEGE_TYPE='CREATE ROUTINE' AND 'db' LIKE `TABLE_SCHEMA`",
+            []
+        );
+        $this->dummyDbi->addResult('SELECT 1 FROM mysql.user LIMIT 1', []);
+        // ... but EXECUTE was granted on it.
+        $this->dummyDbi->addResult(
+            "SELECT `PRIVILEGE_TYPE` FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES` WHERE GRANTEE='''john''@''%''' AND PRIVILEGE_TYPE='EXECUTE'",
+            []
+        );
+        $this->dummyDbi->addResult(
+            "SELECT `PRIVILEGE_TYPE` FROM `INFORMATION_SCHEMA`.`SCHEMA_PRIVILEGES` WHERE GRANTEE='''john''@''%''' AND PRIVILEGE_TYPE='EXECUTE' AND 'db' LIKE `TABLE_SCHEMA`",
+            [['EXECUTE']],
+            ['PRIVILEGE_TYPE']
+        );
+        // The server hides the body of the routine from this user.
+        $this->dummyDbi->addResult(
+            'SHOW CREATE PROCEDURE `db`.`test_proc`',
+            [['test_proc', null]],
+            ['Procedure', 'Create Procedure']
+        );
+        // phpcs:enable
+
+        $actual = $this->routines->getRow(['name' => 'test_proc', 'type' => 'PROCEDURE', 'returns' => '']);
+
+        self::assertStringContainsString('exec_anchor', $actual);
+        self::assertStringContainsString('ic_b_nextpage', $actual);
+        self::assertStringNotContainsString('ic_bd_nextpage', $actual);
+        // Editing and exporting still require more than the EXECUTE privilege.
+        self::assertStringContainsString('ic_bd_edit', $actual);
+        self::assertStringContainsString('ic_bd_export', $actual);
+        $this->assertAllQueriesConsumed();
+    }
+
+    /**
+     * When the source of a routine is hidden, its parameters are still readable from
+     * INFORMATION_SCHEMA.PARAMETERS, so the execution dialog can be built from those.
+     *
+     * @see https://github.com/phpmyadmin/phpmyadmin/issues/19543
+     */
+    public function testGetDataFromNameWithoutReadableDefinition(): void
+    {
+        $this->dummyDbi->removeDefaultResults();
+        $this->dummyDbi->addResult('SELECT @@lower_case_table_names', []);
+        // phpcs:disable Generic.Files.LineLength.TooLong
+        $this->dummyDbi->addResult(
+            "SELECT SPECIFIC_NAME, ROUTINE_TYPE, DTD_IDENTIFIER, ROUTINE_DEFINITION, IS_DETERMINISTIC, SQL_DATA_ACCESS, ROUTINE_COMMENT, SECURITY_TYPE FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_SCHEMA ='db' AND SPECIFIC_NAME='test_proc'AND ROUTINE_TYPE='PROCEDURE';",
+            [['test_proc', 'PROCEDURE', null, null, 'NO', 'CONTAINS SQL', '', 'DEFINER']],
+            ['SPECIFIC_NAME', 'ROUTINE_TYPE', 'DTD_IDENTIFIER', 'ROUTINE_DEFINITION', 'IS_DETERMINISTIC', 'SQL_DATA_ACCESS', 'ROUTINE_COMMENT', 'SECURITY_TYPE']
+        );
+        $this->dummyDbi->addResult(
+            'SHOW CREATE PROCEDURE `db`.`test_proc`',
+            [['test_proc', null]],
+            ['Procedure', 'Create Procedure']
+        );
+        $this->dummyDbi->addResult(
+            "SELECT PARAMETER_MODE, PARAMETER_NAME, DTD_IDENTIFIER FROM INFORMATION_SCHEMA.PARAMETERS WHERE SPECIFIC_SCHEMA ='db' AND SPECIFIC_NAME='test_proc' AND ROUTINE_TYPE='PROCEDURE' AND ORDINAL_POSITION > 0 ORDER BY ORDINAL_POSITION;",
+            [['IN', 'inputParam', 'int unsigned'], ['OUT', 'outputParam', "enum('a','b')"]],
+            ['PARAMETER_MODE', 'PARAMETER_NAME', 'DTD_IDENTIFIER']
+        );
+        // phpcs:enable
+
+        $actual = $this->routines->getDataFromName('test_proc', 'PROCEDURE', false, true);
+
+        self::assertIsArray($actual);
+        self::assertSame(2, $actual['item_num_params']);
+        self::assertSame(['IN', 'OUT'], $actual['item_param_dir']);
+        self::assertSame(['inputParam', 'outputParam'], $actual['item_param_name']);
+        self::assertSame(['INT', 'ENUM'], $actual['item_param_type']);
+        self::assertSame(['', "'a','b'"], $actual['item_param_length']);
+        self::assertSame(['UNSIGNED', ''], $actual['item_param_opts_num']);
+        $this->assertAllQueriesConsumed();
+    }
+
+    /**
+     * The parameters alone do not describe the body of a routine, so the editor must
+     * keep refusing a routine whose source cannot be read: saving it back would
+     * recreate the routine with an empty body.
+     *
+     * @see https://github.com/phpmyadmin/phpmyadmin/issues/19543
+     */
+    public function testGetDataFromNameWithoutReadableDefinitionForTheEditor(): void
+    {
+        $this->dummyDbi->removeDefaultResults();
+        $this->dummyDbi->addResult('SELECT @@lower_case_table_names', []);
+        // phpcs:disable Generic.Files.LineLength.TooLong
+        $this->dummyDbi->addResult(
+            "SELECT SPECIFIC_NAME, ROUTINE_TYPE, DTD_IDENTIFIER, ROUTINE_DEFINITION, IS_DETERMINISTIC, SQL_DATA_ACCESS, ROUTINE_COMMENT, SECURITY_TYPE FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_SCHEMA ='db' AND SPECIFIC_NAME='test_proc'AND ROUTINE_TYPE='PROCEDURE';",
+            [['test_proc', 'PROCEDURE', null, null, 'NO', 'CONTAINS SQL', '', 'DEFINER']],
+            ['SPECIFIC_NAME', 'ROUTINE_TYPE', 'DTD_IDENTIFIER', 'ROUTINE_DEFINITION', 'IS_DETERMINISTIC', 'SQL_DATA_ACCESS', 'ROUTINE_COMMENT', 'SECURITY_TYPE']
+        );
+        $this->dummyDbi->addResult(
+            'SHOW CREATE PROCEDURE `db`.`test_proc`',
+            [['test_proc', null]],
+            ['Procedure', 'Create Procedure']
+        );
+        // phpcs:enable
+
+        self::assertNull($this->routines->getDataFromName('test_proc', 'PROCEDURE'));
+        $this->assertAllQueriesConsumed();
+    }
 }


### PR DESCRIPTION
Fixes #19543

## Problem

After `GRANT EXECUTE ON db.* TO john`, `john` can run `CALL Hello('world')` from the
MySQL CLI, but the Execute action for that routine is greyed out in phpMyAdmin.

## Root cause

The privilege check itself is fine: `Util::currentUserHasPrivilege('EXECUTE', $db)`
returns `true`, because `INFORMATION_SCHEMA.SCHEMA_PRIVILEGES` does report the grant.

The action is disabled by a second, unrelated condition. `Routines::getRow()` also
needs the routine's parameter list, which it obtains by parsing the routine's DDL:

```php
$definition = $this->dbi->getDefinition($db, $routine['type'], $routine['name']);
$executeAction = '';

if ($definition !== null) {
    // ... only here is $executeAction ever set
}
```

and the template requires both flags:

```twig
{% if has_execute_privilege and execute_action is not empty %}
```

`getDefinition()` runs `SHOW CREATE PROCEDURE`. Reading a routine's source requires
`SHOW_ROUTINE`, or the global `SELECT` privilege, or being the routine's `DEFINER`;
`EXECUTE` alone is not enough. The server does not reject the statement in that case —
it returns a row whose `Create Procedure` column is `NULL`:

```
| Procedure | sql_mode | Create Procedure | ... |
| Hello     | ONLY_...  | NULL             | ... |
```

`getDefinition()` maps that to `null`, `$executeAction` stays empty, and the row renders
the disabled `bd_nextpage` icon. In short, phpMyAdmin was treating "may I read this
routine's source?" as if it answered "may I run it?".

The same `$definition === null` bail-out exists in `getDataFromName()`, so simply
enabling the link is not enough: the execution dialog would fail with
"No routine with name ... found in database ...".

## Fix

1. `getRow()` decides the Execute action from the privilege, and only uses the DDL as an
   optimisation. When the DDL is readable the existing behaviour is unchanged (routines
   with no input parameters still get one-click `execute_routine`). When it is not, it
   falls back to `execute_dialog`.
2. `getDataFromName()` rebuilds a parameters-only definition from
   `INFORMATION_SCHEMA.PARAMETERS` when the source is hidden, which the server does
   expose to a user holding `EXECUTE`. It is fed to the existing parser, so length,
   `UNSIGNED`, `ENUM`/`SET` values and parameter direction are all derived by the same
   code as before.

Because such a rebuilt definition carries no body, it is opt-in through a new
`$paramsOnlyData` argument that only the two execution paths pass. The routine editor
keeps refusing a routine whose source it cannot read — otherwise saving it back would
recreate the routine with an empty body. There is a regression test for this.

The baseline files only move by three counters, for one extra `escapeString($db)` call
and one extra `(string)` cast on a column read from INFORMATION_SCHEMA — both follow the
`global $db` / mixed-array patterns already used all over this class.

## Testing

Verified against **MySQL 8.4.2** (the version in the report) and **MariaDB 11.4.4**, with
exactly the grants from the issue, `GRANT USAGE ON *.*` + `GRANT EXECUTE ON db.*`. Both
servers behave the same: `SHOW CREATE` returns a `NULL` body, `ROUTINE_DEFINITION` is
`NULL`, `INFORMATION_SCHEMA.PARAMETERS` is readable, and `CALL` works — so the bug and
the fix are identical on both.

| | before | after |
|---|---|---|
| Execute icon | `ic_bd_nextpage` (disabled) | `ic_b_nextpage` (enabled) |
| Execution dialog | "No routine with name ... found" | renders the correct fields |
| `CALL Hello('world')` | not possible | `SET @p0='world'; CALL Hello(@p0);` → `Hello world` |
| `AddUp(10, 0.25)` (FUNCTION) | not possible | `SELECT AddUp(@p0, @p1)` → `10.25` |

Also checked that `IN` / `OUT` / `INOUT`, `int unsigned`, `enum('x','y')` and
`decimal(10,2)` all parse identically whether they come from the real DDL or from the
rebuilt one, and that Edit and Export stay disabled for this user. Both servers report
`PARAMETER_MODE` for every parameter past position 0, including a function's, so the
rebuilt parameter list never has a missing direction.

Three tests were added. The two that cover the reported bug fail without this change.
`phpcs`, `phpstan` and `psalm` are clean on the changed files, and the test suite shows
no new failures.

## Not covered

A grant on one specific routine, `GRANT EXECUTE ON PROCEDURE db.Hello TO jane`, still
shows a disabled Execute action. `Util::currentUserHasPrivilege()` only looks at
`USER_PRIVILEGES` and `SCHEMA_PRIVILEGES`, and a routine-level grant appears in neither
(it lives in `mysql.procs_priv`, which the user cannot read) — the long-standing comment
above the check already says as much. `master` has the same gap.

Closing it would mean changing how the privilege is detected rather than when the
definition is needed, so it felt like a separate change. Happy to fold it in if you would
rather see both handled at once.
