### PR TITLE
Fix #20442 - Replace Name with TABLE_NAME

### DIFF
--- a/libraries/classes/Controllers/Database/ExportController.php
+++ b/libraries/classes/Controllers/Database/ExportController.php
@@ -90,6 +90,7 @@ final class ExportController extends AbstractController
 
         $tablesForMultiValues = [];
 
+        /** @var array{TABLE_NAME: string} $each_table */
         foreach ($tables as $each_table) {
             if (isset($_POST['table_select']) && is_array($_POST['table_select'])) {
                 $is_checked = $this->export->getCheckedClause($each_table['TABLE_NAME'], $_POST['table_select']);

--- a/libraries/classes/Controllers/Database/ExportController.php
+++ b/libraries/classes/Controllers/Database/ExportController.php
@@ -90,7 +90,7 @@ final class ExportController extends AbstractController
 
         $tablesForMultiValues = [];
 
-        /** @var array{TABLE_NAME: string} $each_table */
+        /** @var list<array{TABLE_NAME: string}> $tables */
         foreach ($tables as $each_table) {
             if (isset($_POST['table_select']) && is_array($_POST['table_select'])) {
                 $is_checked = $this->export->getCheckedClause($each_table['TABLE_NAME'], $_POST['table_select']);

--- a/libraries/classes/Controllers/Database/ExportController.php
+++ b/libraries/classes/Controllers/Database/ExportController.php
@@ -92,27 +92,27 @@ final class ExportController extends AbstractController
 
         foreach ($tables as $each_table) {
             if (isset($_POST['table_select']) && is_array($_POST['table_select'])) {
-                $is_checked = $this->export->getCheckedClause($each_table['Name'], $_POST['table_select']);
+                $is_checked = $this->export->getCheckedClause($each_table['TABLE_NAME'], $_POST['table_select']);
             } elseif (isset($table_select)) {
-                $is_checked = $this->export->getCheckedClause($each_table['Name'], $table_select);
+                $is_checked = $this->export->getCheckedClause($each_table['TABLE_NAME'], $table_select);
             } else {
                 $is_checked = true;
             }
 
             if (isset($_POST['table_structure']) && is_array($_POST['table_structure'])) {
-                $structure_checked = $this->export->getCheckedClause($each_table['Name'], $_POST['table_structure']);
+                $structure_checked = $this->export->getCheckedClause($each_table['TABLE_NAME'], $_POST['table_structure']);
             } else {
                 $structure_checked = $is_checked;
             }
 
             if (isset($_POST['table_data']) && is_array($_POST['table_data'])) {
-                $data_checked = $this->export->getCheckedClause($each_table['Name'], $_POST['table_data']);
+                $data_checked = $this->export->getCheckedClause($each_table['TABLE_NAME'], $_POST['table_data']);
             } else {
                 $data_checked = $is_checked;
             }
 
             $tablesForMultiValues[] = [
-                'name' => $each_table['Name'],
+                'name' => $each_table['TABLE_NAME'],
                 'is_checked_select' => $is_checked,
                 'is_checked_structure' => $structure_checked,
                 'is_checked_data' => $data_checked,

--- a/libraries/classes/Controllers/Database/ExportController.php
+++ b/libraries/classes/Controllers/Database/ExportController.php
@@ -65,6 +65,7 @@ final class ExportController extends AbstractController
 
         $urlParams['goto'] = Url::getFromRoute('/database/export');
 
+        /** @var list<array{TABLE_NAME: string}> $tables */
         [
             $tables,
             $num_tables,
@@ -90,7 +91,6 @@ final class ExportController extends AbstractController
 
         $tablesForMultiValues = [];
 
-        /** @var list<array{TABLE_NAME: string}> $tables */
         foreach ($tables as $each_table) {
             if (isset($_POST['table_select']) && is_array($_POST['table_select'])) {
                 $is_checked = $this->export->getCheckedClause($each_table['TABLE_NAME'], $_POST['table_select']);

--- a/libraries/classes/Controllers/Database/ExportController.php
+++ b/libraries/classes/Controllers/Database/ExportController.php
@@ -100,7 +100,10 @@ final class ExportController extends AbstractController
             }
 
             if (isset($_POST['table_structure']) && is_array($_POST['table_structure'])) {
-                $structure_checked = $this->export->getCheckedClause($each_table['TABLE_NAME'], $_POST['table_structure']);
+                $structure_checked = $this->export->getCheckedClause(
+                    $each_table['TABLE_NAME'],
+                    $_POST['table_structure']
+                );
             } else {
                 $structure_checked = $is_checked;
             }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -116,11 +116,6 @@ parameters:
 			path: js/messages.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: libraries/classes/Advisor.php
-
-		-
 			message: "#^Cannot access an offset on mixed\\.$#"
 			count: 3
 			path: libraries/classes/Advisor.php
@@ -2678,11 +2673,6 @@ parameters:
 		-
 			message: "#^Cannot access offset 'table_info' on mixed\\.$#"
 			count: 3
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
-			message: "#^Cannot access offset 'table_name' on mixed\\.$#"
-			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3716,7 +3716,7 @@ parameters:
 			path: libraries/classes/Controllers/Database/ExportController.php
 
 		-
-			message: "#^Cannot access offset 'Name' on mixed\\.$#"
+			message: "#^Cannot access offset 'TABLE_NAME' on mixed\\.$#"
 			count: 5
 			path: libraries/classes/Controllers/Database/ExportController.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3736,11 +3736,6 @@ parameters:
 			path: libraries/classes/Controllers/Database/ExportController.php
 
 		-
-			message: "#^Parameter \\#1 \\$key of method PhpMyAdmin\\\\Export\\:\\:getCheckedClause\\(\\) expects string, mixed given\\.$#"
-			count: 4
-			path: libraries/classes/Controllers/Database/ExportController.php
-
-		-
 			message: "#^Parameter \\#1 \\$params of static method PhpMyAdmin\\\\Url\\:\\:getCommon\\(\\) expects array\\<string, bool\\|int\\|string\\>, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/ExportController.php
@@ -4888,11 +4883,6 @@ parameters:
 		-
 			message: "#^Cannot access offset 'DefaultTabDatabase' on mixed\\.$#"
 			count: 1
-			path: libraries/classes/Controllers/Database/Structure/RealRowCountController.php
-
-		-
-			message: "#^Cannot access offset 'TABLE_NAME' on mixed\\.$#"
-			count: 2
 			path: libraries/classes/Controllers/Database/Structure/RealRowCountController.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -116,6 +116,11 @@ parameters:
 			path: js/messages.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: libraries/classes/Advisor.php
+
+		-
 			message: "#^Cannot access an offset on mixed\\.$#"
 			count: 3
 			path: libraries/classes/Advisor.php
@@ -2676,6 +2681,11 @@ parameters:
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
+			message: "#^Cannot access offset 'table_name' on mixed\\.$#"
+			count: 1
+			path: libraries/classes/ConfigStorage/Relation.php
+
+		-
 			message: "#^Cannot access offset 'table_schema' on mixed\\.$#"
 			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
@@ -3696,18 +3706,8 @@ parameters:
 			path: libraries/classes/Controllers/Database/EventsController.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Database/ExportController.php
-
-		-
 			message: "#^Cannot access offset 'DefaultTabDatabase' on mixed\\.$#"
 			count: 1
-			path: libraries/classes/Controllers/Database/ExportController.php
-
-		-
-			message: "#^Cannot access offset 'TABLE_NAME' on mixed\\.$#"
-			count: 5
 			path: libraries/classes/Controllers/Database/ExportController.php
 
 		-
@@ -4873,6 +4873,11 @@ parameters:
 		-
 			message: "#^Cannot access offset 'DefaultTabDatabase' on mixed\\.$#"
 			count: 1
+			path: libraries/classes/Controllers/Database/Structure/RealRowCountController.php
+
+		-
+			message: "#^Cannot access offset 'TABLE_NAME' on mixed\\.$#"
+			count: 2
 			path: libraries/classes/Controllers/Database/Structure/RealRowCountController.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1233,10 +1233,10 @@
     <MixedArgument occurrences="11">
       <code>$db</code>
       <code>$db</code>
-      <code>$each_table['Name']</code>
-      <code>$each_table['Name']</code>
-      <code>$each_table['Name']</code>
-      <code>$each_table['Name']</code>
+      <code>$each_table['TABLE_NAME']</code>
+      <code>$each_table['TABLE_NAME']</code>
+      <code>$each_table['TABLE_NAME']</code>
+      <code>$each_table['TABLE_NAME']</code>
       <code>$num_tables</code>
       <code>$sql_query</code>
       <code>$table</code>
@@ -1247,11 +1247,11 @@
       <code>['db' =&gt; $db]</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess occurrences="5">
-      <code>$each_table['Name']</code>
-      <code>$each_table['Name']</code>
-      <code>$each_table['Name']</code>
-      <code>$each_table['Name']</code>
-      <code>$each_table['Name']</code>
+      <code>$each_table['TABLE_NAME']</code>
+      <code>$each_table['TABLE_NAME']</code>
+      <code>$each_table['TABLE_NAME']</code>
+      <code>$each_table['TABLE_NAME']</code>
+      <code>$each_table['TABLE_NAME']</code>
     </MixedArrayAccess>
     <MixedArrayAssignment occurrences="1">
       <code>$urlParams['goto']</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1230,13 +1230,9 @@
     </MixedArgumentTypeCoercion>
   </file>
   <file src="libraries/classes/Controllers/Database/ExportController.php">
-    <MixedArgument occurrences="11">
+    <MixedArgument occurrences="7">
       <code>$db</code>
       <code>$db</code>
-      <code>$each_table['TABLE_NAME']</code>
-      <code>$each_table['TABLE_NAME']</code>
-      <code>$each_table['TABLE_NAME']</code>
-      <code>$each_table['TABLE_NAME']</code>
       <code>$num_tables</code>
       <code>$sql_query</code>
       <code>$table</code>
@@ -1246,19 +1242,11 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>['db' =&gt; $db]</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="5">
-      <code>$each_table['TABLE_NAME']</code>
-      <code>$each_table['TABLE_NAME']</code>
-      <code>$each_table['TABLE_NAME']</code>
-      <code>$each_table['TABLE_NAME']</code>
-      <code>$each_table['TABLE_NAME']</code>
-    </MixedArrayAccess>
     <MixedArrayAssignment occurrences="1">
       <code>$urlParams['goto']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$GLOBALS['single_table']</code>
-      <code>$each_table</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Database/ImportController.php">


### PR DESCRIPTION
### Description

At first I was thinking to make something like

```PHP
$tableName = $each_table['Name'] ?? $each_table['TABLE_NAME'];
```

but since now is clear when it happens, I think replacing `Name` with `TABLE_NAME` is the right approach.

When table is `in use` only this array is sent:

https://github.com/phpmyadmin/phpmyadmin/blob/0b055dd889b4c55b82a004f1fa4824884fce97e8/libraries/classes/Util.php#L2388-L2396

Fixes #20442

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
