### PR TITLE
Fix #18749 - Remove the X-XSS-Protection header

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -98,5 +98,6 @@ All notable changes of the phpMyAdmin 6.0 release series are documented in this 
 * [#19550](https://github.com/phpmyadmin/phpmyadmin/pull/19550): Replace jQuery UI's tooltip with Bootstrap's Tooltip
 * [#19852](https://github.com/phpmyadmin/phpmyadmin/pull/19852): Bump Node version to 20
 * [#19854](https://github.com/phpmyadmin/phpmyadmin/pull/19854): Drop support for BaconQrCode v2
+* [#18749](https://github.com/phpmyadmin/phpmyadmin/issues/18749): Remove the obsolete `X-XSS-Protection` HTTP header
 
 [6.0.0]: https://github.com/phpmyadmin/phpmyadmin/compare/QA_5_2...master

--- a/src/Header.php
+++ b/src/Header.php
@@ -335,13 +335,6 @@ class Header
             'Content-Security-Policy' => $this->getCspHeader(),
 
             /**
-             * Re-enable possible disabled XSS filters.
-             *
-             * @see https://developer.mozilla.org/docs/Web/HTTP/Headers/X-XSS-Protection
-             */
-            'X-XSS-Protection' => '1; mode=block',
-
-            /**
              * "nosniff", prevents Internet Explorer and Google Chrome from MIME-sniffing
              * a response away from the declared content-type.
              *

--- a/tests/unit/HeaderTest.php
+++ b/tests/unit/HeaderTest.php
@@ -268,7 +268,6 @@ class HeaderTest extends AbstractTestCase
         $expected = [
             'Referrer-Policy' => 'same-origin',
             'Content-Security-Policy' => $expectedCsp,
-            'X-XSS-Protection' => '1; mode=block',
             'X-Content-Type-Options' => 'nosniff',
             'X-Permitted-Cross-Domain-Policies' => 'none',
             'X-Robots-Tag' => 'noindex, nofollow',


### PR DESCRIPTION
Fixes #18749

I noticed this had been sitting open since 2023 and it looked like a quick one, so I've done it.

The XSS auditor this header controlled is gone from all the major browsers, and OWASP now
says not to send it at all:
https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-xss-protection

What I changed:
- removed the header from `src/Header.php`
- removed the matching line from `tests/unit/HeaderTest.php`
- added a line to `CHANGELOG-6.0.md` under Removed

HeaderTest passes and phpcs is clean on both files. This is against master.

Cheers
