### PR TITLE
Do not regenerate session on every login form render

### DIFF
--- a/src/Plugins/AuthenticationPlugin.php
+++ b/src/Plugins/AuthenticationPlugin.php
@@ -236,8 +236,10 @@ abstract class AuthenticationPlugin
 
         /* Show login form (this exits) */
         if (! $success) {
-            /* Force generating of new session */
-            Session::secure();
+            /* Generate session token if missing; regeneration happens on successful login */
+            if (Session::getToken() === '') {
+                Session::secure();
+            }
 
             $response = $this->showLoginForm();
             if ($response !== null) {


### PR DESCRIPTION
Fixes #20462. See the issue for full analysis and a server-side reproduction with two curl requests. Approach pre-validated by @kamil-tekiela in the issue thread. Session fixation protection on successful login (AuthenticationCookie) is unchanged; logout/re-login still rotates the session id (verified on a live deployment).