### PR TITLE
Fix #20453 - Fix SkipLockedTables not showing tables in database

### DIFF
--- a/resources/templates/database/structure/structure_table_row.twig
+++ b/resources/templates/database/structure/structure_table_row.twig
@@ -234,8 +234,8 @@
 
         <td colspan="{{ action_colspan }}"
             class="text-center">
-            {% if current_table['Comment'] is not empty %}
-                {{ current_table['Comment'] }}
+            {% if current_table['TABLE_COMMENT'] is not empty %}
+                {{ current_table['TABLE_COMMENT'] }}
             {% else %}
                 {{ t('in use') }}
             {% endif %}

--- a/src/Controllers/Database/StructureController.php
+++ b/src/Controllers/Database/StructureController.php
@@ -1055,11 +1055,6 @@ final class StructureController implements InvocableController
             $openTableNames[] = $tableName;
         }
 
-        // is there at least one "in use" table?
-        if ($openTableNames === []) {
-            return [];
-        }
-
         $tables = [];
         $tblGroupSql = '';
         $whereAdded = false;


### PR DESCRIPTION
### Description

Before:

Database with no locked tables:

<img width="1089" height="433" alt="before1" src="https://github.com/user-attachments/assets/27371091-7698-43cc-84cd-5d6e38b76b4e" />

Database with a locked table:

<img width="919" height="95" alt="before2" src="https://github.com/user-attachments/assets/7f7734cb-4ee3-4a42-b806-26739c8ea1ab" />

After - `$cfg['SkipLockedTables'] = true;`

<img width="1411" height="554" alt="after" src="https://github.com/user-attachments/assets/84e16131-841a-452e-a52e-0fb45de09c06" />

After - `$cfg['SkipLockedTables'] = false;`

<img width="1416" height="586" alt="after2" src="https://github.com/user-attachments/assets/94a2b5c7-dcdf-45cf-b126-ac5a3f84aa29" />

Fixes #20453

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
