### PR TITLE
Add character set support for CSV with LOAD DATA in table imports

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6039,9 +6039,6 @@
     <MixedArgument>
       <code><![CDATA[ImportSettings::$importFile]]></code>
     </MixedArgument>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[string[]]]></code>
-    </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Plugins/Import/ImportMediawiki.php">
     <InvalidNullableReturnType>
@@ -6245,11 +6242,6 @@
     <UnusedClass>
       <code><![CDATA[UploadSession]]></code>
     </UnusedClass>
-  </file>
-  <file src="src/Plugins/ImportPlugin.php">
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[string[]]]></code>
-    </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Plugins/Schema/Dia/DiaRelationSchema.php">
     <MixedArgumentTypeCoercion>

--- a/src/Plugins/Import/ImportLdi.php
+++ b/src/Plugins/Import/ImportLdi.php
@@ -36,6 +36,28 @@ class ImportLdi extends AbstractImportCsv
     private string $escaped = '';
     private string $newLine = '';
     private string $columns = '';
+    private const CHARSET_MAP = [
+        'iso-8859-1' => 'latin1',
+        'iso-8859-2' => 'latin2',
+        'iso-8859-7' => 'greek',
+        'iso-8859-8' => 'hebrew',
+        'iso-8859-9' => 'latin5',
+        'iso-8859-13' => 'latin7',
+        'koi8-r' => 'koi8r',
+        'windows-1250' => 'cp1250',
+        'windows-1251' => 'cp1251',
+        'windows-1252' => 'latin1',
+        'windows-1256' => 'cp1256',
+        'windows-1257' => 'cp1257',
+        'tis-620' => 'tis620',
+        'SHIFT_JIS' => 'sjis',
+        'SJIS' => 'sjis',
+        'SJIS-win' => 'cp932',
+        'big5' => 'big5',
+        'gb2312' => 'gb2312',
+        'euc-jp' => 'ujis',
+        'ks_c_5601-1987' => 'euckr',
+    ];
 
     /** @psalm-return non-empty-lowercase-string */
     public function getName(): string
@@ -116,7 +138,7 @@ class ImportLdi extends AbstractImportCsv
             $compression = $importHandle->getCompression();
         }
 
-        if (ImportSettings::$importFile === 'none' || $compression !== 'none' || ImportSettings::$charsetConversion) {
+        if (ImportSettings::$importFile === 'none' || $compression !== 'none') {
             // We handle only some kind of data!
             Current::$message = Message::error(
                 __('This plugin does not support compressed imports!'),
@@ -139,6 +161,22 @@ class ImportLdi extends AbstractImportCsv
         }
 
         $sql .= ' INTO TABLE ' . Util::backquote(Current::$table);
+
+        // UTF-8 charset imports don't get routed here since it is presumed ImportSettings::$charsetConversion is falsy
+        if (ImportSettings::$charsetConversion) {
+            $charset = $this->getDBCharset(ImportSettings::$charsetOfFile);
+
+            if ($charset === null) {
+                Current::$message = Message::error(
+                    __('The selected character set is not supported by the database system!'),
+                );
+                Import::$hasError = true;
+
+                return [];
+            }
+
+            $sql .= ' CHARACTER SET ' . $charset;
+        }
 
         if ($this->terminated !== '') {
             $sql .= ' FIELDS TERMINATED BY \'' . $this->terminated . '\'';
@@ -215,5 +253,18 @@ class ImportLdi extends AbstractImportCsv
         }
 
         $this->config->settings['Import']['ldi_local_option'] = true;
+    }
+
+    /**
+     * Returns the database charset name for a file charset, or null if
+     * the charset is not supported by LOAD DATA.
+     */
+    private function getDBCharset(string $charset): string|null
+    {
+        if ($charset === 'utf-16' && $this->dbi->isMariaDB()) {
+            return 'utf16';
+        }
+
+        return self::CHARSET_MAP[$charset] ?? null;
     }
 }

--- a/tests/unit/Plugins/Import/ImportLdiTest.php
+++ b/tests/unit/Plugins/Import/ImportLdiTest.php
@@ -18,6 +18,7 @@ use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Medium;
 
 use function __;
@@ -198,6 +199,118 @@ final class ImportLdiTest extends AbstractTestCase
         self::assertStringContainsString('IGNORE 1 LINES', Current::$sqlQuery);
 
         self::assertTrue(ImportSettings::$finished);
