### PR TITLE
Do not expose the phpMyAdmin version in asset URLs

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -82,6 +82,7 @@ All notable changes of the phpMyAdmin 6.0 release series are documented in this 
 * [#19795](https://github.com/phpmyadmin/phpmyadmin/pull/19795): Use `additional-methods.min.js` instead of `additional-methods.js`
 * [#19564](https://github.com/phpmyadmin/phpmyadmin/pull/19564): Update the table comment field to a textarea
 * [#19947](https://github.com/phpmyadmin/phpmyadmin/pull/19947): Export ODS column headers by default
+* [#15993](https://github.com/phpmyadmin/phpmyadmin/issues/15993): Do not expose the phpMyAdmin version in the cache-busting `?v=` query string of CSS and JS assets
 
 ### Removed
 

--- a/resources/js/modules/ajax.ts
+++ b/resources/js/modules/ajax.ts
@@ -716,10 +716,10 @@ const AJAX = {
             // Clear loaded scripts if they are from another version of phpMyAdmin.
             // Depends on common params being set before loading scripts in responseHandler
             if (self.scriptsVersion === null) {
-                self.scriptsVersion = CommonParams.get('version');
-            } else if (self.scriptsVersion !== CommonParams.get('version')) {
+                self.scriptsVersion = CommonParams.get('asset_version');
+            } else if (self.scriptsVersion !== CommonParams.get('asset_version')) {
                 self.scripts = [];
-                self.scriptsVersion = CommonParams.get('version');
+                self.scriptsVersion = CommonParams.get('asset_version');
             }
 
             self.scriptsCompleted = false;
@@ -786,7 +786,7 @@ const AJAX = {
             const script = document.createElement('script');
             const self = this;
 
-            script.src = 'js/' + name + '?' + 'v=' + encodeURIComponent(CommonParams.get('version'));
+            script.src = 'js/' + name + '?' + 'v=' + encodeURIComponent(CommonParams.get('asset_version'));
             script.async = false;
             script.onload = function () {
                 self.done(name, callback);

--- a/resources/templates/base.twig
+++ b/resources/templates/base.twig
@@ -15,13 +15,13 @@
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <link rel="stylesheet" type="text/css" href="{{ header.theme_path }}/jquery/jquery-ui.css">
   {% if header.codemirror_enable -%}
-    <link rel="stylesheet" type="text/css" href="js/vendor/codemirror/lib/codemirror.css?v={{ pma.version|url_encode }}">
-    <link rel="stylesheet" type="text/css" href="js/vendor/codemirror/addon/hint/show-hint.css?v={{ pma.version|url_encode }}">
+    <link rel="stylesheet" type="text/css" href="js/vendor/codemirror/lib/codemirror.css?v={{ header.asset_version|url_encode }}">
+    <link rel="stylesheet" type="text/css" href="js/vendor/codemirror/addon/hint/show-hint.css?v={{ header.asset_version|url_encode }}">
     {% if header.lint_enable -%}
-      <link rel="stylesheet" type="text/css" href="js/vendor/codemirror/addon/lint/lint.css?v={{ pma.version|url_encode }}">
+      <link rel="stylesheet" type="text/css" href="js/vendor/codemirror/addon/lint/lint.css?v={{ header.asset_version|url_encode }}">
     {% endif %}
   {% endif %}
-  <link rel="stylesheet" type="text/css" href="{{ header.theme_path }}/css/theme{{ pma.text_dir == 'rtl' ? '.rtl' }}.css?v={{ pma.version|url_encode }}">
+  <link rel="stylesheet" type="text/css" href="{{ header.theme_path }}/css/theme{{ pma.text_dir == 'rtl' ? '.rtl' }}.css?v={{ header.asset_version|url_encode }}">
   <title>{{ header.title }}</title>
   {{ header.scripts|raw }}
   <noscript><style>html{display:block}</style></noscript>

--- a/resources/templates/scripts.twig
+++ b/resources/templates/scripts.twig
@@ -1,6 +1,6 @@
 {% for file in files %}
   <script data-cfasync="false" src="{{ file.filename starts with 'index.php' ? file.filename : 'js/' ~ file.filename -}}
-    {{- '.php' in file.filename ? get_common(file.params|merge({'v': pma.version})) : '?v=' ~ pma.version|url_encode }}"></script>
+    {{- '.php' in file.filename ? get_common(file.params|merge({'v': asset_version})) : '?v=' ~ asset_version|url_encode }}"></script>
 {% endfor %}
 
 <script data-cfasync="false">

--- a/src/Config.php
+++ b/src/Config.php
@@ -15,6 +15,7 @@ use function __;
 use function array_key_last;
 use function array_shift;
 use function array_slice;
+use function bin2hex;
 use function count;
 use function defined;
 use function explode;
@@ -26,6 +27,7 @@ use function fopen;
 use function fread;
 use function function_exists;
 use function get_defined_constants;
+use function hash_hmac;
 use function implode;
 use function in_array;
 use function ini_get;
@@ -41,6 +43,7 @@ use function mkdir;
 use function ob_end_clean;
 use function ob_start;
 use function parse_url;
+use function random_bytes;
 use function realpath;
 use function rtrim;
 use function setcookie;
@@ -48,6 +51,7 @@ use function sprintf;
 use function str_ends_with;
 use function stripos;
 use function strtolower;
+use function substr;
 use function sys_get_temp_dir;
 use function time;
 use function trim;
@@ -741,5 +745,42 @@ class Config
     public function getChangeLogFilePath(): string
     {
         return CHANGELOG_FILE;
+    }
+
+    /**
+     * Returns an opaque token that changes with every phpMyAdmin version.
+     *
+     * It is used as the cache-busting query string of CSS and JS assets instead of the
+     * plain version number, so that the version is not exposed to unauthenticated
+     * visitors (e.g. on the login page). It is keyed with the blowfish secret so it
+     * cannot be mapped back to a version with a lookup table.
+     */
+    public function getAssetVersion(): string
+    {
+        return substr(hash_hmac('sha256', Version::VERSION, $this->getAssetVersionKey()), 0, 12);
+    }
+
+    /**
+     * Returns the key used to derive the asset version token.
+     *
+     * When no blowfish secret is configured, a random per-session key is used instead,
+     * so that the token does not degrade to a publicly computable hash of the version.
+     */
+    private function getAssetVersionKey(): string
+    {
+        if ($this->config->blowfish_secret !== '') {
+            return $this->config->blowfish_secret;
+        }
+
+        /** @var mixed $key */
+        $key = $_SESSION['asset_version_key'] ?? null;
+        if (is_string($key) && $key !== '') {
+            return $key;
+        }
+
+        $key = bin2hex(random_bytes(16));
+        $_SESSION['asset_version_key'] = $key;
+
+        return $key;
     }
 }

--- a/src/Footer.php
+++ b/src/Footer.php
@@ -37,7 +37,7 @@ class Footer
 
     public function __construct(Template $template, private readonly Config $config)
     {
-        $this->scripts = new Scripts($template);
+        $this->scripts = new Scripts($template, $config);
     }
 
     /**

--- a/src/Header.php
+++ b/src/Header.php
@@ -84,7 +84,7 @@ class Header
             return $this->scripts;
         }
 
-        $this->scripts = new Scripts($this->template);
+        $this->scripts = new Scripts($this->template, $this->config);
 
         $this->scripts->addFile('runtime.js');
         $this->scripts->addFile('vendor/jquery/jquery.min.js');
@@ -134,7 +134,7 @@ class Header
             'is_https' => $this->config->isHttps(),
             'rootPath' => $this->config->getRootPath(),
             'arg_separator' => Url::getArgSeparator(),
-            'version' => Version::VERSION,
+            'asset_version' => $this->config->getAssetVersion(),
         ];
         if ($this->config->hasSelectedServer()) {
             $params['auth_type'] = $this->config->selectedServer['auth_type'];
@@ -283,6 +283,7 @@ class Header
             'codemirror_enable' => $this->config->config->CodemirrorEnable,
             'lint_enable' => $this->config->config->LintEnable,
             'theme_path' => $theme->getPath(),
+            'asset_version' => $this->config->getAssetVersion(),
             'server' => Current::$server,
             'title' => $this->getPageTitle(),
             'scripts' => $scripts->getDisplay(),

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -30,7 +30,7 @@ class Scripts
     /**
      * Generates new Scripts objects
      */
-    public function __construct(private readonly Template $template)
+    public function __construct(private readonly Template $template, private readonly Config $config)
     {
     }
 
@@ -119,6 +119,10 @@ class Scripts
      */
     public function getDisplay(): string
     {
-        return $this->template->render('scripts', ['files' => $this->files, 'code' => $this->code]);
+        return $this->template->render('scripts', [
+            'files' => $this->files,
+            'code' => $this->code,
+            'asset_version' => $this->config->getAssetVersion(),
+        ]);
     }
 }

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\Config\Settings;
 use PhpMyAdmin\Config\Settings\Server;
 use PhpMyAdmin\Dbal\ConnectionType;
 use PhpMyAdmin\Dbal\DatabaseInterface;
+use PhpMyAdmin\Version;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
@@ -18,9 +19,11 @@ use ReflectionProperty;
 
 use function file_put_contents;
 use function get_defined_constants;
+use function hash_hmac;
 use function md5;
 use function realpath;
 use function stristr;
+use function substr;
 use function sys_get_temp_dir;
 use function tempnam;
 use function unlink;
@@ -646,5 +649,35 @@ class ConfigTest extends AbstractTestCase
     public function testGetChangeLogFilePath(): void
     {
         self::assertSame(CHANGELOG_FILE, (new Config())->getChangeLogFilePath());
+    }
+
+    public function testGetAssetVersion(): void
+    {
+        $config = new Config();
+        $config->config = new Settings(['blowfish_secret' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+        $assetVersion = $config->getAssetVersion();
+
+        self::assertMatchesRegularExpression('/^[0-9a-f]{12}$/', $assetVersion);
+        self::assertSame($assetVersion, $config->getAssetVersion());
+        self::assertStringNotContainsString(Version::VERSION, $assetVersion);
+        self::assertSame(
+            substr(hash_hmac('sha256', Version::VERSION, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'), 0, 12),
+            $assetVersion,
+        );
+
+        $config->config = new Settings(['blowfish_secret' => 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb']);
+        self::assertNotSame($assetVersion, $config->getAssetVersion());
+    }
+
+    public function testGetAssetVersionWithoutBlowfishSecret(): void
+    {
+        $config = new Config();
+        $config->config = new Settings(['blowfish_secret' => '']);
+        $assetVersion = $config->getAssetVersion();
+
+        self::assertMatchesRegularExpression('/^[0-9a-f]{12}$/', $assetVersion);
+        self::assertSame($assetVersion, $config->getAssetVersion());
+        // The token must not be a publicly computable hash of the version.
+        self::assertNotSame(substr(hash_hmac('sha256', Version::VERSION, ''), 0, 12), $assetVersion);
     }
 }

--- a/tests/unit/HeaderTest.php
+++ b/tests/unit/HeaderTest.php
@@ -21,6 +21,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\Clock\MockClock;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Theme\ThemeManager;
+use PhpMyAdmin\Version;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Medium;
@@ -108,6 +109,7 @@ class HeaderTest extends AbstractTestCase
             'codemirror_enable' => true,
             'lint_enable' => true,
             'theme_path' => '',
+            'asset_version' => $config->getAssetVersion(),
             'server' => 0,
             'title' => 'phpMyAdmin',
             'scripts' => $header->getScripts()->getDisplay(),
@@ -141,6 +143,15 @@ class HeaderTest extends AbstractTestCase
             'common_query',
             $header->getJsParams(),
         );
+    }
+
+    public function testGetJsParamsDoesNotExposeVersion(): void
+    {
+        $header = $this->getNewHeaderInstance();
+        $params = $header->getJsParams();
+        self::assertArrayHasKey('asset_version', $params);
+        self::assertArrayNotHasKey('version', $params);
+        self::assertStringNotContainsString(Version::VERSION, $header->getJsParamsCode());
     }
 
     public function testGetJsParamsCode(): void

--- a/tests/unit/ResponseRendererTest.php
+++ b/tests/unit/ResponseRendererTest.php
@@ -104,6 +104,7 @@ final class ResponseRendererTest extends AbstractTestCase
                     'codemirror_enable' => true,
                     'lint_enable' => true,
                     'theme_path' => '',
+                    'asset_version' => Config::getInstance()->getAssetVersion(),
                     'server' => 0,
                     'title' => 'phpMyAdmin',
                     'scripts' => $header->getScripts()->getDisplay(),

--- a/tests/unit/ScriptsTest.php
+++ b/tests/unit/ScriptsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Config;
+use PhpMyAdmin\Config\Settings;
 use PhpMyAdmin\Scripts;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Version;
@@ -18,6 +19,8 @@ class ScriptsTest extends AbstractTestCase
 {
     protected Scripts $object;
 
+    private string $assetVersion;
+
     /**
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
@@ -26,7 +29,10 @@ class ScriptsTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->object = new Scripts(new Template(new Config()));
+        $config = new Config();
+        $config->config = new Settings(['blowfish_secret' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+        $this->object = new Scripts(new Template($config), $config);
+        $this->assetVersion = $config->getAssetVersion();
     }
 
     /**
@@ -40,14 +46,12 @@ class ScriptsTest extends AbstractTestCase
 
         $actual = $this->object->getDisplay();
 
+        self::assertStringContainsString('src="js/common.js?v=' . $this->assetVersion . '"', $actual);
         self::assertStringContainsString(
-            'src="js/common.js?v=' . rawurlencode(Version::VERSION) . '"',
+            'src="index.php?route=%2Fmessages&l=en&v=' . $this->assetVersion . '&lang=en"',
             $actual,
         );
-        self::assertStringContainsString(
-            'src="index.php?route=%2Fmessages&l=en&v=' . rawurlencode(Version::VERSION) . '&lang=en"',
-            $actual,
-        );
+        self::assertStringNotContainsString(rawurlencode(Version::VERSION), $actual);
         self::assertStringContainsString(
             'window.AJAX.scriptHandler.add(\'vendor\/codemirror\/lib\/codemirror.js\', false);',
             $actual,


### PR DESCRIPTION
Fixes #15993

Right now every CSS and JS asset gets loaded with `?v=<version>` as a cache buster, so anyone who can reach the login page can read the exact phpMyAdmin version straight out of the page source (32 places on the login page alone).

This swaps the version for an opaque token: an HMAC-SHA256 of the version, keyed with the configured `blowfish_secret` and trimmed to 12 hex characters. It still changes on every upgrade, so cache busting keeps working exactly like it does today, but there's no way to map it back to a version with a lookup table. If no blowfish secret is configured, it falls back to a random per-session key, so it never turns into a hash anyone could compute for themselves.
