### PR TITLE
Fix db structure summary timestamp

### DIFF
--- a/libraries/classes/Controllers/Database/StructureController.php
+++ b/libraries/classes/Controllers/Database/StructureController.php
@@ -324,7 +324,7 @@ class StructureController extends AbstractController
 
             if ($GLOBALS['cfg']['ShowDbStructureLastUpdate']) {
                 $updateTime = $currentTable['Update_time'] ?? '';
-                if ($updateTime && (! $updateTimeAll || $updateTime < $updateTimeAll)) {
+                if ($updateTime && (! $updateTimeAll || $updateTime > $updateTimeAll)) {
                     $updateTimeAll = $updateTime;
                 }
             }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41704,6 +41704,16 @@ parameters:
 			path: test/classes/Controllers/Database/StructureControllerTest.php
 
 		-
+			message: "#^Cannot access offset 'ShowDbStructureCrea…' on mixed\\.$#"
+			count: 1
+			path: test/classes/Controllers/Database/StructureControllerTest.php
+
+		-
+			message: "#^Cannot access offset 'ShowDbStructureLast…' on mixed\\.$#"
+			count: 2
+			path: test/classes/Controllers/Database/StructureControllerTest.php
+
+		-
 			message: "#^Cannot access offset 'ShowStats' on mixed\\.$#"
 			count: 1
 			path: test/classes/Controllers/Database/StructureControllerTest.php
@@ -41730,16 +41740,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$array of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayNotHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
-			count: 1
-			path: test/classes/Controllers/Database/StructureControllerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, mixed given\\.$#"
-			count: 4
-			path: test/classes/Controllers/Database/StructureControllerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringNotContainsString\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: test/classes/Controllers/Database/StructureControllerTest.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14641,10 +14641,8 @@
     </MixedAssignment>
   </file>
   <file src="test/classes/Controllers/Database/StructureControllerTest.php">
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="1">
       <code>$currentTable</code>
-      <code>$result</code>
-      <code>$result</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="23">
       <code>$currentTable</code>
@@ -14676,9 +14674,7 @@
       <code>$currentTable['ENGINE']</code>
       <code>$currentTable['ENGINE']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="10">
-      <code>$result</code>
-      <code>$result</code>
+    <MixedAssignment occurrences="8">
       <code>[$currentTable, , , $sumSize]</code>
       <code>[$currentTable, , , $sumSize]</code>
       <code>[$currentTable, , , $sumSize]</code>

--- a/templates/database/structure/body_for_table_summary.twig
+++ b/templates/database/structure/body_for_table_summary.twig
@@ -69,19 +69,13 @@
         <th></th>
     {% endif %}
     {% if show_creation %}
-        <th class="value tbl_creation font-monospace text-end">
-            {{ create_time_all }}
-        </th>
+        <th class="value tbl_creation font-monospace text-end">{{ create_time_all }}</th>
     {% endif %}
     {% if show_last_update %}
-        <th class="value tbl_last_update font-monospace text-end">
-            {{ update_time_all }}
-        </th>
+        <th class="value tbl_last_update font-monospace text-end">{{ update_time_all }}</th>
     {% endif %}
     {% if show_last_check %}
-        <th class="value tbl_last_check font-monospace text-end">
-            {{ check_time_all }}
-        </th>
+        <th class="value tbl_last_check font-monospace text-end">{{ check_time_all }}</th>
     {% endif %}
 </tr>
 </tfoot>

--- a/test/classes/Controllers/Database/StructureControllerTest.php
+++ b/test/classes/Controllers/Database/StructureControllerTest.php
@@ -389,6 +389,10 @@ class StructureControllerTest extends AbstractTestCase
      */
     public function testDisplayTableList(): void
     {
+        $GLOBALS['cfg']['ShowDbStructureCreation'] = true;
+        $GLOBALS['cfg']['ShowDbStructureLastUpdate'] = true;
+        $GLOBALS['cfg']['ShowDbStructureLastCheck'] = true;
+
         $class = new ReflectionClass(StructureController::class);
         $method = $class->getMethod('displayTableList');
         if (PHP_VERSION_ID < 80100) {
@@ -425,34 +429,59 @@ class StructureControllerTest extends AbstractTestCase
             $numTables->setAccessible(true);
         }
 
-        $numTables->setValue($controller, 1);
+        $_REQUEST['db'] = 'my_unique_test_db';
 
         //no tables
-        $_REQUEST['db'] = 'my_unique_test_db';
+        $numTables->setValue($controller, 0);
         $tablesProperty->setValue($controller, []);
+        /** @var string $result */
         $result = $method->invoke($controller, ['status' => false]);
         self::assertStringContainsString($_REQUEST['db'], $result);
         self::assertStringNotContainsString('id="overhead"', $result);
 
         //with table
-        $_REQUEST['db'] = 'my_unique_test_db';
+        $tableInfo = [
+            'ENGINE' => 'Maria',
+            'TABLE_TYPE' => 'BASE TABLE',
+            'TABLE_ROWS' => '0',
+            'TABLE_COMMENT' => 'test',
+            'Data_length' => '5000',
+            'Index_length' => '100',
+            'Data_free' => '10000',
+        ];
         $tablesProperty->setValue($controller, [
-            [
-                'TABLE_NAME' => 'my_unique_test_db',
-                'ENGINE' => 'Maria',
-                'TABLE_TYPE' => 'BASE TABLE',
-                'TABLE_ROWS' => 0,
-                'TABLE_COMMENT' => 'test',
-                'Data_length' => 5000,
-                'Index_length' => 100,
-                'Data_free' => 10000,
-            ],
+            'my_unique_test_table_1' => [
+                'TABLE_NAME' => 'my_unique_test_table_1',
+                'Create_time' => '2026-09-04 09:11:00',
+                'Update_time' => '2026-09-04 10:11:00',
+                'Check_time' => '2026-09-04 11:11:00',
+            ] + $tableInfo,
+            'my_unique_test_table_2' => [
+                'TABLE_NAME' => 'my_unique_test_table_2',
+                'Create_time' => '2026-09-04 09:22:00',
+                'Update_time' => '2026-09-04 10:22:00',
+                'Check_time' => '2026-09-04 11:22:00',
+            ] + $tableInfo,
         ]);
+        $numTables->setValue($controller, 2);
+        /** @var string $result */
         $result = $method->invoke($controller, ['status' => false]);
 
         self::assertStringContainsString($_REQUEST['db'], $result);
         self::assertStringContainsString('id="overhead"', $result);
         self::assertStringContainsString('9.8', $result);
+        self::assertStringContainsString(
+            '<th class="value tbl_creation font-monospace text-end">Sep 04, 2026 at 09:11 AM</th>',
+            $result
+        );
+        self::assertStringContainsString(
+            '<th class="value tbl_last_update font-monospace text-end">Sep 04, 2026 at 10:22 AM</th>',
+            $result
+        );
+        self::assertStringContainsString(
+            '<th class="value tbl_last_check font-monospace text-end">Sep 04, 2026 at 11:11 AM</th>',
+            $result
+        );
     }
 
     /**


### PR DESCRIPTION
### Description

In Database -> Structure `Creation`, `Last update`, and `Last check` all showed the min timestamp of any table in the `Sum` row. `Last update` should display the highest instead.
Not so sure if the other two columns should continue to display the min or max timestamp.

The other two timestamps are calculate just above and below the changed code for the max update timestamp.

Enable in `config.inc.php`:
```php
$cfg['ShowDbStructureLastUpdate'] = true;
$cfg['ShowDbStructureCreation'] = true;
$cfg['ShowDbStructureLastCheck'] = true;
```