### PR TITLE
Fix color for XML code

### DIFF
--- a/public/themes/bootstrap/scss/_common.scss
+++ b/public/themes/bootstrap/scss/_common.scss
@@ -2375,6 +2375,7 @@ pre {
 
 code.json,
 code.php,
-code.sql {
+code.sql,
+code.xml {
   color: var(--#{$prefix}code-color);
 }

--- a/public/themes/metro/scss/_common.scss
+++ b/public/themes/metro/scss/_common.scss
@@ -2539,6 +2539,7 @@ pre {
 
 code.json,
 code.php,
-code.sql {
+code.sql,
+code.xml {
   color: var(--#{$prefix}code-color);
 }

--- a/public/themes/original/scss/_common.scss
+++ b/public/themes/original/scss/_common.scss
@@ -2357,6 +2357,7 @@ pre {
 
 code.json,
 code.php,
-code.sql {
+code.sql,
+code.xml {
   color: var(--#{$prefix}code-color);
 }

--- a/public/themes/pmahomme/scss/_common.scss
+++ b/public/themes/pmahomme/scss/_common.scss
@@ -2538,6 +2538,7 @@ pre {
 
 code.json,
 code.php,
-code.sql {
+code.sql,
+code.xml {
   color: var(--#{$prefix}code-color);
 }


### PR DESCRIPTION
Fix color for XML code if XML is selected in `Browser display transformation`. Related #20143

Before:

<img width="1187" height="413" alt="before" src="https://github.com/user-attachments/assets/6ccd0081-016a-49f8-bad9-aafc2da258ca" />

After:

<img width="1186" height="419" alt="after" src="https://github.com/user-attachments/assets/bebb8bb3-2c51-46e1-a281-9bc83e6dc2f9" />
