### PR TITLE
Fix #20394 - restore mutation dashboard reporting

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -72,5 +72,5 @@ jobs:
       - name: Run Infection for all files
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         env:
-          INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
+          INFECTION_DASHBOARD_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
         run: infection --threads=max --no-interaction --log-verbosity=none --logger-github=false


### PR DESCRIPTION
### Description

Update the environment mapping on the existing full-suite Infection step so the current `${{ secrets.INFECTION_BADGE_API_KEY }}` value is exported as `INFECTION_DASHBOARD_API_KEY`, one of the names explicitly accepted by the failing client. Keep the repository secret identifier unchanged so the patch does not require an out-of-band secret rename, and leave the changed-files push/pull-request path untouched because it does not publish a dashboard report. Preserve the existing `infection.json5.dist` Stryker report name (`master`) and the scheduled/manual event conditions; the defect is at the workflow-to-client credential boundary, not in report selection.

The scheduled and manually dispatched mutation-test job is intended to publish its full Infection report to the Stryker dashboard configured by `infection.json5.dist`. The workflow currently exposes the stored credential as `INFECTION_BADGE_API_KEY`, but the job log says the installed Infection client now requires `INFECTION_DASHBOARD_API_KEY` or `STRYKER_DASHBOARD_API_KEY`. As a result, the upload is skipped and the master-branch dashboard and mutation-score badge have no report. The issue remains open and unassigned, and its bundle contains no prior or competing pull request.

Fixes #20394
