### PR TITLE
Fix PHP 8.6 deprecations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46461,11 +46461,6 @@ parameters:
 			path: test/classes/Plugins/Transformations/TransformationPluginsTest.php
 
 		-
-			message: "#^Variable method call on object\\.$#"
-			count: 1
-			path: test/classes/Plugins/Transformations/TransformationPluginsTest.php
-
-		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:anything\\(\\)\\.$#"
 			count: 2
 			path: test/classes/Plugins/TwoFactor/WebAuthnTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46461,6 +46461,11 @@ parameters:
 			path: test/classes/Plugins/Transformations/TransformationPluginsTest.php
 
 		-
+			message: "#^Variable method call on object\\.$#"
+			count: 1
+			path: test/classes/Plugins/Transformations/TransformationPluginsTest.php
+
+		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:anything\\(\\)\\.$#"
 			count: 2
 			path: test/classes/Plugins/TwoFactor/WebAuthnTest.php

--- a/test/classes/AbstractTestCase.php
+++ b/test/classes/AbstractTestCase.php
@@ -322,7 +322,7 @@ abstract class AbstractTestCase extends TestCase
             $method->setAccessible(true);
         }
 
-        return $method->invokeArgs($object, $params);
+        return $method->invokeArgs($method->isStatic() ? null : $object, $params);
     }
 
     /**

--- a/test/classes/Plugins/Transformations/TransformationPluginsTest.php
+++ b/test/classes/Plugins/Transformations/TransformationPluginsTest.php
@@ -760,7 +760,9 @@ class TransformationPluginsTest extends AbstractTestCase
         }
 
         $reflectionMethod = new ReflectionMethod($object, $method);
-        self::assertEquals($expected, $reflectionMethod->invokeArgs($object, $args));
+        self::assertEquals($expected, $reflectionMethod->invokeArgs(
+            $reflectionMethod->isStatic() ? null : $object, $args
+        ));
     }
 
     /**
@@ -1313,7 +1315,9 @@ class TransformationPluginsTest extends AbstractTestCase
         string $error = ''
     ): void {
         $reflectionMethod = new ReflectionMethod($object, 'applyTransformation');
-        self::assertEquals($transformed, $reflectionMethod->invokeArgs($object, $applyArgs));
+        self::assertEquals($transformed, $reflectionMethod->invokeArgs(
+            $reflectionMethod->isStatic() ? null : $object, $applyArgs
+        ));
 
         // For output transformation plugins, this method may not exist
         if (method_exists($object, 'isSuccess')) {

--- a/test/classes/Plugins/Transformations/TransformationPluginsTest.php
+++ b/test/classes/Plugins/Transformations/TransformationPluginsTest.php
@@ -380,7 +380,7 @@ class TransformationPluginsTest extends AbstractTestCase
             [
                 new Image_JPEG_Link(),
                 'applyTransformationNoWrap',
-                null,
+                false,
             ],
             // Test data for PhpMyAdmin\Plugins\Transformations\Output\Image_PNG_Inline plugin
             [
@@ -759,11 +759,7 @@ class TransformationPluginsTest extends AbstractTestCase
             return;
         }
 
-        $reflectionMethod = new ReflectionMethod($object, $method);
-        self::assertEquals($expected, $reflectionMethod->invokeArgs(
-            $reflectionMethod->isStatic() ? null : $object,
-            $args
-        ));
+        self::assertSame($expected, $object->$method(...$args));
     }
 
     /**

--- a/test/classes/Plugins/Transformations/TransformationPluginsTest.php
+++ b/test/classes/Plugins/Transformations/TransformationPluginsTest.php
@@ -761,7 +761,8 @@ class TransformationPluginsTest extends AbstractTestCase
 
         $reflectionMethod = new ReflectionMethod($object, $method);
         self::assertEquals($expected, $reflectionMethod->invokeArgs(
-            $reflectionMethod->isStatic() ? null : $object, $args
+            $reflectionMethod->isStatic() ? null : $object,
+            $args
         ));
     }
 

--- a/test/classes/Plugins/Transformations/TransformationPluginsTest.php
+++ b/test/classes/Plugins/Transformations/TransformationPluginsTest.php
@@ -1315,9 +1315,7 @@ class TransformationPluginsTest extends AbstractTestCase
         string $error = ''
     ): void {
         $reflectionMethod = new ReflectionMethod($object, 'applyTransformation');
-        self::assertEquals($transformed, $reflectionMethod->invokeArgs(
-            $reflectionMethod->isStatic() ? null : $object, $applyArgs
-        ));
+        self::assertEquals($transformed, $reflectionMethod->invokeArgs($object, $applyArgs));
 
         // For output transformation plugins, this method may not exist
         if (method_exists($object, 'isSuccess')) {

--- a/test/classes/Plugins/Transformations/TransformationPluginsTest.php
+++ b/test/classes/Plugins/Transformations/TransformationPluginsTest.php
@@ -755,11 +755,9 @@ class TransformationPluginsTest extends AbstractTestCase
     #[DataProvider('multiDataProvider')]
     public function testGetMulti($object, string $method, $expected, array $args = []): void
     {
-        if (! method_exists($object, $method)) {
-            return;
-        }
-
-        self::assertSame($expected, $object->$method(...$args));
+        $testMethod = [$object, $method];
+        self::assertIsCallable($testMethod);
+        self::assertSame($expected, $testMethod(...$args));
     }
 
     /**


### PR DESCRIPTION
This should fix:

https://github.com/phpmyadmin/phpmyadmin/actions/runs/32332620113/job/96357454416

```
67) /home/runner/work/phpmyadmin/phpmyadmin/tests/unit/Plugins/Transformations/TransformationPluginsTest.php:404
Calling ReflectionMethod::invokeArgs() for static method PhpMyAdmin\Plugins\Transformations\Abs\DateFormatTransformationsPlugin::getName() does not need an object parameter

68) /home/runner/work/phpmyadmin/phpmyadmin/tests/unit/FooterTest.php:81
Calling ReflectionMethod::invokeArgs() for static method PhpMyAdmin\Footer::removeRecursion() does not need an object parameter
```