### PR TITLE
fix: preserve geometry display for joined results

### DIFF
--- a/resources/templates/display/results/table.twig
+++ b/resources/templates/display/results/table.twig
@@ -257,12 +257,10 @@
             </div>
 
             <fieldset class="col-auto">
-              {% if headers.options.possible_as_geometry %}
-                <div class="form-check">
-                  <input class="form-check-input" type="radio" name="geoOption" id="geoOptionRadioGeom{{ unique_id }}" value="GEOM"{{ headers.options.geo_option == 'GEOM' ? ' checked' }}>
-                  <label class="form-check-label" for="geoOptionRadioGeom{{ unique_id }}">{{ t('Geometry') }}</label>
-                </div>
-              {% endif %}
+              <div class="form-check">
+                <input class="form-check-input" type="radio" name="geoOption" id="geoOptionRadioGeom{{ unique_id }}" value="GEOM"{{ headers.options.geo_option == 'GEOM' ? ' checked' }}>
+                <label class="form-check-label" for="geoOptionRadioGeom{{ unique_id }}">{{ t('Geometry') }}</label>
+              </div>
               <div class="form-check">
                 <input class="form-check-input" type="radio" name="geoOption" id="geoOptionRadioWkt{{ unique_id }}" value="WKT"{{ headers.options.geo_option == 'WKT' ? ' checked' }}>
                 <label class="form-check-label" for="geoOptionRadioWkt{{ unique_id }}">{{ t('Well Known Text') }}</label>

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -1070,21 +1070,12 @@ class Results
      */
     private function getOptionsBlock(): array
     {
-        if (
-            isset($_SESSION['tmpval']['possible_as_geometry'])
-            && ! $_SESSION['tmpval']['possible_as_geometry']
-            && $_SESSION['tmpval']['geoOption'] === self::GEOMETRY_DISP_GEOM
-        ) {
-            $_SESSION['tmpval']['geoOption'] = self::GEOMETRY_DISP_WKT;
-        }
-
         return [
             'geo_option' => $_SESSION['tmpval']['geoOption'],
             'hide_transformation' => $_SESSION['tmpval']['hide_transformation'],
             'display_blob' => $_SESSION['tmpval']['display_blob'],
             'display_binary' => $_SESSION['tmpval']['display_binary'],
             'relational_display' => $_SESSION['tmpval']['relational_display'],
-            'possible_as_geometry' => $_SESSION['tmpval']['possible_as_geometry'],
             'pftext' => $_SESSION['tmpval']['pftext'],
         ];
     }

--- a/src/Sql.php
+++ b/src/Sql.php
@@ -1345,8 +1345,6 @@ class Sql
             && $justOneTable
             && ! Utilities::isSystemSchema($db);
 
