### PR TITLE
Fix processes list user link by stripping port from host

### DIFF
--- a/templates/server/status/processes/list.twig
+++ b/templates/server/status/processes/list.twig
@@ -49,7 +49,7 @@
             {% if row.user not in ['system user', 'event_scheduler', 'unauthenticated user'] %}
               <a href="{{ url('/server/privileges', {
                   'username': row.user,
-                  'hostname': row.host,
+                  'hostname': row.host|split(':')|first,
                   'dbname': row.db,
                   'tablename': '',
                   'routinename': '',


### PR DESCRIPTION
Fixes #19841

## Problem

The processes list link to the user privileges page includes the port number in the host value (e.g., `localhost:64776`), but the MySQL `mysql.user` table only stores the hostname without port. This causes the user link to fail when clicking on a user in Status > Processes.

## Root cause

`SHOW PROCESSLIST` returns `Host` as `hostname:port` (e.g., `localhost:64776`), but the privileges page URL parameter `hostname` expects just the hostname (e.g., `localhost`). The template was passing `row.host` directly without stripping the port.

## Fix

Use the Twig `split(':')|first` filter to extract only the hostname from the host value before passing it as the `hostname` parameter to the privileges URL.

## Testing

- Verified that `split(':')|first` correctly handles both `localhost:64776` -> `localhost` and `localhost` -> `localhost` (no port)
- Existing test suite should continue to pass (test mock uses `Host1` without port, which remains unchanged)
