### PR TITLE
Fix Uncaught ReferenceError: CodeMirror is not defined

### DIFF
--- a/libraries/classes/Plugins/Transformations/Input/Text_Plain_JsonEditor.php
+++ b/libraries/classes/Plugins/Transformations/Input/Text_Plain_JsonEditor.php
@@ -35,7 +35,8 @@ class Text_Plain_JsonEditor extends CodeMirrorEditorTransformationPlugin
     public function getScripts()
     {
         $scripts = [];
-        if ($GLOBALS['cfg']['CodemirrorEnable']) {
+        // See #20159, why we need to check for HTTP_USER_AGENT here
+        if ($GLOBALS['cfg']['CodemirrorEnable'] && isset($_SERVER['HTTP_USER_AGENT'])) {
             $scripts[] = 'vendor/codemirror/lib/codemirror.js';
             $scripts[] = 'vendor/codemirror/mode/javascript/javascript.js';
             $scripts[] = 'transformations/json_editor.js';

--- a/libraries/classes/Plugins/Transformations/Input/Text_Plain_SqlEditor.php
+++ b/libraries/classes/Plugins/Transformations/Input/Text_Plain_SqlEditor.php
@@ -35,7 +35,8 @@ class Text_Plain_SqlEditor extends CodeMirrorEditorTransformationPlugin
     public function getScripts()
     {
         $scripts = [];
-        if ($GLOBALS['cfg']['CodemirrorEnable']) {
+        // See #20159, why we need to check for HTTP_USER_AGENT here
+        if ($GLOBALS['cfg']['CodemirrorEnable'] && isset($_SERVER['HTTP_USER_AGENT'])) {
             $scripts[] = 'vendor/codemirror/lib/codemirror.js';
             $scripts[] = 'vendor/codemirror/mode/sql/sql.js';
             $scripts[] = 'transformations/sql_editor.js';

--- a/libraries/classes/Plugins/Transformations/Input/Text_Plain_XmlEditor.php
+++ b/libraries/classes/Plugins/Transformations/Input/Text_Plain_XmlEditor.php
@@ -35,7 +35,8 @@ class Text_Plain_XmlEditor extends CodeMirrorEditorTransformationPlugin
     public function getScripts()
     {
         $scripts = [];
-        if ($GLOBALS['cfg']['CodemirrorEnable']) {
+        // See #20159, why we need to check for HTTP_USER_AGENT here
+        if ($GLOBALS['cfg']['CodemirrorEnable'] && isset($_SERVER['HTTP_USER_AGENT'])) {
             $scripts[] = 'vendor/codemirror/lib/codemirror.js';
             $scripts[] = 'vendor/codemirror/mode/xml/xml.js';
             $scripts[] = 'transformations/xml_editor.js';

--- a/libraries/classes/Plugins/Transformations/Output/Text_Plain_Json.php
+++ b/libraries/classes/Plugins/Transformations/Output/Text_Plain_Json.php
@@ -21,7 +21,8 @@ class Text_Plain_Json extends TransformationsPlugin
 {
     public function __construct()
     {
-        if (empty($GLOBALS['cfg']['CodemirrorEnable'])) {
+        // See #20159, why we need to check for HTTP_USER_AGENT here
+        if (empty($GLOBALS['cfg']['CodemirrorEnable']) || ! isset($_SERVER['HTTP_USER_AGENT'])) {
             return;
         }
 

--- a/libraries/classes/Plugins/Transformations/Output/Text_Plain_Sql.php
+++ b/libraries/classes/Plugins/Transformations/Output/Text_Plain_Sql.php
@@ -17,7 +17,8 @@ class Text_Plain_Sql extends SQLTransformationsPlugin
 {
     public function __construct()
     {
-        if (empty($GLOBALS['cfg']['CodemirrorEnable'])) {
+        // See #20159, why we need to check for HTTP_USER_AGENT here
+        if (empty($GLOBALS['cfg']['CodemirrorEnable']) || ! isset($_SERVER['HTTP_USER_AGENT'])) {
             return;
         }
 

--- a/libraries/classes/Plugins/Transformations/Output/Text_Plain_Xml.php
+++ b/libraries/classes/Plugins/Transformations/Output/Text_Plain_Xml.php
@@ -21,7 +21,8 @@ class Text_Plain_Xml extends TransformationsPlugin
 {
     public function __construct()
     {
-        if (empty($GLOBALS['cfg']['CodemirrorEnable'])) {
+        // See #20159, why we need to check for HTTP_USER_AGENT here
+        if (empty($GLOBALS['cfg']['CodemirrorEnable']) || ! isset($_SERVER['HTTP_USER_AGENT'])) {
             return;
         }
 


### PR DESCRIPTION
This will fix `Uncaught ReferenceError: CodeMirror is not defined` if user-agent is empty. Related #20159

Before:

https://github.com/user-attachments/assets/1b8fb27a-293c-469d-80c3-65c147f78e13

After:

https://github.com/user-attachments/assets/0a568f8a-c033-4320-aa95-005a15c57c15