### PR TITLE
Replace remaining request globals in CentralColumns structure control…

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1492,12 +1492,6 @@ parameters:
 			path: src/Controllers/Database/RoutinesController.php
 
 		-
-			message: '#^Parameter \#1 \$database of method PhpMyAdmin\\Database\\CentralColumns\:\:deleteColumnsFromList\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Controllers/Database/Structure/CentralColumns/RemoveController.php
-
-		-
 			message: '''
 				#^Call to deprecated method getInstance\(\) of class PhpMyAdmin\\Dbal\\DatabaseInterface\:
 				Use dependency injection instead\.$#

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -876,17 +876,6 @@
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="src/Controllers/Database/Structure/CentralColumns/RemoveController.php">
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$_POST['db']]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyInvalidCast>
-      <code><![CDATA[$_POST['db']]]></code>
-    </PossiblyInvalidCast>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[__construct]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="src/Controllers/Database/Structure/CopyFormController.php">
     <DeprecatedMethod>
       <code><![CDATA[DatabaseInterface::getInstance()]]></code>

--- a/src/Controllers/Database/Structure/CentralColumns/AddController.php
+++ b/src/Controllers/Database/Structure/CentralColumns/AddController.php
@@ -48,8 +48,6 @@ final readonly class AddController implements InvocableController
 
         Current::$message = $error instanceof Message ? $error : Message::success(__('Success!'));
 
-        unset($_POST['submit_mult']);
-
         return ($this->structureController)($request);
     }
 }

--- a/src/Controllers/Database/Structure/CentralColumns/MakeConsistentController.php
+++ b/src/Controllers/Database/Structure/CentralColumns/MakeConsistentController.php
@@ -47,8 +47,6 @@ final readonly class MakeConsistentController implements InvocableController
 
         Current::$message = $error instanceof Message ? $error : Message::success(__('Success!'));
 
-        unset($_POST['submit_mult']);
-
         return ($this->structureController)($request);
     }
 }

--- a/src/Controllers/Database/Structure/CentralColumns/RemoveController.php
+++ b/src/Controllers/Database/Structure/CentralColumns/RemoveController.php
@@ -43,11 +43,9 @@ final readonly class RemoveController implements InvocableController
         Assert::allString($selected);
 
         $centralColumns = new CentralColumns($this->dbi);
-        $error = $centralColumns->deleteColumnsFromList($_POST['db'], $selected);
+        $error = $centralColumns->deleteColumnsFromList(Current::$database, $selected);
 
         Current::$message = $error instanceof Message ? $error : Message::success(__('Success!'));
-
-        unset($_POST['submit_mult']);
 
         return ($this->structureController)($request);
     }

--- a/tests/unit/Controllers/Database/Structure/CentralColumns/RemoveControllerTest.php
+++ b/tests/unit/Controllers/Database/Structure/CentralColumns/RemoveControllerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Controllers\Database\Structure\CentralColumns;
+
+use Fig\Http\Message\StatusCodeInterface;
+use PhpMyAdmin\Clock\Clock;
+use PhpMyAdmin\Config;
+use PhpMyAdmin\Config\PageSettings;
+use PhpMyAdmin\Config\UserPreferences;
+use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\ConfigStorage\RelationParameters;
+use PhpMyAdmin\Controllers\Database\Structure\CentralColumns\RemoveController;
+use PhpMyAdmin\Controllers\Database\StructureController;
+use PhpMyAdmin\Current;
+use PhpMyAdmin\DbTableExists;
+use PhpMyAdmin\Favorites\RecentFavoriteTables;
+use PhpMyAdmin\Http\Factory\ServerRequestFactory;
+use PhpMyAdmin\Message;
+use PhpMyAdmin\Replication\Replication;
+use PhpMyAdmin\Template;
+use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\DbiDummy;
+use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
+use PhpMyAdmin\Tracking\TrackingChecker;
+use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionProperty;
+
+#[CoversClass(RemoveController::class)]
+final class RemoveControllerTest extends AbstractTestCase
+{
+    public function testRemoveUsesCurrentDatabase(): void
+    {
+        (new ReflectionProperty(RecentFavoriteTables::class, 'instances'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, RelationParameters::fromArray([
+            RelationParameters::CENTRAL_COLUMNS_WORK => true,
+            RelationParameters::DATABASE => 'phpmyadmin',
+            RelationParameters::CENTRAL_COLUMNS => 'pma_central_columns',
+        ]));
+        $_SESSION['tmpval'] = [];
+        $_SERVER['SCRIPT_NAME'] = 'index.php';
+        $_REQUEST['db'] = Current::$database = 'test_db';
+
+        $dbiDummy = $this->createDbiDummy();
+        // CentralColumns::deleteColumnsFromList() must target Current::$database
+        $dbiDummy->addResult(
+            'SELECT col_name FROM `phpmyadmin`.`pma_central_columns`'
+                . " WHERE db_name = 'test_db' AND col_name IN ('id','name','datetimefield');",
+            [['id'], ['name'], ['datetimefield']],
+            ['col_name'],
+        );
+        $dbiDummy->addResult(
+            'DELETE FROM `phpmyadmin`.`pma_central_columns`'
+                . " WHERE db_name = 'test_db' AND col_name IN ('id','name','datetimefield');",
+            true,
+        );
+        // StructureController renders the database structure page afterwards
+        $dbiDummy->addSelectDb('test_db');
+        $dbiDummy->addResult('SHOW TABLES FROM `test_db`;', [['test_table']], ['Tables_in_test_db']);
+        $dbiDummy->addResult('SELECT COUNT(*) FROM `test_db`.`test_table`', [['3']]);
+        $dbiDummy->addResult(
+            "SELECT DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = 'test_db' LIMIT 1",
+            [['utf8mb4_uca1400_ai_ci']],
+            ['DEFAULT_COLLATION_NAME'],
+        );
+        $dbiDummy->addResult('SELECT @@default_storage_engine;', [['InnoDB']]);
+
+        $request = ServerRequestFactory::create()->createServerRequest('POST', 'https://example.com/')
+            ->withParsedBody(['db' => 'test_db', 'selected_tbl' => ['test_table']]);
+
+        $response = ($this->getRemoveController($dbiDummy))($request);
+
+        $dbiDummy->assertAllSelectsConsumed();
+        $dbiDummy->assertAllQueriesConsumed();
+        self::assertEquals(Message::success('Success!'), Current::$message);
+        self::assertSame(StatusCodeInterface::STATUS_OK, $response->getStatusCode());
+    }
+
+    private function getRemoveController(DbiDummy $dbiDummy): RemoveController
+    {
+        $config = new Config();
+        $dbi = $this->createDatabaseInterface($dbiDummy, $config);
+        $relation = new Relation($dbi, $config);
+        $responseRenderer = new ResponseRenderer();
+        $template = new Template($config);
+        $structureController = new StructureController(
+            $responseRenderer,
+            $template,
+            $relation,
+            new Replication($dbi),
+            $dbi,
+            new TrackingChecker($dbi, $relation),
+            new PageSettings(new UserPreferences($dbi, $relation, $template, $config, new Clock()), $responseRenderer),
+            new DbTableExists($dbi),
+            $config,
+        );
+
+        return new RemoveController($responseRenderer, $dbi, $structureController);
+    }
+}


### PR DESCRIPTION
### Description

Part of #17769.

Replaces the last `$_POST` access in the CentralColumns structure controllers.
`RemoveController` now takes the database from `Current::$database`, like
`MakeConsistentController` already does. The `unset($_POST['submit_mult'])`
in the three controllers is removed: the parsed body is a copy of `$_POST`
taken in `ServerRequestFactory::fromGlobals()`, and `StructureController`
does not read `submit_mult`, so it had no effect.

Added `RemoveControllerTest` to cover the changed line, and dropped the
phpstan/psalm baseline entries that no longer apply.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
