### PR TITLE
fix: Preserve spatial axis order when saving edited rows

### DIFF
--- a/src/InsertEdit.php
+++ b/src/InsertEdit.php
@@ -1064,12 +1064,18 @@ class InsertEdit
             return $this->dbi->quoteString($uuid);
         }
 
-        if (
-            in_array($editField->function, $this->getGisFromTextFunctions(), true)
-            || in_array($editField->function, $this->getGisFromWKBFunctions(), true)
-        ) {
+        $isGisFromTextFunction = in_array($editField->function, $this->getGisFromTextFunctions(), true);
+        if ($isGisFromTextFunction || in_array($editField->function, $this->getGisFromWKBFunctions(), true)) {
             preg_match('/^(\'?)(.*?)\1(?:,(\d+))?$/', $editField->value, $matches);
             $escapedParams = $this->dbi->quoteString($matches[2]) . (isset($matches[3]) ? ',' . $matches[3] : '');
+            if (
+                $isGisFromTextFunction
+                && isset($matches[3])
+                && $this->dbi->getVersion() >= 80001
+                && ! $this->dbi->isMariaDB()
+            ) {
+                $escapedParams .= ',' . $this->dbi->quoteString('axis-order=long-lat');
+            }
 
             return $editField->function . '(' . $escapedParams . ')';
         }

--- a/tests/unit/InsertEditTest.php
+++ b/tests/unit/InsertEditTest.php
@@ -1785,6 +1785,64 @@ class InsertEditTest extends AbstractTestCase
     }
 
     /**
+     * @param array<string, string> $version
+     */
+    #[DataProvider('spatialConstructorProvider')]
+    public function testGetQueryValueForInsertFormatsSpatialConstructor(
+        array $version,
+        string $function,
+        string $value,
+        string $expected,
+    ): void {
+        $this->dbi->setVersion($version);
+
+        $result = $this->insertEdit->getQueryValueForInsert(
+            new EditField('', $value, '', true, false, false, $function, null, null, false),
+            false,
+            '',
+        );
+
+        self::assertSame($expected, $result);
+    }
+
+    /** @return array<string, array{array<string, string>, string, string, string}> */
+    public static function spatialConstructorProvider(): array
+    {
+        return [
+            'MySQL 8.0.1 WKT with SRID' => [
+                ['@@version' => '8.0.1', '@@version_comment' => 'MySQL Community Server - GPL'],
+                'ST_GeomFromText',
+                "'POINT(1 2)',4326",
+                "ST_GeomFromText('POINT(1 2)',4326,'axis-order=long-lat')",
+            ],
+            'MariaDB WKT with SRID' => [
+                ['@@version' => '10.9.3-MariaDB', '@@version_comment' => 'mariadb.org binary distribution'],
+                'ST_GeomFromText',
+                "'POINT(1 2)',4326",
+                "ST_GeomFromText('POINT(1 2)',4326)",
+            ],
+            'MySQL 8.0.0 WKT with SRID' => [
+                ['@@version' => '8.0.0', '@@version_comment' => 'MySQL Community Server - GPL'],
+                'ST_GeomFromText',
+                "'POINT(1 2)',4326",
+                "ST_GeomFromText('POINT(1 2)',4326)",
+            ],
+            'MySQL 8.0.1 WKT without SRID' => [
+                ['@@version' => '8.0.1', '@@version_comment' => 'MySQL Community Server - GPL'],
+                'ST_GeomFromText',
+                'POINT(1 2)',
+                "ST_GeomFromText('POINT(1 2)')",
+            ],
+            'MySQL 8.0.1 WKB with SRID' => [
+                ['@@version' => '8.0.1', '@@version_comment' => 'MySQL Community Server - GPL'],
+                'ST_GeomFromWKB',
+                "'0101',4326",
+                "ST_GeomFromWKB('0101',4326)",
+            ],
+        ];
+    }
+
+    /**
      * Test for getQueryValuesForUpdate
      */
     public function testGetQueryValuesForUpdate(): void
@@ -1980,6 +2038,34 @@ class InsertEditTest extends AbstractTestCase
         );
 
         self::assertSame('`fld` = NULL', $result);
+    }
+
+    public function testGetQueryValueForUpdatePreservesSpatialAxisOrder(): void
+    {
+        $this->dbi->setVersion([
+            '@@version' => '8.0.1',
+            '@@version_comment' => 'MySQL Community Server - GPL',
+        ]);
+
+        $result = $this->insertEdit->getQueryValueForUpdate(
+            new EditField(
+                'location',
+                "'POINT(1 2)',4326",
+                '',
+                true,
+                false,
+                false,
+                'ST_GeomFromText',
+                null,
+                "'POINT(1 2)',4326",
+                false,
+            ),
+        );
+
+        self::assertSame(
+            "`location` = ST_GeomFromText('POINT(1 2)',4326,'axis-order=long-lat')",
+            $result,
+        );
     }
 
     /**


### PR DESCRIPTION
### Description

Update the existing GIS text-constructor branch in `InsertEdit::formatAsSqlFunction()` so MySQL 8.0.1 and newer appends the `axis-order=long-lat` options argument when rebuilding WKT that includes an SRID, mirroring the established read-side convention. Keep the existing parsing and quoting flow, and leave WKT without an SRID, WKB constructors, pre-8.0.1 MySQL, and MariaDB SQL unchanged. Extend the existing `InsertEditTest` coverage around `getQueryValueForInsert()` and `getQueryValueForUpdate()` to prove that both callers of the shared formatter preserve the option under the supported MySQL condition while retaining the existing compatibility behavior.

Editing a MySQL 8 spatial value with a geographic SRID is not a lossless round trip: phpMyAdmin reads the value with `axis-order=long-lat`, but reconstructs it with a WKT constructor that omits the matching option. For SRID 4326, saving an unchanged `POINT(1 2)` therefore reverses its coordinates, and repeating the edit can reverse them again. The latest issue diagnosis anchors the mismatch in the existing GIS display and insert/update formatting paths; MariaDB is explicitly unaffected, and there are no competing or prior closed pull requests in the supplied issue evidence.

Fixes #19669