-        $_SESSION['tmpval']['possible_as_geometry'] = $editable;
-
         $displayParts = DisplayParts::fromArray([
             'hasEditLink' => true,
             'deleteLink' => DeleteLinkEnum::DELETE_ROW,

--- a/tests/unit/Controllers/Database/MultiTableQuery/Fixtures/Query-testController.html
+++ b/tests/unit/Controllers/Database/MultiTableQuery/Fixtures/Query-testController.html
@@ -150,8 +150,12 @@
             </div>
 
             <fieldset class="col-auto">
-                            <div class="form-check">
-                <input class="form-check-input" type="radio" name="geoOption" id="geoOptionRadioWkt%d" value="WKT" checked>
+              <div class="form-check">
+                <input class="form-check-input" type="radio" name="geoOption" id="geoOptionRadioGeom%d" value="GEOM" checked>
+                <label class="form-check-label" for="geoOptionRadioGeom%d">Geometry</label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" type="radio" name="geoOption" id="geoOptionRadioWkt%d" value="WKT">
                 <label class="form-check-label" for="geoOptionRadioWkt%d">Well Known Text</label>
               </div>
               <div class="form-check">

--- a/tests/unit/Display/ResultsTest.php
+++ b/tests/unit/Display/ResultsTest.php
@@ -50,6 +50,7 @@ use const MYSQLI_TYPE_BLOB;
 use const MYSQLI_TYPE_DATE;
 use const MYSQLI_TYPE_DATETIME;
 use const MYSQLI_TYPE_DECIMAL;
+use const MYSQLI_TYPE_GEOMETRY;
 use const MYSQLI_TYPE_LONG;
 use const MYSQLI_TYPE_STRING;
 use const MYSQLI_TYPE_TIME;
@@ -808,6 +809,77 @@ class ResultsTest extends AbstractTestCase
         self::assertSame('P', $_SESSION['tmpval']['pftext']);
     }
 
+    public function testNonEditableGeometryResultKeepsCompactDisplay(): void
+    {
+        $_SESSION['tmpval'] = [
+            'geoOption' => DisplayResults::GEOMETRY_DISP_GEOM,
+            'hide_transformation' => false,
+            'display_blob' => false,
+            'display_binary' => true,
+            'relational_display' => DisplayResults::RELATIONAL_KEY,
+            'possible_as_geometry' => false,
+            'pftext' => DisplayResults::DISPLAY_PARTIAL_TEXT,
+        ];
+
+        $options = (new ReflectionMethod(DisplayResults::class, 'getOptionsBlock'))->invoke($this->object);
+
+        self::assertSame(DisplayResults::GEOMETRY_DISP_GEOM, $options['geo_option']);
+        self::assertArrayNotHasKey('possible_as_geometry', $options);
+
+        $geometry = (string) hex2bin('000000000101000000000000000000f03f000000000000f03f');
+        $meta = FieldHelper::fromArray([
+            'type' => MYSQLI_TYPE_GEOMETRY,
+            'name' => 'location',
+            'orgname' => 'location',
+            'orgtable' => 'locations',
+        ]);
+        [$statementInfo] = ParseAnalyze::sqlQuery(
+            'SELECT locations.location FROM locations JOIN owners ON owners.id = locations.owner_id',
+            'test_db',
+            false,
+        );
+        $getDataCell = new ReflectionMethod(DisplayResults::class, 'getDataCellForGeometryColumns');
+
+        $output = $getDataCell->invokeArgs(
+            $this->object,
+            [$geometry, 'data', $meta, [], [], false, null, [], $statementInfo],
+        );
+
+        self::assertStringContainsString('[GEOMETRY - 25 B]', $output);
+        self::assertStringNotContainsString('POINT(1 1)', $output);
+
+        Config::getInstance()->set('LimitChars', 7);
+        $_SESSION['tmpval']['geoOption'] = DisplayResults::GEOMETRY_DISP_WKT;
+        $output = $getDataCell->invokeArgs(
+            $this->object,
+            [$geometry, 'data', $meta, [], [], false, null, [], $statementInfo],
+        );
+
+        self::assertStringContainsString('POINT(1...', $output);
+        self::assertStringNotContainsString('POINT(1 1)', $output);
+
+        $_SESSION['tmpval']['geoOption'] = DisplayResults::GEOMETRY_DISP_WKB;
+        $output = $getDataCell->invokeArgs(
+            $this->object,
+            [$geometry, 'data', $meta, [], [], false, null, [], $statementInfo],
+        );
+
+        self::assertStringContainsString('0101000...', $output);
+
+        $_SESSION['tmpval']['geoOption'] = DisplayResults::GEOMETRY_DISP_GEOM;
+        $nullOutput = $getDataCell->invokeArgs(
+            $this->object,
+            [null, 'data', $meta, [], [], false, null, [], $statementInfo],
+        );
+        $emptyOutput = $getDataCell->invokeArgs(
+            $this->object,
+            ['', 'data', $meta, [], [], false, null, [], $statementInfo],
+        );
+
+        self::assertStringContainsString('<em>NULL</em>', $nullOutput);
+        self::assertStringContainsString('class="data text-nowrap"', $emptyOutput);
+    }
+
     /**
      * @param array<string, array<string, array<string, array<string, bool|int|string>>>|string> $session
      * @param array<string, string>                                                              $queryParams
@@ -1111,7 +1183,6 @@ class ResultsTest extends AbstractTestCase
         $_SESSION['tmpval']['display_blob'] = '';
         $_SESSION['tmpval']['display_binary'] = '';
         $_SESSION['tmpval']['relational_display'] = '';
-        $_SESSION['tmpval']['possible_as_geometry'] = '';
         $_SESSION['tmpval']['pftext'] = '';
         $_SESSION['tmpval']['max_rows'] = 25;
         $_SESSION['tmpval']['pos'] = 0;
@@ -1288,7 +1359,6 @@ class ResultsTest extends AbstractTestCase
                     'display_blob' => null,
                     'display_binary' => null,
                     'relational_display' => null,
-                    'possible_as_geometry' => null,
                     'pftext' => null,
                 ],
                 'has_bulk_actions_form' => false,
@@ -1403,7 +1473,6 @@ class ResultsTest extends AbstractTestCase
         $_SESSION['tmpval']['display_blob'] = '';
         $_SESSION['tmpval']['display_binary'] = '';
         $_SESSION['tmpval']['relational_display'] = '';
-        $_SESSION['tmpval']['possible_as_geometry'] = '';
         $_SESSION['tmpval']['pftext'] = '';
         $_SESSION['tmpval']['max_rows'] = 25;
         $_SESSION['tmpval']['pos'] = 0;
@@ -1525,7 +1594,6 @@ class ResultsTest extends AbstractTestCase
                     'display_blob' => null,
                     'display_binary' => null,
                     'relational_display' => null,
-                    'possible_as_geometry' => null,
                     'pftext' => null,
                 ],
                 'has_bulk_actions_form' => false,


### PR DESCRIPTION
### Description

Decouple geometry presentation from row editability by removing the `possible_as_geometry` session value written by `Sql` and the `DisplayResults` fallback that replaces `GEOM` with `WKT` for non-editable results. Render the Geometry radio option unconditionally and remove the obsolete option data passed to the Twig template, while leaving edit/delete-link eligibility unchanged. Update the existing result-rendering expectations and multi-table query fixture to reflect the always-available Geometry choice.

A geometry column is normally rendered as a compact `[GEOMETRY - N B]` value, but a query containing a join is classified as non-editable and silently switches the geometry display mode to WKT. That exposes the full polygon text even when partial-text display is active. The editability decision is valid for row action links, but it is unrelated to whether a result value can be rendered in the compact geometry mode. The issue includes a reproducible schema and query, and the thread identifies the `possible_as_geometry` gate as the cause.

Fixes #20430
