### PR TITLE
Fix #20425 - OOM error when creating a view

### DIFF
--- a/libraries/classes/Controllers/View/CreateController.php
+++ b/libraries/classes/Controllers/View/CreateController.php
@@ -161,8 +161,6 @@ class CreateController extends AbstractController
                 $view_columns = explode(',', $_POST['view']['column_names']);
             }
 
-            $column_map = $this->dbi->getColumnMapFromSql($_POST['view']['as'], $view_columns);
-
             $systemDb = $this->dbi->getSystemDatabase();
             $pma_transformation_data = $systemDb->getExistingTransformationData($db);
 
@@ -170,7 +168,8 @@ class CreateController extends AbstractController
                 // SQL for store new transformation details of VIEW
                 $new_transformations_sql = $systemDb->getNewTransformationDataSql(
                     $pma_transformation_data,
-                    $column_map,
+                    $view_columns,
+                    $_POST['view']['as'],
                     $_POST['view']['name'],
                     $db
                 );

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -806,15 +806,15 @@ class DatabaseInterface implements DbalInterface
     /**
      * returns detailed array with all columns for sql
      *
-     * @param string $sql_query    target SQL query to get columns
+     * @param string $sqlQuery     target SQL query to get columns
      * @param array  $view_columns alias for columns
      *
      * @return array
      * @psalm-return list<array<string, mixed>>
      */
