### PR TITLE
[5.2] Fix PHPUnit 13 deprecations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -42421,6 +42421,11 @@ parameters:
 			path: test/classes/Controllers/Table/SearchControllerTest.php
 
 		-
+			message: "#^Cannot call method expects\\(\\) on mixed\\.$#"
+			count: 1
+			path: test/classes/Controllers/Table/SearchControllerTest.php
+
+		-
 			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
 			count: 1
 			path: test/classes/Controllers/Table/SearchControllerTest.php
@@ -42442,6 +42447,11 @@ parameters:
 
 		-
 			message: "#^Cannot call method with\\(\\) on mixed\\.$#"
+			count: 1
+			path: test/classes/Controllers/Table/SearchControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:once\\(\\)\\.$#"
 			count: 1
 			path: test/classes/Controllers/Table/SearchControllerTest.php
 
@@ -42692,7 +42702,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method expects\\(\\) on mixed\\.$#"
-			count: 7
+			count: 8
 			path: test/classes/Database/CentralColumnsTest.php
 
 		-
@@ -42717,7 +42727,7 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:exactly\\(\\)\\.$#"
-			count: 1
+			count: 2
 			path: test/classes/Database/CentralColumnsTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14756,12 +14756,13 @@
     </TypeDoesNotContainType>
   </file>
   <file src="test/classes/Controllers/Table/SearchControllerTest.php">
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall occurrences="3">
+      <code>method</code>
       <code>willReturn</code>
       <code>with</code>
     </MixedMethodCall>
     <UndefinedMethod occurrences="1">
-      <code>method</code>
+      <code>expects</code>
     </UndefinedMethod>
   </file>
   <file src="test/classes/CoreTest.php">
@@ -14852,7 +14853,8 @@
     <MixedAssignment occurrences="1">
       <code>$list_detail_cols</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="24">
+    <MixedMethodCall occurrences="25">
+      <code>method</code>
       <code>method</code>
       <code>method</code>
       <code>method</code>
@@ -14889,7 +14891,7 @@
       <code>expects</code>
       <code>expects</code>
       <code>expects</code>
-      <code>method</code>
+      <code>expects</code>
       <code>method</code>
       <code>method</code>
     </UndefinedMethod>

--- a/test/classes/AbstractNetworkTestCase.php
+++ b/test/classes/AbstractNetworkTestCase.php
@@ -61,7 +61,7 @@ abstract class AbstractNetworkTestCase extends AbstractTestCase
             ])
             ->getMock();
 
-        $mockResponse->method('headersSent')->with()->willReturn(false);
+        $mockResponse->method('headersSent')->willReturn(false);
 
         if (count($param) > 0) {
             if (is_array($param[0])) {

--- a/test/classes/Controllers/Table/SearchControllerTest.php
+++ b/test/classes/Controllers/Table/SearchControllerTest.php
@@ -102,7 +102,8 @@ class SearchControllerTest extends AbstractTestCase
     {
         $expected = 'SELECT MIN(`column`) AS `min`, MAX(`column`) AS `max` FROM `PMA`.`PMA_BookMark`';
 
-        $GLOBALS['dbi']->method('fetchSingleRow')
+        $GLOBALS['dbi']->expects($this->once())
+            ->method('fetchSingleRow')
             ->with($expected)
             ->willReturn([$expected]);
 

--- a/test/classes/CoreTest.php
+++ b/test/classes/CoreTest.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Sanitize;
 use PhpMyAdmin\Url;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -525,6 +526,7 @@ class CoreTest extends AbstractNetworkTestCase
     /**
      * Test for Core::sendHeaderLocation
      */
+    #[AllowMockObjectsWithoutExpectations]
     public function testSendHeaderLocationIisLongUri(): void
     {
         $GLOBALS['server'] = 0;

--- a/test/classes/Database/CentralColumnsTest.php
+++ b/test/classes/Database/CentralColumnsTest.php
@@ -342,7 +342,8 @@ class CentralColumnsTest extends AbstractTestCase
      */
     public function testGetHtmlForEditingPage(): void
     {
-        $GLOBALS['dbi']->method('fetchResult')
+        $GLOBALS['dbi']->expects($this->exactly(2))
+            ->method('fetchResult')
             ->with(
                 'SELECT * FROM `pma_central_columns` '
                 . "WHERE db_name = 'phpmyadmin' AND col_name IN ('col1','col2');",

--- a/test/classes/Database/QbeTest.php
+++ b/test/classes/Database/QbeTest.php
@@ -30,8 +30,7 @@ class QbeTest extends AbstractTestCase
         $GLOBALS['server'] = 0;
         $GLOBALS['db'] = 'pma_test';
         $this->object = new Qbe(new Relation($GLOBALS['dbi']), new Template(), $GLOBALS['dbi'], 'pma_test');
-        //mock DBI
-        $dbi = $this->createMock(DatabaseInterface::class);
+        $dbi = $this->createStub(DatabaseInterface::class);
 
         $create_table = 'CREATE TABLE `table1` ('
             . '`id` int(11) NOT NULL,'
@@ -41,7 +40,6 @@ class QbeTest extends AbstractTestCase
             . ') ENGINE=InnoDB DEFAULT CHARSET=latin1';
 
         $dbi->method('fetchValue')
-            ->with('SHOW CREATE TABLE `pma_test`.`table1`', 1)
             ->willReturn($create_table);
 
         $dbi->method('getTableIndexes')->willReturn([]);

--- a/test/classes/Database/SearchTest.php
+++ b/test/classes/Database/SearchTest.php
@@ -32,11 +32,9 @@ class SearchTest extends AbstractTestCase
         $GLOBALS['db'] = 'pma';
         $GLOBALS['_POST'] = [];
 
-        //mock DBI
-        $dbi = $this->createMock(DatabaseInterface::class);
+        $dbi = $this->createStub(DatabaseInterface::class);
 
         $dbi->method('getColumns')
-            ->with('pma', 'table1')
             ->willReturn([
                 ['Field' => 'column1'],
                 ['Field' => 'column2'],

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -592,11 +592,10 @@ class ExportSqlTest extends AbstractTestCase
         $GLOBALS['sql_drop_table'] = true;
         $GLOBALS['sql_if_not_exists'] = true;
 
-        $dbi = $this->createMock(DatabaseInterface::class);
+        $dbi = $this->createStub(DatabaseInterface::class);
         $dbi->method('escapeString')->willReturnArgument(0);
 
         $dbi->method('getColumns')
-            ->with('db', 'view')
             ->willReturn([
                 'cname' => [
                     'Type' => 'char',
@@ -625,11 +624,10 @@ class ExportSqlTest extends AbstractTestCase
         // case 2
         unset($GLOBALS['sql_compatibility']);
 
-        $dbi = $this->createMock(DatabaseInterface::class);
+        $dbi = $this->createStub(DatabaseInterface::class);
         $dbi->method('escapeString')->willReturnArgument(0);
 
         $dbi->method('getColumns')
-            ->with('db', 'view')
             ->willReturn([
                 'cname' => [
                     'Type' => 'char',


### PR DESCRIPTION
This should fix those PHPUnit 13 deprecations:

https://github.com/phpmyadmin/phpmyadmin/actions/runs/32364421032/job/96410739346#step:7:79