### PR TITLE
[6.0] Fix PHPUnit 13 deprecations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15244,30 +15244,6 @@ parameters:
 			path: tests/unit/Database/EventsTest.php
 
 		-
-			message: '#^Attribute class PHPUnit\\Framework\\Attributes\\AllowMockObjectsWithoutExpectations does not exist\.$#'
-			identifier: attribute.notFound
-			count: 1
-			path: tests/unit/Database/RoutinesTest.php
-
-		-
-			message: '''
-				#^Call to deprecated method getInstance\(\) of class PhpMyAdmin\\Config\:
-				Use dependency injection instead\.$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 2
-			path: tests/unit/Database/RoutinesTest.php
-
-		-
-			message: '''
-				#^Call to deprecated method getInstance\(\) of class PhpMyAdmin\\Dbal\\DatabaseInterface\:
-				Use dependency injection instead\.$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 2
-			path: tests/unit/Database/RoutinesTest.php
-
-		-
 			message: '''
 				#^Call to deprecated method getInstance\(\) of class PhpMyAdmin\\Dbal\\DatabaseInterface\:
 				Use dependency injection instead\.$#

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9589,20 +9589,11 @@
     </DeprecatedMethod>
   </file>
   <file src="tests/unit/Database/RoutinesTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[Config::getInstance()]]></code>
-      <code><![CDATA[Config::getInstance()]]></code>
-      <code><![CDATA[DatabaseInterface::getInstance()]]></code>
-      <code><![CDATA[DatabaseInterface::getInstance()]]></code>
-    </DeprecatedMethod>
     <MixedAssignment>
       <code><![CDATA[$_POST[$key]]]></code>
       <code><![CDATA[$_REQUEST[$key]]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <UndefinedAttributeClass>
-      <code><![CDATA[AllowMockObjectsWithoutExpectations]]></code>
-    </UndefinedAttributeClass>
   </file>
   <file src="tests/unit/Database/SearchTest.php">
     <DeprecatedMethod>

--- a/tests/unit/Database/RoutinesTest.php
+++ b/tests/unit/Database/RoutinesTest.php
@@ -13,12 +13,10 @@ use PhpMyAdmin\Dbal\DatabaseInterface;
 use PhpMyAdmin\Http\Factory\ServerRequestFactory;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Types;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(Routines::class)]
-#[AllowMockObjectsWithoutExpectations]
 class RoutinesTest extends AbstractTestCase
 {
     private Routines $routines;
@@ -32,10 +30,11 @@ class RoutinesTest extends AbstractTestCase
 
         $this->setLanguage();
 
-        DatabaseInterface::$instance = $this->createDatabaseInterface();
-        $config = Config::getInstance();
+        $dbiDummy = $this->createDbiDummy();
+        $config = new Config();
+        $dbi = $this->createDatabaseInterface($dbiDummy, $config);
 
-        $this->routines = new Routines(DatabaseInterface::getInstance(), $config);
+        $this->routines = new Routines($dbi, $config);
     }
 
     /**
@@ -232,27 +231,21 @@ class RoutinesTest extends AbstractTestCase
     #[DataProvider('providerGetQueryFromRequest')]
     public function testGetQueryFromRequest(array $request, string $query, int $numErr): void
     {
-        $config = Config::getInstance();
-        $oldDbi = DatabaseInterface::getInstance();
-        $dbi = $this->createMock(DatabaseInterface::class);
+        $config = new Config();
+        $dbi = self::createStub(DatabaseInterface::class);
         $dbi->types = new Types($dbi);
-        $dbi->expects($this->any())->method('quoteString')->willReturnMap([
+        $dbi->method('quoteString')->willReturnMap([
             ['foo', ConnectionType::User, "'foo'"],
             ["foo's bar", ConnectionType::User, "'foo\'s bar'"],
         ]);
-        DatabaseInterface::$instance = $dbi;
 
         $routines = new Routines($dbi, $config);
 
-        unset($_POST);
         $_POST = $request;
         $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/')
             ->withParsedBody($request);
         self::assertSame($query, $routines->getQueryFromRequest($request));
         self::assertSame($numErr, $routines->getErrorCount());
-
-        // reset
-        DatabaseInterface::$instance = $oldDbi;
     }
 
     /**


### PR DESCRIPTION
This should fix those PHPUnit 13 deprecations:

https://github.com/phpmyadmin/phpmyadmin/actions/runs/32520607355/job/96891764628#step:7:113