-    public function getColumnMapFromSql(string $sql_query, array $view_columns = []): array
+    public function getColumnMapFromSql(string $sqlQuery, array $view_columns = []): array
     {
-        $result = $this->tryQuery($sql_query);
+        $result = $this->tryQuery('SELECT * FROM (' . $sqlQuery . ') AS tmp LIMIT 0');
 
         if ($result === false) {
             return [];

--- a/libraries/classes/Dbal/DbalInterface.php
+++ b/libraries/classes/Dbal/DbalInterface.php
@@ -149,12 +149,12 @@ interface DbalInterface
     /**
      * returns detailed array with all columns for sql
      *
-     * @param string $sql_query    target SQL query to get columns
+     * @param string $sqlQuery     target SQL query to get columns
      * @param array  $view_columns alias for columns
      *
      * @return array
      */
-    public function getColumnMapFromSql(string $sql_query, array $view_columns = []): array;
+    public function getColumnMapFromSql(string $sqlQuery, array $view_columns = []): array;
 
     /**
      * returns detailed array with all columns for given table in database,

--- a/libraries/classes/SystemDatabase.php
+++ b/libraries/classes/SystemDatabase.php
@@ -60,7 +60,7 @@ class SystemDatabase
      * Get SQL query for store new transformation details of a VIEW
      *
      * @param ResultInterface $transformationData Result set of SQL execution
-     * @param array           $columnMap          Details of VIEW columns
+     * @param string[]        $view_columns       Details of VIEW columns
      * @param string          $viewName           Name of the VIEW
      * @param string          $db                 Database name of the VIEW
      *
@@ -68,7 +68,8 @@ class SystemDatabase
      */
     public function getNewTransformationDataSql(
         ResultInterface $transformationData,
-        array $columnMap,
+        array $view_columns,
+        string $viewSql,
         $viewName,
         $db
     ) {
@@ -76,6 +77,8 @@ class SystemDatabase
         if ($browserTransformationFeature === null) {
             return '';
         }
+
+        $columnMap = $this->dbi->getColumnMapFromSql($viewSql, $view_columns);
 
         // Need to store new transformation details for VIEW
         $newTransformationsSql = sprintf(

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -1722,7 +1722,7 @@ class Table implements Stringable
     public function getColumnsMeta(): array
     {
         $moveColumnsSqlQuery = sprintf(
-            'SELECT * FROM %s.%s LIMIT 1',
+            'SELECT * FROM %s.%s LIMIT 0',
             Util::backquote($this->dbName),
             Util::backquote($this->name)
         );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11896,11 +11896,6 @@ parameters:
 			path: libraries/classes/Controllers/View/CreateController.php
 
 		-
-			message: "#^Parameter \\#1 \\$sql_query of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getColumnMapFromSql\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/View/CreateController.php
-
-		-
 			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:escapeString\\(\\) expects string, mixed given\\.$#"
 			count: 2
 			path: libraries/classes/Controllers/View/CreateController.php
@@ -11926,12 +11921,17 @@ parameters:
 			path: libraries/classes/Controllers/View/CreateController.php
 
 		-
-			message: "#^Parameter \\#3 \\$viewName of method PhpMyAdmin\\\\SystemDatabase\\:\\:getNewTransformationDataSql\\(\\) expects string, mixed given\\.$#"
+			message: "#^Parameter \\#3 \\$viewSql of method PhpMyAdmin\\\\SystemDatabase\\:\\:getNewTransformationDataSql\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/View/CreateController.php
 
 		-
-			message: "#^Parameter \\#4 \\$db of method PhpMyAdmin\\\\SystemDatabase\\:\\:getNewTransformationDataSql\\(\\) expects string, mixed given\\.$#"
+			message: "#^Parameter \\#4 \\$viewName of method PhpMyAdmin\\\\SystemDatabase\\:\\:getNewTransformationDataSql\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/View/CreateController.php
+
+		-
+			message: "#^Parameter \\#5 \\$db of method PhpMyAdmin\\\\SystemDatabase\\:\\:getNewTransformationDataSql\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/View/CreateController.php
 
@@ -34756,27 +34756,7 @@ parameters:
 			path: libraries/classes/StorageEngine.php
 
 		-
-			message: "#^Cannot access offset 'real_column' on mixed\\.$#"
-			count: 1
-			path: libraries/classes/SystemDatabase.php
-
-		-
-			message: "#^Cannot access offset 'refering_column' on mixed\\.$#"
-			count: 1
-			path: libraries/classes/SystemDatabase.php
-
-		-
-			message: "#^Cannot access offset 'table_name' on mixed\\.$#"
-			count: 1
-			path: libraries/classes/SystemDatabase.php
-
-		-
 			message: "#^Cannot call method escapeString\\(\\) on mixed\\.$#"
-			count: 1
-			path: libraries/classes/SystemDatabase.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\SystemDatabase\\:\\:getNewTransformationDataSql\\(\\) has parameter \\$columnMap with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/SystemDatabase.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13076,15 +13076,6 @@
     <MixedArgument occurrences="1">
       <code>$column['real_column'] ?? $column['refering_column']</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="4">
-      <code>$column['real_column']</code>
-      <code>$column['refering_column']</code>
-      <code>$column['refering_column']</code>
-      <code>$column['table_name']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
-      <code>$column</code>
-    </MixedAssignment>
     <PossiblyNullArgument occurrences="4">
       <code>$dataRow['comment']</code>
       <code>$dataRow['mimetype']</code>

--- a/test/classes/DatabaseInterfaceTest.php
+++ b/test/classes/DatabaseInterfaceTest.php
@@ -186,7 +186,7 @@ class DatabaseInterfaceTest extends AbstractTestCase
     public function testPMAGetColumnMap(): void
     {
         $this->dummyDbi->addResult(
-            'PMA_sql_query',
+            'SELECT * FROM (PMA_sql_query) AS tmp LIMIT 0',
             [true],
             [],
             [

--- a/test/classes/Http/Factory/ServerRequestFactoryTest.php
+++ b/test/classes/Http/Factory/ServerRequestFactoryTest.php
@@ -128,7 +128,7 @@ class ServerRequestFactoryTest extends AbstractTestCase
             return ['Content-Type' => 'application/x-www-form-urlencoded'];
         });
 
-        $method = (new ReflectionMethod(ServerRequestFactory::class, 'createServerRequestFromGlobals'));
+        $method = new ReflectionMethod(ServerRequestFactory::class, 'createServerRequestFromGlobals');
         if (PHP_VERSION_ID < 80100) {
             $method->setAccessible(true);
         }
@@ -186,7 +186,7 @@ class ServerRequestFactoryTest extends AbstractTestCase
     #[DataProvider('providerCreateUriFromGlobals')]
     public function testCreateUriFromGlobals(string $expected, array $server): void
     {
-        $createUriFromGlobals = (new ReflectionMethod(ServerRequestFactory::class, 'createUriFromGlobals'));
+        $createUriFromGlobals = new ReflectionMethod(ServerRequestFactory::class, 'createUriFromGlobals');
         if (PHP_VERSION_ID < 80100) {
             $createUriFromGlobals->setAccessible(true);
         }

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -2327,7 +2327,7 @@ class DbiDummy implements DbiExtension
                 ],
             ],
             [
-                'query' => 'SELECT * FROM `testdb`.`mytable` LIMIT 1',
+                'query' => 'SELECT * FROM `testdb`.`mytable` LIMIT 0',
                 'columns' => ['aid', '_id'],
                 'result' => [
                     [

--- a/test/classes/SystemDatabaseTest.php
+++ b/test/classes/SystemDatabaseTest.php
@@ -41,6 +41,14 @@ class SystemDatabaseTest extends AbstractTestCase
 
         $dbi->method('tryQuery')->willReturn($this->createStub(DummyResult::class));
 
+        $column_map = [
+            [
+                'table_name' => 'table_name',
+                'refering_column' => 'column_name',
+            ],
+        ];
+        $dbi->method('getColumnMapFromSql')->willReturn($column_map);
+
         $_SESSION['relation'] = [];
         $_SESSION['relation'][$GLOBALS['server']] = RelationParameters::fromArray([
             'table_coords' => 'table_name',
@@ -88,17 +96,12 @@ class SystemDatabaseTest extends AbstractTestCase
             ]);
 
         $db = 'PMA_db';
-        $column_map = [
-            [
-                'table_name' => 'table_name',
-                'refering_column' => 'column_name',
-            ],
-        ];
         $view_name = 'view_name';
 
         $ret = $this->sysDb->getNewTransformationDataSql(
             $resultStub,
-            $column_map,
+            [],
+            '',
             $view_name,
             $db
         );

--- a/test/classes/TableTest.php
+++ b/test/classes/TableTest.php
@@ -1301,7 +1301,7 @@ class TableTest extends AbstractTestCase
 
         $dbi->expects($this->once())
             ->method('tryQuery')
-            ->with('SELECT * FROM `db`.`table` LIMIT 1')
+            ->with('SELECT * FROM `db`.`table` LIMIT 0')
             ->willReturn($resultStub);
 
         $dbi->expects($this->once())


### PR DESCRIPTION
Fixes #20425

Queries that only fetch metadata should not fetch the data. MySQL allows `LIMIT 0` for exactly that reason. When running it on the view query, we wrap it in a subquery as we don't know the structure of the SQL and manipulating it with SQL Parser is not possible. The subquery is very likely to have its own LIMIT. 

The `getColumnMapFromSql` method was moved into the other method in `SystemDatabase`, but on 6.0 it was kept as an argument value probably for easier testing. I believe that it could be made private on 6.0.