+    }
+
+    #[DataProvider('charsetMappingProvider')]
+    public function testDoImportWithCharsetConversion(
+        string $charsetOfFile,
+        string $expectedCharset,
+    ): void {
+        ImportSettings::$sqlQueryDisabled = false;
+        ImportSettings::$charsetConversion = true;
+        ImportSettings::$charsetOfFile = $charsetOfFile;
+
+        $dbi = $this->createMock(DatabaseInterface::class);
+        $dbi->method('quoteString')
+            ->willReturnCallback(static fn (string $string): string => "'" . $string . "'");
+
+        $importHandle = new File(ImportSettings::$importFile);
+        $importHandle->open();
+
+        $this->getImportLdi($dbi)->doImport($importHandle);
+
+        self::assertStringContainsString('CHARACTER SET ' . $expectedCharset, Current::$sqlQuery);
+    }
+
+    /** @return array<string, array{string, string}> */
+    public static function charsetMappingProvider(): array
+    {
+        return [
+            'ISO-8859-1' => ['iso-8859-1', 'latin1'],
+            'ISO-8859-2' => ['iso-8859-2', 'latin2'],
+            'ISO-8859-7' => ['iso-8859-7', 'greek'],
+            'ISO-8859-8' => ['iso-8859-8', 'hebrew'],
+            'ISO-8859-9' => ['iso-8859-9', 'latin5'],
+            'ISO-8859-13' => ['iso-8859-13', 'latin7'],
+            'KOI8-R' => ['koi8-r', 'koi8r'],
+            'Windows-1250' => ['windows-1250', 'cp1250'],
+            'Windows-1251' => ['windows-1251', 'cp1251'],
+            'Windows-1252' => ['windows-1252', 'latin1'],
+            'Windows-1256' => ['windows-1256', 'cp1256'],
+            'Windows-1257' => ['windows-1257', 'cp1257'],
+            'TIS-620' => ['tis-620', 'tis620'],
+            'Shift_JIS' => ['SHIFT_JIS', 'sjis'],
+            'SJIS' => ['SJIS', 'sjis'],
+            'SJIS-win' => ['SJIS-win', 'cp932'],
+            'Big5' => ['big5', 'big5'],
+            'GB2312' => ['gb2312', 'gb2312'],
+            'euc-jp' => ['euc-jp', 'ujis'],
+            'ks_c_5601-1987' => ['ks_c_5601-1987', 'euckr'],
+        ];
+    }
+
+    public function testDoImportWithUtf16OnMariaDb(): void
+    {
+        ImportSettings::$sqlQueryDisabled = false;
+        ImportSettings::$charsetConversion = true;
+        ImportSettings::$charsetOfFile = 'utf-16';
+
+        $dbi = $this->createMock(DatabaseInterface::class);
+        $dbi->method('quoteString')
+            ->willReturnCallback(static fn (string $string): string => "'" . $string . "'");
+
+        $dbi->method('isMariaDB')->willReturn(true);
+
+        $importHandle = new File(ImportSettings::$importFile);
+        $importHandle->open();
+
+        $this->getImportLdi($dbi)->doImport($importHandle);
+
+        self::assertStringContainsString('CHARACTER SET utf16', Current::$sqlQuery);
+    }
+
+    public function testDoImportWithUtf16OnMySql(): void
+    {
+        ImportSettings::$sqlQueryDisabled = false;
+        ImportSettings::$charsetConversion = true;
+        ImportSettings::$charsetOfFile = 'utf-16';
+
+        $dbi = $this->createMock(DatabaseInterface::class);
+        $dbi->method('quoteString')
+            ->willReturnCallback(static fn (string $string): string => "'" . $string . "'");
+        $dbi->method('isMariaDB')->willReturn(false);
+
+        $importHandle = new File(ImportSettings::$importFile);
+        $importHandle->open();
+
+        $importLdi = $this->getImportLdi($dbi);
+        $result = $importLdi->doImport($importHandle);
+
+        self::assertSame([], $result);
+        self::assertTrue(Import::$hasError);
+        self::assertInstanceOf(Message::class, Current::$message);
+        self::assertStringContainsString(
+            __('The selected character set is not supported by the database system!'),
+            Current::$message->__toString(),
+        );
+    }
+
+    public function testDoImportWithUnsupportedCharsetDoesNotAddCharacterSet(): void
+    {
+        ImportSettings::$sqlQueryDisabled = false;
+        ImportSettings::$charsetConversion = true;
+        ImportSettings::$charsetOfFile = 'iso-8859-3';
+
+        $dbi = $this->createMock(DatabaseInterface::class);
+        $dbi->method('quoteString')
+            ->willReturnCallback(static fn (string $string): string => "'" . $string . "'");
+
+        $importHandle = new File(ImportSettings::$importFile);
+        $importHandle->open();
+
+        $this->getImportLdi($dbi)->doImport($importHandle);
+
+        self::assertStringNotContainsString('CHARACTER SET', Current::$sqlQuery);
     }
 
     private function getImportLdi(DatabaseInterface|null $dbi = null, Config|null $config = null): ImportLdi


### PR DESCRIPTION
### Description

This pull request includes support for the majority of character sets using CSV with LOAD DATA. MySQL and MariaDB support this using the `CHARACTER SET` (or `CHARSET`) clause. It includes native support for them by creating a character set mapping. Apart from being a new feature, it also prevents the display of an unhelpful error message: "This plugin does not support compressed imports!"

The previous implementation handled non-UTF-8 character sets ungracefully and it resulted in an error. However, this new implementation includes support for the *supported* character sets. Special care has been taken for MySQL limitations by not using UTF-16 character encoding with MySQL databases, instead opting to do so for MariaDB.

Fixes #20400 

#### Sources

https://dev.mysql.com/doc/refman/8.4/en/charset-mysql.html
https://dev.mysql.com/doc/refman/8.4/en/charset-restrictions.html
https://dev.mysql.com/doc/refman/8.0/en/charset-charsets.html